### PR TITLE
changelog: the 0.9.1 entry, and retarget the migration guide to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Notable changes per release. Versions follow [semver](https://semver.org).
 
+## 0.9.1 — 2026-08-12
+
+The packaging patch, and the recommended target for a 0.8→0.9 port. The two Node-consumed exports ship compiled, the duplicate-TypeGPU check catches a same-version double-load, and `Profile` grows the GPU byte and pipeline counters a budget gate can read.
+
+- **packaging** — `./vite` and `./harness/browser` resolve to compiled `dist/*.js`, with types still coming from source. A `vite.config.ts`, a `playwright.config.ts`, or a plain Node script can now import `projectPlugin` and `REAL_GPU_LAUNCH` directly; through 0.9.0 that threw `ERR_UNKNOWN_FILE_EXTENSION`, because Node applies no TypeScript transform to a `node_modules` import. A linked dev checkout builds them once (`bun run scripts/build-tooling.ts`, which `bun pm pack` runs via `prepack`): the `default` condition points at `dist/` with no source fallback.
+- **gpu** — the duplicate-TypeGPU check counts writes to `__TYPEGPU_VERSION__` instead of comparing its value, so two copies of the same pinned minor no longer read as one. TypeGPU stamps that key on every module evaluation, which a value comparison cannot see; the shape that motivated it is a consumer's own direct `typegpu/data` import in a zero-config registry install. `checkTgsl`'s JSDoc now records what it still cannot catch (a duplicate whose write lands before the counter installs, and a metadata-free bundle whose canary resolves anyway), with the real-device install gate as the backstop for both.
+- **profile** — GPU byte totals and honest pipeline accounting on the public seam: `bufferBytes`, `textureBytes`, per-label `allocBytes`, and `lazyBytes`, plus `compiledPipelines` and `pipelineCalls` beside `compile`, which now keys by descriptor label rather than scope name. An allocator declares a lazily-grown pool entry with `LazyAlloc` (`{ lazy: true }` on the create descriptor) so a byte budget can exclude what real GPU backpressure grows rather than inferring it from a label string.
+- **verify** — `--timings` reads the exact in-page `__harness` install moment instead of quantizing it to a 500 ms poll, and adds a resource-timing readout (request count, summed transfer duration, slowest N) with a raised buffer, so a symlinked workspace dependency's unbundled modules cannot saturate the spec's 250-entry default and flatten the number. Stdout flushes before exit, so a truncated pipe no longer reports as a crash.
+- **cli** — `--target windows|mac|linux` says what it needs. Native builds run from a Shallot source checkout, since the rust crate they link is not in the npm package; `bunx shallot build` from an installed package is web.
+- **internals** — the sky's star hash and the glTF PBR path each shipped a second, dead implementation of code the live path already had, and the scene codec's attribute parser carried an unreachable branch. All three are gone, each with the check that keeps it gone. The fountain and voxel showcase gates skip on a software adapter instead of crashing.
+
 ## 0.9.0 — 2026-08-03
 
 The GPU substrate is now TypeGPU end to end: one schema defines each CPU↔GPU layout, engine-authored shaders are TGSL, and GPU logic can run on the CPU for exact unit tests. See [`packages/shallot/MIGRATION.md`](packages/shallot/MIGRATION.md) for the complete 0.8→0.9 consumer port.

--- a/bun.lock
+++ b/bun.lock
@@ -297,12 +297,12 @@
     },
     "packages/create-shallot": {
       "name": "create-shallot",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "bin": "./index.ts",
     },
     "packages/shallot": {
       "name": "@dylanebert/shallot",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "bin": {
         "shallot": "./bin/cli.ts",
       },

--- a/packages/shallot/MIGRATION.md
+++ b/packages/shallot/MIGRATION.md
@@ -1,13 +1,15 @@
-# Migrating from 0.8 to 0.9
+# Migrating from 0.8 to 0.9.1
 
 Shallot 0.9 moves its GPU substrate to TypeGPU. GPU layouts now come from TypeGPU schemas, custom shaders use TGSL, and render registries carry typed resources. The ECS, scene, and ordinary component APIs keep their 0.8 shape.
+
+Port to 0.9.1, not 0.9.0. The API is the same, and 0.9.1 carries the packaging and diagnostics fixes a port hits first: compiled tooling exports, and a duplicate-TypeGPU check that catches two copies of the same pinned minor. [`CHANGELOG.md`](https://github.com/dylanebert/shallot/blob/main/CHANGELOG.md) has the list.
 
 ## Install the GPU toolchain
 
 Install the engine and its TypeGPU peer at the same time. Keep TypeGPU on the 0.11 minor used by Shallot; two copies in one bundle race over the same metadata map.
 
 ```bash
-bun add @dylanebert/shallot@^0.9 typegpu@~0.11.9
+bun add @dylanebert/shallot@^0.9.1 typegpu@~0.11.9
 bun add -d unplugin-typegpu@~0.11.6 eslint@^9 eslint-plugin-typegpu@~0.11.1
 bun add -d @babel/core@^7.28.6 @babel/eslint-parser@^7.28.6 @babel/plugin-syntax-typescript@^7.28.5
 ```
@@ -27,6 +29,8 @@ export default defineConfig({
     optimizeDeps: { exclude: ["@dylanebert/shallot", "typegpu"] },
 });
 ```
+
+`@dylanebert/shallot/vite` ships compiled as of 0.9.1, which is what lets a config file import it at all. Vite's default config loader bundles `vite.config.ts` and runs it in a real `node` subprocess, and Node applies no TypeScript transform to a `node_modules` import, so against 0.9.0 this recipe throws `ERR_UNKNOWN_FILE_EXTENSION` before Vite starts. `@dylanebert/shallot/harness/browser` in a `playwright.config.ts` is the same shape.
 
 The direct `unplugin-typegpu/vite` plugin is the supported ejected-project route. `typegpuPlugin()` is reserved for Shallot's synthesized CLI config; do not add it here. A second transform rewrites generated metadata and breaks it.
 


### PR DESCRIPTION
## Problem

0.9.1 published to npm and tagged on `main` with no `CHANGELOG.md` entry, and `MIGRATION.md` still targeting `0.9`. A consumer reading the repo sees 0.9.0 as the newest release and ports to it.

## Cause

Both are release-checklist steps nothing gates. `check-versions.ts` catches a *partial* version bump across the four version sites, but no check reads `CHANGELOG.md`, `MIGRATION.md`, or `bun.lock` — so the release can be complete and correct by every gate while the docs still describe the previous version.

## Fix

- **CHANGELOG.md** — the 0.9.1 entry, written off the `v0.9.0..v0.9.1` diff rather than the commit subjects: compiled `./vite` + `./harness/browser`, the write-counting duplicate-TypeGPU check, `Profile`'s GPU byte and pipeline counters plus `LazyAlloc`, `--timings`' in-page harness-install probe and resource-timing readout, the `native --target` honesty fix, and three retired duplicate implementations.
- **MIGRATION.md** — titled and pinned to 0.9.1, with the reason stated once: same API, and 0.9.1 carries the packaging and diagnostics fixes a port hits first. The ejected Vite recipe gains the sentence that explains why it boots against 0.9.1 and throws `ERR_UNKNOWN_FILE_EXTENSION` against 0.9.0.
- **bun.lock** — both workspace packages still recorded `0.9.0`. A fifth version site the release bump missed, and one `check-versions.ts` does not read.

## Evidence

- `bun run check` exit 0 (the two biome warnings are broken symlinks into gitignored asset trees, pre-existing and environmental).
- The `vite.config.ts` claim is grounded in `scripts/install-test.ts:248`, not inferred: Vite's default `configLoader: "bundle"` runs the config in a real `node` subprocess, which applies no TS transform to a `node_modules` import. The `ejectedFlow` fixture boots that exact recipe against a packed tarball.
- Every changelog bullet was read against the shipped diff. `materialPreamble` / `SAMPLE_ALBEDO` were confirmed absent from `gltf/core`'s barrel before being described as internal rather than breaking.