### PR TITLE
shallot-typegpu-012: S2 bump the four flows examples off the stale 0.11.6 unplugin-typegpu pin

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
         "@dylanebert/shallot": "workspace:*",
       },
       "devDependencies": {
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
       },
     },
     "examples/flows/no-walls": {
@@ -36,7 +36,7 @@
         "@dylanebert/shallot": "workspace:*",
       },
       "devDependencies": {
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
       },
     },
     "examples/flows/survive-reload": {
@@ -46,7 +46,7 @@
         "@dylanebert/shallot": "workspace:*",
       },
       "devDependencies": {
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
       },
     },
     "examples/flows/ui-containment": {
@@ -56,7 +56,7 @@
         "@dylanebert/shallot": "workspace:*",
       },
       "devDependencies": {
-        "unplugin-typegpu": "~0.11.6",
+        "unplugin-typegpu": "~0.12.1",
       },
     },
     "examples/gym": {
@@ -907,35 +907,11 @@
 
     "espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
-    "flow-blank/unplugin-typegpu": ["unplugin-typegpu@0.11.6", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.1", "tinyest-for-wgsl": "~0.3.2", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.11.9" } }, "sha512-vtSqYUDOzlGkrlOTEa7wkaaz8HQdV/A7tktebBbSSxobFjEZqgeRz/GYF1KJXPCreNJ7HwBA+iEdl3xBKHHLPg=="],
-
-    "flow-no-walls/unplugin-typegpu": ["unplugin-typegpu@0.11.6", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.1", "tinyest-for-wgsl": "~0.3.2", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.11.9" } }, "sha512-vtSqYUDOzlGkrlOTEa7wkaaz8HQdV/A7tktebBbSSxobFjEZqgeRz/GYF1KJXPCreNJ7HwBA+iEdl3xBKHHLPg=="],
-
-    "flow-survive-reload/unplugin-typegpu": ["unplugin-typegpu@0.11.6", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.1", "tinyest-for-wgsl": "~0.3.2", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.11.9" } }, "sha512-vtSqYUDOzlGkrlOTEa7wkaaz8HQdV/A7tktebBbSSxobFjEZqgeRz/GYF1KJXPCreNJ7HwBA+iEdl3xBKHHLPg=="],
-
-    "flow-ui-containment/unplugin-typegpu": ["unplugin-typegpu@0.11.6", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "ast-kit": "^2.2.0", "defu": "^6.1.4", "magic-string": "^0.30.21", "pathe": "^2.0.3", "picomatch": "^4.0.4", "tinyest": "~0.3.1", "tinyest-for-wgsl": "~0.3.2", "unplugin": "^3.0.0" }, "peerDependencies": { "typegpu": "^0.11.9" } }, "sha512-vtSqYUDOzlGkrlOTEa7wkaaz8HQdV/A7tktebBbSSxobFjEZqgeRz/GYF1KJXPCreNJ7HwBA+iEdl3xBKHHLPg=="],
-
     "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@nicolo-ribaudo/eslint-scope-5-internals/eslint-scope/estraverse": ["estraverse@4.3.0", "", {}, "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.9", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
-
-    "flow-blank/unplugin-typegpu/tinyest-for-wgsl": ["tinyest-for-wgsl@0.3.3", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-fo1oDSWVm901/2oZPZe6TsDjNPDhz/RArGSOLxon58NhkdxtD5GYovFj+gF1qrIDlxMpTxU/mPtYZNhFP2oJZw=="],
-
-    "flow-blank/unplugin-typegpu/typegpu": ["typegpu@0.11.9", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg=="],
-
-    "flow-no-walls/unplugin-typegpu/tinyest-for-wgsl": ["tinyest-for-wgsl@0.3.3", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-fo1oDSWVm901/2oZPZe6TsDjNPDhz/RArGSOLxon58NhkdxtD5GYovFj+gF1qrIDlxMpTxU/mPtYZNhFP2oJZw=="],
-
-    "flow-no-walls/unplugin-typegpu/typegpu": ["typegpu@0.11.9", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg=="],
-
-    "flow-survive-reload/unplugin-typegpu/tinyest-for-wgsl": ["tinyest-for-wgsl@0.3.3", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-fo1oDSWVm901/2oZPZe6TsDjNPDhz/RArGSOLxon58NhkdxtD5GYovFj+gF1qrIDlxMpTxU/mPtYZNhFP2oJZw=="],
-
-    "flow-survive-reload/unplugin-typegpu/typegpu": ["typegpu@0.11.9", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg=="],
-
-    "flow-ui-containment/unplugin-typegpu/tinyest-for-wgsl": ["tinyest-for-wgsl@0.3.3", "", { "dependencies": { "tinyest": "~0.3.1" } }, "sha512-fo1oDSWVm901/2oZPZe6TsDjNPDhz/RArGSOLxon58NhkdxtD5GYovFj+gF1qrIDlxMpTxU/mPtYZNhFP2oJZw=="],
-
-    "flow-ui-containment/unplugin-typegpu/typegpu": ["typegpu@0.11.9", "", { "dependencies": { "tinyest": "~0.3.2", "tsover-runtime": "^0.0.7", "typed-binary": "^4.3.3" }, "bin": { "typegpu": "./bin.mjs" } }, "sha512-AqBV6P9lW2jA7pEVDeiMD7Qoza9doPgueQbwyUyf09u4ndb9jOttHwpZ18c+BEzwLHaPlV50jw0hx5QsmVJGNg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
   }

--- a/examples/flows/blank/package.json
+++ b/examples/flows/blank/package.json
@@ -7,6 +7,6 @@
         "@dylanebert/shallot": "workspace:*"
     },
     "devDependencies": {
-        "unplugin-typegpu": "~0.11.6"
+        "unplugin-typegpu": "~0.12.1"
     }
 }

--- a/examples/flows/no-walls/package.json
+++ b/examples/flows/no-walls/package.json
@@ -7,6 +7,6 @@
         "@dylanebert/shallot": "workspace:*"
     },
     "devDependencies": {
-        "unplugin-typegpu": "~0.11.6"
+        "unplugin-typegpu": "~0.12.1"
     }
 }

--- a/examples/flows/survive-reload/package.json
+++ b/examples/flows/survive-reload/package.json
@@ -7,6 +7,6 @@
         "@dylanebert/shallot": "workspace:*"
     },
     "devDependencies": {
-        "unplugin-typegpu": "~0.11.6"
+        "unplugin-typegpu": "~0.12.1"
     }
 }

--- a/examples/flows/ui-containment/package.json
+++ b/examples/flows/ui-containment/package.json
@@ -7,6 +7,6 @@
         "@dylanebert/shallot": "workspace:*"
     },
     "devDependencies": {
-        "unplugin-typegpu": "~0.11.6"
+        "unplugin-typegpu": "~0.12.1"
     }
 }


### PR DESCRIPTION
Inherited from S1: examples/flows/{blank,no-walls,survive-reload,ui-containment}/package.json
still pinned unplugin-typegpu ~0.11.6, nesting a stale typegpu 0.11.9 under each — the version-
mixing false signal the spec names. bun run flows exercises these directly. Bumped all four to
~0.12.1 to match root, bun install re-resolved bun.lock with no stale nested 0.11.x remaining.
