### PR TITLE
shallot typegpu 012/s1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@playwright/test": "^1.58.2",
         "@types/pngjs": "^6.0.5",
         "eslint": "^9.0.0",
-        "eslint-plugin-typegpu": "~0.11.1",
+        "eslint-plugin-typegpu": "~0.12.0",
         "jiti": "^2.7.0",
         "playwright": "^1.58.2",
         "pngjs": "^7.0.0",
@@ -64,10 +64,10 @@
       "version": "0.0.0",
       "dependencies": {
         "@dylanebert/shallot": "workspace:*",
-        "typegpu": "~0.11.9",
+        "typegpu": "~0.12.0",
       },
       "devDependencies": {
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
         "vite": "^8.0.0",
       },
     },
@@ -258,7 +258,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@dylanebert/shallot": "workspace:*",
-        "typegpu": "~0.11.9",
+        "typegpu": "~0.12.0",
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -276,11 +276,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@dylanebert/shallot": "workspace:*",
-        "typegpu": "~0.11.9",
+        "typegpu": "~0.12.0",
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
         "vite": "^8.0.0",
       },
     },
@@ -289,7 +289,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@dylanebert/shallot": "workspace:*",
-        "typegpu": "~0.11.9",
+        "typegpu": "~0.12.0",
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -309,19 +309,19 @@
       "dependencies": {
         "@webgpu/types": "^0.1.70",
         "meshoptimizer": "^0.22.0",
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
         "vite": "^8.0.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "bun-webgpu": "^0.1.4",
         "fast-check": "^4.6.0",
-        "typegpu": "~0.11.9",
+        "typegpu": "~0.12.0",
         "wgpu-matrix": "^3.4.0",
       },
       "peerDependencies": {
         "playwright": "^1.0.0",
-        "typegpu": "~0.11.9",
+        "typegpu": "~0.12.0",
       },
       "optionalPeers": [
         "playwright",
@@ -629,7 +629,7 @@
 
     "eslint": ["eslint@9.39.5", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.1", "@eslint/config-array": "^0.21.2", "@eslint/config-helpers": "^0.4.2", "@eslint/core": "^0.17.0", "@eslint/eslintrc": "^3.3.6", "@eslint/js": "9.39.5", "@eslint/plugin-kit": "^0.4.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "chalk": "^4.0.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^8.4.0", "eslint-visitor-keys": "^4.2.1", "espree": "^10.4.0", "esquery": "^1.5.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "lodash.merge": "^4.6.2", "minimatch": "^3.1.5", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw=="],
 
-    "eslint-plugin-typegpu": ["eslint-plugin-typegpu@0.11.1", "", { "dependencies": { "@typescript-eslint/utils": "^8.57.2" }, "peerDependencies": { "eslint": "^9.0.0" } }, "sha512-eFAIIlkX+cbcAXXnRqDl4lRmaWTPIjJR9j1mdKEKjaVqAtKDEyjnjXVm736eNGLOdUkryPj5ROQrXVUTADRlFg=="],
+    "eslint-plugin-typegpu": ["eslint-plugin-typegpu@0.12.0", "", { "dependencies": { "@typescript-eslint/utils": "^8.57.2" }, "peerDependencies": { "eslint": "^9.0.0" } }, "sha512-pP2PXmle3KX6deqtoTkID5PSimY4Y2PlzmZofxfvoJU79vo/32kxWtqbxw05OrFQYffPs4g5K8yNMYdV69J2Tw=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
 
@@ -847,7 +847,7 @@
 
     "tinyest": ["tinyest@0.3.2", "", {}, "sha512-1wqSt97RLezWzeogLSVXHr+E3jpYO8jxyaK2AIdJeGoZZTCubwNxQ9IqU5gbQpJVcxlbPugPAsII+m9/gqpPSA=="],
 
-    "tinyest-for-wgsl": ["tinyest-for-wgsl@0.3.3", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-fo1oDSWVm901/2oZPZe6TsDjNPDhz/RArGSOLxon58NhkdxtD5GYovFj+gF1qrIDlxMpTxU/mPtYZNhFP2oJZw=="],
+    "tinyest-for-wgsl": ["tinyest-for-wgsl@0.4.0", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-3vkeNf74HrJ1C6QJUiL92ArsaigD8ra52JBMTeyDfqEz6SawyCO1aiF+XCKiMt3MBaL5QIsKOHG5gl/v21MqKA=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
@@ -861,7 +861,7 @@
 
     "typed-binary": ["typed-binary@4.3.3", "", {}, "sha512-W2hLsSzt3k/tg38gDE4Fn/QiwcoqGuUHBc2cb3mXuH7KcYxe/GM57vzW14s2/bawB4R5knGgGq8Xb57vsaJ4Sg=="],
 
-    "typegpu": ["typegpu@0.11.9", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg=="],
+    "typegpu": ["typegpu@0.12.0", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-onz2jmLierL9cQUCfUhyP8x9XROyWFoFuHTFqyz4p45FTEBYFY9zNfnSntswuREGGZdPaZxQYOlBERAidhybWg=="],
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
@@ -869,7 +869,7 @@
 
     "unplugin": ["unplugin@3.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.4", "webpack-virtual-modules": "^0.6.2" }, "peerDependencies": { "@farmfe/core": "*", "@rspack/core": "*", "bun-types-no-globals": "*", "esbuild": "*", "rolldown": "*", "rollup": "*", "unloader": "*", "vite": "*", "webpack": "*" }, "optionalPeers": ["@farmfe/core", "@rspack/core", "bun-types-no-globals", "esbuild", "rolldown", "rollup", "unloader", "vite", "webpack"] }, "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg=="],
 
-    "unplugin-typegpu": ["unplugin-typegpu@0.11.6", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.1", "tinyest-for-wgsl": "~0.3.2", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.11.9" } }, "sha512-vtSqYUDOzlGkrlOTEa7wkaaz8HQdV/A7tktebBbSSxobFjEZqgeRz/GYF1KJXPCreNJ7HwBA+iEdl3xBKHHLPg=="],
+    "unplugin-typegpu": ["unplugin-typegpu@0.12.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.2", "tinyest-for-wgsl": "~0.4.0", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.12.0" } }, "sha512-UII2efnC4eRywJr/ot/U4+xB/3kzu5aTnhHMkXOwwLKSi1i0iKoQbVFXQEQYCaBvOwF8Sy2jqnTPdMaa+aF0PA=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
@@ -907,11 +907,35 @@
 
     "espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
+    "flow-blank/unplugin-typegpu": ["unplugin-typegpu@0.11.6", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.1", "tinyest-for-wgsl": "~0.3.2", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.11.9" } }, "sha512-vtSqYUDOzlGkrlOTEa7wkaaz8HQdV/A7tktebBbSSxobFjEZqgeRz/GYF1KJXPCreNJ7HwBA+iEdl3xBKHHLPg=="],
+
+    "flow-no-walls/unplugin-typegpu": ["unplugin-typegpu@0.11.6", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.1", "tinyest-for-wgsl": "~0.3.2", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.11.9" } }, "sha512-vtSqYUDOzlGkrlOTEa7wkaaz8HQdV/A7tktebBbSSxobFjEZqgeRz/GYF1KJXPCreNJ7HwBA+iEdl3xBKHHLPg=="],
+
+    "flow-survive-reload/unplugin-typegpu": ["unplugin-typegpu@0.11.6", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.1", "tinyest-for-wgsl": "~0.3.2", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.11.9" } }, "sha512-vtSqYUDOzlGkrlOTEa7wkaaz8HQdV/A7tktebBbSSxobFjEZqgeRz/GYF1KJXPCreNJ7HwBA+iEdl3xBKHHLPg=="],
+
+    "flow-ui-containment/unplugin-typegpu": ["unplugin-typegpu@0.11.6", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.1", "tinyest-for-wgsl": "~0.3.2", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.11.9" } }, "sha512-vtSqYUDOzlGkrlOTEa7wkaaz8HQdV/A7tktebBbSSxobFjEZqgeRz/GYF1KJXPCreNJ7HwBA+iEdl3xBKHHLPg=="],
+
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@nicolo-ribaudo/eslint-scope-5-internals/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "flow-blank/unplugin-typegpu/tinyest-for-wgsl": ["tinyest-for-wgsl@0.3.3", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-fo1oDSWVm901/2oZPZe6TsDjNPDhz/RArGSOLxon58NhkdxtD5GYovFj+gF1qrIDlxMpTxU/mPtYZNhFP2oJZw=="],
+
+    "flow-blank/unplugin-typegpu/typegpu": ["typegpu@0.11.9", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg=="],
+
+    "flow-no-walls/unplugin-typegpu/tinyest-for-wgsl": ["tinyest-for-wgsl@0.3.3", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-fo1oDSWVm901/2oZPZe6TsDjNPDhz/RArGSOLxon58NhkdxtD5GYovFj+gF1qrIDlxMpTxU/mPtYZNhFP2oJZw=="],
+
+    "flow-no-walls/unplugin-typegpu/typegpu": ["typegpu@0.11.9", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg=="],
+
+    "flow-survive-reload/unplugin-typegpu/tinyest-for-wgsl": ["tinyest-for-wgsl@0.3.3", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-fo1oDSWVm901/2oZPZe6TsDjNPDhz/RArGSOLxon58NhkdxtD5GYovFj+gF1qrIDlxMpTxU/mPtYZNhFP2oJZw=="],
+
+    "flow-survive-reload/unplugin-typegpu/typegpu": ["typegpu@0.11.9", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg=="],
+
+    "flow-ui-containment/unplugin-typegpu/tinyest-for-wgsl": ["tinyest-for-wgsl@0.3.3", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-fo1oDSWVm901/2oZPZe6TsDjNPDhz/RArGSOLxon58NhkdxtD5GYovFj+gF1qrIDlxMpTxU/mPtYZNhFP2oJZw=="],
+
+    "flow-ui-containment/unplugin-typegpu/typegpu": ["typegpu@0.11.9", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }

--- a/examples/gym/package.json
+++ b/examples/gym/package.json
@@ -10,10 +10,10 @@
     },
     "dependencies": {
         "@dylanebert/shallot": "workspace:*",
-        "typegpu": "~0.11.9"
+        "typegpu": "~0.12.0"
     },
     "devDependencies": {
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
         "vite": "^8.0.0"
     }
 }

--- a/examples/showcase/fountain/package.json
+++ b/examples/showcase/fountain/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "@dylanebert/shallot": "workspace:*",
-        "typegpu": "~0.11.9"
+        "typegpu": "~0.12.0"
     },
     "devDependencies": {
         "@playwright/test": "^1.58.2"

--- a/examples/showcase/visualization/package.json
+++ b/examples/showcase/visualization/package.json
@@ -11,11 +11,11 @@
     },
     "dependencies": {
         "@dylanebert/shallot": "workspace:*",
-        "typegpu": "~0.11.9"
+        "typegpu": "~0.12.0"
     },
     "devDependencies": {
         "@playwright/test": "^1.58.2",
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
         "vite": "^8.0.0"
     }
 }

--- a/examples/showcase/voxel/package.json
+++ b/examples/showcase/voxel/package.json
@@ -9,7 +9,7 @@
     },
     "dependencies": {
         "@dylanebert/shallot": "workspace:*",
-        "typegpu": "~0.11.9"
+        "typegpu": "~0.12.0"
     },
     "devDependencies": {
         "@playwright/test": "^1.58.2"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "@playwright/test": "^1.58.2",
         "@types/pngjs": "^6.0.5",
         "eslint": "^9.0.0",
-        "eslint-plugin-typegpu": "~0.11.1",
+        "eslint-plugin-typegpu": "~0.12.0",
         "jiti": "^2.7.0",
         "playwright": "^1.58.2",
         "pngjs": "^7.0.0",

--- a/packages/shallot/package.json
+++ b/packages/shallot/package.json
@@ -93,12 +93,12 @@
     "dependencies": {
         "@webgpu/types": "^0.1.70",
         "meshoptimizer": "^0.22.0",
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
         "vite": "^8.0.0"
     },
     "peerDependencies": {
         "playwright": "^1.0.0",
-        "typegpu": "~0.11.9"
+        "typegpu": "~0.12.0"
     },
     "peerDependenciesMeta": {
         "playwright": {
@@ -109,7 +109,7 @@
         "@types/bun": "latest",
         "bun-webgpu": "^0.1.4",
         "fast-check": "^4.6.0",
-        "typegpu": "~0.11.9",
+        "typegpu": "~0.12.0",
         "wgpu-matrix": "^3.4.0"
     },
     "trustedDependencies": [

--- a/packages/shallot/src/engine/utils/tgsl.ts
+++ b/packages/shallot/src/engine/utils/tgsl.ts
@@ -92,7 +92,6 @@ export const packSnorm2x16 = tgpu.fn(
     d.u32,
 )((v) => {
     "use gpu";
-    // eslint-disable-next-line typegpu/no-unsupported-syntax -- the unsigned shift is confined to the folded-away CPU arm
     return isBeingTranspiled() ? packSnorm2x16Wgsl(v) : ((snorm16(v.y) << 16) | snorm16(v.x)) >>> 0;
 });
 
@@ -118,7 +117,6 @@ export const packUnorm2x16 = tgpu.fn(
     d.u32,
 )((v) => {
     "use gpu";
-    // eslint-disable-next-line typegpu/no-unsupported-syntax -- the unsigned shift is confined to the folded-away CPU arm
     return isBeingTranspiled() ? packUnorm2x16Wgsl(v) : ((unorm16(v.y) << 16) | unorm16(v.x)) >>> 0;
 });
 
@@ -132,8 +130,7 @@ export const unpackUnorm2x16 = tgpu.fn(
     "use gpu";
     return isBeingTranspiled()
         ? unpackUnorm2x16Wgsl(e)
-        : // eslint-disable-next-line typegpu/no-unsupported-syntax -- the unsigned shift is confined to the folded-away CPU arm
-          d.vec2f((e & 0xffff) / 65535, (e >>> 16) / 65535);
+        : d.vec2f((e & 0xffff) / 65535, (e >>> 16) / 65535);
 });
 
 /** pack four [0,1] lanes into a `u32` of four unorm8 bytes (lane x → byte 0): WGSL `pack4x8unorm`.
@@ -149,8 +146,7 @@ export const packUnorm4x8 = tgpu.fn(
     "use gpu";
     return isBeingTranspiled()
         ? packUnorm4x8Wgsl(v)
-        : // eslint-disable-next-line typegpu/no-unsupported-syntax -- the unsigned shift is confined to the folded-away CPU arm
-          (unorm8(v.x) | (unorm8(v.y) << 8) | (unorm8(v.z) << 16) | (unorm8(v.w) << 24)) >>> 0;
+        : (unorm8(v.x) | (unorm8(v.y) << 8) | (unorm8(v.z) << 16) | (unorm8(v.w) << 24)) >>> 0;
 });
 
 /** reinterpret an `f32`'s bits as a `u32`: WGSL `bitcast<u32>(e)`. The f32→u32 direction only;

--- a/packages/shallot/src/extras/gltf/live.ts
+++ b/packages/shallot/src/extras/gltf/live.ts
@@ -51,7 +51,11 @@ const liveLayout = surfaceLayout({
 });
 const LivePatch = vsPatchSchema();
 const LiveCtx = fsCtxSchema();
-const liveBound = liveLayout.bound;
+// 0.12 removed `layout.bound`; the dereferenced `layout.$.x` throws outside an actual TGSL body ("Direct
+// access to buffer values..."), so a raw-WGSL-string `$uses` external can't bind a per-field value —
+// the whole `$` proxy rides as one external and the WGSL text's own `bound.x` dot chain defers the field
+// read to resolution time (see standard/sear/pipelines.ts's `typedVaryingVs` for the same fix in full).
+const liveBound = liveLayout.$;
 
 // The dynamic vec4 lane reads are the one WGSL-bodied leaf the 4a lock names. The surface itself is still
 // a typed fn: schemas own every argument/resource and `$uses` binds the raw body's free names.
@@ -66,15 +70,16 @@ const liveVs = tgpu
     let localNormal = vsIn.localNormal;
     var world = vsIn.world;
     var worldNormal = vsIn.worldNormal;
-${LIVE_SKIN_VS.replace("let xf = transforms[eid];", "let xf = vsIn.xform;")}
+${LIVE_SKIN_VS.replace(/\bskinData\b/g, "bound.skinData")
+    .replace(/\bskinParams\b/g, "bound.skinParams")
+    .replace(/\bskin\b/g, "bound.skin")
+    .replace("let xf = transforms[eid];", "let xf = vsIn.xform;")}
     return LivePatch(world, worldNormal, vec4f(0.0));
 }`)
     .$uses({
         VsIn,
         LivePatch,
-        skinData: liveBound.skinData,
-        skinParams: liveBound.skinParams,
-        skin: liveBound.skin,
+        bound: liveBound,
         Xform,
         xformPoint,
         xformNormal,

--- a/packages/shallot/src/standard/bvh/bounds.ts
+++ b/packages/shallot/src/standard/bvh/bounds.ts
@@ -73,12 +73,9 @@ export const orderU32 = tgpu.fn(
     // `>>> 0` the transpiler rejects (the `tgsl.ts` dual shape — the ternary folds at shader-gen)
     return std.isBeingTranspiled()
         ? std.select(~u, u | 0x80000000, u >> 31 === 0)
-        : // eslint-disable-next-line typegpu/no-unsupported-syntax -- unsigned shift confined to folded-away CPU arm
-          u >>> 31 === 0
-          ? // eslint-disable-next-line typegpu/no-unsupported-syntax -- unsigned shift confined to folded-away CPU arm
-            (u | 0x80000000) >>> 0
-          : // eslint-disable-next-line typegpu/no-unsupported-syntax -- unsigned shift confined to folded-away CPU arm
-            ~u >>> 0;
+        : u >>> 31 === 0
+          ? (u | 0x80000000) >>> 0
+          : ~u >>> 0;
 });
 
 /**
@@ -95,12 +92,9 @@ export const unorderU32 = tgpu.fn(
     return std.bitcastU32toF32(
         std.isBeingTranspiled()
             ? std.select(~o, o ^ 0x80000000, o >> 31 === 1)
-            : // eslint-disable-next-line typegpu/no-unsupported-syntax -- unsigned shift confined to folded-away CPU arm
-              o >>> 31 === 1
-              ? // eslint-disable-next-line typegpu/no-unsupported-syntax -- unsigned shift confined to folded-away CPU arm
-                (o ^ 0x80000000) >>> 0
-              : // eslint-disable-next-line typegpu/no-unsupported-syntax -- unsigned shift confined to folded-away CPU arm
-                ~o >>> 0,
+            : o >>> 31 === 1
+              ? (o ^ 0x80000000) >>> 0
+              : ~o >>> 0,
     );
 });
 

--- a/packages/shallot/src/standard/sear/pipelines.test.ts
+++ b/packages/shallot/src/standard/sear/pipelines.test.ts
@@ -783,6 +783,9 @@ test("a specializing surface compiled at two distinct variants emits two distinc
             queue: { onSubmittedWorkDone: async () => {} },
             pushErrorScope: () => {},
             popErrorScope: async () => null,
+            // typegpu 0.12's shader-module resolution reads `device.limits` to warn on overflow
+            // (core/pipeline/limitsOverflow.js) — absent on 0.11, so this mock had none.
+            limits: { maxUniformBuffersPerShaderStage: 12, maxStorageBuffersPerShaderStage: 10 },
             createShaderModule: () => ({}),
             createBindGroupLayout: () => ({}),
             createPipelineLayout: () => ({}),

--- a/packages/shallot/src/standard/sear/pipelines.ts
+++ b/packages/shallot/src/standard/sear/pipelines.ts
@@ -832,7 +832,6 @@ function typedVaryingVs(surface: AnySurface, clip = false, suffix = clip ? "Clip
     // still projects
     const screen = !!surface.screen;
     const layout = surface.layout;
-    const bound = layout.bound as unknown as Record<string, unknown>;
     const OutStruct = d
         .struct({
             pos: d.vec4f,
@@ -849,10 +848,18 @@ function typedVaryingVs(surface: AnySurface, clip = false, suffix = clip ? "Clip
         .map((k) => `    out.${k} = patched.${k};`)
         .join("\n");
     const fragmentAssigns = `${surface.fragmentInputs?.uv ? "    out.uv = uv;\n" : ""}${surface.fragmentInputs?.localPos ? "    out.localPos = localPos;\n" : ""}`;
+    // 0.12 removed `layout.bound`: the dereferenced `layout.$.x` throws outside an actual TGSL body
+    // ("Direct access to buffer values..."), including inside a `tgpu.lazy` compute (it forces normal
+    // mode). The fix a raw-WGSL-string `uses` external needs is to defer the per-field property read
+    // to resolution time itself — pass the whole `layout.$` proxy as one external and let the WGSL
+    // text's own `bound.vertices`-style dot chain do the (codegen-mode-safe) lookup.
+    const bound = layout.$;
+    const engine = engineLayout.$;
+    const shadowG = shadowLayout.$;
     const uses: Record<string, unknown> = {
         Out: OutStruct,
-        vertices: bound.vertices,
-        meshQuant: engineLayout.bound.meshQuant,
+        bound,
+        engine,
         decodePos,
         decodeUv,
         meshIdOf,
@@ -865,11 +872,8 @@ function typedVaryingVs(surface: AnySurface, clip = false, suffix = clip ? "Clip
     }
     // a `screen` copier projects nothing — `view` would resolve as an unused external (a warning plus a
     // dead group-0 declaration in the emitted module)
-    if (!screen) uses.view = engineLayout.bound.view;
-    if (clip) uses.tileRects = shadowLayout.bound.tileRects;
+    if (clip) uses.shadowG = shadowG;
     if (instanced) {
-        uses.eids = bound.eids;
-        uses.transforms = bound.transforms;
         uses.xformPoint = xformPoint;
         uses.xformNormal = xformNormal;
     }
@@ -878,8 +882,8 @@ function typedVaryingVs(surface: AnySurface, clip = false, suffix = clip ? "Clip
             [d.u32, d.u32],
             OutStruct,
         )(/* wgsl */ `(vidx: u32, iid: u32) -> Out {
-    let v = vertices[vidx];
-    let mq = meshQuant[meshIdOf(v.y)];
+    let v = bound.vertices[vidx];
+    let mq = engine.meshQuant[meshIdOf(v.y)];
     let localPos = decodePos(v.x, v.y, mq);
     let localNormal = octDecodeNormal(v.z);
     let uv = decodeUv(v.w, mq);
@@ -889,8 +893,8 @@ function typedVaryingVs(surface: AnySurface, clip = false, suffix = clip ? "Clip
     var worldNormal = vec3f(localNormal);
 ${
     instanced
-        ? `    eid = eids[iid];
-    xform = transforms[eid];
+        ? `    eid = bound.eids[iid];
+    xform = bound.transforms[eid];
     world = vec4f(xformPoint(xform, world.xyz), world.w);
     worldNormal = vec3f(xformNormal(xform, worldNormal));
 `
@@ -904,7 +908,7 @@ ${
         : ""
 }
     var out: Out;
-    out.pos = ${screen ? "patched.clip" : "view.viewProj * world"}${clip ? " + vec4f(tileRects.rects[0].x * 0.0)" : ""};
+    out.pos = ${screen ? "patched.clip" : "engine.view.viewProj * world"}${clip ? " + vec4f(shadowG.tileRects.rects[0].x * 0.0)" : ""};
     out.worldNormal = normalize(worldNormal);
     out.eid = eid;
     out.world = world.xyz;
@@ -1766,8 +1770,10 @@ function varyingShadowVs(
     const hasVs = !!surface.vs;
     const fragmentFields = fragmentInterstage(surface);
     const layout = surface.layout;
-    const bound = layout.bound as unknown as Record<string, unknown>;
-    const shadow = shadowGroup.bound as unknown as Record<string, unknown>;
+    // see typedVaryingVs's why: `layout.$.x` throws outside codegen mode (including inside `tgpu.lazy`),
+    // so the whole `$` proxy rides as one external and the WGSL text's own dot chain defers the field read.
+    const bound = layout.$;
+    const shadow = shadowGroup.$;
     const Out = d
         .struct({
             pos: d.vec4f,
@@ -1787,15 +1793,15 @@ function varyingShadowVs(
             [d.u32, d.u32],
             Out,
         )(/* wgsl */ `(vidx: u32, iid: u32) -> Out {
-    let v = vertices[vidx];
-    let mq = meshQuant[meshIdOf(v.y)];
+    let v = bound.vertices[vidx];
+    let mq = engine.meshQuant[meshIdOf(v.y)];
     let localPos = decodePos(v.x, v.y, mq);
     let localNormal = octDecodeNormal(v.z);
     let uv = decodeUv(v.w, mq);
-    let packed = eids[iid];
+    let packed = bound.eids[iid];
     let eid = packed & ${EID_MASK}u;
     let combo = packed >> ${COMBO_SHIFT}u;
-    let xform = transforms[eid];
+    let xform = bound.transforms[eid];
     var world = vec4f(xformPoint(xform, localPos), 1.0);
     var worldNormal = vec3f(xformNormal(xform, localNormal));
 ${
@@ -1806,10 +1812,10 @@ ${
 `
         : ""
 }
-    let m = comboMeta.m[combo];
-    let rect = tileRects.rects[${rect}];
+    let m = shadow.comboMeta.m[combo];
+    let rect = shadow.tileRects.rects[${rect}];
     var out: Out;
-    out.pos = faceVP.m[combo] * world;
+    out.pos = shadow.faceVP.m[combo] * world;
     out.tileBox = vec4f(${atlas}.0 * rect.xy, rect.z * ${atlas}.0, 0.0);
     out.worldNormal = normalize(worldNormal);
     out.eid = eid;
@@ -1820,13 +1826,9 @@ ${assigns}
 }`)
         .$uses({
             Out,
-            vertices: bound.vertices,
-            eids: bound.eids,
-            transforms: bound.transforms,
-            meshQuant: engineLayout.bound.meshQuant,
-            faceVP: shadow.faceVP,
-            comboMeta: shadow.comboMeta,
-            tileRects: shadow.tileRects,
+            bound,
+            engine: engineLayout.$,
+            shadow,
             decodePos,
             decodeUv,
             meshIdOf,

--- a/packages/shallot/src/standard/sear/pipelines.ts
+++ b/packages/shallot/src/standard/sear/pipelines.ts
@@ -870,8 +870,9 @@ function typedVaryingVs(surface: AnySurface, clip = false, suffix = clip ? "Clip
         uses.VsIn = VsIn;
         uses.vs = vsFn;
     }
-    // a `screen` copier projects nothing — `view` would resolve as an unused external (a warning plus a
-    // dead group-0 declaration in the emitted module)
+    // `engine` rides unconditionally even for a `screen` copier, which projects nothing: resolution is
+    // per dot-chain reference in the WGSL text, not per top-level external, so an unreferenced
+    // `engine.view` emits no group-0 declaration (pinned by pipelines.test.ts's `not.toContain("var<uniform> view: View;")`)
     if (clip) uses.shadowG = shadowG;
     if (instanced) {
         uses.xformPoint = xformPoint;


### PR DESCRIPTION
- **shallot-typegpu-012: bump to 0.12, burn down the eager .$ floor (S1)**
- **shallot-typegpu-012: retire the stale view-guard comment, state the per-dot-chain resolution invariant it now sits over**
