### PR TITLE
clear the 0.12 warnings the suite emits, and a red gym gate the bump left behind

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -169,10 +169,11 @@ The suffix is the tier — bun only auto-discovers `.test.`/`.spec.`, so a diffe
 
 ## A fresh checkout's `bun test` count isn't a floor yet
 
-Three fixture trees live outside the commit, so a fresh clone or worktree silently runs a smaller suite than an established one. Measured 2026-08-10: 1826 pass / 33 fail where the populated tree read 2632 / 0. Place all three before quoting a count as the floor a later run is compared against.
+Four fixture trees live outside the commit, so a fresh clone or worktree silently runs a smaller suite than an established one. Measured 2026-08-10: 1826 pass / 33 fail where the populated tree read 2632 / 0. Place all four before quoting a count as the floor a later run is compared against. A worktree also needs its own `bun install` inside `shallot/` — without one every test file dies at import and the suite reads 0 pass / 157 fail, which is a provisioning failure wearing a red suite's clothes.
 
 - `packages/shallot/rust/audio/pkg/` — the gitignored wasm build artifact. Absent, five registry/standards tests fail on an unresolvable import, which reads as real red rather than a missing fixture. Build it, or copy it from a populated tree.
 - `packages/shallot/tests/fixtures/avbd/` — gitignored, ~161 MB. Copy it in.
+- `examples/gym/public/sponza`, a committed symlink to `reference/sponza-optimized` in the containing workspace. Not a submodule and not fetchable: copy the directory in. Absent, the `render` scenario's four import rows and the whole `gltf` scenario have no asset, and `bun bench` fails on a device rather than skipping. It is the quietest of the four, because nothing in `bun test` reads it.
 - The glTF corpus, a submodule at `reference/gltf-sample-assets` in the containing workspace, outside the package (`git submodule update --init reference/gltf-sample-assets`). Its absence is the dangerous one: 292 conformance tests degrade to an announced skip that no fail count shows. Run the required arm, `GLTF_CORPUS_REQUIRED=1 bun test`, so an absent corpus is red instead of quiet. In a worktree the init is near-instant — the superproject worktree shares `.git/modules`, so the objects are already local.
 
 ## Bumping a dep many packages pin, bump it everywhere at once

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,8 @@
             "examples/**/*.ts",
             "evals/**/*.ts",
             "research/**/*.ts",
