### PR TITLE
shallot peer identity/seam error

### DIFF
--- a/packages/shallot/src/standard/render/contract.ts
+++ b/packages/shallot/src/standard/render/contract.ts
@@ -296,7 +296,7 @@ export const Surfaces: Registry<Surface> = new Registry<Surface>();
  * brand-check one incoming TGSL fn against this engine's own resolution of typegpu, at the seam where a
  * consumer-built object first meets the engine ({@link registerSurface}/{@link registerBackground}).
  * typegpu's brand markers are a per-copy `Symbol(...)` (never `Symbol.for`, `typegpu/shared/symbols.js`),
- * so `isTgpuFn` — imported from *this* engine's own resolution — reads `false` for a foreign copy's fn
+ * so `isTgpuFn`, imported from *this* engine's own resolution, reads `false` for a foreign copy's fn
  * even when its shape matches exactly (de-risked 2026-08-10, spec `shallot-peer-identity` stage 1: same
  * copy `true`, cross-copy `false`). This closes the ordering gap the module-load write-counter
  * (`checkTgsl`, `engine/runtime/gpu.ts`) can't: that counter can fold a duplicate's write into its own
@@ -304,16 +304,16 @@ export const Surfaces: Registry<Surface> = new Registry<Surface>();
  * check regardless of evaluation order.
  */
 export function assertOwnFn(label: string, fn: unknown): void {
-    if (fn === undefined || isTgpuFn(fn)) return;
+    if (fn == null || isTgpuFn(fn)) return;
     throw new Error(
-        `${label}: this isn't a TGSL function the engine can recognize. If it came from tgpu.fn, it ` +
-            "resolved from a different, foreign copy of typegpu than the one this engine built " +
-            "against: two physical copies loaded in the same bundle (a bundler dedupe miss — Vite " +
-            "prebundling and pnpm's isolated node_modules are the two known triggers) stamp different " +
-            "internal markers even when authoring identical code, and a kernel built from this fn " +
-            "would resolve against the wrong metadata map, or not resolve at all. Dedupe typegpu to a " +
-            "single copy; it is the engine's peerDependency for exactly this reason. Otherwise this " +
-            "value simply isn't a tgpu.fn — build it with tgpu.fn(args, ret)(body).",
+        `${label}: this isn't a TGSL function the engine can recognize. ` +
+            "If it came from tgpu.fn, it resolved from a foreign copy of typegpu, not the one this " +
+            "engine built against. Two physical copies in one bundle stamp different internal " +
+            "markers even when the code is identical, so a kernel built from this fn resolves " +
+            "against the wrong metadata map, or not at all. Known triggers: a bundler dedupe miss " +
+            "(Vite prebundling) and pnpm's isolated node_modules. Dedupe typegpu to a single copy; " +
+            "it is the engine's peerDependency for exactly this reason. " +
+            "If it never came from tgpu.fn, build it with tgpu.fn(args, ret)(body).",
     );
 }
 

--- a/packages/shallot/src/standard/render/contract.ts
+++ b/packages/shallot/src/standard/render/contract.ts
@@ -9,7 +9,7 @@
 // "layout is a superset of what one shader declares" precedent, `engine.test.ts`).
 
 import type { TgpuBindGroupLayout, TgpuFn } from "typegpu";
-import tgpu from "typegpu";
+import tgpu, { isTgpuFn } from "typegpu";
 import type { AnyWgslData, AnyWgslStruct, WgslArray } from "typegpu/data";
 import * as d from "typegpu/data";
 import { Registry, type State } from "../../engine";
@@ -292,6 +292,31 @@ export interface Surface<
 /** every schema-backed surface, keyed by name with a stable renderer-owned id. */
 export const Surfaces: Registry<Surface> = new Registry<Surface>();
 
