### PR TITLE
shallot-cli-tests: stage 5 native.ts — extract + test the decision table, close the missing-crate gap

### DIFF
--- a/packages/shallot/bin/native.test.ts
+++ b/packages/shallot/bin/native.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+    cargoTarget,
+    dropSwiftshader,
+    findCefDir,
+    isStaleLocaleEntry,
+    macHelperBin,
+    macInfoPlist,
+    missingCrateDiagnostic,
+    nativeOutDir,
+    resolveCargoInvocation,
+} from "./native";
+
+describe("nativeOutDir", () => {
+    test("builds <projectDir>/build/<platform>/<profile>-<mode>", () => {
+        expect(nativeOutDir("/proj", "mac", true, true)).toBe(
+            resolve("/proj", "build", "mac", "release-portable"),
+        );
+    });
+
+    test("release/portable each independently flip their segment", () => {
+        expect(nativeOutDir("/proj", "windows", false, false)).toBe(
+            resolve("/proj", "build", "windows", "debug-system"),
+        );
+        expect(nativeOutDir("/proj", "windows", true, false)).toBe(
+            resolve("/proj", "build", "windows", "release-system"),
+        );
+        expect(nativeOutDir("/proj", "windows", false, true)).toBe(
+            resolve("/proj", "build", "windows", "debug-portable"),
+        );
+    });
+
+    // the mode segment exists precisely so a portable and a system build of the same project+profile
+    // don't share a path and clobber each other's output.
+    test("portable and system builds of the same profile land in different dirs", () => {
+        const system = nativeOutDir("/proj", "linux", true, false);
+        const portable = nativeOutDir("/proj", "linux", true, true);
+        expect(system).not.toBe(portable);
+    });
+});
+
+describe("cargoTarget", () => {
+    test("windows targets get an .exe suffix, others don't", () => {
+        expect(cargoTarget("x86_64-pc-windows-msvc", true, "/t")).toBe(
+            resolve("/t", "x86_64-pc-windows-msvc/release/shallot-window.exe"),
+        );
+        expect(cargoTarget("x86_64-unknown-linux-gnu", true, "/t")).toBe(
+            resolve("/t", "x86_64-unknown-linux-gnu/release/shallot-window"),
+        );
+    });
+
+    test("release selects the release profile dir, debug the debug dir", () => {
+        expect(cargoTarget("aarch64-apple-darwin", false, "/t")).toBe(
+            resolve("/t", "aarch64-apple-darwin/debug/shallot-window"),
+        );
+    });
+});
+
+describe("resolveCargoInvocation", () => {
+    // the decision table cargoBuild used to inline: msvc + WSL + portable is the one combination that
+    // needs the host's native MSVC toolchain via PowerShell (devShellBuild) rather than cargo/cargo-xwin.
+    test("msvc target, on WSL, portable -> devshell", () => {
+        const inv = resolveCargoInvocation("x86_64-pc-windows-msvc", false, true, true);
+        expect(inv.kind).toBe("devshell");
+    });
+
+    test("msvc target, on WSL, system (not portable) -> xwin, not devshell", () => {
+        const inv = resolveCargoInvocation("x86_64-pc-windows-msvc", false, false, true);
+        expect(inv.kind).toBe("xwin");
+    });
+
+    test("msvc target, not on WSL, portable -> xwin (cross-compiled)", () => {
+        const inv = resolveCargoInvocation("x86_64-pc-windows-msvc", false, true, false);
+        expect(inv.kind).toBe("xwin");
+    });
+
+    test("non-msvc target is always native, regardless of WSL/portable", () => {
+        expect(resolveCargoInvocation("x86_64-unknown-linux-gnu", false, true, true).kind).toBe(
+            "native",
+        );
+        expect(resolveCargoInvocation("aarch64-apple-darwin", true, false, false).kind).toBe(
+            "native",
+        );
+    });
+
+    test("flags carry --target always, --release only when release, and the portable feature flags only when portable", () => {
+        expect(
+            resolveCargoInvocation("x86_64-unknown-linux-gnu", false, false, false).flags,
+        ).toEqual(["--target", "x86_64-unknown-linux-gnu"]);
+        expect(
+            resolveCargoInvocation("x86_64-unknown-linux-gnu", true, false, false).flags,
+        ).toEqual(["--target", "x86_64-unknown-linux-gnu", "--release"]);
+        expect(
+            resolveCargoInvocation("x86_64-unknown-linux-gnu", false, true, false).flags,
+        ).toEqual([
+            "--target",
+            "x86_64-unknown-linux-gnu",
+            "--no-default-features",
+            "--features",
+            "portable",
+        ]);
+    });
+});
+
+describe("missingCrateDiagnostic", () => {
+    test("null when the crate dir exists", () => {
+        const dir = mkdtempSync(join(tmpdir(), "shallot-crate-"));
+        expect(missingCrateDiagnostic(dir)).toBeNull();
+    });
+
+    test("names the missing dir when it doesn't exist", () => {
+        const dir = join(mkdtempSync(join(tmpdir(), "shallot-crate-")), "rust/window");
+        const msg = missingCrateDiagnostic(dir);
+        expect(msg).not.toBeNull();
+        expect(msg).toContain(dir);
+        expect(msg).toContain("native builds aren't available from an installed package");
+    });
+});
+
+describe("isStaleLocaleEntry", () => {
+    // CefSettings.locale defaults to en-US, so both spellings of the English .lproj bundle survive —
+    // the regionless en.lproj and the region-qualified en_US.lproj.
+    test("keeps both English .lproj spellings, strips every other .lproj", () => {
+        expect(isStaleLocaleEntry("en.lproj")).toBe(false);
+        expect(isStaleLocaleEntry("en_US.lproj")).toBe(false);
+        expect(isStaleLocaleEntry("fr.lproj")).toBe(true);
+        expect(isStaleLocaleEntry("de_DE.lproj")).toBe(true);
+    });
+
+    test("keeps en-US.pak, strips every other .pak", () => {
+        expect(isStaleLocaleEntry("en-US.pak")).toBe(false);
+        expect(isStaleLocaleEntry("ja.pak")).toBe(true);
+    });
+
+    test("ignores entries that are neither shape", () => {
+        expect(isStaleLocaleEntry("icudtl.dat")).toBe(false);
+        expect(isStaleLocaleEntry("README")).toBe(false);
+    });
+});
+
+describe("macHelperBin", () => {
+    test("resolves under the crate's target dir for the given profile", () => {
+        expect(macHelperBin(true)).toContain("target/aarch64-apple-darwin/release/shallot-helper");
+        expect(macHelperBin(false)).toContain("target/aarch64-apple-darwin/debug/shallot-helper");
+    });
+});
+
+describe("macInfoPlist", () => {
+    const base = { executable: "demo", bundleName: "demo", identifier: "com.multiplekex.demo" };
+
+    test("a helper bundle gets LSUIElement, a main app doesn't", () => {
+        const helper = macInfoPlist({ ...base, helper: true, icon: false });
+        const main = macInfoPlist({ ...base, helper: false, icon: false });
+        expect(helper).toContain("<key>LSUIElement</key>\n    <true/>");
+        expect(main).not.toContain("LSUIElement");
+    });
+
+    test("icon: true carries the CFBundleIconFile key, icon: false omits it", () => {
+        const withIcon = macInfoPlist({ ...base, helper: false, icon: true });
+        const withoutIcon = macInfoPlist({ ...base, helper: false, icon: false });
+        expect(withIcon).toContain("<key>CFBundleIconFile</key>\n    <string>app</string>");
+        expect(withoutIcon).not.toContain("CFBundleIconFile");
+    });
+
+    test("the two branches compose independently (helper + icon both set)", () => {
+        const both = macInfoPlist({ ...base, helper: true, icon: true });
+        expect(both).toContain("LSUIElement");
+        expect(both).toContain("CFBundleIconFile");
+    });
+});
+
+describe("findCefDir", () => {
+    test("CEF_PATH short-circuits the search when the marker exists there", () => {
+        const cefPath = mkdtempSync(join(tmpdir(), "shallot-cef-path-"));
+        writeFileSync(join(cefPath, "libcef.so"), "");
+        const prev = process.env.CEF_PATH;
+        process.env.CEF_PATH = cefPath;
+        try {
+            expect(findCefDir("x86_64-unknown-linux-gnu", "libcef.so", "/nonexistent")).toBe(
+                cefPath,
+            );
+        } finally {
+            if (prev === undefined) delete process.env.CEF_PATH;
+            else process.env.CEF_PATH = prev;
+        }
+    });
+
+    test("CEF_PATH set but missing the marker falls through to the build-tree search", () => {
+        const prev = process.env.CEF_PATH;
+        process.env.CEF_PATH = mkdtempSync(join(tmpdir(), "shallot-cef-empty-"));
+        try {
+            const targetDir = mkdtempSync(join(tmpdir(), "shallot-cef-tree-"));
+            const out = resolve(
+                targetDir,
+                "x86_64-unknown-linux-gnu/release/build/cef-dll-sys-abc123/out/cef-linux64",
+            );
+            mkdirSync(out, { recursive: true });
+            writeFileSync(join(out, "libcef.so"), "");
+            expect(findCefDir("x86_64-unknown-linux-gnu", "libcef.so", targetDir)).toBe(out);
+        } finally {
+            if (prev === undefined) delete process.env.CEF_PATH;
+            else process.env.CEF_PATH = prev;
+        }
+    });
+
+    test("searches release before debug, and returns null when neither has the marker", () => {
+        delete process.env.CEF_PATH;
+        const targetDir = mkdtempSync(join(tmpdir(), "shallot-cef-tree-"));
+        const releaseOut = resolve(
+            targetDir,
+            "aarch64-apple-darwin/release/build/cef-dll-sys-1/out/cef-mac",
+        );
+        const debugOut = resolve(
+            targetDir,
+            "aarch64-apple-darwin/debug/build/cef-dll-sys-2/out/cef-mac",
+        );
+        mkdirSync(releaseOut, { recursive: true });
+        mkdirSync(debugOut, { recursive: true });
+        writeFileSync(join(releaseOut, "marker.txt"), "");
+        writeFileSync(join(debugOut, "marker.txt"), "");
+        expect(findCefDir("aarch64-apple-darwin", "marker.txt", targetDir)).toBe(releaseOut);
+
+        const emptyTargetDir = mkdtempSync(join(tmpdir(), "shallot-cef-empty-tree-"));
+        expect(findCefDir("aarch64-apple-darwin", "marker.txt", emptyTargetDir)).toBeNull();
+    });
+});
+
+describe("dropSwiftshader", () => {
+    // read per call, not frozen at module load — a caller (a test, a script driving multiple builds)
+    // that sets the env var mid-process must be honored rather than seeing whatever it was on import.
+    test("reflects the env var's current value, not its value at import time", () => {
+        const prev = process.env.SHALLOT_DROP_SWIFTSHADER;
+        try {
+            delete process.env.SHALLOT_DROP_SWIFTSHADER;
+            expect(dropSwiftshader()).toBe(false);
+            process.env.SHALLOT_DROP_SWIFTSHADER = "1";
+            expect(dropSwiftshader()).toBe(true);
+            delete process.env.SHALLOT_DROP_SWIFTSHADER;
+            expect(dropSwiftshader()).toBe(false);
+        } finally {
+            if (prev === undefined) delete process.env.SHALLOT_DROP_SWIFTSHADER;
+            else process.env.SHALLOT_DROP_SWIFTSHADER = prev;
+        }
+    });
+});

