### PR TITLE
release: 0.9.2, and a gate for the doc pin sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Newest first. **Breaking:** marks a change that needs consumer action; [`packages/shallot/MIGRATION.md`](packages/shallot/MIGRATION.md) is the 0.8→0.9 port. Versions follow [semver](https://semver.org).
 
+## 0.9.2 — 2026-08-14
+
+The TypeGPU 0.12 bump, and native builds that work from a standard npm install.
+
+**Breaking:** custom GPU consumers move to `typegpu@~0.12.0`, `unplugin-typegpu@~0.12.1`, and `eslint-plugin-typegpu@~0.12.0`. Shallot's own API is unchanged (no export moved, no signature changed), so the port is the install line unless your own code calls TypeGPU directly. TypeGPU's own 0.12 migration guide covers that case.
+
+- **gpu** — the TypeGPU peer moves to the 0.12 minor. 0.12 removes `layout.bound`, and the dereferenced `layout.$.x` throws outside an actual TGSL body, so a raw-WGSL surface that bound per-field externals through `$uses` now passes the whole `$` proxy as one external and lets the WGSL text's own dot chain defer the field read to resolution time. `standard/sear/pipelines.ts` and `extras/gltf/live.ts` carry the pattern.
+- **gpu** — `eslint-plugin-typegpu` 0.12 correctly stops flagging an unsigned shift confined to a ternary's folded-away CPU arm, so the ten `eslint-disable typegpu/no-unsupported-syntax` directives over the `utils/tgsl.ts` and `bvh/bounds.ts` dual-shape helpers are gone.
+- **cli** — `shallot build --target windows|mac|linux` works from a standard install. The `rust/window` host ships as crate source and compiles on first build, so the prerequisite is the Rust toolchain plus the target's system dependencies (the repo README has the per-target table), not a Shallot source checkout. A crate that isn't there reports a corrupt install rather than a raw `ENOENT` out of cargo.
+- **docs** — the npm README's install block omitted the required TypeGPU peer and the single `unplugin-typegpu` transform, an install that broke at pipeline warm. `verify`'s optional playwright peer is named in both READMEs, npm-relative links resolve against the package rather than the repo root, and `AGENTS.md` stops listing `audio` and `mirror` under `/extras`, which are bare-barrel only.
+
 ## 0.9.1 — 2026-08-12
 
 The packaging patch, and the recommended target for a 0.8→0.9 port. The two Node-consumed exports ship compiled, the duplicate-TypeGPU check catches a same-version double-load, and `Profile` grows the GPU byte and pipeline counters a budget gate can read.

--- a/bun.lock
+++ b/bun.lock
@@ -297,12 +297,12 @@
     },
     "packages/create-shallot": {
       "name": "create-shallot",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "bin": "./index.ts",
     },
     "packages/shallot": {
       "name": "@dylanebert/shallot",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "bin": {
         "shallot": "./bin/cli.ts",
       },

--- a/packages/create-shallot/package.json
+++ b/packages/create-shallot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-shallot",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "type": "module",
     "bin": "./index.ts",
     "files": ["index.ts"],

--- a/packages/shallot/AGENTS.md
+++ b/packages/shallot/AGENTS.md
@@ -12,7 +12,7 @@ bunx shallot run [dir]      # build + preview
 bunx shallot verify [dir]   # headless-browser gate, exit 0/nonzero (below)
 ```
 
-The check is `bunx tsc --noEmit` — run it after every change. Native builds (`bunx shallot build --target windows|mac|linux`, `--portable` for bundled Chromium) run only from a shallot source checkout — the rust crate they need isn't in the npm package. If you author TGSL, add `eslint-plugin-typegpu` too; the engine runs its recommended rules with zero warnings allowed.
+The check is `bunx tsc --noEmit` — run it after every change. Native builds (`bunx shallot build --target windows|mac|linux`, `--portable` for bundled Chromium) work from a standard install — the rust window host ships as crate source and compiles on first build, so they need the Rust toolchain plus the target's system dependencies. If you author TGSL, add `eslint-plugin-typegpu` too; the engine runs its recommended rules with zero warnings allowed.
 
 A project is pure data: `shallot.json` (the manifest: scene + plugin enablement) + `public/scenes/*.scene` + plugin modules under `src/`. No index.html, no vite config — the CLI supplies the scaffolding.
 

--- a/packages/shallot/MIGRATION.md
+++ b/packages/shallot/MIGRATION.md
@@ -1,16 +1,18 @@
-# Migrating from 0.8 to 0.9.1
+# Migrating from 0.8 to 0.9.2
 
 This port touches GPU code only: the ECS, scene, and ordinary component APIs keep their 0.8 shape. What moves is the GPU substrate. Layouts now come from TypeGPU schemas, custom shaders use TGSL, and render registries carry typed resources.
 
-Port to 0.9.1, not 0.9.0. The API is the same, and 0.9.1 carries the packaging and diagnostics fixes a port hits first: compiled tooling exports, and a duplicate-TypeGPU check that catches two copies of the same pinned minor. [`CHANGELOG.md`](https://github.com/dylanebert/shallot/blob/main/CHANGELOG.md) has the list.
+Port to 0.9.2, the newest patch. The 0.9 API is the same across all three, and the patches carry the fixes a port hits first: compiled tooling exports, a duplicate-TypeGPU check that catches two copies of the same pinned minor, and the TypeGPU 0.12 toolchain the install block below pins. [`CHANGELOG.md`](https://github.com/dylanebert/shallot/blob/main/CHANGELOG.md) has the list.
+
+Already on 0.9.0 or 0.9.1? You need none of this guide: only the TypeGPU toolchain bump in that install block, since 0.9.2 moved the peer to the 0.12 minor.
 
 ## Install the GPU toolchain
 
-Install the engine and its TypeGPU peer at the same time. Keep TypeGPU on the 0.11 minor used by Shallot; two copies in one bundle race over the same metadata map.
+Install the engine and its TypeGPU peer at the same time. Keep TypeGPU on the 0.12 minor used by Shallot; two copies in one bundle race over the same metadata map. The TypeGPU plugin versions move with the library, never independently.
 
 ```bash
-bun add @dylanebert/shallot@^0.9.1 typegpu@~0.11.9
-bun add -d unplugin-typegpu@~0.11.6 eslint@^9 eslint-plugin-typegpu@~0.11.1
+bun add @dylanebert/shallot@^0.9.2 typegpu@~0.12.0
+bun add -d unplugin-typegpu@~0.12.1 eslint@^9 eslint-plugin-typegpu@~0.12.0
 bun add -d @babel/core@^7.28.6 @babel/eslint-parser@^7.28.6 @babel/plugin-syntax-typescript@^7.28.5
 ```
 

--- a/packages/shallot/README.md
+++ b/packages/shallot/README.md
@@ -15,12 +15,12 @@ bun install
 bunx shallot dev    # run it, with hot reload
 ```
 
-`bunx shallot build` ships it as a web bundle. `bunx shallot verify` boots the project in a headless browser and exits 0 or nonzero; it needs the optional playwright peer (`bun add -d playwright && bunx playwright install chromium`). Native builds (`--target windows|mac|linux`) run from a shallot source checkout, not an installed package: the rust crate they need isn't published to npm.
+`bunx shallot build` ships it as a web bundle. `bunx shallot verify` boots the project in a headless browser and exits 0 or nonzero; it needs the optional playwright peer (`bun add -d playwright && bunx playwright install chromium`). Native builds (`--target windows|mac|linux`) work from a standard install: the rust window host ships as crate source and compiles on first build, so you need the Rust toolchain plus your target's system dependencies.
 
 ## add to an existing project
 
 ```bash
-bun add @dylanebert/shallot typegpu@~0.11.9
+bun add @dylanebert/shallot typegpu@~0.12.0
 bun add -d unplugin-typegpu
 ```
 

--- a/packages/shallot/package.json
+++ b/packages/shallot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dylanebert/shallot",
-    "version": "0.9.1",
+    "version": "0.9.2",
     "description": "WebGPU game engine. Procedural-first, ECS, declarative scenes. In development.",
     "sideEffects": [
         "./src/standard/index.ts",

--- a/packages/shallot/rust/audio/Cargo.toml
+++ b/packages/shallot/rust/audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shallot-audio"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [lib]

--- a/packages/shallot/rust/window/Cargo.toml
+++ b/packages/shallot/rust/window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shallot-window"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 
 [[bin]]

--- a/scripts/check-docs.ts
+++ b/scripts/check-docs.ts
@@ -64,4 +64,78 @@ if (violations.length > 0) {
     process.exit(1);
 }
 
-console.log(`✓ doc commands clean (${TARGETS.length + ruleFiles.length} file(s))`);
+// The docs are a pin site too. `testing.md`'s atomic-multi-pin rule enumerates the six *manifest*
+// sites, and a bump that hits all six still leaves the install block a reader actually runs pinned to
+// the old minor — which is what shipped: 0.9.2's tree carried a `~0.12.0` peer while README.md and
+// MIGRATION.md both still said `typegpu@~0.11.9`, a documented install that resolves to a peer
+// conflict or a duplicate TypeGPU identity that dies at pipeline warm.
+//
+// Scope is a fenced `bun add` line: a command the reader runs, never prose. That distinction is
+// load-bearing — CHANGELOG.md's 0.9.0 entry names `typegpu@~0.11.9` as a historical fact about what
+// that release shipped with, and a blanket version sweep would be wrong to move it (same law as
+// MIGRATION.md's dated prose, `check-versions.ts`).
+const PIN_SOURCES: Record<string, { manifest: string; field: string }> = {
+    typegpu: { manifest: "packages/shallot/package.json", field: "peerDependencies" },
+    "unplugin-typegpu": { manifest: "packages/shallot/package.json", field: "dependencies" },
+    "eslint-plugin-typegpu": { manifest: "package.json", field: "devDependencies" },
+};
+
+const declared: Record<string, string> = {};
+for (const [name, { manifest, field }] of Object.entries(PIN_SOURCES)) {
+    const json = await Bun.file(resolve(root, manifest)).json();
+    const range = json[field]?.[name];
+    if (typeof range !== "string") {
+        console.error(
+            `✗ ${manifest} declares no ${field}.${name} — update check-docs.ts's PIN_SOURCES.`,
+        );
+        process.exit(1);
+    }
+    declared[name] = range;
+}
+
+// `name@range`, where name is one of the tracked packages. A bare `unplugin-typegpu` with no `@` is
+// unpinned prose-in-a-command and has nothing to disagree with, so it doesn't match.
+const PIN_RE = new RegExp(`\\b(${Object.keys(declared).join("|")})@(\\S+)`, "g");
+
+type PinDrift = { file: string; line: number; name: string; found: string; want: string };
+const drift: PinDrift[] = [];
+let scanned = 0;
+
+const docGlob = new Glob("**/*.md");
+for await (const match of docGlob.scan({ cwd: root })) {
+    if (match.startsWith("node_modules/") || match.includes("/node_modules/")) continue;
+    scanned++;
+    const lines = (await Bun.file(resolve(root, match)).text()).split("\n");
+    let inFence = false;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (line.trim().startsWith("```")) {
+            inFence = !inFence;
+            continue;
+        }
+        if (!inFence || !line.trim().startsWith("bun add")) continue;
+        for (const [, name, found] of line.matchAll(PIN_RE)) {
+            if (found !== declared[name]) {
+                drift.push({ file: match, line: i + 1, name, found, want: declared[name] });
+            }
+        }
+    }
+}
+
+if (drift.length > 0) {
+    console.error(`✗ ${drift.length} documented install pin(s) disagree with the manifests:\n`);
+    for (const d of drift) {
+        console.error(`  ${d.file}:${d.line}`);
+        console.error(`    ${d.name}@${d.found} — the manifest declares ${d.want}`);
+    }
+    console.error(
+        "\nA documented install a reader runs must resolve against the shipped manifests. " +
+            "Bump the doc install blocks with the manifest pins, in the same commit.",
+    );
+    process.exit(1);
+}
+
+console.log(
+    `✓ doc commands clean (${TARGETS.length + ruleFiles.length} file(s)), ` +
+        `install pins match the manifests (${scanned} doc(s))`,
+);


