### PR TITLE
audit-behavioral: fix findings 1-6, engine-core behavioral defects

### DIFF
--- a/packages/shallot/src/document/document.test.ts
+++ b/packages/shallot/src/document/document.test.ts
@@ -552,6 +552,19 @@ describe("Document", () => {
         expect(doc.nodes[0].attrs[0].value).toBe("shape: box");
     });
 
+    test("addAttr for an existing name coalesces into setAttr, not a duplicate entry", () => {
+        const doc = new Document('<scene><a id="a" /></scene>');
+        doc.addAttr(doc.nodes[0], "mesh", "shape: box");
+        doc.addAttr(doc.nodes[0], "mesh", "shape: sphere");
+        expect(doc.nodes[0].attrs).toHaveLength(1);
+        expect(doc.nodes[0].attrs[0].value).toBe("shape: sphere");
+
+        // undo must revert the value, not delete the pre-existing attr the second addAttr collided with
+        doc.undo();
+        expect(doc.nodes[0].attrs).toHaveLength(1);
+        expect(doc.nodes[0].attrs[0].value).toBe("shape: box");
+    });
+
     test("setAttr updates attribute value", () => {
         const doc = new Document('<scene><a id="a" /></scene>');
         doc.addAttr(doc.nodes[0], "mesh", "shape: box");

--- a/packages/shallot/src/document/index.ts
+++ b/packages/shallot/src/document/index.ts
@@ -62,6 +62,12 @@ export class Document {
     }
 
     addAttr(node: Node, name: string, value: string): void {
+        // an existing attr coalesces into setAttr — addAttr's reverse deletes the first attr matching
+        // `name`, which would be the pre-existing one, not the one this call just pushed
+        if (node.attrs.some((a) => a.name === name)) {
+            this.setAttr(node, name, value);
+            return;
+        }
         execute(this.history, this.nodes, { type: "addAttr", node, name, value }, [
             ...this.selection,
         ]);

--- a/packages/shallot/src/engine/ecs/component.ts
+++ b/packages/shallot/src/engine/ecs/component.ts
@@ -120,7 +120,12 @@ function f16encode(x: number): number {
         const m = (mantissa | 0x800000) >>> (1 - exp);
         return sign | (m >>> 13);
     }
-    if (exp >= 31) return sign | 0x7c00 | (mantissa ? 1 : 0);
+    if (exp >= 31) {
+        // A finite f32 overflowing f16 range saturates to signed infinity;
+        // only a genuine NaN/Infinity input carries its payload through.
+        if (!Number.isFinite(x)) return sign | 0x7c00 | (mantissa ? 1 : 0);
+        return sign | 0x7c00;
+    }
     return sign | (exp << 10) | (mantissa >>> 13);
 }
 

--- a/packages/shallot/src/engine/ecs/scheduler.test.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.test.ts
@@ -236,6 +236,23 @@ describe("Scheduler", () => {
             state.step(Time.FIXED_DT * 3);
             expect(fixedCount).toBe(0);
         });
+
+        test("a large timescale caps fixed steps at MAX_FIXED_STEPS and marks the frame throttled", () => {
+            let fixedCount = 0;
+            state.addSystem({ group: "fixed", update: () => fixedCount++ });
+            // real dt stays well under the pre-scale clamp; the overrun only appears post-scale
+            state.timescale(10);
+            state.step(Time.FIXED_DT);
+            expect(fixedCount).toBeLessThanOrEqual(Time.MAX_FIXED_STEPS);
+            expect(state.time.fixedSteps).toBeLessThanOrEqual(Time.MAX_FIXED_STEPS);
+            expect(state.time.throttled).toBe(true);
+        });
+
+        test("a large raw dt while paused is not throttled — no fixed work is owed", () => {
+            state.pause();
+            state.step(1); // far past the pre-scale clamp, but paused freezes the accumulator at 0
+            expect(state.time.throttled).toBe(false);
+        });
     });
 
     describe("Setup Lifecycle", () => {

--- a/packages/shallot/src/engine/ecs/scheduler.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.ts
@@ -126,6 +126,7 @@ export class Scheduler {
     unregister(system: System): void {
         if (this._systems.delete(system)) {
             this._errored.delete(system);
+            this._names.delete(system);
             this._systemsVersion++;
         }
     }
@@ -160,7 +161,6 @@ export class Scheduler {
         const maxDt = fixedDt * Time.MAX_FIXED_STEPS;
 
         this._time.rawDeltaTime = deltaTime;
-        this._time.throttled = deltaTime > maxDt;
         // clamp on the real dt — the spiral-of-death gate, before scaling (a large scale must not reintroduce it)
         const real = Math.min(deltaTime, maxDt);
         this._time.realDeltaTime = real;
@@ -175,14 +175,21 @@ export class Scheduler {
 
         this.runGroup(state, "setup");
 
+        // the cap runs on the post-scale accumulator — timescale must not reintroduce the spiral it clamps
+        // out of `real` above. Past the cap, drop the backlog rather than carry debt into future frames.
         let steps = 0;
-        while (this._accumulator >= fixedDt) {
+        while (this._accumulator >= fixedDt && steps < Time.MAX_FIXED_STEPS) {
             this._time.deltaTime = fixedDt;
             this._time.fixedTick++;
             this.runGroup(state, "fixed");
             this._accumulator -= fixedDt;
             steps++;
         }
+        // throttled if either clock overran its budget: the pre-scale clamp discarded raw frame time
+        // (moot while paused — no virtual work was owed), or the scaled accumulator outran the step cap.
+        const postScaleOverrun = this._accumulator >= fixedDt;
+        if (postScaleOverrun) this._accumulator %= fixedDt;
+        this._time.throttled = (!this._time.paused && deltaTime > maxDt) || postScaleOverrun;
         this._time.fixedSteps = steps;
         this._time.fixedAlpha = this._accumulator / fixedDt;
 

--- a/packages/shallot/src/engine/ecs/sparse.test.ts
+++ b/packages/shallot/src/engine/ecs/sparse.test.ts
@@ -31,6 +31,14 @@ describe("sparse scalar", () => {
         expect(Math.abs(field.get(5) - 0.1)).toBeLessThanOrEqual(0.1 * 2 ** -11);
     });
 
+    test("f16 saturates a finite out-of-range value to signed infinity, not NaN", () => {
+        const field = sparse(f16);
+        field.set(5, 70000);
+        expect(field.get(5)).toBe(Infinity);
+        field.set(5, -70000);
+        expect(field.get(5)).toBe(-Infinity);
+    });
+
     test("unset eids return the type's zero", () => {
         const field = sparse(f32);
         expect(field.get(99999)).toBe(0);

--- a/packages/shallot/src/engine/ecs/state.test.ts
+++ b/packages/shallot/src/engine/ecs/state.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./core";
 import { schemas } from "./reflection";
 import { sparse } from "./sparse";
+import { capacity as sharedCapacity } from "./state";
 
 const formatHex = Object.assign((n: number) => "0x" + (n >>> 0).toString(16).padStart(6, "0"), {
     kind: "color" as const,
@@ -57,6 +58,17 @@ describe("State", () => {
             state.removeSystem(system);
             state.step();
             expect(count).toBe(1);
+        });
+
+        test("unregister drops the system's profiler-name entry, not just its scheduling slot", () => {
+            const system = { group: "simulation" as const, name: "leaky", update: () => {} };
+            state.addSystem(system, "plugin");
+
+            state.removeSystem(system);
+
+            const names = (state as unknown as { _scheduler: { _names: Map<unknown, string> } })
+                ._scheduler._names;
+            expect(names.has(system)).toBe(false);
         });
     });
 
@@ -250,6 +262,27 @@ describe("State", () => {
 
             expect(state.stamp(a)).toBe(stamp);
             expect(state.exists(a)).toBe(false);
+        });
+    });
+
+    describe("Capacity", () => {
+        test("an over-capacity create() leaves no live entity behind its exception", () => {
+            const restore = sharedCapacity;
+            try {
+                const capped = new State({ capacity: 2 });
+                capped.create(); // fills the one available slot (eid 1; capacity 2 allows eid+1<=2)
+                let thrown: unknown;
+                try {
+                    capped.create();
+                } catch (e) {
+                    thrown = e;
+                }
+                expect(thrown).toBeInstanceOf(Error);
+                expect(capped.exists(2)).toBe(false);
+                expect(capped.entities()).toHaveLength(1);
+            } finally {
+                new State({ capacity: restore });
+            }
         });
     });
 });

--- a/packages/shallot/src/engine/ecs/state.ts
+++ b/packages/shallot/src/engine/ecs/state.ts
@@ -96,6 +96,7 @@ export class State {
     create(): number {
         const eid = this._entities.add();
         if (eid + 1 > capacity) {
+            this._entities.remove(eid);
             throw new Error(
                 `Entity count ${eid + 1} exceeds configured capacity ${capacity}. ` +
                     `Increase via app build config: { capacity: ${Math.max(eid + 1, capacity * 2)} }.`,

--- a/packages/shallot/src/engine/utils/math.test.ts
+++ b/packages/shallot/src/engine/utils/math.test.ts
@@ -251,6 +251,15 @@ describe("invert", () => {
         expect(result[13]).toBe(-3);
         expect(result[14]).toBe(-2);
     });
+
+    test("singular input zeroes a dirty out, rather than leaving its stale contents", () => {
+        const singular = new Float32Array(16); // all-zero matrix — det is 0
+        const dirty = new Float32Array(16).fill(9);
+        const result = math.invert(singular, dirty);
+        for (let i = 0; i < 16; i++) {
+            expect(result[i]).toBe(0);
+        }
+    });
 });
 
 describe("multiply", () => {

--- a/packages/shallot/src/engine/utils/math.ts
+++ b/packages/shallot/src/engine/utils/math.ts
@@ -366,7 +366,7 @@ export function multiply(a: Float32Array, b: Float32Array, out?: Float32Array): 
     return out;
 }
 
-/** general mat4 inverse; returns the input unchanged when the matrix is singular */
+/** general mat4 inverse; a singular matrix zeroes `out` and returns it (an all-zero matrix) */
 export function invert(m: Float32Array, out?: Float32Array): Float32Array {
     if (!out) out = new Float32Array(16);
 
@@ -402,6 +402,7 @@ export function invert(m: Float32Array, out?: Float32Array): Float32Array {
 
     let det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
     if (Math.abs(det) < 1e-10) {
+        out.fill(0);
         return out;
     }
     det = 1 / det;


### PR DESCRIPTION
- component.ts f16encode: saturate finite f16 overflow to signed infinity
  instead of a NaN bit pattern (mantissa leaking a NaN payload)
- math.ts invert: zero a dirty `out` on the singular branch instead of
  leaving its stale contents, and correct the JSDoc
- scheduler.ts: cap fixed steps on the post-scale accumulator so a large
  timescale can't reintroduce the spiral-of-death it clamps out of `real`;
  throttled now reflects real work owed, not raw dt alone or a paused clock
- scheduler.ts unregister: drop the system's `_names` entry so it isn't
  held as a strong ref forever
- document/commands.ts via index.ts addAttr: coalesce into setAttr when
  the name already exists, so undo doesn't delete the pre-existing attr
- ecs/state.ts create(): roll back the over-capacity entity before
  throwing, so no live entity survives the exception
