### PR TITLE
showcase gates: skip on a software adapter instead of crashing

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -142,6 +142,8 @@ A live `State` is reused across hot reloads — a live host swaps a reloaded plu
 
 One browser session per test file. Don't split related assertions into multiple `test()` blocks — use phases within a single test instead. Starting a new browser session is expensive and loses page state. Reconstruct state within the session if needed.
 
+**A real-device gate display-gates on the adapter's *name*, not its floor, and says which adapter it got.** A showcase project owns its own Playwright driver and can't reach `scripts/verify.ts`'s `skipReason()`, so it probes `adapter.info` after `page.goto` and `test.skip`s on a software rasterizer (`swiftshader`, `llvmpipe`, `lavapipe`, `warp`) — before any boot wait, or the skip costs the wait's full timeout. A capability probe can't stand in: SwiftShader clears the entire base floor and 10 storage buffers per stage, then dies during execution (`mapAsync` mid-readback, or never installing the hook), which is why `fountain` and `voxel` crashed here for a release cycle. Keep the pattern narrow and log the adapter on both paths — an over-broad match reports green having tested nothing, and a silent skip is the same defect as a crash. Not every gate earns it: `visualization` genuinely passes on SwiftShader, so it stays ungated.
+
 ## Pairwise testing for combinatorial GPU features
 
 Most bugs come from 2-factor interactions. For combinatorial feature spaces (surfaces × pipelines × opaque/transparent × shadow × instance fields), generate pairwise test matrices (~40-60 combos instead of thousands). `compileSurfaceBlock` is a pure function — feed it pairwise inputs, validate structurally + GPU-compile.

--- a/examples/showcase/fountain/test/fountain.spec.ts
+++ b/examples/showcase/fountain/test/fountain.spec.ts
@@ -1,10 +1,27 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 interface Check {
     name: string;
     pass: boolean;
     detail: string;
 }
