### PR TITLE
shallot-cli-tests: stage 3 vite.ts — projectPlugin's hooks, the fs readers, and the traversal guard extracted

### DIFF
--- a/packages/shallot/src/project/vite.test.ts
+++ b/packages/shallot/src/project/vite.test.ts
@@ -1,6 +1,24 @@
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Rollup } from "vite";
-import { assetSrc, manifestWarnings, orphanedAssets } from "./vite";
+import {
+    assetSrc,
+    contentType,
+    discoverScenes,
+    findPublicDirs,
+    manifestWarnings,
+    orphanedAssets,
+    projectPlugin,
+    readManifest,
+    resolveAssetPath,
+} from "./vite";
+
+// a fresh project dir per test, cleaned up after — the shape every fs-reader / hook test needs
+function projectDir(): string {
+    return mkdtempSync(join(tmpdir(), "shallot-vite-test-"));
+}
 
 // minimal bundle builders — the pure prune reads only type / fileName / code|source
 const chunk = (fileName: string, code: string) =>
@@ -101,5 +119,436 @@ describe("manifestWarnings", () => {
                 known,
             ),
         ).toEqual([]);
+    });
+});
+
+// MIME for a project's public/ assets — without it res.end() sends no Content-Type and a browser
+// misclassifies the response (an SVG icon rejected as a favicon).
+describe("contentType", () => {
+    test("maps the project-asset extensions the MIME table declares", () => {
+        expect(contentType("icon.svg")).toBe("image/svg+xml");
+        expect(contentType("model.glb")).toBe("model/gltf-binary");
+        expect(contentType("data.wasm")).toBe("application/wasm");
+    });
+
+    test("matches the extension case-insensitively", () => {
+        expect(contentType("ICON.SVG")).toBe("image/svg+xml");
+    });
+
+    test("is undefined for an unmapped or missing extension", () => {
+        expect(contentType("readme.md")).toBeUndefined();
+        expect(contentType("noext")).toBeUndefined();
+    });
+});
+
+// resolveAssetPath is the extraction of configureServer's join-then-guard: given `new URL(req.url,
+// "http://localhost")`'s own WHATWG dot-segment normalization already strips every crafted req.url this
+// stage tried (encoded and raw ".." forms alike — see the extraction's own comment), the guard's
+// `!filePath.startsWith(dir)` branch is unreachable through any real request. Tested directly on a raw
+// pathname the URL layer never gets to normalize first, so the guard's own logic is still pinned.
+describe("resolveAssetPath", () => {
+    test("resolves an existing file under dir", () => {
+        const dir = projectDir();
+        writeFileSync(join(dir, "icon.svg"), "<svg/>");
+        expect(resolveAssetPath(dir, "/icon.svg")).toBe(join(dir, "icon.svg"));
+    });
+
+    test("returns null for a file that doesn't exist under dir", () => {
+        const dir = projectDir();
+        expect(resolveAssetPath(dir, "/missing.svg")).toBeNull();
+    });
+
+    test("returns null for a directory — not a file", () => {
+        const dir = projectDir();
+        mkdirSync(join(dir, "sub"));
+        expect(resolveAssetPath(dir, "/sub")).toBeNull();
+    });
+
+    test("rejects a pathname that joins outside dir — the traversal guard", () => {
+        // a sibling file that WOULD resolve if the guard didn't reject the escape first
+        const parent = projectDir();
+        const dir = join(parent, "public");
+        mkdirSync(dir);
+        writeFileSync(join(parent, "secret.txt"), "top secret");
+        expect(resolveAssetPath(dir, "/../secret.txt")).toBeNull();
+    });
+
+    test("rejects a sibling dir whose name merely extends dir's — a prefix is not a boundary", () => {
+        // the case a string-prefix guard gets wrong: "/a/public-secrets".startsWith("/a/public") is
+        // true, but the escape target is a sibling of dir, not a descendant. Only a separator-aware
+        // boundary check rejects it.
+        const parent = projectDir();
+        const dir = join(parent, "public");
+        const sibling = join(parent, "public-secrets");
+        mkdirSync(dir);
+        mkdirSync(sibling);
+        writeFileSync(join(sibling, "secret.txt"), "top secret");
+        expect(resolveAssetPath(dir, join("..", "public-secrets", "secret.txt"))).toBeNull();
+    });
+});
+
+// readManifest: the toolchain boundary between a project's raw shallot.json and the normalized Manifest
+// projectPlugin's `load` hook generates from.
+describe("readManifest", () => {
+    test("returns {} when the project has no manifest — a scene-only project", () => {
+        expect(readManifest(projectDir())).toEqual({});
+    });
+
+    test("parses a valid manifest", () => {
+        const dir = projectDir();
+        writeFileSync(
+            join(dir, "shallot.json"),
+            JSON.stringify({ scene: "main.scene", plugins: { Render: false } }),
+        );
+        expect(readManifest(dir)).toEqual({ scene: "main.scene", plugins: { Render: false } });
+    });
+
+    test("tolerates a corrupt manifest — returns {} rather than throwing", () => {
+        const dir = projectDir();
+        writeFileSync(join(dir, "shallot.json"), "{ not json");
+        expect(readManifest(dir)).toEqual({});
+    });
+});
+
+describe("discoverScenes", () => {
+    test("finds nested .scene files, sorted, relative to dir", () => {
+        const dir = projectDir();
+        mkdirSync(join(dir, "levels"));
+        writeFileSync(join(dir, "b.scene"), "");
+        writeFileSync(join(dir, "levels", "a.scene"), "");
+        expect(discoverScenes(dir)).toEqual(["b.scene", join("levels", "a.scene")]);
+    });
+
+    test("skips node_modules and dist", () => {
+        const dir = projectDir();
+        mkdirSync(join(dir, "node_modules"));
+        writeFileSync(join(dir, "node_modules", "vendored.scene"), "");
+        mkdirSync(join(dir, "dist"));
+        writeFileSync(join(dir, "dist", "built.scene"), "");
+        expect(discoverScenes(dir)).toEqual([]);
+    });
+
+    test("returns [] for a dir that doesn't exist", () => {
+        expect(discoverScenes(join(projectDir(), "missing"))).toEqual([]);
+    });
+});
+
+describe("findPublicDirs", () => {
+    test("returns [] when neither the project nor its parent has a public dir", () => {
+        expect(findPublicDirs(projectDir())).toEqual([]);
+    });
+
+    test("includes the project's own public dir", () => {
+        const dir = projectDir();
+        mkdirSync(join(dir, "public"));
+        expect(findPublicDirs(dir)).toEqual([join(dir, "public")]);
+    });
+
+    test("includes a shared parent public dir too, own first", () => {
+        const parent = projectDir();
+        const dir = join(parent, "proj");
+        mkdirSync(dir);
+        mkdirSync(join(dir, "public"));
+        mkdirSync(join(parent, "public"));
+        expect(findPublicDirs(dir)).toEqual([join(dir, "public"), join(parent, "public")]);
+    });
+});
+
+// projectPlugin's hooks — a plain object, each callable against a stub `this` / server (Locked decision:
+// "every seam this unit needs already exists as a parameter"). The stubs below are duck-typed to the
+// members each hook actually touches, never the full Vite/Rollup types, and every hook property is cast
+// at the call site: the plugin object assigns each as a plain function, but Vite's `Plugin` type widens
+// the property to `ObjectHook<fn> | { handler: fn }`, which has no call signature to invoke directly.
+describe("projectPlugin", () => {
+    function stubServer() {
+        const middlewareFns: Array<
+            (req: { url?: string }, res: ReturnType<typeof stubRes>, next: () => void) => void
+        > = [];
+        const sent: unknown[] = [];
+        const invalidated: unknown[] = [];
+        let moduleById: unknown;
+        const server = {
+            middlewares: { use: (fn: unknown) => middlewareFns.push(fn as never) },
+            watcher: { add: () => {}, on: () => {} },
+            ws: { send: (msg: unknown) => sent.push(msg) },
+            moduleGraph: {
+                getModuleById: () => moduleById,
+                invalidateModule: (mod: unknown) => invalidated.push(mod),
+            },
+        };
+        return {
+            server,
+            middlewareFns,
+            sent,
+            invalidated,
+            setModuleById: (m: unknown) => {
+                moduleById = m;
+            },
+        };
+    }
+
+    function stubRes() {
+        return {
+            headers: {} as Record<string, string>,
+            ended: undefined as unknown,
+            setHeader(name: string, value: string) {
+                this.headers[name] = value;
+            },
+            end(data: unknown) {
+                this.ended = data;
+            },
+        };
+    }
+
+    describe("resolveId", () => {
+        test("resolves the virtual module id to its internal id", async () => {
+            const plugin = projectPlugin();
+            const hook = plugin.resolveId as unknown as (
+                this: unknown,
+                id: string,
+                importer?: string,
+            ) => Promise<string | undefined>;
+            await expect(hook.call({}, "virtual:project")).resolves.toBe("\0virtual:project");
+        });
+
+        test("resolves a project-relative import against the project dir via the stub this.resolve", async () => {
+            const dir = projectDir();
+            const plugin = projectPlugin(dir);
+            const hook = plugin.resolveId as unknown as (
+                this: {
+                    resolve: (
+                        id: string,
+                        importer: string,
+                        opts: { skipSelf: boolean },
+                    ) => Promise<{ id: string } | null>;
+                },
+                id: string,
+                importer?: string,
+            ) => Promise<{ id: string } | undefined>;
+            const calls: unknown[] = [];
+            const stubThis = {
+                resolve: async (id: string, importer: string, opts: { skipSelf: boolean }) => {
+                    calls.push({ id, importer, opts });
+                    return { id: `/resolved/${id}` };
+                },
+            };
+            const resolved = await hook.call(stubThis, "orrstead/core/grid", "\0virtual:project");
+            expect(resolved).toEqual({ id: "/resolved/orrstead/core/grid" });
+            expect(calls).toEqual([
+                {
+                    id: "orrstead/core/grid",
+                    importer: join(dir, "__project__.js"),
+                    opts: { skipSelf: true },
+                },
+            ]);
+        });
+
+        test("resolves nothing for an unrelated importer, or without a projectDir", async () => {
+            const plugin = projectPlugin(); // no projectDir
+            const hook = plugin.resolveId as unknown as (
+                this: unknown,
+                id: string,
+                importer?: string,
+            ) => Promise<string | undefined>;
+            await expect(hook.call({}, "some/pkg", "\0virtual:project")).resolves.toBeUndefined();
+        });
+    });
+
+    describe("load", () => {
+        function loadHook(plugin: ReturnType<typeof projectPlugin>) {
+            return plugin.load as unknown as (this: unknown, id: string) => string | undefined;
+        }
+
+        test("generates an empty-manifest module when the plugin carries no projectDir", () => {
+            const plugin = projectPlugin();
+            const out = loadHook(plugin).call({}, "\0virtual:project");
+            expect(out).toContain("const manifest = {};");
+            expect(out).toContain("const scenes = [];");
+        });
+
+        test("threads readManifest + discoverScenes into the generated module for a real project", () => {
+            const dir = projectDir();
+            writeFileSync(
+                join(dir, "shallot.json"),
+                JSON.stringify({ plugins: { Render: false } }),
+            );
+            writeFileSync(join(dir, "main.scene"), "");
+            const plugin = projectPlugin(dir);
+            const out = loadHook(plugin).call({}, "\0virtual:project");
+            expect(out).toContain('"main.scene"');
+            expect(out).toContain('"Render":false');
+        });
+
+        test("returns nothing for an id other than the virtual module's", () => {
+            const plugin = projectPlugin(projectDir());
+            expect(loadHook(plugin).call({}, "some/other/module")).toBeUndefined();
+        });
+    });
+
+    describe("configureServer's middleware", () => {
+        function install(dir?: string) {
+            const plugin = projectPlugin(dir);
+            const stub = stubServer();
+            const configureServer = plugin.configureServer as unknown as (server: unknown) => void;
+            configureServer(stub.server);
+            return stub;
+        }
+
+        test("registers no middleware when the project has no public dir", () => {
+            const { middlewareFns } = install(projectDir()); // no public/ subdir
+            expect(middlewareFns).toHaveLength(0);
+        });
+
+        test("serves a project asset with the right MIME and a no-store cache header", () => {
+            const dir = projectDir();
+            mkdirSync(join(dir, "public"));
+            writeFileSync(join(dir, "public", "icon.svg"), "<svg/>");
+            const { middlewareFns } = install(dir);
+            expect(middlewareFns).toHaveLength(1);
+
+            const res = stubRes();
+            let calledNext = false;
+            middlewareFns[0]({ url: "/icon.svg" }, res, () => {
+                calledNext = true;
+            });
+
+            expect(res.headers["Content-Type"]).toBe("image/svg+xml");
+            expect(res.headers["Cache-Control"]).toBe("no-store");
+            expect(res.ended?.toString()).toBe("<svg/>");
+            expect(calledNext).toBe(false);
+        });
+
+        test("falls through to next() for a request with no matching asset", () => {
+            const dir = projectDir();
+            mkdirSync(join(dir, "public"));
+            const { middlewareFns } = install(dir);
+
+            const res = stubRes();
+            let calledNext = false;
+            middlewareFns[0]({ url: "/missing.svg" }, res, () => {
+                calledNext = true;
+            });
+            expect(calledNext).toBe(true);
+            expect(res.ended).toBeUndefined();
+        });
+
+        test("falls through to next() when req.url is absent", () => {
+            const dir = projectDir();
+            mkdirSync(join(dir, "public"));
+            writeFileSync(join(dir, "public", "icon.svg"), "<svg/>");
+            const { middlewareFns } = install(dir);
+
+            const res = stubRes();
+            let calledNext = false;
+            middlewareFns[0]({}, res, () => {
+                calledNext = true;
+            });
+            expect(calledNext).toBe(true);
+        });
+    });
+
+    describe("handleHotUpdate", () => {
+        function handleHotUpdateHook(plugin: ReturnType<typeof projectPlugin>) {
+            return plugin.handleHotUpdate as unknown as (ctx: {
+                file: string;
+            }) => unknown[] | undefined;
+        }
+        function configureServerHook(plugin: ReturnType<typeof projectPlugin>) {
+            return plugin.configureServer as unknown as (server: unknown) => void;
+        }
+
+        test("invalidates the virtual module and signals a reload on a .scene change, swallowing default HMR", () => {
+            const dir = projectDir();
+            const plugin = projectPlugin(dir);
+            const stub = stubServer();
+            configureServerHook(plugin)(stub.server); // sets the closure's live viteServer
+
+            const mod = { id: "\0virtual:project" };
+            stub.setModuleById(mod);
+            const result = handleHotUpdateHook(plugin)({ file: join(dir, "main.scene") });
+
+            expect(result).toEqual([]);
+            expect(stub.invalidated).toEqual([mod]);
+            expect(stub.sent).toEqual([{ type: "full-reload" }]);
+        });
+
+        test("invalidates on a shallot.json change too", () => {
+            const dir = projectDir();
+            const plugin = projectPlugin(dir);
+            const stub = stubServer();
+            configureServerHook(plugin)(stub.server);
+
+            const result = handleHotUpdateHook(plugin)({ file: join(dir, "shallot.json") });
+            expect(result).toEqual([]);
+            expect(stub.sent).toEqual([{ type: "full-reload" }]);
+        });
+
+        test("falls through to default HMR for an unrelated file", () => {
+            const dir = projectDir();
+            const plugin = projectPlugin(dir);
+            const stub = stubServer();
+            configureServerHook(plugin)(stub.server);
+
+            const result = handleHotUpdateHook(plugin)({ file: join(dir, "src", "Local.ts") });
+
+            expect(result).toBeUndefined();
+            expect(stub.sent).toEqual([]);
+            expect(stub.invalidated).toEqual([]);
+        });
+
+        test("does nothing without a live server, or without a projectDir", () => {
+            // configureServer never ran — the closure's viteServer is still unset
+            const notConfigured = projectPlugin(projectDir());
+            expect(
+                handleHotUpdateHook(notConfigured)({ file: "/whatever/main.scene" }),
+            ).toBeUndefined();
+
+            const noProjectDir = projectPlugin();
+            const stub = stubServer();
+            configureServerHook(noProjectDir)(stub.server);
+            expect(
+                handleHotUpdateHook(noProjectDir)({ file: "/whatever/main.scene" }),
+            ).toBeUndefined();
+        });
+    });
+
+    describe("generateBundle", () => {
+        function generateBundleHook(plugin: ReturnType<typeof projectPlugin>) {
+            return plugin.generateBundle as unknown as (
+                this: { info: (msg: string) => void },
+                options: unknown,
+                bundle: Rollup.OutputBundle,
+            ) => void;
+        }
+
+        test("drops an orphaned asset and reports its pruned byte count", () => {
+            const plugin = projectPlugin();
+            // deliberately NOT a KB multiple: at 2048 every rounding mode agrees and the report's
+            // truncating `| 0` goes unpinned. 3000 B truncates to 2KB and rounds up to 3KB.
+            const source = "x".repeat(3000);
+            const outputBundle = bundle(
+                chunk("assets/index-AAA.js", `console.log("no reference")`),
+                asset("assets/draco-BBB.wasm", source),
+            );
+            const infoMsgs: string[] = [];
+            generateBundleHook(plugin).call({ info: (m) => infoMsgs.push(m) }, {}, outputBundle);
+
+            expect(outputBundle["assets/draco-BBB.wasm"]).toBeUndefined();
+            expect(infoMsgs).toEqual(["pruned 1 orphaned asset(s), 2KB"]);
+        });
+
+        test("leaves a fully-referenced bundle untouched and reports nothing", () => {
+            const plugin = projectPlugin();
+            const outputBundle = bundle(
+                chunk("assets/index-AAA.js", `new URL("./assets/draco-BBB.wasm", import.meta.url)`),
+                asset("assets/draco-BBB.wasm", "x"),
+            );
+            const before = { ...outputBundle };
+            const infoMsgs: string[] = [];
+            generateBundleHook(plugin).call({ info: (m) => infoMsgs.push(m) }, {}, outputBundle);
+
+            expect(outputBundle).toEqual(before);
+            expect(infoMsgs).toEqual([]);
+        });
     });
 });

