### PR TITLE
codec: collapse parseAttrs, drop the dead handled re-check, test levenshtein

### DIFF
--- a/packages/shallot/src/engine/scene/codec.ts
+++ b/packages/shallot/src/engine/scene/codec.ts
@@ -294,71 +294,23 @@ function applyComponent(
         setFieldValue(component, field, eid, val as number | number[]);
     }
 
-    const props: Record<string, string> = {};
-    if (value !== "") {
-        props["_value"] = value;
-    }
-
-    const result = parseAttrs(def, props);
-    const values = result.values;
-    const entityRefs = result.entityRefs;
-    for (const err of result.errors) {
-        errors.push({ message: `<${name}> ${err}` });
-    }
-
-    for (const [field, val] of Object.entries(values)) {
-        setFieldValue(component, field, eid, val);
-    }
-
-    for (const ref of entityRefs) {
-        pendingFieldRefs.push({
-            eid,
-            component,
-            field: ref.field,
-            targetName: ref.targetName,
-        });
-    }
-}
-
-function parseAttrs(
-    def: Registered,
-    props: Record<string, string>,
-): {
-    values: Record<string, number>;
-    entityRefs: { field: string; targetName: string }[];
-    errors: string[];
-} {
-    const allValues: Record<string, number> = {};
-    const allEntityRefs: { field: string; targetName: string }[] = [];
-    const allErrors: string[] = [];
-
-    if (props._value) {
-        if (isCSSAttrSyntax(props._value)) {
-            const result = parsePropertyString(def, props._value);
-            Object.assign(allValues, result.values);
-            allEntityRefs.push(...result.entityRefs);
-            allErrors.push(...result.errors);
+    if (value !== "" && isCSSAttrSyntax(value)) {
+        const result = parsePropertyString(def, value);
+        for (const err of result.errors) {
+            errors.push({ message: `<${name}> ${err}` });
+        }
+        for (const [field, val] of Object.entries(result.values)) {
+            setFieldValue(component, field, eid, val);
+        }
+        for (const ref of result.entityRefs) {
+            pendingFieldRefs.push({
+                eid,
+                component,
+                field: ref.field,
+                targetName: ref.targetName,
+            });
         }
     }
-
-    for (const [propName, propValue] of Object.entries(props)) {
-        if (propName === "_value") continue;
-        if (!propValue) continue;
-
-        if (isCSSAttrSyntax(propValue)) {
-            const result = parsePropertyString(def, propValue);
-            Object.assign(allValues, result.values);
-            allEntityRefs.push(...result.entityRefs);
-            allErrors.push(...result.errors);
-        } else {
-            const result = parsePropertyString(def, `${propName}: ${propValue}`);
-            Object.assign(allValues, result.values);
-            allEntityRefs.push(...result.entityRefs);
-            allErrors.push(...result.errors);
-        }
-    }
-
-    return { values: allValues, entityRefs: allEntityRefs, errors: allErrors };
 }
 
 /**
@@ -818,7 +770,6 @@ export function formatFields(
     }
 
     for (const field of remaining) {
-        if (handled.has(field)) continue;
         const value = fields[field];
         const def = defaults[field];
 

--- a/packages/shallot/src/engine/scene/xml.test.ts
+++ b/packages/shallot/src/engine/scene/xml.test.ts
@@ -110,6 +110,15 @@ describe("XML", () => {
             expect(() => load(nodes, state)).toThrow('did you mean "x"');
         });
 
+        // a typo shaped like "positon" (dropped letter, not a suffix/prefix of the real name) fails both
+        // the exact-kebab and endsWith shortcuts in findClosestMatch, so this is the only test that reaches
+        // the levenshtein call itself.
+        test("suggests field name at a real edit distance (not exact-kebab or endsWith)", () => {
+            register("comp", { position: [] as number[] });
+            const nodes = parse(`<scene><a comp="positon: 5" /></scene>`);
+            expect(() => load(nodes, state)).toThrow('did you mean "position"');
+        });
+
         test("skips unknown component", () => {
             const nodes = parse(`<scene><a id="ball" unknown="value: 1" /></scene>`);
             const map = load(nodes, state);


### PR DESCRIPTION
## Problem
Three oracle-visible drift findings in `engine/scene/codec.ts`, left over from `idiom-verification`'s close: two branches that can never execute, and a helper extracted on a testability promise nothing collected.

## Cause
- `parseAttrs`'s multi-prop loop had one caller, `applyComponent`, which builds `props` as a `_value`-only singleton — the loop could never see a non-`_value` key.
- `formatFields`'s second loop iterates `remaining` *live*, and every `handled.add` in the function pairs with a `remaining.delete` at the same site, so `remaining` and `handled` stay disjoint and its `handled.has(field)` check never fired.
- `levenshtein` had no test reaching it: the existing typo test (`xx` to `x`) exits `findClosestMatch` through the `endsWith` early return.

## Fix
Inline the surviving `_value` branch into `applyComponent` and delete `parseAttrs`; delete the dead re-check; add a dropped-letter typo test (`positon` against `position`) that fails both the exact-kebab and `endsWith` shortcuts.

The twin check one loop above is kept deliberately — that loop iterates a snapshot `[...remaining]` taken before the prefix deletions, so a later lane in the snapshot can already be handled.

## Evidence
Every deletion is perturbation-proven, not read-proven: each claimed-dead branch was replaced with a `throw` and the full suite watched green before removal. An isolated reviewer re-ran both mutations independently — the kept check at the snapshot loop produces **23 failures** when mutated (real conformance/reload and `ReadbackSystem` paths), the deleted one **0** across 2633 tests. The new test was seen red by mutating `levenshtein` and reading the failure message.

Gates against recorded floors: `bun test` 2633 pass / 0 fail (floor 2632/0, +1 the new test), `bun check` exit 0, `bun run format` 0 formatted / 34 unchanged, `bun run flows` green on real GPU (`nvidia / lovelace`).