--- a/packages/shallot/bin/native.ts
+++ b/packages/shallot/bin/native.ts
@@ -30,8 +30,12 @@ const MAC_HELPER_SUFFIXES = [
 
 // SwiftShader is Chromium's software-GL fallback. WebGPU runs on Vulkan/Metal/D3D12 directly, so a
 // real-GPU target doesn't need it — but the Chromium compositor may, so dropping it risks a black
-// window. Off by default until validated per platform; opt in with SHALLOT_DROP_SWIFTSHADER set.
-const DROP_SWIFTSHADER = process.env.SHALLOT_DROP_SWIFTSHADER != null;
+// window. Off by default until validated per platform; opt in with SHALLOT_DROP_SWIFTSHADER set. Read
+// per call, not once at module load, so a caller that sets the env var mid-process (a test, a script
+// driving multiple builds) is honored rather than frozen at whatever it was on import.
+export function dropSwiftshader(): boolean {
+    return process.env.SHALLOT_DROP_SWIFTSHADER != null;
+}
 
 /**
  * a native build's output dir: `build/<platform>/<profile>-<mode>`. The mode segment keeps a portable
@@ -53,7 +57,7 @@ export function nativeOutDir(
 // Windows dir (winBuildDir) instead; everything else uses this.
 const CRATE_TARGET = resolve(RUST_CRATE, "target");
 
-function cargoTarget(target: string, release: boolean, targetDir = CRATE_TARGET): string {
+export function cargoTarget(target: string, release: boolean, targetDir = CRATE_TARGET): string {
     const profile = release ? "release" : "debug";
     return resolve(
         targetDir,
@@ -109,6 +113,49 @@ function devShellBuild(flags: string[], distDir?: string, winTargetDir?: string)
     ].join(" ");
 }
 
+export type CargoInvocation =
+    | { kind: "devshell"; flags: string[] }
+    | { kind: "xwin"; flags: string[] }
+    | { kind: "native"; flags: string[] };
+
+/**
+ * cargoBuild's portable/target/WSL decision table, pulled out pure: which cargo invocation a
+ * (target, release, portable, isWSL) combination selects, and the flags it carries. `devshell` is
+ * windows-portable under WSL (needs the host's native MSVC toolchain via PowerShell, see
+ * devShellBuild); `xwin` is any other msvc target (cross-compiled with cargo-xwin); `native` is
+ * everything else (`cargo build` in place).
+ */
+export function resolveCargoInvocation(
+    target: string,
+    release: boolean,
+    portable: boolean,
+    isWSL: boolean,
+): CargoInvocation {
+    const flags: string[] = ["--target", target];
+    if (portable) flags.push("--no-default-features", "--features", "portable");
+    if (release) flags.push("--release");
+
+    const msvc = target.includes("msvc");
+    if (msvc && isWSL && portable) return { kind: "devshell", flags };
+    return { kind: msvc ? "xwin" : "native", flags };
+}
+
+// rust/window isn't shipped in package.json's `files` (`bun pm pack --dry-run` ships 0 rust/window
+// entries — audio's wasm ships prebuilt, native needs the crate itself), so an installed package's
+// `cwd: RUST_CRATE` below would otherwise die on a raw ENOENT. Fail loud instead, before spawning cargo.
+export function missingCrateDiagnostic(crateDir: string): string | null {
+    if (existsSync(crateDir)) return null;
+    return `no rust/window crate found at ${crateDir} — native builds aren't available from an installed package (the crate isn't shipped; only the source repo has it). Build from source, or run inside the shallot monorepo.`;
+}
+
+function requireRustCrate(): void {
+    const msg = missingCrateDiagnostic(RUST_CRATE);
+    if (msg) {
+        console.error(`  ${msg}`);
+        process.exit(1);
+    }
+}
+
 // SHALLOT_DIST bakes the web assets into the binary at compile time (release only) so the exe carries
 // no appended overlay and never extracts itself at runtime. Debug serves from the sibling dist/ for
 // fast iteration. `portable` selects the CEF backend (self-contained Chromium) over the default
@@ -120,9 +167,8 @@ function cargoBuild(
     distDir?: string,
     winTargetDir?: string,
 ): void {
-    const flags: string[] = ["--target", target];
-    if (portable) flags.push("--no-default-features", "--features", "portable");
-    if (release) flags.push("--release");
+    requireRustCrate();
+    const invocation = resolveCargoInvocation(target, release, portable, isWSL);
 
     // Windows portable (CEF) under WSL builds natively on the host via PowerShell — the same
     // WSL→Windows bridge the bench uses. cargo-xwin's clang-cl can't build CEF's libcef_dll_wrapper
@@ -131,14 +177,14 @@ function cargoBuild(
     // runs in-place over the crate's UNC path (devShellBuild cd's there), so its target/ dir is the
     // one bundling reads back. The powershell process is launched with a real Windows cwd (the C:\
     // mount) so the dev-shell's internal cmd.exe doesn't choke on a UNC working directory.
-    if (target.includes("msvc") && isWSL && portable) {
+    if (invocation.kind === "devshell") {
         const winCwd = execSync("wslpath -u 'C:\\'", { encoding: "utf-8" }).trim();
         const r = Bun.spawnSync(
             [
                 "powershell.exe",
                 "-NoProfile",
                 "-Command",
-                devShellBuild(flags, distDir, winTargetDir),
+                devShellBuild(invocation.flags, distDir, winTargetDir),
             ],
             { cwd: winCwd, stdout: "inherit", stderr: "inherit" },
         );
@@ -152,9 +198,9 @@ function cargoBuild(
     }
 
     // cross-compile a Windows target from a non-WSL host (cargo-xwin), or build a native target.
-    const cmd = target.includes("msvc") ? "cargo xwin build" : "cargo build";
+    const cmd = invocation.kind === "xwin" ? "cargo xwin build" : "cargo build";
     const env = distDir ? { ...process.env, SHALLOT_DIST: distDir } : process.env;
-    execSync([cmd, ...flags].join(" "), { cwd: RUST_CRATE, stdio: "inherit", env });
+    execSync([cmd, ...invocation.flags].join(" "), { cwd: RUST_CRATE, stdio: "inherit", env });
 }
 
 function ensureIcon(distDir: string): void {
@@ -166,7 +212,11 @@ function ensureIcon(distDir: string): void {
 
 // the downloaded CEF runtime lives in cef-dll-sys's build OUT_DIR (or CEF_PATH when set). Return the
 // subdir under it holding `marker` (libcef.so / libcef.dll / the framework) for a target's build.
-function findCefDir(target: string, marker: string, targetDir = CRATE_TARGET): string | null {
+export function findCefDir(
+    target: string,
+    marker: string,
+    targetDir = CRATE_TARGET,
+): string | null {
     const cefPath = process.env.CEF_PATH;
     if (cefPath && existsSync(resolve(cefPath, marker))) return cefPath;
 
@@ -294,12 +344,12 @@ function convertIconToIcns(pngPath: string, icnsPath: string): void {
     rmSync(macIcon);
 }
 
-function macHelperBin(release: boolean): string {
+export function macHelperBin(release: boolean): string {
     const profile = release ? "release" : "debug";
     return resolve(RUST_CRATE, `target/${MAC_TARGET}/${profile}/shallot-helper`);
 }
 
-function macInfoPlist(opts: {
+export function macInfoPlist(opts: {
     executable: string;
     bundleName: string;
     identifier: string;
@@ -333,6 +383,16 @@ function macInfoPlist(opts: {
 </plist>`;
 }
 
+// CefSettings.locale defaults to en-US (see copyLocale), so only the active locale's forms are kept:
+// the `.lproj` bundle folder (both its regionless and region-qualified spelling) or the flat
+// `locales/*.pak` file. Anything else matching either shape is stale weight to strip. Pulled out of
+// trimMacLocales' two directory walks so the delete rule is testable without touching a filesystem.
+export function isStaleLocaleEntry(entry: string): boolean {
+    if (entry.endsWith(".lproj")) return entry !== "en.lproj" && entry !== "en_US.lproj";
+    if (entry.endsWith(".pak")) return entry !== "en-US.pak";
+    return false;
+}
+
 // strip non-English locale paks from a copied CEF mac framework — covers both the per-locale `.lproj`
 // layout and a flat `locales/` dir of paks, so it's a no-op if neither is present. Runs before
 // codesign (which re-signs the trimmed tree).
@@ -340,14 +400,14 @@ function trimMacLocales(frameworkDir: string): void {
     const resources = resolve(frameworkDir, "Resources");
     if (!existsSync(resources)) return;
     for (const entry of readdirSync(resources)) {
-        if (entry.endsWith(".lproj") && entry !== "en.lproj" && entry !== "en_US.lproj") {
+        if (isStaleLocaleEntry(entry)) {
             rmSync(resolve(resources, entry), { recursive: true, force: true });
         }
     }
     const locales = resolve(resources, "locales");
     if (existsSync(locales)) {
         for (const entry of readdirSync(locales)) {
-            if (entry.endsWith(".pak") && entry !== "en-US.pak") {
+            if (isStaleLocaleEntry(entry)) {
                 rmSync(resolve(locales, entry), { force: true });
             }
         }
@@ -494,7 +554,7 @@ function copyCefLibs(outputDir: string, release: boolean): void {
         "chrome_200_percent.pak",
         "resources.pak",
     ];
-    if (!DROP_SWIFTSHADER) files.push("libvk_swiftshader.so");
+    if (!dropSwiftshader()) files.push("libvk_swiftshader.so");
 
     for (const file of files) {
         const src = resolve(cefSrc, file);
@@ -503,7 +563,7 @@ function copyCefLibs(outputDir: string, release: boolean): void {
 
     copyLocale(resolve(cefSrc, "locales"), resolve(cefOut, "locales"));
 
-    if (!DROP_SWIFTSHADER) {
+    if (!dropSwiftshader()) {
         const swiftshaderSrc = resolve(cefSrc, "swiftshader");
         if (existsSync(swiftshaderSrc)) {
             cpSync(swiftshaderSrc, resolve(cefOut, "swiftshader"), { recursive: true });
@@ -540,7 +600,7 @@ function copyCefDlls(outputDir: string, targetDir = CRATE_TARGET): void {
         "chrome_200_percent.pak",
         "resources.pak",
     ];
-    if (!DROP_SWIFTSHADER) files.push("vk_swiftshader.dll", "vk_swiftshader_icd.json");
+    if (!dropSwiftshader()) files.push("vk_swiftshader.dll", "vk_swiftshader_icd.json");
 
     for (const file of files) {
         const src = resolve(cefSrc, file);

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -208,22 +208,26 @@ export const CLI_COVERAGE: readonly CoverageRow[] = [
         file: "packages/shallot/bin/native.ts",
         arm: "gap",
         reason:
-            "nativeOutDir (exported, pure, currently zero test callers), cargoTarget, a pure " +
-            "resolveCargoInvocation carved out of cargoBuild's portable/target/WSL decision table, " +
-            "trimMacLocales' delete-predicate, macHelperBin, macInfoPlist's two independent branches " +
-            "(helper/LSUIElement, icon key — both are string-template conditionals with no external " +
-            "effect), and findCefDir's CEF_PATH/build-tree search are pure or temp-dir-testable logic " +
-            "stage 5 extracts and tests. What stays permanently untested, by decision, past stage 5: " +
-            "devShellBuild (declared manual — its PowerShell DevShell-entry template would be restated " +
-            "byte-for-byte by any test) and the subprocess-orchestrating bulk that calls real " +
-            "cargo/sips/iconutil/strip (cargoBuild's execSync/spawnSync arms, bundleNativeMac, " +
-            "bundleNativeWindows, bundleNativeLinux, ensureIcon, tryStrip, copyLocale, copyCefLibs, " +
-            "copyCefDlls, prepareMacIcon, convertIconToIcns) — frozen out of the `unit` arm by the Locked " +
-            'decision itself ("native.ts extracts and declares; it gets no real-cargo gate"). The one ' +
-            "closed rung against this gap is the missing-crate guard (rust/window isn't shipped in " +
-            "package.json's `files`, so an installed `--target <os>` build dies on a raw ENOENT instead of " +
-            "a named diagnostic), asserted in the install gate rather than here.",
-        stage: 5,
+            "stage 5 discharged the extraction: nativeOutDir, cargoTarget, resolveCargoInvocation (the " +
+            "pure portable/target/WSL decision table cargoBuild now delegates to), missingCrateDiagnostic, " +
+            "isStaleLocaleEntry (trimMacLocales' delete-predicate), macHelperBin, macInfoPlist's two " +
+            "independent branches (helper/LSUIElement, icon key), and findCefDir's CEF_PATH/build-tree " +
+            "search (by temp dir, both the short-circuit and the fall-through) are all now directly " +
+            "asserted by native.test.ts. dropSwiftshader was fixed from a module-load constant to a " +
+            "per-call env read (SHALLOT_DROP_SWIFTSHADER honored mid-process, not frozen at import) and is " +
+            "tested for that property directly. What stays permanently untested, by decision: devShellBuild " +
+            "(declared manual — its PowerShell DevShell-entry template would be restated byte-for-byte by " +
+            "any test) and the subprocess-orchestrating bulk that calls real cargo/sips/iconutil/strip " +
+            "(cargoBuild's execSync/spawnSync arms, bundleNativeMac, bundleNativeWindows, bundleNativeLinux, " +
+            "ensureIcon, tryStrip, copyLocale, copyCefLibs, copyCefDlls, prepareMacIcon, convertIconToIcns) " +
+            '— frozen out of the `unit` arm by the Locked decision itself ("native.ts extracts and ' +
+            "declares; it gets no real-cargo gate\"). The missing-crate guard (rust/window isn't shipped in " +
+            "package.json's `files`, so an installed `--target <os>` build used to die on a raw ENOENT) is " +
+            "now closed end to end: requireRustCrate calls missingCrateDiagnostic before cargoBuild spawns " +
+            "anything, and `bun run test:install`'s \"native build fails with the missing-crate diagnostic, " +
+            'not a raw ENOENT" rung asserts it from a real installed package via `shallot build --target ' +
+            "linux`, red-proved by removing the requireRustCrate() call (surfaces a raw ENOENT from " +
+            "posix_spawn instead).",
     },
     {
         file: "packages/shallot/bin/recipe.ts",

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -543,6 +543,21 @@ try {
             assets.join(", ") || "(no assets dir)",
         );
 
+        // rust/window isn't in `files` (audio's wasm ships prebuilt, native needs the crate itself —
+        // `bun pm pack --dry-run` ships 0 rust/window entries), so `--target <os>` from this installed
+        // package must fail with native.ts's named missingCrateDiagnostic, not a raw ENOENT from
+        // cargoBuild's `cwd: RUST_CRATE`. The spec's Locked decision: native.ts "extracts and declares;
+        // it gets no real-cargo gate" — this is the one closed rung against that gap.
+        console.log("shallot build --target linux (missing rust/window crate → named diagnostic)…");
+        const nativeBuild = run(["bun", CLI, "build", ".", "--target", "linux"], sandbox);
+        check(
+            "native build fails with the missing-crate diagnostic, not a raw ENOENT",
+            !nativeBuild.ok &&
+                /no rust\/window crate found at/.test(nativeBuild.out) &&
+                !/ENOENT/.test(nativeBuild.out),
+            nativeBuild.out.slice(-900),
+        );
+
         tgslFlow(sandbox, dist);
 
         // the dev server: live resolution + asset serving over vite (a different path than the build


### PR DESCRIPTION
Extracted and tested from cargoBuild's effectful body: nativeOutDir (already exported, pure, now
23 tests over it in native.test.ts), cargoTarget, resolveCargoInvocation (the pure
portable/target/WSL decision table cargoBuild now delegates to), missingCrateDiagnostic,
isStaleLocaleEntry (trimMacLocales' delete predicate), macHelperBin, macInfoPlist's two branches
(helper/LSUIElement, icon key), and findCefDir by temp dir plus CEF_PATH (short-circuit and
fall-through, release-before-debug search order). dropSwiftshader fixed from a module-load
constant to a per-call env read, per the spec's Locked decision. devShellBuild stays declared
manual. Zero mock.module/spyOn — every test drives real pure functions or a temp dir.

Closed the missing-crate gap the spec identified: rust/window isn't shipped in package.json's
`files`, so `shallot build --target <os>` from an installed package used to die on a raw ENOENT.
requireRustCrate now guards cargoBuild with missingCrateDiagnostic, and
scripts/install-test.ts gained a rung asserting the named diagnostic (not ENOENT) from a real
installed package via `bun CLI build . --target linux`.

Registry: bin/native.ts's row stays permanent `gap` (stage dropped) with a shorter occupant
list — devShellBuild plus the subprocess-orchestrating bulk (cargoBuild's execSync/spawnSync
arms, the three bundleNative* functions, ensureIcon, tryStrip, copyLocale, copyCefLibs,
copyCefDlls, prepareMacIcon, convertIconToIcns) frozen out of `unit` by the Locked decision
itself. Matches stage 4's pattern: an extract row's discharge is usually gap, not unit.

Red-first mutations, each run against native.test.ts and reverted after confirming a red for
the right reason:
- nativeOutDir: hardcoded profile to "debug" -> reds the release/portable segment tests
- cargoTarget: dropped the .exe suffix logic -> reds the windows-suffix test
- resolveCargoInvocation: dropped the `&& portable` guard on devshell -> reds the
  system/WSL/msvc case (wrongly returns devshell instead of xwin)
- missingCrateDiagnostic: inverted the existsSync check -> reds both directions
- isStaleLocaleEntry: dropped the en_US.lproj exception -> reds the both-spellings test
- macHelperBin: hardcoded profile to "debug" -> reds the release-profile assertion
- macInfoPlist: dropped the LSUIElement branch -> reds both helper-branch tests
- findCefDir: CEF_PATH short-circuited without checking the marker exists -> reds the
  fall-through test
- findCefDir: swapped the release/debug search order -> reds the ordering test
- dropSwiftshader: reverted to a module-load-frozen constant -> reds the mid-process test
- requireRustCrate: removed the call from cargoBuild -> reds the install-gate rung with a raw
  ENOENT (posix_spawn '/bin/sh' ENOENT) instead of the named diagnostic

Gates: `bun run test:install` floor recorded green before any change (all rungs passed,
"shallot dev boots a server" did not flake this run); green after, including the new
missing-crate rung. `bun run format` 0, `bun check` exit 0 (biome 711 files, tsc, eslint,
versions, imports, boundary 35 projects, docs 17 files, pack 403 files).
`GLTF_CORPUS_REQUIRED=1 bun test` 2601 pass / 0 fail across 152 files — this device's floor is
stage 3's (2578/151, stage 4's commit is mac-only and absent here), so the delta is exactly the
23 new tests in the 1 new file.