+
+// Software rasterizers by the name they report in `GPUAdapterInfo`: Chromium's SwiftShader, Mesa's two,
+// and D3D's WARP. Deliberately a name list rather than a capability probe — SwiftShader clears shallot's
+// whole base floor (all three `BASE_FEATURES` plus 10 storage buffers per stage, measured under WSL
+// 2026-08-10), so nothing about the floor distinguishes it, and it is only the *execution* that dies.
+// Bias narrow: an unlisted software adapter re-crashes loudly, while an over-broad pattern would skip this
+// gate on real hardware and report green having tested nothing.
+const SOFTWARE = /swiftshader|llvmpipe|lavapipe|warp|basic render/i;
+
+/** the adapter's self-reported identity, or `""` when the browser hands out none. */
+const adapterName = (page: Page): Promise<string> =>
+    page.evaluate(async () => {
+        const adapter = await navigator.gpu?.requestAdapter();
+        if (!adapter) return "";
+        const { vendor, architecture, device, description } = adapter.info;
+        return [vendor, architecture, device, description].filter(Boolean).join(" ");
+    });
 
 test("fountain showcase gate — TGSL integrator and GPU readback", async ({ page }) => {
     const errors: string[] = [];
@@ -20,6 +37,17 @@ test("fountain showcase gate — TGSL integrator and GPU readback", async ({ pag
     });
 
     await page.goto("/");
+
+    // Full device testing: the TGSL integrator and its readback need a real GPU. Probe before the boot
+    // wait, so a GPU-less host skips honestly instead of dying inside `mapAsync` — display-gated the same
+    // way `shallot verify`'s callers are.
+    const adapter = await adapterName(page);
+    console.log(`fountain gate adapter: ${adapter || "none offered"}`);
+    test.skip(
+        adapter === "" || SOFTWARE.test(adapter),
+        `no real-GPU adapter (${adapter || "none offered"})`,
+    );
+
     await page.waitForFunction(() => typeof window.__fountainGate === "function", null, {
         timeout: 120_000,
     });

--- a/examples/showcase/voxel/test/voxel.spec.ts
+++ b/examples/showcase/voxel/test/voxel.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 // Drive the voxel mesher's device gate: load the app, wait for it to warm and expose `window.__voxelGate`,
 // run it on the real GPU, and assert every check passes (and the page raised no error). The checks
@@ -11,12 +11,40 @@ interface Check {
     detail: string;
 }
 
+// Software rasterizers by the name they report in `GPUAdapterInfo`: Chromium's SwiftShader, Mesa's two,
+// and D3D's WARP. Deliberately a name list rather than a capability probe — SwiftShader clears shallot's
+// whole base floor (all three `BASE_FEATURES` plus 10 storage buffers per stage, measured under WSL
+// 2026-08-10), so nothing about the floor distinguishes it, and it is only the *execution* that dies.
+// Bias narrow: an unlisted software adapter re-crashes loudly, while an over-broad pattern would skip this
+// gate on real hardware and report green having tested nothing.
+const SOFTWARE = /swiftshader|llvmpipe|lavapipe|warp|basic render/i;
+
+/** the adapter's self-reported identity, or `""` when the browser hands out none. */
+const adapterName = (page: Page): Promise<string> =>
+    page.evaluate(async () => {
+        const adapter = await navigator.gpu?.requestAdapter();
+        if (!adapter) return "";
+        const { vendor, architecture, device, description } = adapter.info;
+        return [vendor, architecture, device, description].filter(Boolean).join(" ");
+    });
+
 test("voxel mesher gate — watertight, deterministic, carve (real GPU)", async ({ page }) => {
     const errors: string[] = [];
     page.on("pageerror", (e) => errors.push(String(e)));
 
     // standalone runtime — the gate only touches GPU buffers, no editor/scene writes.
     await page.goto("/");
+
+    // Full device testing: the mesher needs a real GPU. Probe before waiting on the boot hook, because on
+    // a software adapter the app never installs it and the wait burns its full 120 s before failing —
+    // display-gated the same way `shallot verify`'s callers are, so a GPU-less host skips instead of reds.
+    const adapter = await adapterName(page);
+    console.log(`voxel gate adapter: ${adapter || "none offered"}`);
+    test.skip(
+        adapter === "" || SOFTWARE.test(adapter),
+        `no real-GPU adapter (${adapter || "none offered"})`,
+    );
+
     // the boot plugin generates the terrain then installs the hook once the mesher buffers exist (see
     // boot.ts). A cold vite build is slower than the warm path, so allow longer than steady-state needs.
     await page.waitForFunction(() => typeof window.__voxelGate === "function", null, {

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -58,6 +58,19 @@ import {
 
 const REPO_ROOT = resolve(import.meta.dir, "../../..");
 
+/**
+ * a scratch dir under the repo's own `node_modules/.cache`, not `tmpdir()` — the bundles and fixture
+ * projects below are loaded by a Node subprocess that has to resolve the repo's dependencies, which only
+ * works from inside the tree. `mkdtempSync` does not create parents, and `.cache` is a build artifact
+ * absent from a fresh clone or a fresh worktree, so create it first: without this the suite reds with a
+ * bare `ENOENT ... mkdtemp` that reads as a real failure.
+ */
+const cacheDir = (prefix: string): string => {
+    const base = join(REPO_ROOT, "node_modules/.cache");
+    mkdirSync(base, { recursive: true });
+    return mkdtempSync(join(base, prefix));
+};
+
 describe("parseVerifyArgs", () => {
     test("defaults: dir '.', dev boot, 60s budget", () => {
         const a = parseVerifyArgs([]);
@@ -1002,7 +1015,7 @@ describe("stdout survives process.exit — the 64 KiB pipe truncation (shallot-p
     test.skipIf(!hasNode)(
         "a >64 KiB batch report exits truncated without flushStdout, whole with it",
         async () => {
-            const dir = mkdtempSync(join(REPO_ROOT, "node_modules/.cache/shallot-flush-test-"));
+            const dir = cacheDir("shallot-flush-test-");
             try {
                 buildVerifyBundle(dir);
 
@@ -1063,9 +1076,7 @@ describe("stdout survives process.exit — the 64 KiB pipe truncation (shallot-p
     test.skipIf(!hasNode)(
         "a >64 KiB setup-error payload through runVerify survives process.exit; a bare exit does not",
         async () => {
-            const dir = mkdtempSync(
-                join(REPO_ROOT, "node_modules/.cache/shallot-flush-runverify-test-"),
-            );
+            const dir = cacheDir("shallot-flush-runverify-test-");
             try {
                 buildVerifyBundle(dir);
 
@@ -1308,8 +1319,7 @@ describe("withGpuLog — the verdict merge arithmetic as a branch surface", () =
 });
 
 describe("serve* SetupError guards — by temp dir, asserting the throw class, not message prose", () => {
-    const tempProjectDir = (): string =>
-        mkdtempSync(join(REPO_ROOT, "node_modules/.cache/shallot-verify-guard-"));
+    const tempProjectDir = (): string => cacheDir("shallot-verify-guard-");
 
     test("serveDist: no dist/ at all is a SetupError, not a raw ENOENT", async () => {
         const dir = tempProjectDir();


### PR DESCRIPTION
## Problem

`showcase/fountain` and `showcase/voxel` crash on a software rasterizer instead of skipping the way every other display-gated gate does. Measured on WSL/SwiftShader:

- fountain: `AbortError: Failed to execute 'mapAsync' on 'GPUBuffer'` — 2.1 s to a red
- voxel: the boot hook is never installed, so `waitForFunction` burns its full 120 s timeout

A gate that crashes where it should skip trains the reader to ignore it. Both pass on real hardware (Metal), so this is gate hygiene, not a render defect.

## Cause

No display gate at all. `scripts/verify.ts`'s `skipReason()` covers `bun bench` / `bun run flows`, but a showcase project owns its own Playwright driver and by contract never reaches into repo `scripts/`.

A capability probe cannot stand in for one. SwiftShader clears shallot's **entire** base floor — all three `BASE_FEATURES` (`indirect-first-instance`, `bgra8unorm-storage`, `rg11b10ufloat-renderable`) plus `maxStorageBuffersPerShaderStage: 10`, measured 2026-08-10. Nothing about the floor distinguishes it; only execution dies.

## Fix

Probe `adapter.info` right after `page.goto` and `test.skip` on a named software rasterizer (`swiftshader`, `llvmpipe`, `lavapipe`, `warp`, `basic render`). Before the boot wait, or the skip costs the wait's full timeout.

Two guards against the inverse defect — a gate reporting green having tested nothing:

- the pattern is deliberately narrow, so an unlisted software adapter re-crashes loudly rather than skipping silently
- both paths log the adapter, so every run names the device it exercised

`visualization` genuinely passes on SwiftShader and stays ungated — a blanket skip would have destroyed real coverage.

Also folds in an unrelated blocker hit while running these gates: `verify.test.ts` calls `mkdtempSync` under `node_modules/.cache`, which `mkdtempSync` does not create, so a fresh clone or worktree reds 5 tests with a bare `ENOENT ... mkdtemp` that reads as a real failure.

## Evidence

| | before | after |
|---|---|---|
| `fountain` gate | ✘ failed (mapAsync), 2.1 s | `1 skipped`, adapter logged `google swiftshader` |
| `voxel` gate | ✘ failed (120 s timeout), 2.0 m | `1 skipped`, 3.2 s |
| `visualization` gate | ✓ passed | ✓ passed (unchanged) |
| `bun test` after `rm -rf node_modules/.cache` | 5 fail | 2337 pass / 0 fail |

`bun check` exit 0.

Real-hardware confirmation that the narrow pattern does not over-skip is not available on this host (WSL only offers SwiftShader); the logged adapter line is what makes an over-skip visible on the next Metal run.