### PR TITLE
audit-behavioral: stage 2 — standard/extras findings 7-11

### DIFF
--- a/packages/shallot/src/extras/text/atlas.test.ts
+++ b/packages/shallot/src/extras/text/atlas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { computeGlyphMetrics, type GlyphAtlas } from "./atlas";
+import { computeGlyphMetrics, disposeAtlases, type GlyphAtlas } from "./atlas";
 import type { Font } from "./font";
 
 // computeGlyphMetrics is a shelf packer (place each glyph on the current row, wrap, or refuse once the
@@ -102,5 +102,52 @@ describe("computeGlyphMetrics", () => {
     test("throws once the atlas has no room even at column 0", () => {
         const atlas = fakeAtlas(fakeFont(), { width: 1000, height: 50 });
         expect(() => computeGlyphMetrics(atlas, "A")).toThrow("Glyph atlas full");
+    });
+});
+
+// TextPlugin.dispose() destroys atlas.texture but, before this fix, never called
+// atlas.sdfGenerator.destroy() — leaking the generator's own `_intermediateTexture` on every rebuild.
+// disposeAtlases is the pure iteration TextPlugin.dispose drives, so this test reaches the real teardown
+// path with duck-typed destroy spies instead of a live GPUDevice.
+describe("disposeAtlases", () => {
+    function fakeDisposable(font: Font): GlyphAtlas & {
+        textureDestroyed: boolean;
+        generatorDestroyed: boolean;
+    } {
+        const state = { textureDestroyed: false, generatorDestroyed: false };
+        return {
+            texture: { destroy: () => (state.textureDestroyed = true) } as unknown as GPUTexture,
+            textureView: null as never,
+            width: 0,
+            height: 0,
+            glyphs: new Map(),
+            rowHeight: 0,
+            cursorX: 0,
+            cursorY: 0,
+            font,
+            sdfGenerator: {
+                destroy: () => (state.generatorDestroyed = true),
+            } as unknown as GlyphAtlas["sdfGenerator"],
+            get textureDestroyed() {
+                return state.textureDestroyed;
+            },
+            get generatorDestroyed() {
+                return state.generatorDestroyed;
+            },
+        };
+    }
+
+    test("destroys both the texture and the SDF generator for every atlas", () => {
+        const a = fakeDisposable(fakeFont());
+        const b = fakeDisposable(fakeFont());
+        disposeAtlases([a, b]);
+        expect(a.textureDestroyed).toBe(true);
+        expect(a.generatorDestroyed).toBe(true);
+        expect(b.textureDestroyed).toBe(true);
+        expect(b.generatorDestroyed).toBe(true);
+    });
+
+    test("skips a hole left by a font that failed to load", () => {
+        expect(() => disposeAtlases([undefined])).not.toThrow();
     });
 });

--- a/packages/shallot/src/extras/text/atlas.ts
+++ b/packages/shallot/src/extras/text/atlas.ts
@@ -31,6 +31,17 @@ export interface GlyphAtlas {
     sdfGenerator: SDFGenerator;
 }
 
