### PR TITLE
cli: stop advertising native --target where an installed package can't take it

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ bun install
 bunx shallot dev
 ```
 
-`bunx shallot dev` runs the project with hot reload, and `bunx shallot build` ships it — web by default, or `--target windows|mac|linux` for native.
+`bunx shallot dev` runs the project with hot reload, and `bunx shallot build` ships it as a web bundle. Native builds (`--target windows|mac|linux`) run from a checkout of this repo, not an installed package: the rust crate they need isn't published to npm.
 
 A project is plain data: a `shallot.json` manifest, a scene file, and TypeScript plugins you edit in your IDE. `bunx shallot verify` boots the project in a headless browser and exits 0 or nonzero — a check you, an agent, or CI can run to prove the game still works.
 

--- a/packages/create-shallot/index.ts
+++ b/packages/create-shallot/index.ts
@@ -118,8 +118,9 @@ plugin enablement) in your IDE.
 bunx shallot build
 \`\`\`
 
-Builds a web bundle to \`dist/\`. For native targets:
-\`bunx shallot build --target windows|mac|linux\` (add \`--release\` for an optimized build).
+Builds a web bundle to \`dist/\`. Native targets
+(\`--target windows|mac|linux\`) build from a shallot source checkout, not the
+installed package: the rust crate they need isn't published to npm.
 `;
 
 const agents = (name: string) => `# ${name}
@@ -137,7 +138,7 @@ A WebGPU game built on \`@dylanebert/shallot\`.
 \`\`\`bash
 bunx tsc --noEmit                                # typecheck — run after every change
 bunx shallot dev                                 # run with hot reload while you work
-bunx shallot build [--target windows|mac|linux]  # ship it (web bundle, or a native app)
+bunx shallot build                               # ship it (web bundle to dist/)
 bunx shallot verify                              # prove it: boot headless, check it renders, exit 0/nonzero
 \`\`\`
 

--- a/packages/shallot/AGENTS.md
+++ b/packages/shallot/AGENTS.md
@@ -8,12 +8,11 @@ WebGPU game engine. Data-oriented ECS, declarative scenes, plugins compose every
 bun create shallot <name>   # scaffold a project
 bunx shallot dev [dir]      # run it (vite, hot reload)
 bunx shallot build [dir]    # web build → dist/
-bunx shallot build --target <windows|mac|linux> [--portable] [--release]
-bunx shallot run [dir]      # build + preview (add --target to build and run native)
+bunx shallot run [dir]      # build + preview
 bunx shallot verify [dir]   # headless-browser gate, exit 0/nonzero (below)
 ```
 
-The check is `bunx tsc --noEmit` — run it after every change. `--portable` bundles Chromium (CEF) instead of the system webview; required on Linux, optional elsewhere. If you author TGSL, add `eslint-plugin-typegpu` too; the engine runs its recommended rules with zero warnings allowed.
+The check is `bunx tsc --noEmit` — run it after every change. Native builds (`bunx shallot build --target windows|mac|linux`, `--portable` for bundled Chromium) run only from a shallot source checkout — the rust crate they need isn't in the npm package. If you author TGSL, add `eslint-plugin-typegpu` too; the engine runs its recommended rules with zero warnings allowed.
 
 A project is pure data: `shallot.json` (the manifest: scene + plugin enablement) + `public/scenes/*.scene` + plugin modules under `src/`. No index.html, no vite config — the CLI supplies the scaffolding.
 

--- a/packages/shallot/README.md
+++ b/packages/shallot/README.md
@@ -15,7 +15,7 @@ bun install
 bunx shallot dev    # run it, with hot reload
 ```
 
-`bunx shallot build` ships it — web by default, or `--target windows|mac|linux` for native. `bunx shallot verify` boots the project in a headless browser and exits 0 or nonzero.
+`bunx shallot build` ships it as a web bundle. `bunx shallot verify` boots the project in a headless browser and exits 0 or nonzero. Native builds (`--target windows|mac|linux`) run from a shallot source checkout, not an installed package: the rust crate they need isn't published to npm.
 
 ## add to an existing project
 

--- a/packages/shallot/bin/cli.ts
+++ b/packages/shallot/bin/cli.ts
@@ -18,7 +18,8 @@ const usage = `
     recipe    Copy an example recipe out of the package (bare: list them)
 
   Options
-    --target <platform>   web (default), windows, mac, linux
+    --target <platform>   web (default), windows, mac, linux. The native targets build from the
+                          shallot source repo — the rust crate they need isn't in the npm package.
     --release             Optimized build (build, run)
     --portable            Bundle the Chromium runtime (CEF) instead of the system webview.
                           Larger, but self-contained and runs anywhere. Required on Linux


### PR DESCRIPTION
## Problem

`requireRustCrate` makes `shallot build --target <os>` from an installed package fail with a named diagnostic instead of a raw ENOENT, and the install gate asserts it. But the help and doc surfaces still advertised the path: `cli.ts`'s usage listed `windows, mac, linux` unqualified, and the packaged AGENTS.md, both READMEs, and the `bun create shallot` scaffold all told an installed user to run it. The guard was the only place that said otherwise, and only after they tried.

## Cause

`rust/window` isn't in `package.json`'s `files` (deliberately — the crate, not a prebuilt binary, is what a native build needs). The docs predate that decision and were never re-read against it.

## Fix

Text only, no capability detection — the qualifying phrase matches the diagnostic's own wording ("only the source repo has it").

- `bin/cli.ts` usage: the `--target` line now says the native targets build from the shallot source repo, because the rust crate isn't in the npm package.
- `packages/shallot/AGENTS.md` (shipped): dropped the `--target` command line from the consumer command block entirely and replaced the `--portable` sentence with one that states the source-checkout requirement. Net **-24 B**, which matters — this file's Codex chain sat 41 B under the 32 KiB cap and now has 65 B.
- `packages/shallot/README.md` (npm always ships it) and the root `README.md`: same qualifier.
- `packages/create-shallot/index.ts`: the scaffolded README and AGENTS.md stop offering `--target` as a ship option.

Deliberately left: the repo's own `shallot/AGENTS.md` command block, which documents the full native flow — it's true from a checkout, which is the only place that file is read.

## Evidence

- `bun test ./packages/shallot/bin/cli.test.ts` — 6 pass / 0 fail.
- `bun check` — clean (biome, tsc, eslint, versions, imports, boundary, docs, pack).
- `bun run format` — 0 formatted, 34 unchanged.
- `GLTF_CORPUS_REQUIRED=1 bun test` — **2639 pass / 0 fail**, 155 files, with all three fixture trees placed.
- `bun run test:install` — exit 0, "PASS: real-install flow clean", 79 rungs, including the missing-crate diagnostic rung and all ten `bun create shallot` scaffold-doc rungs.
- `bun scripts/parity.ts --strict` (kex) — clean; packaged-AGENTS chain 32703 B / 32768 B.

No new test. The usage string isn't exported, and the only assertion available over it is a prose match that restates the wording it checks (`coding.md`'s skip case). The behavior underneath is already gated where it's real: the install gate's `shallot build --target linux` rung.