### PR TITLE
cli-coverage: link each row's arm to the code it describes

### DIFF
--- a/packages/shallot/tests/cli-coverage.test.ts
+++ b/packages/shallot/tests/cli-coverage.test.ts
@@ -4,6 +4,7 @@ import {
     CLI_COVERAGE,
     CLI_POPULATION_GLOBS,
     checkCliCoverage,
+    cliCoverageLinks,
     cliPopulation,
     cliTestFiles,
     globToRegExp,
@@ -15,8 +16,12 @@ import {
 // rowed file, adding an oracle/lab scratch file). None of these fixture cases touch the filesystem or
 // the real registry.
 describe("checkCliCoverage (fixtures)", () => {
+    // the cases below predate the per-arm link checks and exercise the structural rules only; they assert
+    // with `toContainEqual`, so an extra link finding on the same fixture row can't mask them.
+    const NoLinks = { importedByTest: [], exports: {} };
+
     test("a walked file with no row is a finding", () => {
-        const findings = checkCliCoverage([], ["real/file.ts"]);
+        const findings = checkCliCoverage([], ["real/file.ts"], NoLinks);
         expect(findings).toContainEqual({ kind: "file-missing-row", detail: "real/file.ts" });
     });
 
@@ -24,6 +29,7 @@ describe("checkCliCoverage (fixtures)", () => {
         const findings = checkCliCoverage(
             [{ file: "ghost.ts", arm: "unit", reason: "not real" }],
             [],
+            NoLinks,
         );
         expect(findings).toContainEqual({ kind: "row-names-unwalked-file", detail: "ghost.ts" });
     });
@@ -33,7 +39,7 @@ describe("checkCliCoverage (fixtures)", () => {
             { file: "a.ts", arm: "unit" as const, reason: "the pure half" },
             { file: "a.ts", arm: "gap" as const, reason: "occupant: theEffectfulHalf" },
         ];
-        const findings = checkCliCoverage(rows, ["a.ts"]);
+        const findings = checkCliCoverage(rows, ["a.ts"], NoLinks);
         expect(findings).toContainEqual({
             kind: "file-has-multiple-rows",
             detail: "a.ts (2 rows)",
@@ -41,7 +47,11 @@ describe("checkCliCoverage (fixtures)", () => {
     });
 
     test("a row with an empty reason is a finding", () => {
-        const findings = checkCliCoverage([{ file: "a.ts", arm: "gap", reason: "  " }], ["a.ts"]);
+        const findings = checkCliCoverage(
+            [{ file: "a.ts", arm: "gap", reason: "  " }],
+            ["a.ts"],
+            NoLinks,
+        );
         expect(findings).toContainEqual({ kind: "row-missing-reason", detail: "a.ts" });
     });
 
@@ -49,6 +59,7 @@ describe("checkCliCoverage (fixtures)", () => {
         const findings = checkCliCoverage(
             [{ file: "a.ts", arm: "extract", reason: "pure logic trapped in an effectful body" }],
             ["a.ts"],
+            NoLinks,
         );
         expect(findings).toContainEqual({
             kind: "undischarged-extract-missing-stage",
@@ -67,6 +78,7 @@ describe("checkCliCoverage (fixtures)", () => {
                 },
             ],
             ["a.ts"],
+            NoLinks,
         );
         expect(findings).toEqual([]);
     });
@@ -76,7 +88,69 @@ describe("checkCliCoverage (fixtures)", () => {
             { file: "a.ts", arm: "unit" as const, reason: "directly asserted by a.test.ts" },
             { file: "b.ts", arm: "tier" as const, reason: "covered by `bun bench`'s foo scenario" },
         ];
-        expect(checkCliCoverage(rows, ["a.ts", "b.ts"])).toEqual([]);
+        expect(
+            checkCliCoverage(rows, ["a.ts", "b.ts"], {
+                importedByTest: ["a.ts"],
+                exports: { "a.ts": ["thing"], "b.ts": ["other"] },
+            }),
+        ).toEqual([]);
+    });
+
+    // the two per-arm link checks. Neither proves the arm — a test may import a file and assert nothing
+    // about it, and a reason may name an export it doesn't actually leave uncovered. Both make a *stale*
+    // row red instead of merely wrong.
+    test("a unit row whose file no test imports is a finding", () => {
+        const findings = checkCliCoverage(
+            [{ file: "a.ts", arm: "unit", reason: "directly asserted by a.test.ts" }],
+            ["a.ts"],
+            { importedByTest: [], exports: { "a.ts": ["thing"] } },
+        );
+        expect(findings).toContainEqual({ kind: "unit-row-file-untested", detail: "a.ts" });
+    });
+
+    test("a unit row whose file a test imports is clean", () => {
+        const findings = checkCliCoverage(
+            [{ file: "a.ts", arm: "unit", reason: "directly asserted by a.test.ts" }],
+            ["a.ts"],
+            { importedByTest: ["a.ts"], exports: { "a.ts": ["thing"] } },
+        );
+        expect(findings).toEqual([]);
+    });
+
+    test("only the unit arm owes an import — a gap row's file needs none", () => {
+        const findings = checkCliCoverage(
+            [{ file: "a.ts", arm: "gap", reason: "occupant: thing" }],
+            ["a.ts"],
+            { importedByTest: [], exports: { "a.ts": ["thing"] } },
+        );
+        expect(findings).toEqual([]);
+    });
+
+    test("a gap row naming no export of its own file is a finding", () => {
+        const findings = checkCliCoverage(
+            [{ file: "a.ts", arm: "gap", reason: "occupant: theRenamedThing" }],
+            ["a.ts"],
+            { importedByTest: [], exports: { "a.ts": ["thing"] } },
+        );
+        expect(findings).toContainEqual({ kind: "gap-row-names-no-export", detail: "a.ts" });
+    });
+
+    test("a gap row's occupant matches on a word boundary, not a substring", () => {
+        const findings = checkCliCoverage(
+            [{ file: "a.ts", arm: "gap", reason: "occupant: buildWebEjected" }],
+            ["a.ts"],
+            { importedByTest: [], exports: { "a.ts": ["buildWeb"] } },
+        );
+        expect(findings).toContainEqual({ kind: "gap-row-names-no-export", detail: "a.ts" });
+    });
+
+    test("a gap row over a file with no exports at all is a finding, not a free pass", () => {
+        const findings = checkCliCoverage(
+            [{ file: "a.ts", arm: "gap", reason: "occupant: thing" }],
+            ["a.ts"],
+            { importedByTest: [], exports: { "a.ts": [] } },
+        );
+        expect(findings).toContainEqual({ kind: "gap-row-names-no-export", detail: "a.ts" });
     });
 });
 
@@ -110,7 +184,9 @@ describe("CLI_COVERAGE against the real repo (both directions)", () => {
     test("every walked file has exactly one row, every row names a walked file", async () => {
         const population = await cliPopulation(root);
         expect(population.length).toBeGreaterThan(0); // the walk itself must reach real files
-        const findings = checkCliCoverage(CLI_COVERAGE, population);
+        const links = await cliCoverageLinks(root, population);
+        expect(links.importedByTest.length).toBeGreaterThan(0); // the import walk must resolve something
+        const findings = checkCliCoverage(CLI_COVERAGE, population, links);
         expect(findings).toEqual([]);
     });
 

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -11,6 +11,8 @@
 // reason, including "by decision, permanently"). The row's reason carries the detail a second row would
 // otherwise have held: what's covered and by what, plus what isn't and who closes it.
 
+import { posix, resolve } from "node:path";
+
 /** the four tiers of truth a row may claim, per the spec's Locked decision. */
 export type Arm = "unit" | "tier" | "extract" | "gap";
 
@@ -93,16 +95,102 @@ export async function cliTestFiles(root: string): Promise<string[]> {
     return out;
 }
 
+/** the filesystem-derived half of the per-arm link checks, gathered by {@link cliCoverageLinks} and
+ *  passed in as plain data so `cli-coverage.test.ts` red-proves the check against fixtures with no
+ *  filesystem. Both fields travel together in one value the check requires, rather than two the caller
+ *  may supply half of (`coding.md`: two values that must agree travel as one). */
+export interface CoverageLinks {
+    /** every population file imported by at least one test-tier file anywhere in the repo. */
+    importedByTest: readonly string[];
+    /** the exported identifier names of each population file, keyed by the same path the rows use. */
+    exports: Readonly<Record<string, readonly string[]>>;
+}
+
+/** every `from "…"` / `import("…")` specifier in a source file. Deliberately lexical, matching inside
+ *  string literals and comments too — over-matching costs a spurious *link*, and a link only ever makes
+ *  the check more permissive for the rowed file it names, never less. */
+const IMPORT_SPECIFIER = /(?:from|import|require)\s*\(?\s*["']([^"']+)["']/g;
+
+/** each `export`ed identifier name: the declaration forms (`export const|function|class|type|…`) plus
+ *  named export lists, where `x as y` exports `y`. `export default` names nothing and is skipped. */
+const EXPORT_DECL =
+    /^export\s+(?:declare\s+)?(?:async\s+)?(?:function\s*\*?|const|let|var|abstract\s+class|class|interface|type|enum)\s+([A-Za-z_$][A-Za-z0-9_$]*)/gm;
+const EXPORT_LIST = /^export\s+(?:type\s+)?\{([^}]*)\}/gm;
+
+function exportsOf(source: string): string[] {
+    const names = new Set<string>();
+    for (const [, name] of source.matchAll(EXPORT_DECL)) if (name) names.add(name);
+    for (const [, list] of source.matchAll(EXPORT_LIST)) {
+        for (const entry of (list ?? "").split(",")) {
+            const parts = entry
+                .trim()
+                .replace(/^type\s+/, "")
+                .split(/\s+as\s+/);
+            const name = parts[parts.length - 1]?.trim();
+            if (name && /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name)) names.add(name);
+        }
+    }
+    return [...names];
+}
+
+/** gathers the filesystem half of the per-arm link checks: which population files any test-tier file in
+ *  the repo imports, and what each population file exports. Kept beside {@link cliPopulation} and
+ *  {@link cliTestFiles} — the pure {@link checkCliCoverage} takes the result as plain data.
+ *
+ *  The import walk spans the whole repo, not {@link cliTestFiles}'s glob-scoped inverse: `catalog.test.ts`
+ *  sits beside `src/project/engine.ts` and inside the population, but `cli-coverage.test.ts` and
+ *  `create-shallot.test.ts` don't, and a row's test may live anywhere. Only relative specifiers resolve —
+ *  a package specifier (`@dylanebert/shallot`) reaches this layer's files only through a barrel, which is
+ *  not the direct import a `unit` row claims. */
+export async function cliCoverageLinks(
+    root: string,
+    population: readonly string[],
+): Promise<CoverageLinks> {
+    const walked = new Set(population);
+    const importedByTest = new Set<string>();
+    for await (const path of new Bun.Glob("**/*.ts").scan({ cwd: root })) {
+        if (path.includes("node_modules/") || !TEST_TIER_SUFFIXES.test(path)) continue;
+        const dir = posix.dirname(path);
+        const source = await Bun.file(resolve(root, path)).text();
+        for (const [, specifier] of source.matchAll(IMPORT_SPECIFIER)) {
+            if (!specifier?.startsWith(".")) continue;
+            const base = posix.join(dir, specifier);
+            for (const candidate of [base, `${base}.ts`, `${base}/index.ts`]) {
+                if (walked.has(candidate)) importedByTest.add(candidate);
+            }
+        }
+    }
+
+    const exports: Record<string, string[]> = {};
+    for (const file of population) {
+        exports[file] = exportsOf(await Bun.file(resolve(root, file)).text());
+    }
+    return { importedByTest: [...importedByTest], exports };
+}
+
 export type FindingKind =
     | "file-missing-row"
     | "row-names-unwalked-file"
     | "file-has-multiple-rows"
     | "row-missing-reason"
-    | "undischarged-extract-missing-stage";
+    | "undischarged-extract-missing-stage"
+    | "unit-row-file-untested"
+    | "gap-row-names-no-export";
 
 export interface Finding {
     kind: FindingKind;
     detail: string;
+}
+
+/** whether `reason`'s prose contains any of `exports` as a whole word. The boundary is the identifier
+ *  character set (`$` and `_` included), not `\b` — `\b` would let a row naming `buildWebEjected` satisfy
+ *  an export called `buildWeb`. A file with no exports can satisfy nothing, which is the intended answer:
+ *  a `gap` row over a file whose exported surface is empty has nothing left to name. */
+function namesAnExport(reason: string, exports: readonly string[]): boolean {
+    return exports.some((name) => {
+        const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        return new RegExp(`(?<![A-Za-z0-9_$])${escaped}(?![A-Za-z0-9_$])`).test(reason);
+    });
 }
 
 /** the both-directions completeness check: every walked file has exactly one row, every row names a
@@ -115,13 +203,28 @@ export interface Finding {
  *  extract row converts to unit by close or moves to gap with its name recorded" — an extract with no
  *  owning stage is a promise nobody is keeping). Pure over the registry + population, so
  *  `cli-coverage.test.ts` red-proves it against fixtures with no filesystem.
+ *
+ *  Two per-arm links make a stale classification red rather than merely wrong, the analogue of
+ *  `coverage.ts`'s resolve-the-glob rule. A `unit` row's file must be imported by at least one test-tier
+ *  file (`unit-row-file-untested`), and a `gap` row's reason must name at least one identifier the file
+ *  actually exports (`gap-row-names-no-export`). **Neither proves the arm.** An import is not an
+ *  assertion — a test importing a file for one export leaves the rest of it untested, and the `unit`
+ *  link cannot see that. Naming an export is not a claim that the export is uncovered: `testing.md`'s
+ *  "a 'references the symbol' check is satisfiable by a mention" applies in full, and this is weaker
+ *  than even that, since an export name appearing anywhere in the prose satisfies it — including inside
+ *  a sentence describing what *is* covered. What they catch is drift: a `unit` row left standing after
+ *  its test file is deleted, and a `gap` row whose named occupants were renamed out of the file. The
+ *  `tier` and `extract` arms are deliberately unlinked — a `tier` row's evidence is a bench or install
+ *  run no static read of this repo can see, and an `extract` row already owes its discharging stage.
  */
 export function checkCliCoverage(
     rows: readonly CoverageRow[],
     population: readonly string[],
+    links: CoverageLinks,
 ): Finding[] {
     const findings: Finding[] = [];
     const walked = new Set(population);
+    const imported = new Set(links.importedByTest);
     const countByFile = new Map<string, number>();
 
     for (const row of rows) {
@@ -133,6 +236,12 @@ export function checkCliCoverage(
         }
         if (row.arm === "extract" && row.stage === undefined) {
             findings.push({ kind: "undischarged-extract-missing-stage", detail: row.file });
+        }
+        if (row.arm === "unit" && !imported.has(row.file)) {
+            findings.push({ kind: "unit-row-file-untested", detail: row.file });
+        }
+        if (row.arm === "gap" && !namesAnExport(row.reason, links.exports[row.file] ?? [])) {
+            findings.push({ kind: "gap-row-names-no-export", detail: row.file });
         }
         countByFile.set(row.file, (countByFile.get(row.file) ?? 0) + 1);
     }


### PR DESCRIPTION
## Problem

The CLI coverage registry's rows carried no machine-checkable claim about their `arm`. `checkCliCoverage` never read `row.arm` except for the extract-needs-a-stage rule, so flipping a `gap` row to `unit`, or leaving a `unit` row standing after its assertions were deleted, produced no finding. Every classification defect the registry actually hit was caught by a human or model reading prose.

## Cause

The population walk was the half that paid: it asserts *completeness* (every walked file has exactly one row, every row names a walked file) and nothing about what a row *says*. `arm` and `reason` were prose the check never opened.

## Fix

Two cheap per-arm links, the analogue of `coverage.ts`'s resolve-the-glob rule:

- **`unit-row-file-untested`** — a `unit` row's file must be imported by at least one test-tier file (`.test.ts` / `.oracle.ts` / `.probes.ts` / `.lab.ts`) anywhere in the repo.
- **`gap-row-names-no-export`** — a `gap` row's reason must name at least one identifier the rowed file actually exports, matched on identifier boundaries so `buildWebEjected` doesn't satisfy an export called `buildWeb`.

`tier` and `extract` stay unlinked on purpose: a `tier` row's evidence is a bench or install run no static read of this repo can see, and an `extract` row already owes its discharging stage.

**Neither proves the arm, and the JSDoc says so.** An import is not an assertion — a test importing a file for one export leaves the rest untested. Naming an export is weaker than `testing.md`'s "a 'references the symbol' check is satisfiable by a mention" bar, since an export name satisfies it from anywhere in the prose, including a sentence describing what *is* covered. What they catch is drift: a `unit` row left standing after its test file is deleted, and a `gap` row whose named occupants were renamed out of the file.

`checkCliCoverage` stays pure. The filesystem-derived inputs come from a new `cliCoverageLinks(root, population)` beside `cliPopulation`/`cliTestFiles`, and travel in as one `CoverageLinks` value the check requires rather than two halves a caller may split.

## Evidence

Red-first, per check. The four new finding-cases were run against the finished signature with no check body and failed behaviorally (`Received: []`), not at compile time.

Real-tree red proofs, not just fixtures:

- `mv packages/shallot/bin/features.test.ts` away, re-walk → `[{"kind":"unit-row-file-untested","detail":"packages/shallot/bin/features.ts"}]`. Restored.
- Flipping every non-imported row to `unit` over the real registry → 2 findings (`outline/index.ts`, `gpu-globals.ts`).
- Suffixing every identifier in every `gap` reason → 8 findings, one per `gap` row.

No registry row was red: all 7 `unit` rows' files are imported by a test, and all 8 `gap` rows name real exports (16 of 18 population files are imported at all; the two that aren't are a `tier` row and a `gap` row, correctly classified). Nothing was weakened to keep the registry green.

Gates, from the repo root: `bun test ./packages/shallot/tests/cli-coverage.test.ts` 20 pass / 0 fail; `GLTF_CORPUS_REQUIRED=1 bun test` 2639 pass / 0 fail across 155 files (the populated-tree baseline is 2632; +7 new tests, with the three gitignored fixture trees placed per `testing.md`); `bun check` exit 0; `bun run format` exit 0.