### PR TITLE
biome 2.5.8, and the two unsafe optional chains its new rule found

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://biomejs.dev/schemas/2.0.x/schema.json",
+    "$schema": "https://biomejs.dev/schemas/2.5.8/schema.json",
     "files": {
         "includes": [
             "packages/**/*.ts",
@@ -13,7 +13,7 @@
     "linter": {
         "enabled": true,
         "rules": {
-            "recommended": true,
+            "preset": "recommended",
             "correctness": {
                 "noUnusedImports": "error",
                 "noUnusedVariables": "error",

--- a/bun.lock
+++ b/bun.lock
@@ -8,7 +8,7 @@
         "@babel/core": "^7.28.6",
         "@babel/eslint-parser": "^7.28.6",
         "@babel/plugin-syntax-typescript": "^7.28.5",
-        "@biomejs/biome": "^2.4.6",
+        "@biomejs/biome": "^2.5.8",
         "@playwright/test": "^1.58.2",
         "@types/pngjs": "^6.0.5",
         "eslint": "^9.0.0",
@@ -371,23 +371,23 @@
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.16", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.16", "@biomejs/cli-darwin-x64": "2.4.16", "@biomejs/cli-linux-arm64": "2.4.16", "@biomejs/cli-linux-arm64-musl": "2.4.16", "@biomejs/cli-linux-x64": "2.4.16", "@biomejs/cli-linux-x64-musl": "2.4.16", "@biomejs/cli-win32-arm64": "2.4.16", "@biomejs/cli-win32-x64": "2.4.16" }, "bin": { "biome": "bin/biome" } }, "sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.8", "@biomejs/cli-darwin-x64": "2.5.8", "@biomejs/cli-linux-arm64": "2.5.8", "@biomejs/cli-linux-arm64-musl": "2.5.8", "@biomejs/cli-linux-x64": "2.5.8", "@biomejs/cli-linux-x64-musl": "2.5.8", "@biomejs/cli-win32-arm64": "2.5.8", "@biomejs/cli-win32-x64": "2.5.8" }, "bin": { "biome": "bin/biome" } }, "sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.16", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mk1QON9PHllvvLN5gU3f4rMxeh4syK5p9OvKyWH6/W8ueh04uaC8TUXXByhGufWf/y5mQc03ZLM45zU+cmqMjA=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.16", "", { "os": "darwin", "cpu": "x64" }, "sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-bsGwFMBNyHPyiLSsQcZJxdoRrg1V4JL+d7wEsvUBczlP9U9lwM+7mzQHxI4o1mhBsTmdOBbAb6fHU3Z3snN45w=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-XmFiA0WPYFC+uiUDC8WRFzAIH9bo7vwQLav38Uoq4ETC+T/+uBi0TsYGJECkugY3r8USl3jc+Ae2/irAF6F2lQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.16", "", { "os": "linux", "cpu": "arm64" }, "sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-VcJNbstduTHx83NGAdhp78/JOcP45BZHXL7yNsfI1uGzdUgegAz2s+mSoT7wK6PBNzLoqG0zDOXaz/RQYVtSiw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.8", "", { "os": "linux", "cpu": "x64" }, "sha512-S5wcm9OBDvLHodD4PUaN488hCpco9QD/9ZxuYJiw4euWtr/oQvLR72z2ixItH8Wd5BCm6FZaeb+YNvOoM1xHtQ=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.16", "", { "os": "linux", "cpu": "x64" }, "sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.8", "", { "os": "linux", "cpu": "x64" }, "sha512-kKmiyokeISRGq2FLwvr+TzsgBusfxaZ0FZNLcOYOpCK/78tRrEjeEBLvq3xLZMpqbANgJdRPI7vZX8ZL37u9/w=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.16", "", { "os": "win32", "cpu": "arm64" }, "sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-nILH0mzm3Hi3iEdd7o7GpB8kBR/mSQwfQG/tyBqyNrY2GFtcgwfV9nV8xLmbtUpMNY/Oi0Ml1XgfR4flOdq+AA=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.16", "", { "os": "win32", "cpu": "x64" }, "sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.8", "", { "os": "win32", "cpu": "x64" }, "sha512-I2czzXTY61f3nFJxXoMDq80t7MivxDEnCjE+8sDKoFfcKMaoQdkqhIFQ3KyY0XLzeSpUBYeNAXgD+iOV/BU0VA=="],
 
     "@dylanebert/shallot": ["@dylanebert/shallot@workspace:packages/shallot"],
 

--- a/examples/gym/src/scenarios/render.ts
+++ b/examples/gym/src/scenarios/render.ts
@@ -3129,12 +3129,10 @@ function buildSky(state: State): void {
     state.add(cam, Sear);
     state.add(cam, Orbit);
     state.add(cam, Backdrop);
-    const backdrop = (
-        SearPlugin.traits?.Backdrop as {
-            parse: { name: (value: string) => number | undefined };
-        }
-    ).parse.name("sky");
-    Backdrop.name.set(cam, backdrop ?? 0);
+    const backdropTrait = SearPlugin.traits?.Backdrop as
+        | { parse: { name: (value: string) => number | undefined } }
+        | undefined;
+    Backdrop.name.set(cam, backdropTrait?.parse.name("sky") ?? 0);
     Camera.mode.set(cam, CameraMode.Perspective);
     Camera.fov.set(cam, 60);
     Camera.clearColor.set(cam, 0x000000); // black clear → an unpainted background pixel reads ~0 and fails

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@babel/core": "^7.28.6",
         "@babel/eslint-parser": "^7.28.6",
         "@babel/plugin-syntax-typescript": "^7.28.5",
-        "@biomejs/biome": "^2.4.6",
+        "@biomejs/biome": "^2.5.8",
         "@playwright/test": "^1.58.2",
         "@types/pngjs": "^6.0.5",
         "eslint": "^9.0.0",

--- a/packages/shallot/bin/toolchain.test.ts
+++ b/packages/shallot/bin/toolchain.test.ts
@@ -164,10 +164,11 @@ describe("loadProjectConfig", () => {
             ].join("\n"),
         );
         const config = await loadProjectConfig(dir, "serve", "development");
-        expect(config?.plugins.map((x) => x.name)).toEqual(["svelte"]);
+        if (!config) throw new Error("no config loaded for the vite.config.mjs written above");
+        expect(config.plugins.map((x) => x.name)).toEqual(["svelte"]);
         // vite's `define` carries the raw injected-source string verbatim (a string constant needs its
         // own literal quotes, since the value is textually substituted, not evaluated)
-        expect((config?.overlay as { define?: unknown }).define).toEqual({ FOO: '"bar"' });
-        expect(config?.path).toBe(join(dir, "vite.config.mjs"));
+        expect((config.overlay as { define?: unknown }).define).toEqual({ FOO: '"bar"' });
+        expect(config.path).toBe(join(dir, "vite.config.mjs"));
     });
 });


