### PR TITLE
strip ANSI before parsing pack output; wait on the dev server's own banner

### DIFF
--- a/scripts/check-pack.ts
+++ b/scripts/check-pack.ts
@@ -21,7 +21,10 @@ if (exitCode !== 0) {
     process.exit(1);
 }
 
-const output = `${stdout}\n${stderr}`;
+// bun colors `packed` when the ambient env asks for it (FORCE_COLOR, a TTY), and the SGR codes sit
+// between `^` and the word — a gate whose verdict depends on ambient color config is a latent red.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ESC is the SGR introducer — matching it is the point.
+const output = `${stdout}\n${stderr}`.replaceAll(/\x1b\[[0-9;]*m/g, "");
 const files = [...output.matchAll(/^packed\s+\S+\s+(.+)$/gm)].map((m) => m[1]);
 
 if (files.length === 0) {

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -39,6 +39,10 @@ function pack(dir: string, dest: string): string {
     return join(dest, tgz);
 }
 
+/** vite colors its banner and its errors; match against the plain text so a TTY can't change a verdict. */
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ESC is the SGR introducer — matching it is the point.
+const strip = (s: string) => s.replaceAll(/\x1b\[[0-9;]*m/g, "");
+
 async function waitFor(cond: () => Promise<boolean>, ms: number): Promise<boolean> {
     const deadline = Date.now() + ms;
     while (Date.now() < deadline) {
@@ -583,16 +587,36 @@ try {
         const drain = pump(dev.stdout);
         const drainErr = pump(dev.stderr);
         try {
-            const up = await waitFor(async () => {
-                try {
-                    // localhost, not 127.0.0.1 — vite binds the family localhost resolves to
-                    // (IPv6-only on macOS), and it's the host the banner advertises
-                    return (await fetch(`http://localhost:${port}/`)).ok;
-                } catch {
-                    return false;
-                }
-            }, 40000);
-            check("shallot dev boots a server", up, up ? "" : devLog.slice(-400));
+            // Wait on the server's own ready signal, not a wall clock: `dev.ts` calls
+            // `server.printUrls()` immediately after `server.listen()` resolves, so the banner is the
+            // moment the socket is up. A fixed HTTP-poll deadline conflated "still starting" with
+            // "never coming" and flaked 2 runs in 5. The child exiting ends the wait too — a crashed
+            // dev server has nothing to wait out. `printUrls` colors its output, so strip SGR first.
+            const banner = new RegExp(`Local:\\s+\\S*http://localhost:${port}/`);
+            const listening = await waitFor(
+                async () => banner.test(strip(devLog)) || dev.exitCode !== null,
+                90000,
+            );
+            // Once listening, a request that can't be served in a second is a real failure, not slow boot.
+            const up =
+                listening &&
+                dev.exitCode === null &&
+                (await waitFor(async () => {
+                    try {
+                        // localhost, not 127.0.0.1 — vite binds the family localhost resolves to
+                        // (IPv6-only on macOS), and it's the host the banner advertises
+                        return (await fetch(`http://localhost:${port}/`)).ok;
+                    } catch {
+                        return false;
+                    }
+                }, 5000));
+            check(
+                "shallot dev boots a server",
+                up,
+                up
+                    ? ""
+                    : `${dev.exitCode !== null ? `dev exited ${dev.exitCode}; ` : listening ? "banner printed, no response; " : "no ready banner; "}${devLog.slice(-400)}`,
+            );
             if (up) {
                 const mod = await fetch(`http://localhost:${port}/@id/__x00__virtual:project`).then(
                     (r) => r.text(),
@@ -637,7 +661,7 @@ try {
             }
             check(
                 "no dev-server errors (resolve / fs allow-list)",
-                !/Failed to resolve|outside of Vite serving allow list/i.test(devLog),
+                !/Failed to resolve|outside of Vite serving allow list/i.test(strip(devLog)),
             );
         } finally {
             dev.kill();


### PR DESCRIPTION
Two 0.9.1 ship chores, both a gate whose verdict depended on ambient config.

check-pack parsed `bun pm pack` with /^packed…/m, which the SGR codes bun emits
under FORCE_COLOR (or a TTY) defeat — it failed closed with a misleading "no
packed files parsed". Strip SGR first. Red-proven at the real gate:
`FORCE_COLOR=1 bun run scripts/check-pack.ts` exited 1 before, 0 after, 403
files parsed either way.

install-test's "shallot dev boots a server" rung polled HTTP against a fixed
40s wall clock and flaked 2 runs in 5. It now waits on vite's own ready banner
(`dev.ts` calls printUrls() right after listen() resolves), fails fast when the
child exits, and gives the first request its own short bound — so "still
starting", "crashed", and "listening but not serving" are three distinct
verdicts instead of one timeout. printUrls colors its output and bolds the port
mid-URL, so the banner match needs the same SGR strip; the dev-error scan gets
it too, same latent class.