--- a/packages/shallot/src/project/vite.ts
+++ b/packages/shallot/src/project/vite.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
-import { dirname, isAbsolute, join, relative, resolve } from "path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "path";
 import typegpu from "unplugin-typegpu/vite";
 import type { Plugin, Rollup, ViteDevServer } from "vite";
 import { KNOWN_ENGINE_PLUGINS } from "./engine";
@@ -72,9 +72,11 @@ export function manifestWarnings(raw: string, known: ReadonlySet<string>): strin
     return warnings;
 }
 
-// read + parse a project's manifest, tolerating its absence (a scene-only project → {}); warn loudly on a
-// corrupt file or an unknown-plugin key before `normalize` normalizes the mistake away
-function readManifest(absDir: string): Manifest {
+/**
+ * read + parse a project's manifest, tolerating its absence (a scene-only project → {}); warn loudly on
+ * a corrupt file or an unknown-plugin key before `normalize` normalizes the mistake away. @internal
+ */
+export function readManifest(absDir: string): Manifest {
     const path = manifestPath(absDir);
     let text: string;
     try {
@@ -154,7 +156,8 @@ const MIME: Record<string, string> = {
     ktx2: "image/ktx2",
 };
 
-function contentType(path: string): string | undefined {
+/** @internal */
+export function contentType(path: string): string | undefined {
     return MIME[path.slice(path.lastIndexOf(".") + 1).toLowerCase()];
 }
 
@@ -163,6 +166,23 @@ function contentType(path: string): string | undefined {
 // invalidated by the caller) and re-fetches assets.
 function signalChange(server: ViteDevServer) {
     server.ws.send({ type: "full-reload" });
+}
+
+/**
+ * the served file `pathname` maps to under `dir`, or `null` if there isn't one — joins, then rejects a
+ * result that lands outside `dir` before ever touching disk. `configureServer`'s own `new URL(req.url,
+ * "http://localhost")` call already strips every dot-segment payload upstream (WHATWG's path-normalize
+ * step resolves "." / ".." — including percent-encoded forms — before this ever sees `pathname`, verified
+ * against curl-style raw request lines), so the escape branch is unreachable through any real request;
+ * it's tested directly here, on a raw `pathname` the URL layer never gets to normalize first. @internal
+ */
+export function resolveAssetPath(dir: string, pathname: string): string | null {
+    const filePath = join(dir, pathname);
+    // segment boundary, not a string prefix: a plain `startsWith(dir)` also admits a *sibling* whose
+    // name extends dir's basename (dir `/a/public` would accept `/a/public-secrets/x`), which is an
+    // escape, not a descendant.
+    if (filePath !== dir && !filePath.startsWith(dir + sep)) return null;
+    return existsSync(filePath) && statSync(filePath).isFile() ? filePath : null;
 }
 
 // serve project public/ assets (the project's own + a shared parent's) with correct MIME
@@ -174,19 +194,17 @@ function configureServer(server: ViteDevServer, projectDir?: string) {
         if (req.url) {
             const pathname = new URL(req.url, "http://localhost").pathname;
             for (const dir of publicDirs) {
-                const filePath = join(dir, pathname);
-                if (!filePath.startsWith(dir)) continue;
-                if (existsSync(filePath) && statSync(filePath).isFile()) {
-                    const data = readFileSync(filePath);
-                    const mime = contentType(filePath);
-                    if (mime) res.setHeader("Content-Type", mime);
-                    // dev assets must never sit in the browser HTTP cache, or a live model edit re-fetches
-                    // the stale bytes after `invalidate` (the worker decode reads the cached response) and the
-                    // swap silently shows the old asset. no-store forces a fresh read every load.
-                    res.setHeader("Cache-Control", "no-store");
-                    res.end(data);
-                    return;
-                }
+                const filePath = resolveAssetPath(dir, pathname);
+                if (!filePath) continue;
+                const data = readFileSync(filePath);
+                const mime = contentType(filePath);
+                if (mime) res.setHeader("Content-Type", mime);
+                // dev assets must never sit in the browser HTTP cache, or a live model edit re-fetches
+                // the stale bytes after `invalidate` (the worker decode reads the cached response) and the
+                // swap silently shows the old asset. no-store forces a fresh read every load.
+                res.setHeader("Cache-Control", "no-store");
+                res.end(data);
+                return;
             }
         }
         next();

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -325,16 +325,29 @@ export const CLI_COVERAGE: readonly CoverageRow[] = [
         file: "packages/shallot/src/project/vite.ts",
         arm: "gap",
         reason:
-            "assetSrc's public-dir-relative matching, manifestWarnings' corrupt-JSON and unknown-plugin " +
-            "branches, and orphanedAssets' fixpoint asset-pruning are directly asserted by vite.test.ts. " +
-            "projectPlugin's hooks (resolveId, load, configureServer's static-asset middleware carrying " +
-            "the path-traversal guard and the no-store rule, handleHotUpdate, generateBundle) run against " +
-            "a stub `this`/server today in production only, never a test; readManifest, discoverScenes, " +
-            "findPublicDirs, manifestPath, and contentType are exercised only transitively through those " +
-            "hooks. Stage 3 covers resolveId/load/configureServer's middleware/handleHotUpdate/" +
-            "generateBundle's orphan deletion + byte accounting, plus the fs readers by temp dir and " +
-            "contentType.",
-        stage: 3,
+            "assetSrc, manifestWarnings, orphanedAssets, contentType, readManifest, discoverScenes, and " +
+            "findPublicDirs are all directly asserted by vite.test.ts against a temp dir. projectPlugin's " +
+            "resolveId, load, configureServer's static-asset middleware, handleHotUpdate, and " +
+            "generateBundle's orphan deletion + byte accounting are each exercised against a stub " +
+            "`this`/server, per hook. The path-traversal guard was extracted into resolveAssetPath and " +
+            "tested there directly, because its escape branch is empirically unreachable through any real " +
+            'req.url: `new URL(req.url, "http://localhost")`\'s own WHATWG dot-segment normalization ' +
+            "strips every crafted payload two independent sweeps tried (raw, percent- and double-encoded " +
+            "dots, encoded slash, backslash, overlong/unicode dot forms, absolute-URL and protocol-relative " +
+            "request targets, %00) before the guard ever runs, ~35 payloads with no exception found. The " +
+            "guard asserts a *segment boundary*, not a string prefix — a bare startsWith(dir) also admits " +
+            "a sibling extending dir's basename (`/a/public-secrets` under `/a/public`), which the " +
+            "adversarial pass proved exploitable on the extracted function and which now has its own test. " +
+            "typegpuPlugin is `tier`: it carries no logic of its own beyond a single-instance constraint, " +
+            "and the property that matters — the TGSL transform actually ran over engine `.ts` — is " +
+            "asserted at runtime by checkTgsl on every GPU boot, so each `bun bench` / `bun run flows` / " +
+            "`bun run recipes` scenario reds if this plugin stops being wired into the synthesized config. " +
+            "What stays reached by nothing: configureServer's " +
+            "onProjectFile watcher callback (the dev-server glue mapping a live `.scene`/manifest file " +
+            "event to invalidate+reload, and a model-asset event through assetSrc to a full-reload) — no " +
+            "test:install/bench/flows/recipes run ever edits a file under a booted dev server's watch, and " +
+            "this stage's stub server never drives a real chokidar event either. No stage in the spec's " +
+            "Approach owns it; occupant: configureServer's onProjectFile callback.",
     },
     {
         file: "packages/create-shallot/index.ts",


### PR DESCRIPTION
Covers projectPlugin's five hooks against a stub `this`/server (resolveId, load,
configureServer's middleware, handleHotUpdate, generateBundle's orphan deletion +
byte accounting), the fs readers by temp dir (readManifest, discoverScenes,
findPublicDirs) and contentType. 33 new tests, no module mocking — every seam is a
pre-existing parameter.

The path-traversal guard moved out of the middleware into `resolveAssetPath`. Its
escape branch is unreachable through any real request — `new URL(req.url, ...)`'s
WHATWG dot-segment normalization strips every payload two sweeps tried (~35: raw,
percent- and double-encoded dots, encoded slash, backslash, overlong/unicode forms,
absolute and protocol-relative targets, %00) — so it's tested directly on a raw
pathname the URL layer never normalizes. The adversarial pass proved the original
`startsWith(dir)` admitted a *sibling* extending dir's basename (`/a/public-secrets`
under `/a/public`); the guard now asserts a segment boundary and has its own test.

Registry: vite.ts's row stays `gap`, occupant frozen by name — configureServer's
onProjectFile watcher callback, which no tier drives (no gate edits a file under a
booted dev server's watch, and a stub server raises no chokidar event). Per the
weakest-arm rule, the extraction landed and the arm didn't move.

Red-first, mutations run this session:
- segment boundary -> bare `startsWith(dir)`: reds "rejects a sibling dir whose name
  merely extends dir's"
- drop the `no-store` setHeader: reds "serves a project asset with the right MIME and
  a no-store cache header"
- delete vite.ts's registry row: reds "every walked file has exactly one row"

Gates: bun run format 0, bun check 0, bun test 2578 pass / 0 fail across 151 files
(floor 2545 at 59be0167; +33 stage-3 tests, corpus tier included via
GLTF_CORPUS_REQUIRED=1).
