### PR TITLE
drift punch list: retire two duplicate implementations, close the doc-block hole

### DIFF
--- a/packages/shallot/src/extras/gltf/image.ts
+++ b/packages/shallot/src/extras/gltf/image.ts
@@ -21,12 +21,12 @@ export const ALBEDO_BUCKETS = 4;
 /** the per-bucket binding names the textured + skin surfaces declare, `albedo0..albedo{N-1}`. */
 export const ALBEDO_NAMES = Array.from({ length: ALBEDO_BUCKETS }, (_, b) => `albedo${b}`);
 
-/**
- * upload pre-transcoded KTX2 images as a compressed `texture_2d_array`, one layer per image, each carrying
- * its own transcoded mip chain straight from the Basis transcoder (no GPU blit; compressed mips are already
- * downsampled). All images must share dimensions + format + block size, the array's one-size constraint,
- * which the caller guarantees. Binds + samples identically to the bitmap arrays: `albedo[layer]`.
- *
+// The compressed path: upload pre-transcoded KTX2 images as a compressed `texture_2d_array`, one layer per
+// image, each carrying its own transcoded mip chain straight from the Basis transcoder (no GPU blit;
+// compressed mips are already downsampled). All images must share dimensions + format + block size, the
+// array's one-size constraint, which the caller guarantees. Binds + samples identically to the bitmap
+// arrays: `albedo[layer]`.
+
 /** allocate (but don't fill) the compressed `texture_2d_array` for `images`: dims/format/mip count from the
  *  first image (all share them). Fill each layer with {@link writeCompressedLayer} — the union stages those
  *  writes one per frame budget step. `label` names the array (the data maps pass their slot name). */
@@ -71,7 +71,7 @@ export function writeCompressedLayer(
  * would skip the whole draw). Color slots are sRGB, data slots (normal / metallic-roughness / occlusion)
  * linear. Its content is never sampled: a material on a fallback carries palette layer `-1`, and both readers
  * short-circuit it — `sampleAlbedo` returns white (the glTF baseColorFactor default) for `layer < 0`, and an
