### PR TITLE
shallot-cli-tests: stage 6 remainder — toolchain.ts, packFog, computeGlyphMetrics, outline registry rows

### DIFF
--- a/packages/shallot/bin/toolchain.test.ts
+++ b/packages/shallot/bin/toolchain.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { Plugin } from "vite";
-import { composeViteConfig, flattenPlugins, type ProjectConfig } from "./toolchain";
+import {
+    composeViteConfig,
+    flattenPlugins,
+    isProject,
+    loadProjectConfig,
+    type ProjectConfig,
+    requireProject,
+} from "./toolchain";
 
 const p = (name: string) => ({ name }) as Plugin;
 
@@ -94,5 +104,70 @@ describe("composeViteConfig", () => {
         };
         const out = composeViteConfig(hostBase, null) as { optimizeDeps?: { exclude?: string[] } };
         expect(out.optimizeDeps?.exclude).toEqual(["@dylanebert/shallot"]);
+    });
+});
+
+// isProject / requireProject / loadProjectConfig, by temp dir — the dev.test.ts technique
+// (mkdtempSync + real fs). requireProject's failure branch (process.exit(1)) is deliberately not
+// exercised here: it can't be called without killing the test runner, and the Locked decision forbids
+// spying on it — that branch stays a named gap occupant in the registry.
+describe("isProject", () => {
+    test("true for a dir with a shallot.json manifest", () => {
+        const dir = mkdtempSync(join(tmpdir(), "shallot-isproject-manifest-"));
+        writeFileSync(join(dir, "shallot.json"), "{}\n");
+        expect(isProject(dir)).toBe(true);
+    });
+
+    test("true for a dir with a nested .scene file and no manifest", () => {
+        const dir = mkdtempSync(join(tmpdir(), "shallot-isproject-scene-"));
+        mkdirSync(join(dir, "scenes"));
+        writeFileSync(join(dir, "scenes", "demo.scene"), "");
+        expect(isProject(dir)).toBe(true);
+    });
+
+    test("false for a dir with neither", () => {
+        const dir = mkdtempSync(join(tmpdir(), "shallot-isproject-empty-"));
+        expect(isProject(dir)).toBe(false);
+    });
+});
+
+describe("requireProject", () => {
+    test("a real project dir returns without throwing or exiting", () => {
+        const dir = mkdtempSync(join(tmpdir(), "shallot-requireproject-"));
+        writeFileSync(join(dir, "shallot.json"), "{}\n");
+        expect(() => requireProject(dir)).not.toThrow();
+    });
+});
+
+describe("loadProjectConfig", () => {
+    test("a dir with no vite.config → null (the zero-config manifest path)", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "shallot-lpc-none-"));
+        expect(await loadProjectConfig(dir, "serve", "development")).toBeNull();
+    });
+
+    test("a dir with its own vite.config → the flattened plugins + resolve/define overlay + path", async () => {
+        // .mjs, not .ts: vite bundles a .ts config through a require() shim that bun's own module
+        // loader rejects mid-test ("require() async module is unsupported") — a bun-test-specific
+        // incompatibility with vite's config bundler, not something loadProjectConfig itself owns.
+        // .mjs skips that bundling path (vite dynamic-imports it directly), which is what a project
+        // authoring a config in plain ESM already gets.
+        const dir = mkdtempSync(join(tmpdir(), "shallot-lpc-config-"));
+        writeFileSync(
+            join(dir, "vite.config.mjs"),
+            [
+                "export default {",
+                '  plugins: [{ name: "svelte" }],',
+                '  resolve: { alias: { "@": "/src" } },',
+                "  define: { FOO: '\"bar\"' },",
+                "};",
+                "",
+            ].join("\n"),
+        );
+        const config = await loadProjectConfig(dir, "serve", "development");
+        expect(config?.plugins.map((x) => x.name)).toEqual(["svelte"]);
+        // vite's `define` carries the raw injected-source string verbatim (a string constant needs its
+        // own literal quotes, since the value is textually substituted, not evaluated)
+        expect((config?.overlay as { define?: unknown }).define).toEqual({ FOO: '"bar"' });
+        expect(config?.path).toBe(join(dir, "vite.config.mjs"));
     });
 });