+/**
+ * brand-check one incoming TGSL fn against this engine's own resolution of typegpu, at the seam where a
+ * consumer-built object first meets the engine ({@link registerSurface}/{@link registerBackground}).
+ * typegpu's brand markers are a per-copy `Symbol(...)` (never `Symbol.for`, `typegpu/shared/symbols.js`),
+ * so `isTgpuFn` — imported from *this* engine's own resolution — reads `false` for a foreign copy's fn
+ * even when its shape matches exactly (de-risked 2026-08-10, spec `shallot-peer-identity` stage 1: same
+ * copy `true`, cross-copy `false`). This closes the ordering gap the module-load write-counter
+ * (`checkTgsl`, `engine/runtime/gpu.ts`) can't: that counter can fold a duplicate's write into its own
+ * baseline depending on which module evaluates first, but a foreign fn arriving here fails the brand
+ * check regardless of evaluation order.
+ */
+export function assertOwnFn(label: string, fn: unknown): void {
+    if (fn === undefined || isTgpuFn(fn)) return;
+    throw new Error(
+        `${label}: this isn't a TGSL function the engine can recognize. If it came from tgpu.fn, it ` +
+            "resolved from a different, foreign copy of typegpu than the one this engine built " +
+            "against: two physical copies loaded in the same bundle (a bundler dedupe miss — Vite " +
+            "prebundling and pnpm's isolated node_modules are the two known triggers) stamp different " +
+            "internal markers even when authoring identical code, and a kernel built from this fn " +
+            "would resolve against the wrong metadata map, or not resolve at all. Dedupe typegpu to a " +
+            "single copy; it is the engine's peerDependency for exactly this reason. Otherwise this " +
+            "value simply isn't a tgpu.fn — build it with tgpu.fn(args, ret)(body).",
+    );
+}
+
 function owned<T extends { name: string }>(registry: Registry<T>) {
     const byState = new WeakMap<State, Map<string, T>>();
     return (state: State, spec: T): number => {
@@ -322,6 +347,9 @@ export function registerSurface<
     B extends Record<string, Binding>,
     V extends Record<string, AnyWgslData>,
 >(state: State, spec: Surface<B, V>): number {
+    assertOwnFn(`registerSurface "${spec.name}" vs`, spec.vs);
+    assertOwnFn(`registerSurface "${spec.name}" fs`, spec.fs);
+    assertOwnFn(`registerSurface "${spec.name}" tag`, spec.tag);
     return ownSurface(state, spec as Surface);
 }
 
@@ -364,5 +392,6 @@ export function registerBackground<B extends Record<string, Binding>>(
     state: State,
     spec: Background<B>,
 ): number {
+    assertOwnFn(`registerBackground "${spec.name}" fs`, spec.fs);
     return ownBackground(state, spec as Background);
 }

--- a/packages/shallot/src/standard/render/core.ts
+++ b/packages/shallot/src/standard/render/core.ts
@@ -39,6 +39,7 @@ export type {
     VsFn,
 } from "./contract";
 export {
+    assertOwnFn,
     Backgrounds,
     BgCtx,
     backgroundLayout,

--- a/packages/shallot/src/standard/sear/contract.test.ts
+++ b/packages/shallot/src/standard/sear/contract.test.ts
@@ -208,3 +208,60 @@ describe("register — State ownership", () => {
         expect(Surfaces.get("replacement")).toBeUndefined();
     });
 });
+
+describe("register — foreign-copy brand check", () => {
+    const fs = tgpu.fn(
+        [fsCtxSchema()],
+        d.vec4f,
+    )(() => {
+        "use gpu";
+        return d.vec4f(1);
+    });
+    const bgFs = tgpu.fn(
+        [BgCtx],
+        d.vec3f,
+    )(() => {
+        "use gpu";
+        return d.vec3f(1);
+    });
+
+    // a real second copy of typegpu stamps its own per-copy `Symbol()` internal marker
+    // (`typegpu/shared/symbols.js`, never `Symbol.for`) — this reproduces exactly that shape without
+    // installing a second copy: right `resourceType`, a foreign `$internal` symbol the engine's own
+    // `isTgpuFn` can't recognize (de-risked 2026-08-10, spec `shallot-peer-identity` stage 1).
+    const foreignInternal = Symbol("typegpu:0.11.9:$internal");
+    const foreignFs = { resourceType: "function", [foreignInternal]: true } as unknown as typeof fs;
+
+    // the name is deliberately not "foreign": the diagnostic prefixes the spec's own name, so matching
+    // a word the caller supplied would pass on an empty message body. Match the diagnostic's own
+    // sentence, the seam that named it, and the remedy — the three parts the message promises.
+    const diagnostic = /registerSurface "tinted" fs:.*foreign copy of typegpu.*Dedupe typegpu/s;
+
+    test("a foreign-copy fs throws a named diagnostic at registerSurface", () => {
+        Surfaces.clear();
+        const state = new State();
+        expect(() =>
+            register(state, { name: "tinted", layout: layout({}), fs: foreignFs }),
+        ).toThrow(diagnostic);
+    });
+
+    test("a foreign-copy fs throws a named diagnostic at registerBackground", () => {
+        Backgrounds.clear();
+        const state = new State();
+        expect(() =>
+            registerBackground(state, {
+                name: "sky",
+                layout: backgroundLayout({}),
+                fs: foreignFs as unknown as typeof bgFs,
+            }),
+        ).toThrow(/registerBackground "sky" fs:.*foreign copy of typegpu.*Dedupe typegpu/s);
+    });
+
+    test("a genuine engine fs registers clean", () => {
+        Surfaces.clear();
+        const state = new State();
+        expect(() => register(state, { name: "genuine", layout: layout({}), fs })).not.toThrow();
+        expect(Surfaces.get("genuine")).toBeDefined();
+        state.dispose();
+    });
+});

--- a/packages/shallot/src/standard/sear/contract.ts
+++ b/packages/shallot/src/standard/sear/contract.ts
@@ -13,6 +13,7 @@ export type {
     VsFn,
 } from "../render/core";
 export {
+    assertOwnFn,
     Backgrounds,
     BgCtx,
     backgroundLayout,

--- a/packages/shallot/src/standard/sear/pipelines.ts
+++ b/packages/shallot/src/standard/sear/pipelines.ts
@@ -24,7 +24,7 @@ import { Draws, Frame, LightCull, Lighting, Meshes, Render } from "../render/cor
 import { cascadeLayout, pointLayout, shadowLayout } from "./atlas";
 import { DEPTH_FORMAT, SAMPLE_COUNT, TAG_FORMAT, TAG_NONE } from "./codegen";
 import type { Background, BgLayout, Binding, Surface, SurfaceLayout } from "./contract";
-import { Backgrounds, BgCtx, type fsCtxSchema, Surfaces, VsIn } from "./contract";
+import { assertOwnFn, Backgrounds, BgCtx, type fsCtxSchema, Surfaces, VsIn } from "./contract";
 import {
     engineLayout,
     fragCoord,
@@ -224,7 +224,13 @@ function typedVariant<B extends Record<string, Binding>, V extends Record<string
     variant: number,
 ): Surface<B, V> {
     const spec = surface.specialize?.(variant);
-    return (spec ? { ...surface, ...spec, specialize: undefined } : surface) as Surface<B, V>;
+    if (!spec) return surface;
+    // `specialize` is the second seam a consumer-built TgpuFn enters through, and `registerSurface`
+    // can't reach it: these fns don't exist until a variant compiles. Same brand check, same reason.
+    const at = `surface "${surface.name}" variant ${variant}`;
+    assertOwnFn(`${at} vs`, spec.vs);
+    assertOwnFn(`${at} fs`, spec.fs);
+    return { ...surface, ...spec, specialize: undefined } as Surface<B, V>;
 }
 
 const identityXform = tgpu


### PR DESCRIPTION
- **shallot-peer-identity: brand-check registerSurface/registerBackground against a foreign typegpu copy**
- **shallot-peer-identity: adversarial pass — split the diagnostic into short sentences, guard null**