- * absent data map emits no sample at all (`materialPreamble`, gated by the map-set bitmask).
+ * absent data map emits no sample at all (`materialFns`, gated by the map-set bitmask).
  */
 export function fallback1x1(device: GPUDevice, format: GPUTextureFormat): GPUTexture {
     return device.createTexture({

--- a/packages/shallot/src/extras/gltf/live.test.ts
+++ b/packages/shallot/src/extras/gltf/live.test.ts
@@ -6,7 +6,7 @@ import { engineLayout } from "../../standard/sear/engine";
 import { prepassWgsl, shadowWgsl, surfaceWgsl } from "../../standard/sear/pipelines";
 import { registerTexturedSurfaces } from "./assets";
 import { liveSkinSurface, registerLiveSkinSurfaces } from "./live";
-import { MAP_ALL } from "./shade";
+import { MAP_ALL, MAP_EMIS, MAP_MR, MAP_NORMAL, MAP_OCC } from "./shade";
 import { registerSkinSurfaces, skinSurface } from "./skin";
 
 const names = [
@@ -75,6 +75,29 @@ describe("typed glTF surface trios", () => {
         expect(albedo).toContain("if ((md.albedoBucket == 1u))");
         expect(albedo).toContain("if ((md.albedoBucket == 2u))");
         expect(albedo).not.toContain("switch");
+    });
+
+    test("each map-set bit gates exactly its own data-map sample, across every variant", () => {
+        // the endpoints above (0 and MAP_ALL) pass even if two bits are swapped — a wrong bit→sample
+        // mapping specializes a pipeline that samples a map the material doesn't carry. Ported from
+        // shade.test.ts, which asserted this against `materialPreamble`, a raw-WGSL twin with no
+        // production caller: the property was only ever pinned on dead code.
+        const surface = Surfaces.get("gltf-albedo")!;
+        const sample: Record<number, string> = {
+            [MAP_NORMAL]: "textureSample(normalTex",
+            [MAP_MR]: "textureSample(mr,",
+            [MAP_OCC]: "textureSample(occlusion",
+            [MAP_EMIS]: "textureSample(emissive",
+        };
+        for (let mapset = 0; mapset <= MAP_ALL; mapset++) {
+            const shade = body(surfaceWgsl(surface, mapset), "fn shadePbr(");
+            for (const bit of [MAP_NORMAL, MAP_MR, MAP_OCC, MAP_EMIS]) {
+                expect(
+                    shade.includes(sample[bit] as string),
+                    `bit ${bit} in mapset ${mapset}`,
+                ).toBe((mapset & bit) !== 0);
+            }
+        }
     });
 
     test("VAT skin samples the baked position and normal using the vertex index", () => {

--- a/packages/shallot/src/extras/gltf/shade.test.ts
+++ b/packages/shallot/src/extras/gltf/shade.test.ts
@@ -1,63 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { GltfMaterial } from "./gltf";
-import { MAP_ALL, MAP_EMIS, MAP_MR, MAP_NORMAL, MAP_OCC, mapSet, materialPreamble } from "./shade";
-
-// the per-map sample each bit gates — the marker its presence/absence is read by below
-const SAMPLE: Record<number, string> = {
-    [MAP_NORMAL]: "textureSample(normalTex",
-    [MAP_MR]: "textureSample(mr,",
-    [MAP_OCC]: "textureSample(occlusion",
-    [MAP_EMIS]: "textureSample(emissive",
-};
-const BITS = [MAP_NORMAL, MAP_MR, MAP_OCC, MAP_EMIS];
-
-describe("materialPreamble — map-set specialization", () => {
-    test("every variant defines the four shade helpers + the albedo switch", () => {
-        for (let mapset = 0; mapset <= MAP_ALL; mapset++) {
-            const wgsl = materialPreamble(mapset);
-            for (const fn of ["pbrOf", "emissiveOf", "perturbNormal", "shadePbr", "sampleAlbedo"]) {
-                expect(wgsl).toContain(`fn ${fn}(`);
-            }
-            // albedo is unconditional (always present on a textured surface), via SAMPLE_ALBEDO
-            expect(wgsl).toContain("textureSampleGrad(");
-        }
-    });
-
-    test("a bit is set iff its data-map sample is emitted", () => {
-        for (let mapset = 0; mapset <= MAP_ALL; mapset++) {
-            const wgsl = materialPreamble(mapset);
-            for (const bit of BITS) {
-                const present = (mapset & bit) !== 0;
-                expect(wgsl.includes(SAMPLE[bit])).toBe(present);
-            }
-        }
-    });
-
-    test("albedo-only (mapset 0) emits no data-map sample, no factor select, no tangent recon", () => {
-        const wgsl = materialPreamble(0);
-        for (const bit of BITS) expect(wgsl).not.toContain(SAMPLE[bit]);
-        // homogeneous bins mean no runtime `*Layer >= 0` gate is needed — the absent path is the factor
-        expect(wgsl).not.toContain("select(");
-        // no normal map → no screen-space derivative tangent frame (dpdx(uv) is the albedo gradient)
-        expect(wgsl).not.toContain("dpdx(world)");
-        expect(wgsl).toContain("return N;");
-    });
-
-    test("the all-maps variant samples every data map and reconstructs the tangent frame", () => {
-        const wgsl = materialPreamble(MAP_ALL);
-        for (const bit of BITS) expect(wgsl).toContain(SAMPLE[bit]);
-        expect(wgsl).toContain("dpdx(world)");
-        // the bitmask guarantees presence, so a present sample indexes its layer directly (no max gate)
-        expect(wgsl).not.toContain("max(md.mrLayer");
-    });
-
-    test("the normal-map bit alone reconstructs the frame without the other samples", () => {
-        const wgsl = materialPreamble(MAP_NORMAL);
-        expect(wgsl).toContain(SAMPLE[MAP_NORMAL]);
-        expect(wgsl).toContain("dpdx(world)");
-        for (const bit of [MAP_MR, MAP_OCC, MAP_EMIS]) expect(wgsl).not.toContain(SAMPLE[bit]);
-    });
-});
+import { MAP_ALL, MAP_EMIS, MAP_MR, MAP_NORMAL, MAP_OCC, mapSet } from "./shade";
 
 // mapSet turns a decoded material into the map-set key (a mesh's `variant`). The bit↔field mapping is
 // load-bearing: a wrong bit specializes a pipeline that then samples a map the material doesn't carry (or

--- a/packages/shallot/src/extras/gltf/shade.ts
+++ b/packages/shallot/src/extras/gltf/shade.ts
@@ -3,35 +3,7 @@ import * as d from "typegpu/data";
 import * as std from "typegpu/std";
 import { litPbr, Pbr } from "../../standard/sear/core";
 import type { GltfMaterial } from "./gltf";
-import { ALBEDO_BUCKETS, ALBEDO_NAMES } from "./image";
-import { MaterialData, materialDataWgsl } from "./palette";
-
-// baseColor lives in one of ALBEDO_BUCKETS size-bucketed arrays (image.ts); `sampleAlbedo` switches on the
-// per-material `albedoBucket` to sample the right one. The switch is dynamically uniform per draw — each glTF
-// mesh has one material, and the pack groups a draw by (surface, mesh), so every instance in a draw shares the
-// bucket — so it's a single non-divergent branch. `textureSampleGrad` (explicit derivatives computed before
-// the switch) is what lets the sample sit inside the branch: unlike `textureSample` it needs no uniform
-// control flow, while still mip-sampling correctly.
-//
-// A material with no baseColor image carries `layer < 0` (union.ts fills -1). The textured path never routes
-// such a material here — `load()` sends a factor-only material to the solid `default` surface — but a skinned
-// one always lands on the skin surface, image or not, so it reaches this function. Return the glTF default
-// baseColor (white) so `albedo × baseColorFactor` yields the factor, not a sample of the black absent-slot
-// fallback. The guard is per-draw uniform (`layer` is), so it costs no divergence.
-const SAMPLE_ALBEDO = /* wgsl */ `
-fn sampleAlbedo(mid: u32, uv: vec2<f32>) -> vec4<f32> {
-    let layer = materialData[mid].layer;
-    // derivatives before the guard: dpdx/dpdy need uniform control flow, so they can't sit after a branch
-    let ddx = dpdx(uv);
-    let ddy = dpdy(uv);
-    if (layer < 0) { return vec4<f32>(1.0); }
-    switch materialData[mid].albedoBucket {
-${ALBEDO_NAMES.map(
-    (name, b) =>
-        `        ${b === ALBEDO_BUCKETS - 1 ? "default" : `case ${b}u`}: { return textureSampleGrad(${name}, albedoSamp, uv, layer, ddx, ddy); }`,
-).join("\n")}
-    }
-}`;
+import { MaterialData } from "./palette";
 
 // the four optional data maps a textured material's map-set is composed of — the compile-time
 // specialization key (Bevy's `StandardMaterialKey` bitflags / the `#ifdef USE_*MAP` idiom). baseColor is
@@ -46,10 +18,10 @@ export const MAP_EMIS = 8;
 export const MAP_ALL = MAP_NORMAL | MAP_MR | MAP_OCC | MAP_EMIS;
 
 /**
- * the material map-set bitmask (a mesh's {@link Mesh.variant} / the {@link materialPreamble} specialization
+ * the material map-set bitmask (a mesh's {@link Mesh.variant} / the {@link materialFns} specialization
  * key) for a decoded material: one bit per present data map, `0` for a factor-only or absent material
  * (albedo-only). The bits read the same `*Image` fields the per-material palette layers derive from, so a
- * set bit and a `>= 0` palette layer always agree, the guarantee that lets the specialized preamble sample
+ * set bit and a `>= 0` palette layer always agree, the guarantee that lets the specialized helpers sample
  * a present map with no `*Layer >= 0` gate.
  */
 export function mapSet(m: GltfMaterial | undefined): number {
@@ -171,76 +143,4 @@ export function materialFns(layout: { $: unknown }, mapset: number) {
         .$name("shadePbr");
 
     return { sampleAlbedo, shadePbr };
-}
-
-/**
- * the metallic-roughness shade helpers specialized to a material map-set `mapset` (a bitmask of the
- * `MAP_*` bits), spliced into a `(surface, mesh)` draw's module scope. Each helper takes the palette
- * index `mid`; a present map samples its `texture_2d_array` directly (the bitmask guarantees its
- * `*Layer >= 0`, so no `select`/`max` gate), an absent one uses the factor alone and emits **no sample**.
- * That's the win over an unconditional ubershader off-L2 (the absent sample is a real DRAM fetch on the
- * integrated floor). `perturbNormal` only reconstructs the tangent frame (Schüler's screen-space
- * cotangent, no TANGENT attribute) when the normal map is present; otherwise it returns the geometric
- * normal with no derivatives. The all-maps form (`MAP_ALL`) is the unconditional shader minus the now-dead
- * gates. Sear compiles one variant per distinct map-set a scene loads (Bevy's on-demand specialization).
- */
-export function materialPreamble(mapset: number): string {
-    const has = (bit: number) => (mapset & bit) !== 0;
-    return /* wgsl */ `
-${materialDataWgsl()}
-${SAMPLE_ALBEDO}
-
-fn pbrOf(mid: u32, uv: vec2<f32>, baseRgb: vec3<f32>) -> Pbr {
-    let md = materialData[mid];
-${
-    has(MAP_MR)
-        ? `    let mrTex = textureSample(mr, albedoSamp, uv, md.mrLayer);
-    let metallic = md.metallic * mrTex.b;
-    let roughness = md.roughness * mrTex.g;`
-        : `    let metallic = md.metallic;
-    let roughness = md.roughness;`
-}
-${
-    has(MAP_OCC)
-        ? `    let occ = 1.0 + md.occStrength * (textureSample(occlusion, albedoSamp, uv, md.occLayer).r - 1.0);`
-        : `    let occ = 1.0;`
-}
-    return Pbr(baseRgb, metallic, roughness, occ, 0.04);
-}
-
-fn emissiveOf(mid: u32, uv: vec2<f32>) -> vec3<f32> {
-    let md = materialData[mid];
-${
-    has(MAP_EMIS)
-        ? `    return md.emissive * textureSample(emissive, albedoSamp, uv, md.emisLayer).rgb;`
-        : `    return md.emissive;`
-}
-}
-
-fn perturbNormal(mid: u32, N: vec3<f32>, world: vec3<f32>, uv: vec2<f32>) -> vec3<f32> {
-${
-    has(MAP_NORMAL)
-        ? `    let md = materialData[mid];
-    let tex = textureSample(normalTex, albedoSamp, uv, md.normalLayer);
-    // reconstruct Z from XY (tangent-space normals have z > 0): a BC5 two-channel map stores only RG, and a
-    // unit normal makes this identical to a stored Z for the RGBA path too — one path for both encodings
-    let nxy = (tex.xy * 2.0 - 1.0) * md.normalScale;
-    let n = vec3<f32>(nxy, sqrt(max(0.0, 1.0 - dot(nxy, nxy))));
-    let dp1 = dpdx(world); let dp2 = dpdy(world);
-    let duv1 = dpdx(uv); let duv2 = dpdy(uv);
-    let dp2perp = cross(dp2, N);
-    let dp1perp = cross(N, dp1);
-    let T = dp2perp * duv1.x + dp1perp * duv2.x;
-    let B = dp2perp * duv1.y + dp1perp * duv2.y;
-    let invmax = inverseSqrt(max(dot(T, T), dot(B, B)));
-    return normalize(mat3x3<f32>(T * invmax, B * invmax, N) * n);`
-        : `    return N;`
-}
-}
-
-fn shadePbr(mid: u32, uv: vec2<f32>, baseRgb: vec3<f32>, geoN: vec3<f32>, world: vec3<f32>) -> vec3<f32> {
-    let n = perturbNormal(mid, geoN, world, uv);
-    return litPbr(pbrOf(mid, uv, baseRgb), n, world) + emissiveOf(mid, uv);
-}
-`;
 }

--- a/packages/shallot/src/extras/sky/shader.ts
+++ b/packages/shallot/src/extras/sky/shader.ts
@@ -117,18 +117,6 @@ const fbm2 = tgpu
     })
     .$name("fbm2");
 
-const hashStar = tgpu
-    .fn(
-        [d.vec2f],
-        d.f32,
-    )((p) => {
-        "use gpu";
-        let p3 = d.vec3f(std.fract(std.mul(d.vec3f(p.x, p.y, p.x), 0.1031)));
-        p3 = d.vec3f(std.add(p3, std.dot(p3, std.add(p3.yzx, 33.33))));
-        return std.fract((p3.x + p3.y) * p3.z);
-    })
-    .$name("hashStar");
-
 const hash2Star = tgpu
     .fn(
         [d.vec2f],
@@ -165,18 +153,18 @@ export const sampleStars = tgpu
         for (let dy = d.i32(-1); dy <= 1; dy = dy + 1) {
             for (let dx = d.i32(-1); dx <= 1; dx = dx + 1) {
                 const neighbor = std.add(cellId, d.vec2f(d.f32(dx), d.f32(dy)));
-                const starHash = hashStar(neighbor);
+                const starHash = hash2(neighbor);
                 if (starHash > amount * 0.7) continue;
                 const starPos = hash2Star(neighbor);
                 const starCenter = std.add(neighbor, starPos);
                 const dist = std.length(std.sub(cell, starCenter));
-                const brightness = hashStar(std.add(neighbor, d.vec2f(100)));
+                const brightness = hash2(std.add(neighbor, d.vec2f(100)));
                 const radius = 0.02 + brightness * 0.03;
                 if (dist < radius) {
                     const twinkle = 0.8 + 0.2 * std.sin(brightness * 100);
                     const strength = intensity * brightness * twinkle;
                     const falloff = 1 - std.smoothstep(0, radius, dist);
-                    const temp = hashStar(std.add(neighbor, d.vec2f(200)));
+                    const temp = hash2(std.add(neighbor, d.vec2f(200)));
                     const tint = std.mix(d.vec3f(1, 0.9, 0.8), d.vec3f(0.8, 0.9, 1), temp);
                     starColor = d.vec3f(
                         std.max(starColor, std.mul(std.mul(tint, strength), falloff)),

--- a/packages/shallot/src/extras/sky/sky.test.ts
+++ b/packages/shallot/src/extras/sky/sky.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import * as d from "typegpu/data";
 import * as std from "typegpu/std";
-import { body, noIntegerDivision } from "../../../tests/wgsl";
+import { body, flat, noIntegerDivision } from "../../../tests/wgsl";
 import { State } from "../..";
 import { clear, register } from "../../engine/ecs/core";
 import { srgbToLinear } from "../../engine/utils/color";
@@ -94,12 +94,6 @@ function referenceFbm2(p: Vec2): number {
     return value;
 }
 
-function referenceHashStar(p: Vec2): number {
-    let p3 = d.vec3f(std.fract(std.mul(d.vec3f(p.x, p.y, p.x), 0.1031)));
-    p3 = d.vec3f(std.add(p3, std.dot(p3, std.add(p3.yzx, 33.33))));
-    return std.fract((p3.x + p3.y) * p3.z);
-}
-
 function referenceHash2Star(p: Vec2): Vec2 {
     let p3 = d.vec3f(std.fract(std.mul(d.vec3f(p.x, p.y, p.x), d.vec3f(0.1031, 0.103, 0.0973))));
     p3 = d.vec3f(std.add(p3, std.dot(p3, std.add(p3.yzx, 33.33))));
@@ -120,7 +114,7 @@ function referenceStars(dir: Vec3, intensity: number, amount: number, stats?: St
     for (let dy = -1; dy <= 1; dy++) {
         for (let dx = -1; dx <= 1; dx++) {
             const neighbor = std.add(cellId, d.vec2f(dx, dy));
-            const starHash = referenceHashStar(neighbor);
+            const starHash = referenceHash2(neighbor);
             if (starHash > amount * 0.7) {
                 if (stats) stats.continued++;
                 continue;
@@ -129,14 +123,14 @@ function referenceStars(dir: Vec3, intensity: number, amount: number, stats?: St
             const starPos = referenceHash2Star(neighbor);
             const starCenter = std.add(neighbor, starPos);
             const dist = std.length(std.sub(cell, starCenter));
-            const brightness = referenceHashStar(std.add(neighbor, d.vec2f(100)));
+            const brightness = referenceHash2(std.add(neighbor, d.vec2f(100)));
             const radius = 0.02 + brightness * 0.03;
             if (dist < radius) {
                 if (stats) stats.hits++;
                 const twinkle = 0.8 + 0.2 * std.sin(brightness * 100);
                 const strength = intensity * brightness * twinkle;
                 const falloff = 1 - std.smoothstep(0, radius, dist);
-                const temp = referenceHashStar(std.add(neighbor, d.vec2f(200)));
+                const temp = referenceHash2(std.add(neighbor, d.vec2f(200)));
                 const tint = std.mix(d.vec3f(1, 0.9, 0.8), d.vec3f(0.8, 0.9, 1), temp);
                 starColor = d.vec3f(std.max(starColor, std.mul(std.mul(tint, strength), falloff)));
             }
@@ -252,7 +246,7 @@ function activeStarDirection(amount: number): { dir: Vec3; stats: StarStats } {
     for (let y = 1; y < 20; y++) {
         for (let x = -20; x < 20; x++) {
             const neighbor = d.vec2f(x, y);
-            if (referenceHashStar(neighbor) > amount * 0.7) continue;
+            if (referenceHash2(neighbor) > amount * 0.7) continue;
             const starPos = referenceHash2Star(neighbor);
             const theta = ((x + starPos.x) * REFERENCE_STAR_PI) / gridSize;
             const phi = ((y + starPos.y) * REFERENCE_STAR_HALF_PI) / gridSize;
@@ -469,6 +463,22 @@ describe("Sky typed shader", () => {
         expect(wgsl).toContain("for (var dy = -1i; (dy <= 1i); dy = (dy + 1i))");
         expect(wgsl).toContain("continue;");
         noIntegerDivision(wgsl);
+    });
+
+    test("no two emitted sky functions share a body", () => {
+        // `hashStar` was a byte-identical second registration of `hash2`, so the sky shipped the same
+        // hash twice under two names. Compare bodies rather than names: a duplicate reintroduced under
+        // any third name is the same defect, and the name is exactly what a reader trusts instead.
+        const wgsl = backgroundWgsl(skyBackground);
+        const seen = new Map<string, string>();
+        for (const [, name] of wgsl.matchAll(/fn (\w+)\s*\(/g)) {
+            const src = flat(body(wgsl, `fn ${name}(`));
+            const decl = src.slice(src.indexOf("{"));
+            const prior = seen.get(decl);
+            expect(prior, `fn ${name} duplicates fn ${prior}`).toBeUndefined();
+            seen.set(decl, name);
+        }
+        expect(seen.size).toBeGreaterThan(4); // the walk reached real functions, not zero
     });
 });
 

--- a/packages/shallot/tests/doc-blocks.test.ts
+++ b/packages/shallot/tests/doc-blocks.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Source hygiene over the real `src/` tree: a `/**` block that never closes swallows everything up to
+ * the next `*​/`, including the JSDoc of the declaration that follows it. That declaration then ships
+ * with no doc — and per `exports.md`, no JSDoc means hidden from the reference — while `bun check`,
+ * `tsc`, and every unit test stay green, because an over-long comment is still valid TypeScript.
+ *
+ * Red-proven against `extras/gltf/image.ts`, where the compressed-path section header ran on into
+ * `allocCompressed`'s contract.
+ */
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+const SRC = resolve(import.meta.dir, "..", "src");
+
+/** `/**` openers that appear while already inside a block comment, as `file:line` */
+function nested(src: string, file: string): string[] {
+    const hits: string[] = [];
+    let inBlock = false;
+    const lines = src.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i] as string;
+        for (let c = 0; c < line.length - 1; c++) {
+            const two = line.slice(c, c + 2);
+            if (!inBlock && two === "//") break; // a line comment can quote anything
+            if (!inBlock && two === "/*") {
+                inBlock = true;
+                c++;
+            } else if (inBlock && two === "/*") {
+                // a second opener with no intervening close: the first block never terminated
+                hits.push(`${file}:${i + 1}`);
+                c++;
+            } else if (inBlock && two === "*/") {
+                inBlock = false;
+                c++;
+            }
+        }
+    }
+    return hits;
+}
+
+test("no source file opens a block comment inside an unclosed one", async () => {
+    const offenders: string[] = [];
+    let scanned = 0;
+    for await (const rel of new Bun.Glob("**/*.ts").scan({ cwd: SRC })) {
+        scanned++;
+        offenders.push(...nested(await Bun.file(resolve(SRC, rel)).text(), rel));
+    }
+    expect(scanned).toBeGreaterThan(100); // the walk reached the real tree, not an empty glob
+    expect(offenders).toEqual([]);
+});
+
+test("the scan reports a nested opener and tolerates the shapes that only look like one", () => {
+    expect(nested("/** a\n/** b */\n", "x.ts")).toEqual(["x.ts:2"]);
+    expect(nested("/** a */\n/** b */\n", "x.ts")).toEqual([]);
+    // a divide followed by a dereference, and an opener quoted in a line comment, are not blocks
+    expect(nested("const n = a / *p;\n// /** not a block\n", "x.ts")).toEqual([]);
+});


### PR DESCRIPTION
## Problem

Three of the six oracle-visible findings that survived `idiom-verification`'s close. Each was a second implementation or a silent hole that no gate could see.

- `extras/sky/shader.ts` — `hashStar` was a byte-identical second `tgpu.fn` registration of `hash2`; the sky shipped one hash under two names.
- `extras/gltf/shade.ts` — `materialPreamble` + `SAMPLE_ALBEDO` were a raw-WGSL second implementation of the PBR path with no production caller, referenced only by their own test.
- `extras/gltf/image.ts` — a `/**` block never closed before the next opened, swallowing `allocCompressed`'s doc.

## Cause

The first two are port residue: the TGSL `materialFns` superseded the raw-WGSL preamble, and the old one was never deleted. Nothing in the repo compares two registered kernels, so a duplicate reads as two distinct functions. The comment defect is invisible to `tsc` and `biome` — an over-long comment is valid TypeScript.

## Fix

Deletions, each with the check that keeps it fixed:

- one hash, call sites repointed, and the test-local `referenceHashStar` collapsed with it
- `materialPreamble` + `SAMPLE_ALBEDO` gone (~90 lines), plus the two stale doc references naming it
- the section header converted to `//` so it can't read as `allocCompressed`'s JSDoc

The deleted `materialPreamble` tests asserted a real property — each map-set bit gates exactly its own sample — but pinned it on dead code, and `materialFns` had **no** test at all. That property moves to `live.test.ts` over `surfaceWgsl`, walking all 16 map-sets; the existing live coverage tested only the `0` and `MAP_ALL` endpoints, which a swapped bit pair survives.

## Evidence

- `bun test` — **2337 pass / 0 fail** (155 files)
- `bun run format` clean
- red-first, each check watched failing for the right reason:
  - sky duplicate-body check → `error: fn hash2 duplicates fn hashStar` after reintroducing the duplicate
  - doc-block scan → `extras/gltf/image.ts:27` after restoring the unterminated block

Remaining three findings (both `codec.ts` dead branches, `levenshtein`'s missing test) stay on the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)