+/** tear down every atlas's GPU-owned state: the glyph texture and the SDF generator's own
+ *  {@link SDFGenerator.destroy} (its `_intermediateTexture`) — both, or a rebuilt atlas leaks the
+ *  generator's texture on every teardown. `@internal`, pure iteration over caller-owned handles so
+ *  `TextPlugin.dispose` and this module's test can drive the same code. */
+export function disposeAtlases(atlases: readonly (GlyphAtlas | null | undefined)[]): void {
+    for (const atlas of atlases) {
+        atlas?.sdfGenerator.destroy();
+        atlas?.texture.destroy();
+    }
+}
+
 export function createGlyphAtlas(device: GPUDevice, font: Font): GlyphAtlas {
     const width = 2048;
     const height = 2048;

--- a/packages/shallot/src/extras/text/index.ts
+++ b/packages/shallot/src/extras/text/index.ts
@@ -35,7 +35,13 @@ import {
     vsPatchSchema,
 } from "../../standard/sear/core";
 import { Transform, TransformsPlugin } from "../../standard/transforms";
-import { createGlyphAtlas, ensureString, type GlyphAtlas, layoutText } from "./atlas";
+import {
+    createGlyphAtlas,
+    disposeAtlases,
+    ensureString,
+    type GlyphAtlas,
+    layoutText,
+} from "./atlas";
 import { type Font, loadFont } from "./font";
 import {
     GLYPH_AT,
@@ -45,6 +51,7 @@ import {
     sdfToSignedDistance,
     textSrgbToLinear,
 } from "./glyph";
+import { resetPipelines } from "./sdf";
 
 // Inter, the default face when the consumer registers no font of its own
 const DEFAULT_FONT =
@@ -519,7 +526,8 @@ export const TextPlugin: Plugin = {
     dispose() {
         _glyphBuf?.destroy();
         _argBuf?.destroy();
-        for (const atlas of _atlases) atlas?.texture.destroy();
+        disposeAtlases(_atlases);
+        resetPipelines();
         _glyphBuf = null;
         _argBuf = null;
         _atlases = [];

--- a/packages/shallot/src/extras/text/sdf.ts
+++ b/packages/shallot/src/extras/text/sdf.ts
@@ -308,11 +308,19 @@ function pipelines() {
     return _pipelines;
 }
 
+/** drop the memoized SDF pipeline pair. Pipelines bind to the root that created them, so a re-adopted
+ *  device (a rebuild against a new `GPUDevice`) needs a fresh pair rather than the stale one — mirrors
+ *  `slab/scatter.ts`'s `resetPipelines`.
+ *  @internal */
+export function resetPipelines(): void {
+    _pipelines = null;
+}
+
 export interface SDFGeneratorConfig {
     device: GPUDevice;
-    sdfSize?: number;
-    exponent?: number;
-    curveSubdivisions?: number;
+    sdfSize: number;
+    exponent: number;
+    curveSubdivisions: number;
 }
 
 export class SDFGenerator {
@@ -337,9 +345,9 @@ export class SDFGenerator {
 
     constructor(config: SDFGeneratorConfig) {
         this._device = config.device;
-        this._sdfSize = config.sdfSize ?? 64;
-        this._exponent = config.exponent ?? SDF_EXPONENT;
-        this._curveSubdivisions = config.curveSubdivisions ?? 16;
+        this._sdfSize = config.sdfSize;
+        this._exponent = config.exponent;
+        this._curveSubdivisions = config.curveSubdivisions;
 
         this._sampler = this._device.createSampler({
             magFilter: "nearest",
@@ -394,7 +402,7 @@ export class SDFGenerator {
             if (segments.length === 0) continue;
             if (segments.length > this._maxSegments) {
                 console.warn(
-                    `Too many segments (${segments.length}), truncating to ${this._maxSegments}`,
+                    `[text] too many segments (${segments.length}), truncating to ${this._maxSegments}`,
                 );
                 segments.length = this._maxSegments;
             }

--- a/packages/shallot/src/project/vite.test.ts
+++ b/packages/shallot/src/project/vite.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Rollup } from "vite";
@@ -106,6 +106,29 @@ describe("discoverScenes", () => {
 
     test("returns [] for a dir that doesn't exist", () => {
         expect(discoverScenes(join(projectDir(), "missing"))).toEqual([]);
+    });
+
+    // discoverScenes used to wrap the WHOLE recursive walk in one try/catch: an unreadable subtree
+    // (a broken symlink here — statSync follows it and throws ENOENT) propagated out of every
+    // enclosing `walk()` frame with no per-directory catch, silently truncating every sibling not yet
+    // visited at EVERY ancestor level, not just the bad subtree. These three entries are named so this
+    // filesystem's `readdirSync` order (deterministic per name-set here, verified empirically — not
+    // alphabetical) visits the broken directory FIRST at the top level, and its own broken symlink
+    // before its scene sibling — so the pre-fix code returns [] entirely, not a partial list.
+    test("an unreadable entry doesn't truncate scanning its siblings or its ancestors' siblings", () => {
+        const dir = projectDir();
+        writeFileSync(join(dir, "1_before.scene"), "");
+        const bad = join(dir, "2_baddir");
+        mkdirSync(bad);
+        symlinkSync(join(bad, "nonexistent-target"), join(bad, "broken"));
+        writeFileSync(join(bad, "3_after.scene"), "");
+        writeFileSync(join(dir, "4_after.scene"), "");
+
+        expect(discoverScenes(dir)).toEqual([
+            "1_before.scene",
+            join("2_baddir", "3_after.scene"),
+            "4_after.scene",
+        ]);
     });
 });
 

--- a/packages/shallot/src/project/vite.ts
+++ b/packages/shallot/src/project/vite.ts
@@ -44,17 +44,33 @@ export function typegpuPlugin(): Plugin {
 
 export function discoverScenes(dir: string): string[] {
     const scenes: string[] = [];
+    // per-directory try/catch, not one around the whole walk: an unreadable subtree (permissions, a
+    // broken symlink) used to throw out of the recursive `walk`, which the outer catch swallowed —
+    // silently truncating every sibling not yet visited at every ancestor level, not just the bad
+    // subtree, with no warning that the scene list was incomplete.
     function walk(current: string) {
-        for (const entry of readdirSync(current)) {
+        let entries: string[];
+        try {
+            entries = readdirSync(current);
+        } catch (e) {
+            console.warn(`  ! scene discovery: skipping unreadable directory "${current}": ${e}`);
+            return;
+        }
+        for (const entry of entries) {
             if (entry === "node_modules" || entry === "dist") continue;
             const full = join(current, entry);
-            if (statSync(full).isDirectory()) walk(full);
+            let isDirectory: boolean;
+            try {
+                isDirectory = statSync(full).isDirectory();
+            } catch (e) {
+                console.warn(`  ! scene discovery: skipping unreadable entry "${full}": ${e}`);
+                continue;
+            }
+            if (isDirectory) walk(full);
             else if (entry.endsWith(".scene")) scenes.push(relative(dir, full));
         }
     }
-    try {
-        walk(dir);
-    } catch {}
+    walk(dir);
     return scenes.sort();
 }
 

--- a/packages/shallot/src/standard/input/index.ts
+++ b/packages/shallot/src/standard/input/index.ts
@@ -43,7 +43,8 @@ export interface Mouse {
 export interface Inputs {
     /** current mouse state: buttons, canvas-relative position, per-frame deltas */
     readonly mouse: Readonly<Mouse>;
-    /** entity id of the canvas holding input focus, or -1 when none is focused */
+    /** document-order index of the canvas holding input focus (the Nth `<canvas>` `InputSystem` bound),
+     *  or -1 when none is focused — not an ECS entity id */
     readonly focused: number;
     /** whether a key is currently held down */
     isKeyDown(code: string): boolean;
@@ -361,7 +362,9 @@ function attachGlobal(s: InputState, signal: AbortSignal): void {
     window.addEventListener("blur", s.windowBlur, { signal });
 }
 
-function setup(state: State, views: Map<number, any>): void {
+// `canvasElements` is document order — `focused`'s index into it, never an ECS entity id (Input has no
+// view/eid substrate of its own to draw a real one from; see the `Inputs.focused` JSDoc).
+function setup(state: State, canvasElements: HTMLCanvasElement[]): void {
     const mouse: Mouse = {
         deltaX: 0,
         deltaY: 0,
@@ -377,13 +380,10 @@ function setup(state: State, views: Map<number, any>): void {
     };
 
     const canvases = new Map<HTMLCanvasElement, number>();
-    let firstCanvasEid = -1;
-
-    for (const [eid, view] of views) {
-        if (!view.element) continue;
-        canvases.set(view.element, eid);
-        view.element.style.touchAction = "none";
-        if (firstCanvasEid < 0) firstCanvasEid = eid;
+    for (let i = 0; i < canvasElements.length; i++) {
+        const element = canvasElements[i];
+        canvases.set(element, i);
+        element.style.touchAction = "none";
     }
 
     if (canvases.size === 0) return;
@@ -396,7 +396,7 @@ function setup(state: State, views: Map<number, any>): void {
         mouse,
         canvases,
         activeCanvas: null,
-        focused: firstCanvasEid,
+        focused: 0,
         lastPointerX: 0,
         lastPointerY: 0,
         activePointerId: null,
@@ -445,11 +445,7 @@ const InputSystem: System = {
         }
         const elements = Array.from(document.querySelectorAll("canvas"));
         if (elements.length === 0) return;
-        const synthetic = new Map<number, { element: HTMLCanvasElement }>();
-        for (let i = 0; i < elements.length; i++) {
-            synthetic.set(i, { element: elements[i] });
-        }
-        setup(state, synthetic);
+        setup(state, elements);
     },
 };
 

--- a/packages/shallot/src/standard/input/input.test.ts
+++ b/packages/shallot/src/standard/input/input.test.ts
@@ -386,3 +386,47 @@ describe("InputPlugin", () => {
         expect(canvas.tracker.added.length).toBe(beforeAttach);
     });
 });
+
+// `Inputs.focused` is document-order index of the bound canvas (the Nth `<canvas>` InputSystem found),
+// never an ECS entity id — InputSystem's sole caller has no real view/eid substrate to draw one from
+// (`querySelectorAll` returns bare elements). Two canvases pin that it's positional, not identity-derived.
+describe("InputPlugin focus with multiple canvases", () => {
+    test("a second canvas focuses at its document-order index, not an eid", () => {
+        clear();
+        const windowTracker = new ListenerTracker();
+        (windowTracker as unknown as { focus: () => void }).focus = () => {};
+        const savedWindow = globalThis.window;
+        const savedDocument = globalThis.document;
+        globalThis.window = windowTracker as unknown as typeof window;
+
+        const first = mockCanvas();
+        const second = mockCanvas();
+        globalThis.document = {
+            pointerLockElement: null,
+            querySelectorAll: (sel: string) => (sel === "canvas" ? [first, second] : []),
+        } as unknown as typeof document;
+
+        const state = new State();
+        for (const [n, c] of Object.entries(InputPlugin.components ?? {}))
+            register(n, c, InputPlugin.traits?.[n]);
+        attach(state, InputPlugin);
+        state.step();
+
+        expect(Inputs.focused).toBe(0); // defaults to the first canvas bound
+
+        const onSecond = (type: string): Fn => second.tracker.added.find(([t]) => t === type)![1];
+        onSecond("pointerdown")({
+            target: second,
+            pointerId: 1,
+            button: 0,
+            buttons: 1,
+            clientX: 0,
+            clientY: 0,
+            preventDefault() {},
+        });
+        expect(Inputs.focused).toBe(1); // the second canvas is index 1 in document order
+
+        globalThis.window = savedWindow;
+        globalThis.document = savedDocument;
+    });
+});

--- a/packages/shallot/src/standard/player/index.test.ts
+++ b/packages/shallot/src/standard/player/index.test.ts
@@ -1,5 +1,27 @@
 import { describe, expect, test } from "bun:test";
 import { State, type System } from "../../engine";
+import { PlayerControlSystem } from "./index";
+
+// biome-ignore lint/complexity/noBannedTypes: test mock tracks arbitrary DOM listeners
+type Fn = Function;
+
+class ListenerTracker {
+    added: [string, Fn][] = [];
+    addEventListener = (type: string, fn: Fn) => {
+        this.added.push([type, fn]);
+    };
+    removeEventListener = () => {};
+}
+
+function mockCanvas(): HTMLCanvasElement & { tracker: ListenerTracker } {
+    const tracker = new ListenerTracker();
+    return {
+        addEventListener: tracker.addEventListener,
+        removeEventListener: tracker.removeEventListener,
+        requestPointerLock: () => Promise.resolve(),
+        tracker,
+    } as unknown as HTMLCanvasElement & { tracker: ListenerTracker };
+}
 
 // Scheduler-driven validation of the camera follow (PlayerSnapshotSystem + followPos), against the REAL
 // scheduler, no GPU. A value that advances on the FIXED clock, snapshotted into prev/curr in the `fixed`
@@ -84,5 +106,60 @@ describe("camera follow interpolation (scheduler)", () => {
         expect(Math.max(...nv)).toBeGreaterThan(V * 2);
 
         state.dispose();
+    });
+});
+
+// PlayerControlSystem.onDispose used to null the module-level `lock` unconditionally: a rebuild-before-
+// dispose ordering (a new State's setup runs before the old State's dispose — the live-host rebuild shape
+// ecs.md "Reload-safety" describes) let the OLD State's teardown clear the NEW State's live pointer-lock
+// ref out from under it. The `standard/input` module guards its own module singleton the same way
+// (`if (inputState === s) inputState = null`) — Player's dispose needed the identical identity check.
+describe("PlayerControlSystem pointer-lock dispose identity", () => {
+    test("disposing a stale State does not clear a newer State's live lock", () => {
+        const canvasA = mockCanvas();
+        const canvasB = mockCanvas();
+        let currentCanvas: typeof canvasA = canvasA;
+        const docTracker = new ListenerTracker();
+        let exitCalls = 0;
+
+        const savedDocument = globalThis.document;
+        globalThis.document = {
+            pointerLockElement: null,
+            querySelector: () => currentCanvas,
+            addEventListener: docTracker.addEventListener,
+            removeEventListener: docTracker.removeEventListener,
+            exitPointerLock: () => {
+                exitCalls++;
+            },
+        } as unknown as typeof document;
+
+        try {
+            const onDocument = (type: string, nth: number): Fn =>
+                docTracker.added.filter(([t]) => t === type)[nth][1];
+
+            const stateA = new State();
+            currentCanvas = canvasA;
+            PlayerControlSystem.setup!(stateA);
+
+            // the rebuild: a newer State's setup binds before the old one's dispose runs
+            const stateB = new State();
+            currentCanvas = canvasB;
+            PlayerControlSystem.setup!(stateB);
+
+            // B's pointer lock engages
+            (globalThis.document as { pointerLockElement: unknown }).pointerLockElement = canvasB;
+            onDocument("pointerlockchange", 1)();
+
+            // A tears down — must not touch B's live, locked pointer-lock state
+            stateA.dispose();
+
+            expect(exitCalls).toBe(0); // A's own lock was never engaged, so no spurious exitPointerLock
+
+            // B's lock is still the live one: disposing B now (its OWN teardown) is what releases it
+            stateB.dispose();
+            expect(exitCalls).toBe(1); // B's own teardown, correctly attributed
+        } finally {
+            globalThis.document = savedDocument;
+        }
     });
 });

--- a/packages/shallot/src/standard/player/index.ts
+++ b/packages/shallot/src/standard/player/index.ts
@@ -202,10 +202,15 @@ export const PlayerControlSystem: System = {
         document.addEventListener("mousemove", pl.onMove, { signal });
         lock = pl;
         // release the input gate + any live pointer lock and drop the module ref when this State tears down.
+        // Guarded so a newer build's `lock` isn't clobbered: a rebuild-then-dispose ordering (the new State's
+        // setup runs before the old one's dispose) would otherwise null out the live State's pointer-lock
+        // state out from under it — the same identity guard `standard/input`'s `setup` uses for `inputState`.
         state.onDispose(() => {
             requirePointerLock(false);
-            if (lock?.locked) document.exitPointerLock();
-            lock = null;
+            if (lock === pl) {
+                if (lock.locked) document.exitPointerLock();
+                lock = null;
+            }
         });
     },
 

--- a/packages/shallot/src/standard/sear/atlas.ts
+++ b/packages/shallot/src/standard/sear/atlas.ts
@@ -238,6 +238,12 @@ let _comboMeta: GPUBuffer | null = null; // dense per-combo (caster slot, face) 
 export const pointRegather = createRegather("point");
 // the casting draws this frame (those whose surface compiled a point pipeline), filled in renderPointShadows
 const _castDraws: { draw: Draw; r: Recorded }[] = [];
+// warn-once (per episode — resets once every point caster shares one indirect buffer again) for a caster
+// dropped because its producer owns a second indirect buffer: renderPointShadows re-gathers only the
+// FIRST-seen buffer (the cascade twin's `_cascadeBatches` batches every distinct source instead — batching
+// the point atlas the same way is unbuilt; this is the loud floor `gpu.md`'s "when you hit the limit" asks
+// for on every drop path in this file, until a real second-indirect-buffer caster earns the batching rewrite)
+let _batchDropWarned = false;
 // per-frame re-gather meta scratch (no per-frame alloc): the view slot each dense combo culled into, and the
 // (surface,mesh) pair each casting draw owns — `Regather.run` reads these. Shared across the point + cascade
 // renders (each fills then consumes them in turn within ShadowMapSystem)
@@ -630,6 +636,7 @@ export function renderPointShadows(frameDraws: { draw: Draw; r: Recorded }[]): v
     _castDraws.length = 0;
     let drawArgs: GPUBuffer | null = null;
     let pairCount = 0;
+    let batchDropped = 0;
     for (const item of frameDraws) {
         const casts = item.r.t.point && item.r.g.point;
         if (!casts) continue;
@@ -638,9 +645,20 @@ export function renderPointShadows(frameDraws: { draw: Draw; r: Recorded }[]): v
             drawArgs = buf;
             pairCount = Math.floor((item.draw.args.viewStride ?? 0) / SHADOW_ARG_STRIDE);
         } else if (buf !== drawArgs) {
+            batchDropped++;
             continue;
         }
         _castDraws.push(item);
+    }
+    if (batchDropped > 0) {
+        if (!_batchDropWarned) {
+            _batchDropWarned = true;
+            console.warn(
+                `sear: ${batchDropped} point-shadow caster(s) dropped — their producer's indirect buffer differs from the first casting draw's, and renderPointShadows batches only one indirect-buffer source per frame`,
+            );
+        }
+    } else {
+        _batchDropWarned = false;
     }
     const D = _castDraws.length;
     const C = pointComboCount();


### PR DESCRIPTION
Player dispose now guards `lock` by identity (input's own pattern), so a
rebuild-before-dispose ordering can't null a newer State's live pointer-lock
state. Text dispose now destroys each atlas's SDFGenerator and resets the
sdf.ts module pipeline memo, plumbing sdf.ts's ctor/warn trivia along with it.
Input's setup collapses the fake eid-keyed views Map (its sole caller
synthesized document-order indices as eids) into a plain canvas array, and
Inputs.focused's doc states it's a document-order index, not an eid.
renderPointShadows now warns/counts instead of silently dropping a caster
whose producer owns a second indirect buffer — bun bench runs headlessly here
but no scenario exercises two distinct point-caster sources, so the spec's
batching alternative stays unbuilt pending one. discoverScenes catches per
directory/entry instead of around the whole walk, so an unreadable subtree no
longer truncates every sibling at every ancestor level.
