### PR TITLE
shallot-cli-tests: stage 4 verify.ts failure arms — the red path every gate's red routes through

### DIFF
--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { SCENARIO_GATES } from "../../../examples/gym/src/scenarios/timeouts";
 import {
@@ -20,6 +20,7 @@ import {
     buildUrl,
     type Checkpoint,
     coerceVerdict,
+    driveHarness,
     type FrameSample,
     failureArtifacts,
     fitMemory,
@@ -37,9 +38,13 @@ import {
     parseVerifyArgs,
     RESOURCE_BUFFER,
     type ResourceEntry,
+    type Result,
     report,
     reportBatch,
     resolveBatchQueries,
+    SetupError,
+    serveDev,
+    serveDist,
     settlePass,
     spansFromCheckpoints,
     stepWait,
@@ -47,6 +52,7 @@ import {
     summarizeResourceTiming,
     TIMINGS_INIT_SCRIPT,
     type WaitState,
+    withGpuLog,
     withTimeout,
 } from "./verify";
 
@@ -1114,4 +1120,306 @@ describe("stdout survives process.exit — the 64 KiB pipe truncation (shallot-p
             }
         },
     );
+});
+
+// Every red verdict this repo's gates ever report routes through driveHarness's failure arms and
+// withGpuLog's merge — bench/flows/recipes only ever drive the green path (spec: shallot-cli-tests,
+// stage 4). A duck-typed page stub is not module mocking: Page is already typed `any`, and the stub
+// supplies only the boundary methods (`waitForFunction`, `evaluate`, `locator`) driveHarness itself
+// calls — the pre-existing seam the Locked decision names.
+describe("driveHarness — the red arms every gate's red routes through", () => {
+    const baseResult = (): Omit<Result, "pass"> => ({
+        project: "/tmp/proj",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        mode: "dev",
+        url: "http://localhost:1234/",
+        hardware: "unknown",
+        harness: false,
+        booted: false,
+        rendered: false,
+        errors: [],
+    });
+
+    // a page that never renders anything real: the compositor screenshot always fails closed, so
+    // `sampleFrame` reads null rather than fabricating a frame. `evaluate` dispatches on the probed
+    // function's own source — the only stable way to tell driveHarness's several distinct evaluate
+    // calls apart without threading a call counter through every test.
+    const stubPage = (evaluate: (fn: (...a: unknown[]) => unknown) => unknown) => ({
+        waitForFunction: async () => {},
+        evaluate: async (fn: (...a: unknown[]) => unknown) => evaluate(fn),
+        locator: () => ({
+            first: () => ({
+                screenshot: async () => {
+                    throw new Error("no canvas in this stub");
+                },
+            }),
+        }),
+    });
+
+    test("ready-timeout: window.__harness.ready never resolves is a hard FAIL, never a settle downgrade", async () => {
+        const page = {
+            waitForFunction: async () => {
+                throw new Error("timed out");
+            },
+            evaluate: async () => {
+                throw new Error("driveHarness must not evaluate before ready resolves");
+            },
+            locator: () => ({
+                first: () => ({
+                    screenshot: async () => {
+                        throw new Error("no canvas");
+                    },
+                }),
+            }),
+        };
+        const args = parseVerifyArgs(["--timeout", "5000"]);
+        const result = await driveHarness(page, baseResult(), args, [], []);
+        expect(result.booted).toBe(true);
+        expect(result.rendered).toBe(false);
+        expect(result.pass).toBe(false);
+        expect(result.verdict).toEqual({
+            ok: false,
+            checks: [
+                {
+                    name: "ready",
+                    ok: false,
+                    detail: "window.__harness.ready never became true within 5000ms",
+                },
+            ],
+        });
+    });
+
+    test('noRender opt-out: rendered reports "opt-out", never a fake true, and the pixel gate is skipped', async () => {
+        const page = stubPage((fn) => {
+            const src = fn.toString();
+            if (src.includes("noRender")) return true;
+            if (src.includes("typeof window.__harness")) return false; // hasRun probe → fallback verdict
+            throw new Error(`unexpected evaluate: ${src}`);
+        });
+        const args = parseVerifyArgs([]);
+        const result = await driveHarness(page, baseResult(), args, [], []);
+        expect(result.rendered).toBe("opt-out");
+        expect(result.verdict).toEqual({ ok: true, checks: [{ name: "ready", ok: true }] });
+        expect(result.pass).toBe(true);
+    });
+
+    test("probe-error verdict: a throwing __harness.run probe is a clean FAIL naming the error, never an unhandled rejection", async () => {
+        const page = stubPage((fn) => {
+            const src = fn.toString();
+            if (src.includes("noRender")) return false;
+            if (src.includes("typeof window.__harness")) throw new Error("page closed");
+            if (src.includes("requestAnimationFrame")) return undefined;
+            if (src.includes("pixelProbe")) return undefined;
+            throw new Error(`unexpected evaluate: ${src}`);
+        });
+        const args = parseVerifyArgs([]);
+        const result = await driveHarness(page, baseResult(), args, [], []);
+        expect(result.verdict).toEqual({
+            ok: false,
+            checks: [
+                { name: "run", ok: false, detail: "could not reach __harness.run: page closed" },
+            ],
+        });
+        expect(result.pass).toBe(false);
+    });
+
+    test("hasRun-fallback verdict: no run() on the harness reads readiness alone, gated on captured page errors", async () => {
+        const page = stubPage((fn) => {
+            const src = fn.toString();
+            if (src.includes("noRender")) return false;
+            if (src.includes("typeof window.__harness")) return false;
+            if (src.includes("requestAnimationFrame")) return undefined;
+            if (src.includes("pixelProbe")) return undefined;
+            throw new Error(`unexpected evaluate: ${src}`);
+        });
+        const args = parseVerifyArgs([]);
+
+        const clean = await driveHarness(page, baseResult(), args, [], []);
+        expect(clean.verdict).toEqual({ ok: true, checks: [{ name: "ready", ok: true }] });
+
+        const withPageError = await driveHarness(page, baseResult(), args, ["a page error"], []);
+        expect(withPageError.verdict).toEqual({ ok: false, checks: [{ name: "ready", ok: true }] });
+    });
+});
+
+describe("withGpuLog — the verdict merge arithmetic as a branch surface", () => {
+    const mkResult = (overrides: Partial<Result>): Result => ({
+        project: "/tmp/proj",
+        timestamp: "t",
+        mode: "dev",
+        url: "http://x/",
+        hardware: "unknown",
+        harness: true,
+        booted: true,
+        rendered: true,
+        errors: [],
+        pass: true,
+        ...overrides,
+    });
+
+    const gpuPage = (gpuLog: unknown, gpuDiagnostics: unknown) => ({
+        evaluate: async (fn: (...a: unknown[]) => unknown) => {
+            const src = fn.toString();
+            if (src.includes("__gpuLog")) return gpuLog;
+            if (src.includes("__gpuDiagnostics")) return gpuDiagnostics;
+            throw new Error(`unexpected evaluate: ${src}`);
+        },
+    });
+
+    test("no GPU log leaves the result unchanged — nothing to merge", async () => {
+        const page = gpuPage(null, null);
+        const result = mkResult({ pass: true });
+        const merged = await withGpuLog(page, result);
+        expect(merged).toEqual(result);
+    });
+
+    test("the ?? fallback reads result.pass only when no verdict exists — it never overrides an existing false", async () => {
+        const page = gpuPage({ lines: ["ok"], errors: [] }, null);
+
+        // no verdict at all: ok falls back to result.pass, in both directions.
+        const noVerdictPass = await withGpuLog(page, mkResult({ pass: true }));
+        expect(noVerdictPass.verdict?.ok).toBe(true);
+        const noVerdictFail = await withGpuLog(page, mkResult({ pass: false }));
+        expect(noVerdictFail.verdict?.ok).toBe(false);
+
+        // an existing false ok is authoritative: `??` (not `||`) must not fall through to a true pass.
+        const existingFalse = await withGpuLog(
+            page,
+            mkResult({ pass: true, verdict: { ok: false, checks: [{ name: "run", ok: false }] } }),
+        );
+        expect(existingFalse.verdict?.ok).toBe(false);
+    });
+
+    test("!failed flips a previously-ok verdict false on a GPU console.error, and appends the checks", async () => {
+        const page = gpuPage({ lines: ["bad thing"], errors: ["bad thing"] }, null);
+        const result = mkResult({
+            pass: true,
+            verdict: { ok: true, checks: [{ name: "ready", ok: true }] },
+        });
+        const merged = await withGpuLog(page, result);
+        expect(merged.verdict?.ok).toBe(false);
+        expect(merged.pass).toBe(false);
+        expect(merged.verdict?.checks).toEqual([
+            { name: "ready", ok: true },
+            { name: "gpu.log", ok: true, detail: "bad thing" },
+            { name: "gpu.error", ok: false, detail: "bad thing" },
+        ]);
+    });
+});
+
+describe("serve* SetupError guards — by temp dir, asserting the throw class, not message prose", () => {
+    const tempProjectDir = (): string =>
+        mkdtempSync(join(REPO_ROOT, "node_modules/.cache/shallot-verify-guard-"));
+
+    test("serveDist: no dist/ at all is a SetupError, not a raw ENOENT", async () => {
+        const dir = tempProjectDir();
+        try {
+            await expect(serveDist(dir, 0)).rejects.toBeInstanceOf(SetupError);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("serveDist: dist/ exists but carries no index.html is the same SetupError", async () => {
+        const dir = tempProjectDir();
+        try {
+            mkdirSync(join(dir, "dist"));
+            await expect(serveDist(dir, 0)).rejects.toBeInstanceOf(SetupError);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    test("serveDev: neither a shallot manifest/.scene nor an index.html is a SetupError", async () => {
+        const dir = tempProjectDir();
+        try {
+            await expect(serveDev(dir, 0)).rejects.toBeInstanceOf(SetupError);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("report — the unrendered arms (⚠ LEAK, compilationError)", () => {
+    const base = {
+        project: "/tmp/gym",
+        mode: "dev",
+        url: "http://localhost/gym",
+        hardware: "test-gpu",
+        harness: false,
+        booted: true,
+        rendered: true,
+        errors: [],
+        pass: true,
+    };
+
+    test("memory.leak marks the line with ⚠ LEAK; a clean slope doesn't", () => {
+        const lines: string[] = [];
+        const original = console.log;
+        console.log = (...args: unknown[]) => lines.push(args.join(" "));
+        try {
+            report(
+                {
+                    ...base,
+                    memory: {
+                        start: 1e6,
+                        end: 1.1e6,
+                        growthPerSecond: 90_000,
+                        leak: true,
+                        gcCount: 2,
+                        gcPauseMs: 3,
+                    },
+                } as never,
+                false,
+            );
+            expect(lines.join("\n")).toContain("⚠ LEAK");
+
+            lines.length = 0;
+            report(
+                {
+                    ...base,
+                    memory: {
+                        start: 1e6,
+                        end: 1.01e6,
+                        growthPerSecond: 500,
+                        leak: false,
+                        gcCount: 2,
+                        gcPauseMs: 3,
+                    },
+                } as never,
+                false,
+            );
+            expect(lines.join("\n")).not.toContain("⚠ LEAK");
+        } finally {
+            console.log = original;
+        }
+    });
+
+    test("a compilationError renders its class and message beneath the artifact", () => {
+        const lines: string[] = [];
+        const original = console.log;
+        console.log = (...args: unknown[]) => lines.push(args.join(" "));
+        try {
+            report(
+                {
+                    ...base,
+                    pass: false,
+                    artifacts: [
+                        {
+                            label: "forward",
+                            stage: "vertex+fragment",
+                            source: "@vertex fn vs() {}",
+                            hash: "0123456789abcdef",
+                            messages: [],
+                            compilationError: { errorClass: "validation", message: "bad binding" },
+                        },
+                    ],
+                } as never,
+                false,
+            );
+            expect(lines.join("\n")).toContain("compilation validation: bad binding");
+        } finally {
+            console.log = original;
+        }
+    });
 });

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -34,7 +34,8 @@ const INSTALL_PLAYWRIGHT = "bun add -d playwright && bunx playwright install chr
 
 // a setup failure the caller reports through the one failure path (JSON under --json) — distinct from
 // a bug, which propagates as a plain Error.
-class SetupError extends Error {}
+/** @internal exported only so the serve* guard tests can assert the throw class directly. */
+export class SetupError extends Error {}
 
 export interface VerifyArgs {
     dir: string;
@@ -520,7 +521,8 @@ export function fitMemory(
     };
 }
 
-interface Result {
+/** @internal exported only so the driveHarness/withGpuLog page-stub tests can type their fixtures. */
+export interface Result {
     project: string;
     timestamp: string;
     mode: "dev" | "dist";
@@ -861,7 +863,8 @@ async function injectLeak(page: Page, bytesPerSec: number): Promise<void> {
         .catch(() => {});
 }
 
-interface Booter {
+/** @internal exported only so serveDist/serveDev's return type resolves for the guard tests. */
+export interface Booter {
     url: string;
     stop: () => Promise<void>;
     mode: "dev" | "dist";
@@ -889,7 +892,8 @@ function pickPort(explicit?: number): Promise<number> {
 // serveEjected already use. Together with pickPort's node:net probe, the whole boot path is now
 // runtime-agnostic (the WSL bridge runs this CLI under node, where Bun is undefined).
 // No implicit build — a missing dist is an actionable error, not a silent recovery.
-async function serveDist(projectDir: string, port: number): Promise<Booter> {
+/** @internal exported only so the SetupError guard can be driven by temp dir without booting vite. */
+export async function serveDist(projectDir: string, port: number): Promise<Booter> {
     // hardcoded rather than read from the project's vite config (which preview() below derives outDir
     // from): build.ts pins `outDir: "dist"` for every manifest build, so this can't diverge in practice.
     const dist = resolve(projectDir, "dist");
@@ -932,7 +936,8 @@ export function bootArm(
 // (synthesized entry + projectPlugin); an ejected project that owns its own index.html gets a plain vite
 // server rooted at it (vite auto-loads the project's own vite.config from root). Never opens a tab, always
 // an auto-picked port. Fails loud through the setup path when the dir is neither shape.
-async function serveDev(projectDir: string, port: number): Promise<Booter> {
+/** @internal exported only so the SetupError guard can be driven by temp dir without booting vite. */
+export async function serveDev(projectDir: string, port: number): Promise<Booter> {
     const arm = bootArm(isProject(projectDir), existsSync(join(projectDir, "index.html")));
     if (arm === "none") {
         throw new SetupError(
@@ -1408,8 +1413,9 @@ async function drive(
 }
 
 /** merge the page's captured GPU log into a finished result. A GPU `console.error` fails the run
- *  outright — a shader-side assert is a real verdict, not a note. */
-async function withGpuLog(page: Page, result: Result): Promise<Result> {
+ *  outright — a shader-side assert is a real verdict, not a note.
+ *  @internal exported only so the merge arithmetic's branch surface can be driven by a page stub. */
+export async function withGpuLog(page: Page, result: Result): Promise<Result> {
     const log = (await page
         .evaluate(() => (window as unknown as { __gpuLog?: GpuLog }).__gpuLog)
         .catch(() => null)) as GpuLog | null;
@@ -1440,7 +1446,9 @@ async function withGpuLog(page: Page, result: Result): Promise<Result> {
 // Verdict. Every page evaluate is guarded — a throwing run() (or a probe on a broken page) is a clean
 // FAIL with the error as detail (the page.ts fatal-envelope precedent), never an unhandled rejection.
 // A harness that never readies is a hard FAIL — never a downgrade to the settle check.
-async function driveHarness(
+/** @internal exported only so the red arms (ready-timeout, noRender, probe-error, hasRun-fallback) can
+ *  be driven directly by a duck-typed page stub. */
+export async function driveHarness(
     page: Page,
     base: Omit<Result, "pass">,
     args: VerifyArgs,

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -276,21 +276,27 @@ export const CLI_COVERAGE: readonly CoverageRow[] = [
         file: "packages/shallot/bin/verify.ts",
         arm: "gap",
         reason:
-            "the majority of this file's exported surface is already directly asserted by verify.test.ts: " +
+            "the majority of this file's exported surface is directly asserted by verify.test.ts: " +
             "parseVerifyArgs, buildUrl, resolveBatchQueries, batchPass, spansFromCheckpoints, " +
             "formatTimings, installHarnessProbe/harnessInstallMs, summarizeResourceTiming, " +
             "formatExtraTimings, structured/hasStructure/gridDiff, stepWait, coerceVerdict, withTimeout, " +
             "harnessPass, gpuLogChecks, failureArtifacts, settlePass, fitMemory, bootArm, flushStdout, " +
-            "reportBatch, and report's rendered arms. verifyCommand's green path (serveDist/serveDev/" +
-            "serveEjected booting a real project, driving a real Playwright page) is exercised on every " +
-            "`bun bench`, `bun run flows`, and `bun run recipes` run. What's reached by nothing: " +
-            "driveHarness's ready-timeout, noRender opt-out, probe-error, and hasRun-fallback verdict " +
-            "arms; withGpuLog's `(result.verdict?.ok ?? result.pass) && !failed` merge; the three serve* " +
-            "SetupError guards; report's unrendered arms (the LEAK line, compilationError); and " +
-            "decodeSample/decodeRgba (pending stage 4's own purity check) — a genuine browser failure, " +
-            "which bench/flows/recipes' green-path runs never produce. Stage 4 covers these with a " +
-            "duck-typed page stub.",
-        stage: 4,
+            "reportBatch, and report's rendered AND unrendered arms (the LEAK line, compilationError). " +
+            "Stage 4 closed the failure-arm gap a red verdict from any tier routes through, by a duck-" +
+            "typed page stub over the pre-existing Page parameter (never a module mock): driveHarness's " +
+            "ready-timeout/noRender-opt-out/probe-error/hasRun-fallback verdicts, withGpuLog's " +
+            "`(result.verdict?.ok ?? result.pass) && !failed` merge and check concatenation (both the " +
+            "`??`-vs-`||` and the `!failed` term proved to change the outcome), and the serveDist/serveDev " +
+            "SetupError guards by temp dir (asserting the throw class, never message prose). " +
+            "verifyCommand's green path — serveDist/serveDev/serveEjected booting a real project and " +
+            "driving a real Playwright page end to end — stays `tier`: exercised on every `bun bench`, " +
+            "`bun run flows`, and `bun run recipes` run, with no unit test standing in for the real boot-" +
+            "and-navigate sequence. What stays reached by nothing, permanently: decodeSample and " +
+            "decodeRgba. The stage's open question — whether they're pure pixel math over a captured " +
+            'buffer — is settled false: both construct `new Image()`, `document.createElement("canvas")`, ' +
+            "and call `getImageData`, genuine in-page DOM serialized into the browser by Playwright's " +
+            "`page.evaluate`, not a CPU-callable function a `bun test` could drive. They run for real only " +
+            "inside a genuine harness/settle pass under bench/flows/recipes.",
     },
     {
         file: "packages/shallot/src/project/engine.ts",


### PR DESCRIPTION
## Problem

`verify.ts` is gate infrastructure: every red verdict any tier in this repo reports routes through `driveHarness`'s failure arms and `withGpuLog`'s verdict merge. Bench, flows and recipes only ever drive the green path, so a bug in those arms turns other gates' reds into greens silently — nothing would notice.

## Cause

The failure arms had no callable test seam exercised by anything. `driveHarness` takes a `Page`, but no test ever passed one; the `serve*` setup guards and `report()`'s `⚠ LEAK` / `compilationError` arms were only reachable through a real browser run.

## Fix

12 tests over a duck-typed `page` stub on the pre-existing `Page` parameter — no module mocking, the seam already existed:

- `driveHarness`: ready-timeout, `noRender` opt-out, probe-error and `hasRun`-fallback verdicts
- `withGpuLog`: merge arithmetic, check concatenation, empty-log short-circuit
- `serveDist` / `serveDev`: `SetupError` guards by temp dir, asserting the throw class rather than message prose
- `report()`: the two unrendered arms

Seven symbols gained `@internal` exports. `bin/verify.ts` sits outside the package's `exports` map, so none reach the public API.

The stage's open question is settled false: `decodeRgba`/`decodeSample` construct `new Image()` and a canvas and call `getImageData` inside `page.evaluate`, so they are genuine in-browser DOM, not CPU-drivable pixel math. They stay permanent `gap` occupants and the registry row does not move — it keeps the `gap` arm with a shorter occupant list.

## Evidence

Red-first: 12 mutations, each redding exactly its one named test. Gates: `bun run format` 0, `bun check` exit 0, `GLTF_CORPUS_REQUIRED=1 bun test` 2590/0 across 151 files against a floor of 2578. Adversarial pass found nothing across five lenses, including a hand-trace that each stub dispatch reaches the arm it names rather than passing on a different path's throw.