### PR DESCRIPTION
Bump every version site to 0.9.2 (both manifests, rust/{audio,window}/Cargo.toml,
both bun.lock workspace entries), write the changelog entry, retarget MIGRATION.md.

Two doc bugs live on main, both shipped by units that updated the code and missed
the prose:

- README.md and MIGRATION.md still documented `typegpu@~0.11.9` /
  `unplugin-typegpu@~0.11.6` / `eslint-plugin-typegpu@~0.11.1` against a tree whose
  peer is `~0.12.0`. Both files ship in the tarball, so that install would have gone
  out with the release: a peer conflict, or a duplicate TypeGPU identity that dies at
  pipeline warm.
- README.md and packages/shallot/AGENTS.md both still said native builds run only
  from a source checkout because the rust crate isn't published. shallot-native-from-npm
  (#30-#32) shipped the opposite; cli.ts's usage text was updated, these two weren't.
  CHANGELOG.md's 0.9.1 entry keeps the old claim, which is a historical fact about
  what 0.9.1 shipped.

check-docs.ts grows an arm for the first class: the three tracked pins are read from
the manifests that declare them and compared against every fenced `bun add` line in
the repo's docs. Scope is a command a reader runs, never prose, so CHANGELOG.md's
dated `typegpu@~0.11.9` is correctly left alone (same law as check-versions.ts's
MIGRATION handling). Red-proven by reverting all four pins: 4 findings across the two
files, exit 1.

Gates: bun check exit 0. GLTF_CORPUS_REQUIRED=1 bun test 2656 pass / 0 fail across
157 files, matching the recorded 0.11 baseline. check-versions.ts --release exit 0
(v0.9.2 not yet tagged). concision.ts passes on CHANGELOG, MIGRATION, README;
AGENTS.md's five over-cap paragraphs are pre-existing, none on the edited line.