### PR DESCRIPTION
`recommended: true` is deprecated in favour of `preset: "recommended"`; the pin moves
^2.4.6 → ^2.5.8 so the resolution stops drifting between checkouts (this repo resolved
2.4.16 while orrstead on the same range resolved 2.5.7, which is how the deprecation
went unnoticed here).

`biome migrate` rewrites the whole config with tabs, discarding this repo's 4-space
style, and biome's own `files.includes` is `*.ts` only so nothing formats it back. The
two semantic lines are applied by hand instead; the migrate output is otherwise identical.

2.5.8's noUnsafeOptionalChaining then found two real defects, both the same shape — an
optional chain immediately defeated by a non-optional access, so an absent value throws
a TypeError rather than short-circuiting:

- examples/gym/src/scenarios/render.ts: `(SearPlugin.traits?.Backdrop as {...}).parse
  .name("sky")`. The optionality now flows into the `?? 0` that was already there, which
  is what the call site meant.
- packages/shallot/bin/toolchain.test.ts: `(config?.overlay as {...}).define`. The test's
  premise is that a config loaded, so it now asserts that once and drops all three `?.` —
  a named failure beats a TypeError.

Gates: bun check exit 0 (biome 0 findings, was 2 errors). GLTF_CORPUS_REQUIRED=1 bun test
2656 pass / 0 fail. bun test ./examples/gym/src 127 pass / 0 fail.
