### PR TITLE
check-docs: scope the pin scan off the glTF corpus symlink

### DIFF
--- a/scripts/check-docs.ts
+++ b/scripts/check-docs.ts
@@ -101,9 +101,19 @@ type PinDrift = { file: string; line: number; name: string; found: string; want:
 const drift: PinDrift[] = [];
 let scanned = 0;
 
+// `examples/*/public/` is asset territory, and `gym/public/gltf-samples` is a symlink into the glTF
+// sample corpus — 451 third-party READMEs the scan would follow, but only in a checkout where that
+// submodule happens to be populated. Skipping it keeps this gate's scope the same in every checkout,
+// which is the property that matters: a check whose coverage depends on local state is how a stale
+// tree reads green (`testing.md`, the release gate). No owned doc lives under those directories.
+const skip = (p: string) =>
+    p.startsWith("node_modules/") ||
+    p.includes("/node_modules/") ||
+    /^examples\/[^/]+\/public\//.test(p);
+
 const docGlob = new Glob("**/*.md");
 for await (const match of docGlob.scan({ cwd: root })) {
-    if (match.startsWith("node_modules/") || match.includes("/node_modules/")) continue;
+    if (skip(match)) continue;
     scanned++;
     const lines = (await Bun.file(resolve(root, match)).text()).split("\n");
     let inFence = false;


### PR DESCRIPTION
The scan followed examples/gym/public/gltf-samples into the sample-assets submodule, so
it read 25 docs in a fresh checkout and 477 in a populated one — third-party READMEs we
neither own nor should gate on. Coverage of the files that matter was never affected,
but a check whose scope depends on local state is precisely how a stale tree reads
green, which this release already paid for once.

Verified the count is now 25 both with the corpus absent and with it checked out, and
re-confirmed the arm still reds by reverting README.md's typegpu pin (1 finding, exit 1).