-            "scripts/**/*.ts"
+            "scripts/**/*.ts",
+            "!examples/*/public"
         ]
     },
     "linter": {

--- a/examples/gym/src/scenarios/sat.test.ts
+++ b/examples/gym/src/scenarios/sat.test.ts
@@ -150,7 +150,7 @@ describe("SAT production kernel resolution reference", () => {
                 "if ((roundedA && roundedB)) { " +
                 "r = collideRounded(c.posA.xyz, c.quatA, c.sizeRadA.xyz, c.sizeRadA.w, " +
                 "c.posB.xyz, c.quatB, c.sizeRadB.xyz, c.sizeRadB.w, c.dRel.xyz); } else { " +
-                "if (!(roundedA || roundedB)) { if (((sA == 0u) && (sB == 0u))) { " +
+                "if (!((roundedA || roundedB))) { if (((sA == 0u) && (sB == 0u))) { " +
                 "r = boxSat(c.posA.xyz, c.quatA, c.sizeRadA.xyz, c.posB.xyz, c.quatB, " +
                 "c.sizeRadB.xyz, c.dRel.xyz); } else { " +
                 "r = collideHull(polyMake(sA, c.posA.xyz, c.quatA, c.sizeRadA.xyz, hA), " +

--- a/packages/shallot/src/engine/utils/encode.ts
+++ b/packages/shallot/src/engine/utils/encode.ts
@@ -163,9 +163,9 @@ export const meshIdOf = tgpu.fn(
     d.u32,
 )((w1) => {
     "use gpu";
-    // masked, not a bare shift: WGSL's `>>` on u32 is logical and JS's is arithmetic, so the two arms
-    // would disagree on a word with bit 31 set (`>>>` has no TGSL binding). The field is 16 bits wide.
-    return (w1 >> 16) & 0xffff;
+    // `>>>`, not `>>`: JS's `>>` is arithmetic and WGSL's on u32 is logical, so the two arms would
+    // disagree on a word with bit 31 set. Both emit WGSL `>>`. The mask states the field's width.
+    return (w1 >>> 16) & 0xffff;
 });
 
 /** decode a quantized vertex position: `w0` = unorm16 pos.xy, `w1` = unorm16 pos.z | (meshId << 16),
@@ -392,8 +392,8 @@ export const unpackHdrColor = tgpu.fn(
 )((p) => {
     "use gpu";
     const r11 = p & 0x7ff;
-    const g11 = (p >> 11) & 0x7ff;
-    const b10 = (p >> 22) & 0x3ff;
+    const g11 = (p >>> 11) & 0x7ff;
+    const b10 = (p >>> 22) & 0x3ff;
     const rgv = unpack2x16float((r11 << 4) | (g11 << 20));
     const bbv = unpack2x16float(b10 << 5);
     return d.vec3f(rgv.x, rgv.y, bbv.x);
@@ -409,7 +409,7 @@ export const packHdrColor = tgpu.fn(
     const c = d.vec3f(clamp(rgb.x, 0, 65024), clamp(rgb.y, 0, 65024), clamp(rgb.z, 0, 65024));
     const rg = pack2x16float(d.vec2f(c.x, c.y));
     const bb = pack2x16float(d.vec2f(c.z, 0));
-    return ((rg >> 4) & 0x7ff) | (((rg >> 20) & 0x7ff) << 11) | (((bb >> 5) & 0x3ff) << 22);
+    return ((rg >>> 4) & 0x7ff) | (((rg >>> 20) & 0x7ff) << 11) | (((bb >>> 5) & 0x3ff) << 22);
 });
 
 /** WGSL `unpackHdrColor(p: u32) -> vec3<f32>`: the HDR color read side (gpu.md rule 6 — `rgb9e5ufloat`

--- a/packages/shallot/src/extras/sprite/surface.ts
+++ b/packages/shallot/src/extras/sprite/surface.ts
@@ -78,7 +78,7 @@ const spriteFillMask = tgpu
         d.f32,
     )((fill, uv) => {
         "use gpu";
-        const mode = fill >> 16;
+        const mode = fill >>> 16;
         if (mode === 0) return d.f32(1);
         const amount = d.f32(fill & 0xffff) / 65535;
         let t = uv.x;

--- a/packages/shallot/src/standard/bvh/bounds.ts
+++ b/packages/shallot/src/standard/bvh/bounds.ts
@@ -70,9 +70,11 @@ export const orderU32 = tgpu.fn(
     "use gpu";
     const u = bitcastF32toU32(f);
     // both arms carry the same formula; JS bitwise ops are signed 32-bit, so the CPU arm needs the
-    // `>>> 0` the transpiler rejects (the `tgsl.ts` dual shape — the ternary folds at shader-gen)
+    // trailing `>>> 0` to land back in u32 range (the `tgsl.ts` dual shape — the ternary folds at
+    // shader-gen). The shifts are `>>>` in both arms: JS `>>` on a u32 is arithmetic and disagrees
+    // with the WGSL `>>` both forms emit.
     return std.isBeingTranspiled()
-        ? std.select(~u, u | 0x80000000, u >> 31 === 0)
+        ? std.select(~u, u | 0x80000000, u >>> 31 === 0)
         : u >>> 31 === 0
           ? (u | 0x80000000) >>> 0
           : ~u >>> 0;
@@ -91,7 +93,7 @@ export const unorderU32 = tgpu.fn(
     "use gpu";
     return std.bitcastU32toF32(
         std.isBeingTranspiled()
-            ? std.select(~o, o ^ 0x80000000, o >> 31 === 1)
+            ? std.select(~o, o ^ 0x80000000, o >>> 31 === 1)
             : o >>> 31 === 1
               ? (o ^ 0x80000000) >>> 0
               : ~o >>> 0,
@@ -215,7 +217,7 @@ const ldsReduce = tgpu
                 ldsMax.$[tid] = std.max(ldsMax.$[tid], ldsMax.$[tid + s]);
             }
             std.workgroupBarrier();
-            s = s >> 1;
+            s = s >>> 1;
         }
         if (tid === 0) publish(Extremes({ mn: ldsMin.$[0], mx: ldsMax.$[0] }));
     })

--- a/packages/shallot/src/standard/bvh/sort-lds.ts
+++ b/packages/shallot/src/standard/bvh/sort-lds.ts
@@ -103,7 +103,7 @@ const histKernel = tgpu
             const gid = base + r * THREADS + lane;
             if (gid < count) {
                 std.atomicAdd(
-                    hist.$[(histLayout.$.keys[gid] >> histLayout.$.params.shift) & DIGIT_MASK],
+                    hist.$[(histLayout.$.keys[gid] >>> histLayout.$.params.shift) & DIGIT_MASK],
                     1,
                 );
             }
@@ -143,7 +143,7 @@ const scanKernel = tgpu
                 temp.$[bi] = temp.$[bi] + temp.$[ai];
             }
             offset = offset * 2;
-            up = up >> 1;
+            up = up >>> 1;
         }
         if (lane === 0) {
             scanLayout.$.chunkSums[input.wid.x] = temp.$[SCAN_ITEMS - 1];
@@ -151,7 +151,7 @@ const scanKernel = tgpu
         }
         let down = d.u32(1);
         while (down < SCAN_ITEMS) {
-            offset = offset >> 1;
+            offset = offset >>> 1;
             std.workgroupBarrier();
             if (lane < down) {
                 const ai = offset * (e0 + 1) - 1;
@@ -198,7 +198,7 @@ const reorderKernel = tgpu
         "use gpu";
         const lane = input.tid;
         const base = input.wid.x * EPW;
-        const word = lane >> 5;
+        const word = lane >>> 5;
         const bit = lane & 31;
         if (lane < RADIX) offsets.$[lane] = 0;
         if (lane < RADIX * MASK_WORDS) std.atomicStore(masks.$[lane], 0);
@@ -213,7 +213,7 @@ const reorderKernel = tgpu
             // an invalid lane parks on the out-of-range digit RADIX, so it flags no real digit's mask
             const digit = std.select(
                 d.u32(RADIX),
-                (k >> reorderLayout.$.params.shift) & DIGIT_MASK,
+                (k >>> reorderLayout.$.params.shift) & DIGIT_MASK,
                 valid,
             );
             const v = std.select(d.u32(0), reorderLayout.$.inVals[gid], valid);

--- a/packages/shallot/src/standard/bvh/sort.ts
+++ b/packages/shallot/src/standard/bvh/sort.ts
@@ -201,9 +201,9 @@ const globalHistKernel = tgpu
         while (j < tileEnd) {
             const k = histLayout.$.keys[j];
             std.atomicAdd(gHist.$[subOff + (k & RADIX_MASK)], 1);
-            std.atomicAdd(gHist.$[subOff + RADIX + ((k >> 8) & RADIX_MASK)], 1);
-            std.atomicAdd(gHist.$[subOff + 2 * RADIX + ((k >> 16) & RADIX_MASK)], 1);
-            std.atomicAdd(gHist.$[subOff + 3 * RADIX + ((k >> 24) & RADIX_MASK)], 1);
+            std.atomicAdd(gHist.$[subOff + RADIX + ((k >>> 8) & RADIX_MASK)], 1);
+            std.atomicAdd(gHist.$[subOff + 2 * RADIX + ((k >>> 16) & RADIX_MASK)], 1);
+            std.atomicAdd(gHist.$[subOff + 3 * RADIX + ((k >>> 24) & RADIX_MASK)], 1);
             j = j + G_HIST_DIM;
         }
         std.workgroupBarrier();
@@ -337,7 +337,7 @@ const binningKernel = tgpu
         uniformityOptOut();
         const shift = paramLayout.$.P.shift;
         const binBlocks = paramLayout.$.P.binBlocks;
-        const passIdx = shift >> 3;
+        const passIdx = shift >>> 3;
         const waveIndex = idiv(input.tid, input.sgsize);
         const waveHists = idiv(WG, input.sgsize) * RADIX;
 
@@ -370,7 +370,7 @@ const binningKernel = tgpu
             const flags = Ballot([0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff]);
             let b = d.u32(0);
             while (b < 8) {
-                const bit = (key >> (b + shift)) & 1;
+                const bit = (key >>> (b + shift)) & 1;
                 const ballot = std.subgroupBallot(bit === 1);
                 const bArr = Ballot([ballot.x, ballot.y, ballot.z, ballot.w]);
                 const m = std.select(d.u32(0xffffffff), d.u32(0), bit === 1);
@@ -381,7 +381,7 @@ const binningKernel = tgpu
                 }
                 b = b + 1;
             }
-            const digit = (key >> shift) & RADIX_MASK;
+            const digit = (key >>> shift) & RADIX_MASK;
             const idx = digit + waveIndex * RADIX;
             let lowest = d.u32(0);
             let scan = d.u32(0);
@@ -457,7 +457,7 @@ const binningKernel = tgpu
         // 5. block-local position = wave-local rank + cross-wave base + block-local digit base
         let s5 = d.u32(0);
         while (s5 < KEYS_PER_THREAD) {
-            const digit = (k[s5] >> shift) & RADIX_MASK;
+            const digit = (k[s5] >>> shift) & RADIX_MASK;
             if (input.tid >= input.sgsize)
                 offsets[s5] =
                     offsets[s5] +
@@ -523,7 +523,7 @@ const binningKernel = tgpu
                 let f = input.tid;
                 while (f < PART_SIZE) {
                     std.atomicAdd(
-                        gD.$[RADIX + ((binLayout.$.srcKeys[fbBase + f] >> shift) & RADIX_MASK)],
+                        gD.$[RADIX + ((binLayout.$.srcKeys[fbBase + f] >>> shift) & RADIX_MASK)],
                         1,
                     );
                     f = f + WG;
@@ -540,13 +540,13 @@ const binningKernel = tgpu
                         FLAG_REDUCTION | (recomputed << 2),
                     );
                     if ((old & FLAG_MASK) === FLAG_INCLUSIVE) {
-                        lookbackReduction = lookbackReduction + (old >> 2);
+                        lookbackReduction = lookbackReduction + (old >>> 2);
                         lookbackComplete = true;
                     } else {
                         lookbackReduction = lookbackReduction + recomputed;
                     }
                 } else {
-                    lookbackReduction = lookbackReduction + (flagPayload >> 2);
+                    lookbackReduction = lookbackReduction + (flagPayload >>> 2);
                     if ((flagPayload & FLAG_MASK) === FLAG_INCLUSIVE) lookbackComplete = true;
                 }
                 spinCount = 0;
@@ -583,7 +583,7 @@ const binningKernel = tgpu
         while (s9 < KEYS_PER_THREAD) {
             const t = input.tid + s9 * WG;
             const key = std.atomicLoad(gD.$[t]);
-            const dg = (key >> shift) & RADIX_MASK;
+            const dg = (key >>> shift) & RADIX_MASK;
             digits[s9] = dg;
             binLayout.$.dstKeys[std.atomicLoad(gD.$[dg + PART_SIZE]) + t] = key;
             s9 = s9 + 1;

--- a/packages/shallot/src/standard/bvh/traverse.ts
+++ b/packages/shallot/src/standard/bvh/traverse.ts
@@ -193,14 +193,14 @@ const bvhTrailGet = tgpu
         d.u32,
     )((level) => {
         "use gpu";
-        return (bvhTrail.$[level >> 4] >> ((level & 15) * 2)) & 3;
+        return (bvhTrail.$[level >>> 4] >>> ((level & 15) * 2)) & 3;
     })
     .$name("bvhTrailGet");
 
 const bvhTrailSet = tgpu
     .fn([d.u32, d.u32])((level, v) => {
         "use gpu";
-        const w = level >> 4;
+        const w = level >>> 4;
         const s = (level & 15) * 2;
         // d.u32 on the mask literals is load-bearing: a bare `3`/`1` materializes i32, so at level 15
         // (s = 30) `3 << s` overflows signed and the `&` becomes a mixed-sign implicit conversion
@@ -212,7 +212,7 @@ const bvhTrailSet = tgpu
 const bvhTrailResetBelow = tgpu
     .fn([d.u32])((pl) => {
         "use gpu";
-        const w0 = pl >> 4;
+        const w0 = pl >>> 4;
         const sub = pl & 15;
         if (sub !== 15) bvhTrail.$[w0] = bvhTrail.$[w0] & ((d.u32(1) << ((sub + 1) * 2)) - 1);
         let w = w0 + 1;

--- a/packages/shallot/src/standard/render/cluster.ts
+++ b/packages/shallot/src/standard/render/cluster.ts
@@ -475,8 +475,8 @@ function compactKernel(
             const intensity = compactLayout.$.intensityF[eid];
             const rgb = std.mul(
                 d.vec3f(
-                    srgbToLinear1(d.f32((hex >> 16) & 0xff) / 255),
-                    srgbToLinear1(d.f32((hex >> 8) & 0xff) / 255),
+                    srgbToLinear1(d.f32((hex >>> 16) & 0xff) / 255),
+                    srgbToLinear1(d.f32((hex >>> 8) & 0xff) / 255),
                     srgbToLinear1(d.f32(hex & 0xff) / 255),
                 ),
                 intensity,

--- a/packages/shallot/src/standard/sear/pipelines.ts
+++ b/packages/shallot/src/standard/sear/pipelines.ts
@@ -1560,7 +1560,7 @@ function typedShadowVs(
             const uv = d.vec2f(0, 0);
             const packed = bound.eids[input.iid];
             const eid = packed & EID_MASK;
-            const combo = packed >> COMBO_SHIFT;
+            const combo = packed >>> COMBO_SHIFT;
             const xform = Xform(bound.transforms[eid]);
             let world = d.vec4f(xformPoint(xform, localPos), 1);
             let worldNormal = d.vec3f(xformNormal(xform, localNormal));
@@ -1632,7 +1632,7 @@ function typedClipShadowVertex(
             const uv = decodeUv(v.w, mq);
             const packed = bound.eids[iid];
             const eid = packed & EID_MASK;
-            const combo = packed >> COMBO_SHIFT;
+            const combo = packed >>> COMBO_SHIFT;
             const xform = Xform(bound.transforms[eid]);
             let world = d.vec4f(xformPoint(xform, localPos), 1);
             let worldNormal = d.vec3f(xformNormal(xform, localNormal));


### PR DESCRIPTION
716 TGSL deprecation warnings, one dangling-symlink warning, and one failing
by-path gate. All three predate this commit and all three come from the 0.11 → 0.12
TypeGPU move.

Shifts. 0.12 deprecates `>>` on a u32 TGSL operand in favour of `>>>`: JS's `>>` is
arithmetic, WGSL's on u32 is logical, so the CPU twin and the shader disagree on any
word with bit 31 set. 31 distinct sites across encode, bvh/{sort,sort-lds,traverse,
bounds}, sear/pipelines, sprite/surface and render/cluster move to `>>>`.

Both forms emit WGSL `>>`, so this changes no shader. Measured, not assumed: a
throwaway `tgpu.resolve` of three touched fns is byte-identical before and after, and
the WGSL-text assertions in bounds/traverse/sort/pipelines tests all still pass on
their exact expected strings.

Deliberately not swept: i32 operands (build.ts's `lMax >> 1` — arithmetic is correct
there and 0.12 doesn't warn), raw WGSL strings (encode.ts's quat chunk, skin/live.ts),
tgsl.ts's sign-extending CPU arm, and plain CPU helpers (color.ts, outline/passes.ts).
Two comments claiming `>>>` has no TGSL binding were true under 0.11 and are rewritten.

Biome. `examples/gym/public/sponza` is a committed symlink to an asset tree that isn't
fetchable, so every `bun check` on a tree without it printed a dereferenced-symlink
warning. Biome's includes never matched anything under those dirs anyway (718 files
checked before and after) — it was traversal, not coverage. testing.md gains sponza as
the fourth outside-the-commit fixture tree.

Gym. examples/gym/src/scenarios/sat.test.ts asserted a satHull body containing
`if (!(roundedA || roundedB))`; 0.12 emits `if (!((roundedA || roundedB)))`. Confirmed
by full-string diff that the doubled paren is the *only* delta (1610 vs 1612 chars),
so this is a codegen formatting change, not a semantic one. The gate read green on
main only because that checkout's node_modules still had typegpu 0.11.9 installed —
the stale-tree hazard testing.md's own atomic-multi-pin rule warns about, landing on
the rule's author.

Gates: bun check exit 0, biome 0 warnings (was 1). GLTF_CORPUS_REQUIRED=1 bun test
2656 pass / 0 fail with 0 deprecation markers (was 716). bun test ./examples/gym/src
127 pass / 0 fail. AVBD oracle 218 pass / 0 fail. bun bench --sweep --for the changed
GPU paths: accel, mesh-fixture, render all pass on real hardware.