--- a/packages/shallot/src/extras/text/atlas.test.ts
+++ b/packages/shallot/src/extras/text/atlas.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import { computeGlyphMetrics, type GlyphAtlas } from "./atlas";
+import type { Font } from "./font";
+
+// computeGlyphMetrics is a shelf packer (place each glyph on the current row, wrap, or refuse once the
+// atlas is full) plus UV math (font-unit box → normalized metrics + atlas-space UV rect). `Font` is a
+// duck-typed interface, so a hand-built fake reaches every branch with no real font file or GPU device —
+// `createGlyphAtlas`/`ensureString`, the rest of this module, stay untested here: both call into a real
+// `GPUDevice`/`SDFGenerator`, outside this function's pure shelf-packing + UV surface.
+
+function fakeFont(overrides: Partial<Font> = {}): Font {
+    return {
+        unitsPerEm: 1000,
+        ascender: 800,
+        descender: -200,
+        lineGap: 0,
+        glyphPath: () => "M0,0L1,1Z",
+        glyphBounds: () => [10, -20, 500, 700],
+        advance: () => 600,
+        kerning: () => 0,
+        ...overrides,
+    };
+}
+
+// texture/textureView/sdfGenerator are never read by computeGlyphMetrics (only ensureString/
+// createGlyphAtlas touch them) — a duck-typed data stub, never a device, per the Locked decision's "every
+// seam this unit needs already exists as a parameter" bar.
+function fakeAtlas(font: Font, size: { width: number; height: number }): GlyphAtlas {
+    return {
+        texture: null as never,
+        textureView: null as never,
+        width: size.width,
+        height: size.height,
+        glyphs: new Map(),
+        rowHeight: 0,
+        cursorX: 0,
+        cursorY: 0,
+        font,
+        sdfGenerator: null as never,
+    };
+}
+
+describe("computeGlyphMetrics", () => {
+    test("returns null and touches no cursor state when the font has no path or bounds for the char", () => {
+        const atlas = fakeAtlas(fakeFont({ glyphPath: () => null }), { width: 1000, height: 1000 });
+        expect(computeGlyphMetrics(atlas, " ")).toBeNull();
+        expect(atlas.glyphs.size).toBe(0);
+        expect(atlas.cursorX).toBe(0);
+        expect(atlas.cursorY).toBe(0);
+    });
+
+    test("packs the font-unit box into normalized metrics and an atlas-space UV rect", () => {
+        // unitsPerEm 1000, bounds [10, -20, 500, 700] -> padding 100 -> paddedBounds [-90, -120, 600, 800]
+        const atlas = fakeAtlas(fakeFont(), { width: 1000, height: 1000 });
+        const entry = computeGlyphMetrics(atlas, "A");
+        const metrics = atlas.glyphs.get("A");
+
+        expect(entry).toEqual({
+            path: "M0,0L1,1Z",
+            paddedBounds: [-90, -120, 600, 800],
+            atlasX: 0,
+            atlasY: 0,
+        });
+        expect(metrics).toBeDefined();
+        expect(metrics!.glyphWidth).toBeCloseTo(690 / 1000, 10); // (600 - -90) / unitsPerEm
+        expect(metrics!.glyphHeight).toBeCloseTo(920 / 1000, 10); // (800 - -120) / unitsPerEm
+        expect(metrics!.glyphTop).toBeCloseTo(800 / 1000, 10);
+        expect(metrics!.glyphLeft).toBeCloseTo(-90 / 1000, 10);
+        expect(metrics!.advance).toBeCloseTo(600 / 1000, 10);
+        // the atlas slot is square (width === height); the UV rect is the slot placed at (cursorX, cursorY)
+        // before this call, both zero for the first glyph on a fresh atlas
+        expect(metrics!.width).toBe(metrics!.height);
+        expect(metrics!.u0).toBe(0);
+        expect(metrics!.v0).toBe(0);
+        expect(metrics!.u1).toBeCloseTo(metrics!.width / 1000, 10);
+        expect(metrics!.v1).toBeCloseTo(metrics!.height / 1000, 10);
+    });
+
+    test("advances the cursor by one slot on the same row for a second glyph", () => {
+        const atlas = fakeAtlas(fakeFont(), { width: 1000, height: 1000 });
+        computeGlyphMetrics(atlas, "A");
+        const slot = atlas.glyphs.get("A")!.width;
+        const second = computeGlyphMetrics(atlas, "B");
+        expect(second!.atlasX).toBe(slot);
+        expect(second!.atlasY).toBe(0);
+        expect(atlas.cursorX).toBe(slot * 2);
+    });
+
+    test("wraps to a new row when the next slot would overflow the atlas width", () => {
+        const atlas = fakeAtlas(fakeFont(), { width: 1000, height: 1000 });
+        const first = computeGlyphMetrics(atlas, "A")!;
+        const slot = atlas.glyphs.get("A")!.width;
+        // force the next slot past the width without depending on how many glyphs that actually takes
+        atlas.cursorX = atlas.width - slot + 1;
+        const wrapped = computeGlyphMetrics(atlas, "B")!;
+        expect(wrapped.atlasX).toBe(0);
+        expect(wrapped.atlasY).toBe(first.atlasY + slot); // rowHeight carried from the first glyph's row
+        expect(atlas.cursorX).toBe(slot);
+        expect(atlas.rowHeight).toBe(slot);
+    });
+
+    test("throws once the atlas has no room even at column 0", () => {
+        const atlas = fakeAtlas(fakeFont(), { width: 1000, height: 50 });
+        expect(() => computeGlyphMetrics(atlas, "A")).toThrow("Glyph atlas full");
+    });
+});

--- a/packages/shallot/src/extras/text/atlas.ts
+++ b/packages/shallot/src/extras/text/atlas.ts
@@ -63,14 +63,19 @@ export function createGlyphAtlas(device: GPUDevice, font: Font): GlyphAtlas {
     };
 }
 
-interface PendingGlyphEntry {
+export interface PendingGlyphEntry {
     path: string;
     paddedBounds: [number, number, number, number];
     atlasX: number;
     atlasY: number;
 }
 
-function computeGlyphMetrics(atlas: GlyphAtlas, char: string): PendingGlyphEntry | null {
+/** the shelf packer: place `char`'s glyph on the atlas's current row (wrapping to a new row, or throwing
+ *  once the atlas is full), record its {@link GlyphMetrics} (UV rect + font-unit-normalized box) into
+ *  `atlas.glyphs`, and return the SDF-render request for the caller to batch. `null` when the font has no
+ *  outline for `char` (e.g. space). @internal, exported for direct testing — `Font` is a duck-typed
+ *  interface, so a hand-built fake reaches this without a real GPU device. */
+export function computeGlyphMetrics(atlas: GlyphAtlas, char: string): PendingGlyphEntry | null {
     const path = atlas.font.glyphPath(char);
     const bounds = atlas.font.glyphBounds(char);
     const advance = atlas.font.advance(char);

--- a/packages/shallot/src/standard/fog/pack.test.ts
+++ b/packages/shallot/src/standard/fog/pack.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { srgbToLinear } from "../../engine/utils/color";
+import { Fog } from "./index";
+import { FOG_MAX_STEPS, FOG_PARAMS } from "./march";
+import { packFog } from "./pack";
+
+// packFog is the CPU→GPU uniform boundary: it reads the `Fog` singleton's sparse components and writes the
+// `FogGpu` staging float array the compute pipeline binds verbatim. `coding.md` names this crossing as
+// earning a test outright — a wrong lane or a missed clamp here is invisible to every WGSL-side check,
+// since the shader only ever sees the packed floats, never the component reads that produced them.
+describe("packFog", () => {
+    test("writes color (sRGB→linear), march, and extra at the schema's own offsets", () => {
+        const eid = 101;
+        Fog.color.set(eid, 0xff8040);
+        Fog.density.set(eid, 0.05);
+        Fog.heightBase.set(eid, 1);
+        Fog.heightFalloff.set(eid, 0.2);
+        Fog.jitter.set(eid, 0.5);
+        Fog.steps.set(eid, 40);
+        Fog.anisotropy.set(eid, 0.3);
+        Fog.absorption.set(eid, 0.1);
+        Fog.scattering.set(eid, 0.8);
+        Fog.scatterIntensity.set(eid, 2);
+
+        const out = new Float32Array(12);
+        packFog(eid, out);
+
+        expect(out[FOG_PARAMS.color]).toBeCloseTo(srgbToLinear(0xff / 255), 6);
+        expect(out[FOG_PARAMS.color + 1]).toBeCloseTo(srgbToLinear(0x80 / 255), 6);
+        expect(out[FOG_PARAMS.color + 2]).toBeCloseTo(srgbToLinear(0x40 / 255), 6);
+        expect(out[FOG_PARAMS.march]).toBeCloseTo(0.05, 6);
+        expect(out[FOG_PARAMS.march + 1]).toBe(1);
+        expect(out[FOG_PARAMS.march + 2]).toBeCloseTo(0.2, 6);
+        expect(out[FOG_PARAMS.march + 3]).toBe(0.5);
+        expect(out[FOG_PARAMS.extra]).toBe(40);
+        expect(out[FOG_PARAMS.extra + 1]).toBeCloseTo(0.3, 6);
+        expect(out[FOG_PARAMS.extra + 2]).toBeCloseTo(0.1, 6);
+        // `extra + 3` is `gain = scattering · scatterIntensity`, not a fourth raw field — the one lane
+        // that isn't a direct component read
+        expect(out[FOG_PARAMS.extra + 3]).toBeCloseTo(0.8 * 2, 6);
+    });
+
+    test("clamps steps to [1, FOG_MAX_STEPS] rather than passing an under- or over-range count through", () => {
+        const eidLow = 102;
+        Fog.steps.set(eidLow, 0);
+        const outLow = new Float32Array(12);
+        packFog(eidLow, outLow);
+        expect(outLow[FOG_PARAMS.extra]).toBe(1);
+
+        const eidHigh = 103;
+        Fog.steps.set(eidHigh, 999);
+        const outHigh = new Float32Array(12);
+        packFog(eidHigh, outHigh);
+        expect(outHigh[FOG_PARAMS.extra]).toBe(FOG_MAX_STEPS);
+    });
+
+    test("zeroes the staging array first, so an unwritten lane (color.a) reads 0, not stale data", () => {
+        const eid = 104;
+        const out = new Float32Array(12).fill(999);
+        packFog(eid, out);
+        expect(out[FOG_PARAMS.color + 3]).toBe(0);
+    });
+});

--- a/packages/shallot/tests/cli-coverage.test.ts
+++ b/packages/shallot/tests/cli-coverage.test.ts
@@ -125,11 +125,12 @@ describe("CLI_COVERAGE against the real repo (both directions)", () => {
         }
     });
 
-    test("the population globs cover the three paths the spec names", () => {
+    test("the population globs cover the three CLI/toolchain paths plus stage 6's outline straggler", () => {
         expect(CLI_POPULATION_GLOBS).toEqual([
             "packages/shallot/bin/*.ts",
             "packages/shallot/src/project/*.ts",
             "packages/create-shallot/index.ts",
+            "packages/shallot/src/extras/outline/*.ts",
         ]);
     });
 });

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -28,11 +28,20 @@ export interface CoverageRow {
     stage?: 2 | 3 | 4 | 5 | 6;
 }
 
-/** the population globs: every non-test `.ts` file the spec's Goal names as the CLI/toolchain layer. */
+/** the population globs: every non-test `.ts` file the spec's Goal names as the CLI/toolchain layer, plus
+ *  stage 6's one named engine straggler — `extras/outline/**` — added to this registry rather than left a
+ *  prose-only mention, so a third row can't drift from the walk the way a hand-declared region list would
+ *  (the Locked decision's "granularity is the file, never the region"). `packFog` and `computeGlyphMetrics`
+ *  stay outside this population: each is one pure function inside a file whose *other* content (the fog
+ *  ECS/system/plugin half, `createGlyphAtlas`/`ensureString`'s real-device calls) would drag the whole
+ *  file's weakest-arm down to `gap` the moment it joined this registry, for content this spec never asked
+ *  this registry to carry — they get a direct test with no row, same as every other `.test.ts` addition
+ *  this unit made without touching the registry. */
 export const CLI_POPULATION_GLOBS: readonly string[] = [
     "packages/shallot/bin/*.ts",
     "packages/shallot/src/project/*.ts",
     "packages/create-shallot/index.ts",
+    "packages/shallot/src/extras/outline/*.ts",
 ];
 
 /** converts a `dir/*.ts`-style glob to a RegExp, re-housed from `coverage.ts` rather than imported —
@@ -294,6 +303,34 @@ export const CLI_COVERAGE: readonly CoverageRow[] = [
             "which bench/flows/recipes' green-path runs never produce. Stage 4 covers these with a " +
             "duck-typed page stub.",
         stage: 4,
+    },
+    {
+        file: "packages/shallot/src/extras/outline/index.ts",
+        arm: "tier",
+        reason:
+            "the component, OutlineSystem's per-camera mask→JFA→composite dispatch, and OutlinePlugin's " +
+            "warm/dispose resource lifecycle are exercised end to end on a real GPU by `bun bench " +
+            "--scenario outline`'s three checks: highlighted entities actually run the outline:mask → " +
+            'outline:jfa → outline:composite passes (hasPass(lit, "outline:")), nothing highlighted ' +
+            "runs zero of them (the zero-cost gate — a bug here would keep paying the dispatch cost with " +
+            "nothing on screen), and fog + outline both composite through the shared post-color seam in " +
+            'one frame (hasPass(lit, "fog:march") && hasPass(lit, "outline:composite")) — the property ' +
+            "that matters is the real pass graph a GPU timestamp query observes, not that the file " +
+            "registers a plugin.",
+    },
+    {
+        file: "packages/shallot/src/extras/outline/passes.ts",
+        arm: "unit",
+        reason:
+            "jfaSteps' clamp/power-of-two ladder and groupByMesh's batching are directly asserted by " +
+            "outline.test.ts. Every other export is a TGSL kernel or bind-group layout, reached through " +
+            "the same file's maskWgsl/outlineWgsl resolved-WGSL structural tests (`testing.md` \"CPU " +
+            'execution of pure TGSL kernels" / "resolved WGSL structure" — the logic-truth tier, not a ' +
+            "real-device claim): maskWgsl(false)/maskWgsl(true) resolve maskVertex/maskFragment over both " +
+            "maskLayoutPlain and maskLayoutOcclude (the reverse-Z occlusion compare, the vertex pull's " +
+            "decode/transform chain), and outlineWgsl() resolves fullscreenVs/jfaFs/jfaLayout (the 3×3 " +
+            "flood-fill neighbor loop) and compositeKernel/compositeLayout (the band's distance-to-alpha " +
+            "math). No export is reached by nothing.",
     },
     {
         file: "packages/shallot/src/project/engine.ts",

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -268,13 +268,12 @@ export const CLI_COVERAGE: readonly CoverageRow[] = [
         arm: "gap",
         reason:
             "flattenPlugins' array/promise/falsy-entry walk and composeViteConfig's merge + name-based " +
-            "drop are both directly asserted by toolchain.test.ts. isProject, requireProject, and " +
-            "loadProjectConfig are untested by `bun test` (requireProject calls process.exit on its " +
-            "failure branch; loadProjectConfig awaits vite's loadConfigFromFile against real disk), though " +
-            "all three run for real whenever `bun run test:install`'s dev/build rungs boot a project — no " +
-            "test asserts on them directly. Stage 6 tests isProject/requireProject/loadProjectConfig by " +
-            "temp dir.",
-        stage: 6,
+            "drop are both directly asserted by toolchain.test.ts, which also covers isProject's " +
+            "manifest/nested-.scene/neither cases, requireProject's returns-without-exiting path, and " +
+            "loadProjectConfig's no-config null plus its flattened-plugins/overlay/path result, all by " +
+            "temp dir. Permanent gap occupant: requireProject's failure branch, which calls process.exit(1) " +
+            "and so cannot be driven without killing the test runner — the Locked decision forbids the " +
+            "spy that would reach it. It runs for real on `bun run test:install`'s dev/build rungs.",
     },
     {
         file: "packages/shallot/bin/verify.ts",


### PR DESCRIPTION
## Problem

Three exports in `bin/toolchain.ts` (`isProject`, `requireProject`, `loadProjectConfig`) had no test. Two engine stragglers the coverage sweep turned up had none either: `packFog`, a CPU→GPU uniform packer — the data-boundary crossing that earns a test outright — and `computeGlyphMetrics`, a shelf packer plus UV math with no export to reach it. `extras/outline/**` sat outside the registry's population entirely.

## Cause

`packFog` and `computeGlyphMetrics` are pure functions living in files whose other half is device-bound, so nothing in the default suite loaded them. `computeGlyphMetrics` wasn't exported at all. The outline plugin's coverage is real but lives in another tier, which the registry had no row to record.

## Fix

14 tests. `toolchain.ts`'s three exports by temp dir (6). `packFog` asserted at `FOG_PARAMS`'s own offsets rather than restated arithmetic — sRGB→linear color, four march lanes, steps clamp, the `out.fill(0)` zero lane. `computeGlyphMetrics` exported (`Font` is an interface, so a hand-built fake reaches the shelf packer with no device) over its null return, padded-bounds/UV/`unitsPerEm` math, same-row advance, row wrap, atlas-full throw.

Registry: `toolchain.ts`'s row becomes a permanent `gap`, occupant frozen as `requireProject`'s `process.exit(1)` branch. `extras/outline/*.ts` joins `CLI_POPULATION_GLOBS` — `passes.ts` → `unit` (every export reached, the TGSL ones through `maskWgsl`/`outlineWgsl`'s resolved-WGSL tests), `index.ts` → `tier` naming `bun bench --scenario outline`'s three checks. `packFog`/`computeGlyphMetrics` deliberately stay outside the population: each is one pure function in a file whose other half is device-bound, so joining would drag the whole file to `gap` under the weakest-arm rule.

## Evidence

Red-first: 11 mutations, each redding exactly its named test, including three against the real repo (deleting a row, duplicating a row, dropping the glob line). Gates re-run by the orchestrator rather than taken on report: `bun run format` 0, `bun check` 0, `GLTF_CORPUS_REQUIRED=1 bun test` 2615/0 across 154 files against a floor of 2607/152 read in the same worktree — delta exactly the new tests. Diff 216 lines of non-mechanical code, under the ~300-line adversarial trigger this stage's Validation sets, so no per-diff pass; the two new registry reasons were verified against the real code by hand instead, a false reason being this registry's known failure mode.