### PR TITLE
audit comment sweep/stage 1

### DIFF
--- a/packages/shallot/src/extras/sprite/surface.ts
+++ b/packages/shallot/src/extras/sprite/surface.ts
@@ -2,7 +2,7 @@
 // alpha) blend — sharing one `surfaceLayout` (the gltf-trio / skin shape). Sprite adopts the
 // `eids`+`transforms` instancing convention (its own layout declares both), so `VsIn.eid`/`VsIn.xform`
 // replace the hand-rolled `transforms[spriteData[iid].eid]` lookup and the engine's instanced
-// `tag = eid` default applies for free — the authored tag line the string contract needed is gone.
+// `tag = eid` default applies for free — the authored tag line is no longer needed.
 // `spriteData` is itself eid-indexed (packed at `eid * SPRITE_FLOATS`, see pack.ts), not slot-indexed:
 // the point/cascade shadow atlas re-gathers casters mesh-major across combos and preserves only
 // `eid` in its own `eids` lane, so `iid` is a re-gather index in the shadow pass, not sprite's slot.

--- a/packages/shallot/src/extras/tween/core.ts
+++ b/packages/shallot/src/extras/tween/core.ts
@@ -4,12 +4,9 @@ export { EASING_FUNCTIONS, type Easing, getEasing, getEasingIndex, getEasingName
 
 /** how a sampled value combines with the field's current value (WAAPI composite). */
 export const Composite = {
-    // overwrite the field. the default.
+    /** overwrite the field. the default. */
     Replace: 0,
-    // add the sampled value to the field's current value as a transient delta.
-    // the base stays authoritative, so an `add` tween over a field a sim also
-    // writes (a recoil, a flash) stops fighting it — completion with a delta of
-    // zero leaves the base untouched. the SSOT relaxation, made explicit.
+    /** add the sampled value to the field's current value as a transient delta. the base stays authoritative, so an `add` tween over a field a sim also writes (a recoil, a flash) stops fighting it — completion with a delta of zero leaves the base untouched. the SSOT relaxation, made explicit. */
     Add: 1,
 } as const;
 
@@ -19,12 +16,13 @@ export const Composite = {
  * tails.
  */
 export const Fill = {
-    // own only during the active interval — transient overlays (recoil, flash).
+    /** own only during the active interval — transient overlays (recoil, flash). */
     None: 0,
-    // also hold the end value after duration. the default — today's hold-end.
+    /** also hold the end value after duration. the default — today's hold-end. */
     Forwards: 1,
-    // also hold the start value before zero.
+    /** also hold the start value before zero. */
     Backwards: 2,
+    /** own both before and after the active interval. */
     Both: 3,
 } as const;
 

--- a/packages/shallot/src/standard/avbd/index.ts
+++ b/packages/shallot/src/standard/avbd/index.ts
@@ -50,7 +50,7 @@ const ALPHA = 0.99;
 // carries λ/k across frames, so the ramp converges from the persisted state — the canonical 1e4 holds
 // a resting box to ~mg/k.
 const BETA_LIN = 1e4;
-// the joint angular penalty-ramp rate (Phase 6.2, joint.ts betaAng) — the canonical AVBD value; contacts
+// the joint angular penalty-ramp rate (Phase 6.2) — the canonical AVBD value; contacts
 // ignore it, so it only matters once a scene authors joints (via Avbd.step.setJoints).
 const BETA_ANG = 100;
 const GAMMA = 0.999;

--- a/packages/shallot/src/standard/avbd/step.ts
+++ b/packages/shallot/src/standard/avbd/step.ts
@@ -3244,7 +3244,7 @@ const solveLdsKernel = tgpu
 /** interpolation alpha uniform — `time.fixedAlpha`, the fraction past the last fixed tick */
 const Interp = d.struct({ alpha: d.f32 }).$name("Interp");
 
-// nlerp toward the shortest arc: flip prev into curr's hemisphere, lerp, renormalize (legacy interpolate.wgsl)
+// nlerp toward the shortest arc: flip prev into curr's hemisphere, lerp, renormalize
 const nlerpShortest = tgpu
     .fn(
         [d.vec4f, d.vec4f, d.f32],

--- a/packages/shallot/src/standard/fog/index.ts
+++ b/packages/shallot/src/standard/fog/index.ts
@@ -4,8 +4,7 @@
 // shadowed by sear's point atlas, plus the directional sun shaft shadowed by sear's sun map (the same
 // froxel grid + shadow service sear's lit path uses, bound through `render/core` + `sear/core`), so
 // occluders cast dark shafts. It runs through the `sceneTransform` seam (after sear's color pass, before
-// glaze's tonemap), so the result is part of the HDR scene the tonemap rolls off — the same pre-glaze slot
-// orrstead's fog uses. A scene opts in with one `Fog` singleton; a camera opts in with sear's `Depth` lane
+// glaze's tonemap), so the result is part of the HDR scene the tonemap rolls off. A scene opts in with one `Fog` singleton; a camera opts in with sear's `Depth` lane
 // (the march needs scene depth). Both absent → the pass no-ops, no auto-add. The march primitives + the Fog
 // uniform schema live in `./march`; the typed pipeline (the two bind-group layouts + the compute kernel
 // calling them) lives in `./pipeline`. Both the kernel and the CPU-side oracle the gym fog probe diffs

--- a/packages/shallot/src/standard/part/part.ts
+++ b/packages/shallot/src/standard/part/part.ts
@@ -337,24 +337,6 @@ function writeMeshBounds(device: GPUDevice): Vec4fBuffer {
     return buffer;
 }
 
-/**
- * register one Draw per `(Part-compatible surface × mesh)` pair and seed every
- * slot's static indexed-indirect args (indexCount = `mesh.indexCount`, firstIndex =
- * `mesh.indexBase`, baseVertex = 0): the per-frame pack fills instanceCount + the
- * compacted firstInstance. The static args repeat across all `_viewDim` slots since a
- * camera attaching later reuses a slot whose geometry never changes; the Draw
- * points at the pair's slot-0 record and carries `viewStride = pairCount × 20`,
- * so sear reads `slot`'s record as `offset + slot * viewStride`. A surface is
- * instanced when it declares the `eids` + `transforms` bindings (sear applies
- * the standard transform). Every combination gets a Draw; the ones no entity uses pack to
- * `instanceCount: 0` and `drawIndirect` no-ops them. So a producer just
- * registers its mesh + surface and spawns Parts: the draw it needs already
- * exists, whenever its entities appear. (When `multi-draw-indirect` lands,
- * these per-pair draws fold into one call per surface on the GPU.) Re-run by
- * `syncBuffers` whenever a mesh registers or the view count grows: it re-seeds
- * every slot and repoints the Draws at the freshly grown `drawArgs`. The pair
- * offset is `mid * surfaceCount + sid`, so a new mesh only appends slots
- */
 /** publish Part's `(surface, mesh)` draw pairs and return the indirect records the GPU buffer needs.
  * Device-free so ordering tests can exercise the production publication seam without an adapter.
  * @internal */

--- a/packages/shallot/src/standard/physics/backend.test.ts
+++ b/packages/shallot/src/standard/physics/backend.test.ts
@@ -1,9 +1,9 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { installBackend, Physics, type PhysicsBackend, uninstallBackend } from "./index";
 
-// The substrate's single-backend guard (specs/tumble-shallot.md "Locked decision"): a scene runs exactly
-// one physics backend at a time, so a second install must fail loud rather than silently clobbering the
-// first. No device or state needed — installBackend/uninstallBackend are pure over the module singleton.
+// The substrate's single-backend guard: a scene runs exactly one physics backend at a time, so a second
+// install must fail loud rather than silently clobbering the first. No device or state needed —
+// installBackend/uninstallBackend are pure over the module singleton.
 
 function fakeBackend(): PhysicsBackend {
     return {

--- a/packages/shallot/src/standard/physics/index.ts
+++ b/packages/shallot/src/standard/physics/index.ts
@@ -7,7 +7,7 @@ import { Transform } from "../transforms";
 
 // The physics substrate — shared authoring components (`Body`/`Spring`/`Joint`), the CPU raycast + pick
 // layer, and a thin typed backend handle (`PhysicsBackend`) a backend plugin (`standard/avbd`'s
-// `AvbdPlugin`, later `standard/tumble`'s `TumblePlugin`) installs at `Physics.backend`. The substrate
+// `AvbdPlugin`, `standard/tumble`'s `TumblePlugin`) installs at `Physics.backend`. The substrate
 // owns the schedule contract (this file's `StepSystem` / `ConstraintSystem` / `ComposeSystem`, each
 // delegating to the installed handle); a backend owns its mechanism (GPU pipelines, a wasm world) plus a
 // richer imperative escape hatch (`Avbd.step`, `Tumble.world`) for anything past the atomic core.

--- a/packages/shallot/src/standard/render/camera.ts
+++ b/packages/shallot/src/standard/render/camera.ts
@@ -23,11 +23,17 @@ export const CameraMode = {
  * ```
  */
 export const Camera = {
+    /** perspective (0) or orthographic (1) projection, set via the `mode` scene attribute */
     mode: sparse(u32),
+    /** field of view in degrees (perspective mode) */
     fov: sparse(f32),
+    /** near plane distance */
     near: sparse(f32),
+    /** far plane distance */
     far: sparse(f32),
+    /** view size in world units (orthographic mode) */
     size: sparse(f32),
+    /** render target color as sRGB-encoded hex (e.g. 0x5cbfbf) */
     clearColor: sparse(u32),
     /** antialiasing: 1 = 4× MSAA (default), 0 = off (single-sample, crisp, for a pixel-art look) */
     antialias: sparse(u32),

--- a/packages/shallot/src/standard/render/contract.ts
+++ b/packages/shallot/src/standard/render/contract.ts
@@ -1,7 +1,7 @@
 // The renderer-neutral schema-backed surface/background contract. Layouts are created before their TGSL functions so
 // shader code can close over `layout.$.name`; registration binds exact spec identity to a State lifetime.
 //
-// Group split (4a-ii design lock): a typed surface's own bindings + the sear-injected `vertices` slot pin
+// Group split: a typed surface's own bindings + the sear-injected `vertices` slot pin
 // to **group 2** (engine 0 / shadow-or-atlas 1 / surface 2) — `surfaceLayout()`'s `$idx(SURFACE_GROUP)`. The
 // `vertices` slot is pass-variant (color pass reads the 16 B main stream, prepass/shadow the 8 B
 // position-only stream, same physical slot) — `surfaceLayout()` synthesizes both variants; typegpu resolves only
@@ -27,7 +27,7 @@ type ShaderStage = "compute" | "vertex" | "fragment";
 /** the default visibility for an immutable surface resource. */
 const VS_FS: ShaderStage[] = ["vertex", "fragment"];
 
-/** group 2 (4a-ii design lock: engine 0 / shadow-or-atlas 1 / surface 2) — where a typed surface's own
+/** group 2 (engine 0 / shadow-or-atlas 1 / surface 2) — where a typed surface's own
  *  bindings + the sear-injected `vertices` slot pin. */
 export const SURFACE_GROUP = 2;
 
@@ -131,7 +131,7 @@ export type SurfaceLayout<B extends Record<string, Binding>> = TgpuBindGroupLayo
 };
 
 /**
- * step one of the two-step typed registration (4a-ii design lock): synthesize a surface's group-2 layout
+ * step one of the two-step typed registration: synthesize a surface's group-2 layout
  * from its own bindings, so a typed `vs`/`fs` can close over `layout.$.name` while it's being authored —
  * before {@link registerSurface} exists to call. Layouts are shareable across surfaces declaring the same
  * bindings (sprite ×6, gltf trios — register the same layout object on each).
@@ -167,8 +167,8 @@ export type BgLayout<B extends Record<string, Binding>> = TgpuBindGroupLayout<{
 }>;
 
 /**
- * step one of a typed background's two-step registration, {@link surfaceLayout}'s twin for the Backgrounds seam
- * (the Backgrounds bindings lock, 4a-ii-c-3a-4): synthesize a background's group-2 layout from its own
+ * step one of a typed background's two-step registration, {@link surfaceLayout}'s twin for the Backgrounds seam:
+ * synthesize a background's group-2 layout from its own
  * bindings, so its typed `fs` can close over `layout.$.name` while it's being authored.
  *
  * @example

--- a/packages/shallot/src/standard/sear/codegen.ts
+++ b/packages/shallot/src/standard/sear/codegen.ts
@@ -53,9 +53,9 @@ export const Tag = {};
 // Each lane is gated by a camera marker (Bevy's DepthPrepass / NormalPrepass shape). Two ship: the `depth`
 // lane (the depth-stencil itself, marker `Depth`, published as `view.depth`) and the id lane (a color
 // attachment, marker `Tag`, published as `view.tag`). normal / motion are the future rows — adding one is
-// a COLOR_LANES entry + a `View.*` field, and the subset codegen in the former string pipeline + the prepass already
-// iterate it; never a new pass. `depth` isn't a color attachment (it's the depth-stencil), so it's stored
-// or discarded by the `Depth` marker, separate from COLOR_LANES (the color attachments the prepass MRTs)
+// a COLOR_LANES entry + a `View.*` field; the prepass already iterates it, never a new pass. `depth` isn't
+// a color attachment (it's the depth-stencil), so it's stored or discarded by the `Depth` marker, separate
+// from COLOR_LANES (the color attachments the prepass MRTs)
 export interface ColorLane {
     // the `view.*` field + lane identity ("tag"); `set` publishes the rendered texture onto that field
     name: string;

--- a/packages/shallot/src/standard/sear/contract.test.ts
+++ b/packages/shallot/src/standard/sear/contract.test.ts
@@ -31,7 +31,7 @@ describe("layout — group-2 synthesis", () => {
         expect(Surfaces.get("broken")).toBeUndefined();
     });
 
-    test("pins to group 2 (4a-ii design lock: engine 0 / shadow-or-atlas 1 / surface 2)", () => {
+    test("pins to group 2 (engine 0 / shadow-or-atlas 1 / surface 2)", () => {
         const l = layout({ items: { type: "storage", element: Item } });
         expect(l.index).toBe(2);
         expect(l.depthVariant.index).toBe(2);

--- a/packages/shallot/src/standard/sear/engine.test.ts
+++ b/packages/shallot/src/standard/sear/engine.test.ts
@@ -7,7 +7,7 @@ import { engineLayout, engineScaffoldWgsl } from "./engine";
 // pin the exact operand order the migrated pipeline uses.
 
 describe("engineLayout", () => {
-    test("the seven pass-invariant group-0 entries, in order — no `vertices` (pass-variant, moves to the surface group at 4a-ii-c)", () => {
+    test("the seven pass-invariant group-0 entries, in order — no `vertices` (pass-variant, in the surface group)", () => {
         expect(Object.keys(engineLayout.entries)).toEqual([
             "frame",
             "view",

--- a/packages/shallot/src/standard/sear/engine.ts
+++ b/packages/shallot/src/standard/sear/engine.ts
@@ -19,11 +19,10 @@ import {
 import { brdf, brdfSphere, halfLambert, Pbr, pointShadowRef } from "./shade";
 
 /**
- * the canonical engine group-0 layout (4a-ii design lock): every pass-invariant binding a sear pipeline
- * reads — frame / view / lighting uniforms, the compacted point-light list, the froxel light grid +
- * index pool, and the per-mesh dequant table. `vertices` is deliberately absent: it's pass-variant
- * (color binds the 16 B main stream, prepass/shadow the 8 B position stream) and moves into the surface
- * group (2) at 4a-ii-c, per the design lock. Pinned at group 0.
+ * the canonical engine group-0 layout: every pass-invariant binding a sear pipeline reads — frame / view /
+ * lighting uniforms, the compacted point-light list, the froxel light grid + index pool, and the per-mesh
+ * dequant table. `vertices` is deliberately absent: it's pass-variant (color binds the 16 B main stream,
+ * prepass/shadow the 8 B position stream) and moves into the surface group (2). Pinned at group 0.
  */
 export const engineLayout = tgpu
     .bindGroupLayout({

--- a/packages/shallot/src/standard/sear/forward.ts
+++ b/packages/shallot/src/standard/sear/forward.ts
@@ -267,9 +267,8 @@ function record(draw: Draw): Recorded | null {
 }
 
 // resolve a typed layout's own bindings (never the sear-injected `vertices`) to live resources by the
-// entry's kind — the typed twin of `record`'s `registryFor`/`bindResource` walk, with the same per-mesh
-// override + warn-once skip semantics. Returns the createBindGroup value record + the identity list, or
-// the missing binding's name
+// entry's kind. Returns the createBindGroup value record + the identity list, or the missing binding's
+// name
 function typedResources(
     entries: Record<string, object>,
     override?: Record<string, BindResource>,
@@ -288,7 +287,7 @@ function typedResources(
         if (!res) return name;
         if (isBuffer(res)) validateMeshBindingOverrides({ entries }, { [name]: res });
         resources.push(res);
-        // a texture binds a view of the schema's own dimension (the legacy `bindResource` shape)
+        // a texture binds a view of the schema's own dimension
         values[name] =
             "texture" in entry
                 ? (res as GPUTexture).createView({
@@ -301,10 +300,10 @@ function typedResources(
 }
 
 /**
- * the typed twin of {@link record}: compiled typed pipelines + the per-draw group-2 state (the two
- * layout-object caches the c-2 verdict names — `color` against `layout`; opaque depth-side groups against
- * `layout.depthVariant`; clip depth-side groups against the full layout so cutoff sees material UVs —
- * plus the atlas `eids` swaps and the slot-0 engine group the atlas passes bind).
+ * the typed twin of {@link record}: compiled typed pipelines + the per-draw group-2 state cached by
+ * layout name — `color` against `layout`; opaque depth-side groups against `layout.depthVariant`; clip
+ * depth-side groups against the full layout so cutoff sees material UVs — plus the atlas `eids` swaps
+ * and the slot-0 engine group the atlas passes bind.
  */
 function recordSurface(draw: Draw, surface: Surface): Recorded | null {
     const mesh = Meshes.get(draw.mesh);
@@ -635,11 +634,10 @@ function renderPrepass(
     view.depth = storeDepth ? depth : null;
 }
 
-// the camera's selected backdrop — legacy or typed, discriminated by the stored id's
-// BACKDROP_TYPED_BASE offset (BackdropTraits) — or null (no `Backdrop` component, or its name isn't a
-// compiled background). Membership-gated — a bare `Backdrop.name.get` reads 0 for a non-member, which
-// would alias the first registered background, so the `state.has` check is what keeps the no-backdrop
-// path on the clear
+// the camera's selected backdrop (legacy or typed) — or null (no `Backdrop` component, or its name
+// isn't a compiled background). Membership-gated — a bare `Backdrop.name.get` reads 0 for a non-member,
+// which would alias the first registered background, so the `state.has` check is what keeps the
+// no-backdrop path on the clear
 type BackdropPick = { bg: Background; ct: CompiledBackground };
 function backdrop(state: State, eid: number): BackdropPick | null {
     if (!state.has(eid, Backdrop)) return null;
@@ -652,9 +650,8 @@ function backdrop(state: State, eid: number): BackdropPick | null {
 }
 
 // build (and cache on the CompiledBackground) a typed background's own group-2 bind group — slot-invariant
-// (the per-slot View rides the engine group 0). Returns null while a binding is unpublished (skip, like
-// `bgGroup`); a binding-free background carries no group at all (its empty layout never enters the
-// pipeline layout)
+// (the per-slot View rides the engine group 0). Returns null while a binding is unpublished (skip); a
+// binding-free background carries no group at all (its empty layout never enters the pipeline layout)
 function backgroundGroup(bg: Background, ct: CompiledBackground): GPUBindGroup | null | "none" {
     const entries = bg.layout.entries as Record<string, object>;
     if (Object.keys(entries).length === 0) return "none";
@@ -938,7 +935,7 @@ const ShadowMapSystem: System = {
 };
 
 // the typed twin of `litBindings`, group 2 (`layout()`'s $idx(2) synthesis) — same four bindings, same
-// element shapes, feeding the typed `default` surface below (4a-ii-c-2's template port).
+// element shapes, feeding the typed `default` surface.
 const typedDefaultLayout = typedLayout({
     eids: { type: "storage", element: d.u32 },
     transforms: { type: "storage", element: Xform },
@@ -972,8 +969,8 @@ const typedColorLayout = typedLayout({
     color: { type: "storage", element: d.u32 },
 });
 
-// the typed twin of the raw `unlit` fs above (4a-ii-c-3): `unpackLdrColor(color[eid]).rgb` verbatim, no
-// lighting call — the simplest surface the typed template carries.
+// the typed twin of the raw `unlit` fs: `unpackLdrColor(color[eid]).rgb` verbatim, no lighting call —
+// the simplest surface the typed template carries.
 const typedUnlitFs = tgpu.fn(
     [fsCtxSchema()],
     d.vec4f,

--- a/packages/shallot/src/standard/sear/pipelines.test.ts
+++ b/packages/shallot/src/standard/sear/pipelines.test.ts
@@ -759,14 +759,10 @@ test("Sear warms Part-published specializing variants; post-build variants stay 
     }
 });
 
-test("a specializing surface compiled at two distinct variants emits two distinct pipeline labels — the observable Profile.compile's pipeline-count golden depends on (shallot-perf-gates stage 3a review)", async () => {
-    // `compileVariant`'s own `args.name` is already `${surface.name}#${variant}` (the pattern
-    // `ensureSingle` reads back), but every `.$name()` call on the pipelines it actually creates used
-    // bare `surface.name` — so two variants of the same specializing surface compiled to the SAME
-    // descriptor label, and `Profile.compile` (keyed by that label, `shallot-perf-gates` stage 3a)
-    // silently dropped one. Assert the real observable — the labels `device.createRenderPipeline`
-    // actually receives are distinct per variant — not `recordCompile`'s own merge/overwrite logic,
-    // which a same-label mutant would satisfy trivially.
+test("a specializing surface compiled at two distinct variants emits two distinct pipeline labels", async () => {
+    // Assert the real observable — the labels `device.createRenderPipeline` actually receives are
+    // distinct per variant — not `recordCompile`'s own merge/overwrite logic, which a same-label
+    // mutant would satisfy trivially.
     const surface: Surface = {
         name: `variant-label-${Math.random()}`,
         layout: layout({
@@ -1110,9 +1106,9 @@ describe("typedVaryingFs — the 1-to-4 varying arity dispatch (gpu.md rule 9's 
     });
 });
 
-// `screen` surfaces (4a-ii-d-1): the raw path's `out.clip = clipPos` (codegen.ts's the former string pipeline) — the
-// vs chunk projects its own clip-space geometry, and back-face culling is off because those quads have no
-// consistent winding. Both typed vs shapes (the shared TGSL body and the per-surface WGSL copier) honor it.
+// `screen` surfaces: the raw path's `out.clip = clipPos` — the vs chunk projects its own clip-space
+// geometry, and back-face culling is off because those quads have no consistent winding. Both typed vs
+// shapes (the shared TGSL body and the per-surface WGSL copier) honor it.
 describe("screen surfaces — the vs chunk's patch.clip IS the clip position", () => {
     const screenLayout = layout({ items: { type: "storage", element: d.f32 } });
     const Patch = vsPatchSchema();
@@ -1440,7 +1436,7 @@ test("typed background pipeline and bind-group caches invalidate on exact spec/l
     }
 });
 
-describe("draw wiring (4a-ii-c-3b) — the depth-pipeline receiver stub + the color pipeline's real receiver", () => {
+describe("draw wiring — the depth-pipeline receiver stub + the color pipeline's real receiver", () => {
     // a vs-chunk surface whose chunk reaches litPbr → pointShadowOf, the shape that forces the stub:
     // the raw path's prepass/shadow modules splice SHADOW_STUB_WGSL for exactly this reach
     const varyings = { litColor: d.vec3f };
@@ -1517,7 +1513,7 @@ describe("draw wiring (4a-ii-c-3b) — the depth-pipeline receiver stub + the co
     });
 });
 
-describe("draw wiring (4a-ii-c-3b) — shadowLayout visibility mirrors the raw _shadowBgl", () => {
+describe("draw wiring — shadowLayout visibility mirrors the raw _shadowBgl", () => {
     test("sampler + point-shadow entries are vertex-visible (a per-vertex vs chunk reaches pointShadowOf); sun map + params stay fragment-only", () => {
         const entries = shadowLayout.entries as Record<string, { visibility?: string[] }>;
         expect(entries.shadowSamp.visibility).toEqual(["vertex", "fragment"]);
@@ -1553,7 +1549,7 @@ describe("draw wiring — the Backdrop registry id space", () => {
     });
 });
 
-describe("draw wiring (4a-ii-c-3b review) — typed group-state eviction", () => {
+describe("draw wiring — typed group-state eviction", () => {
     test("clearGroups drops a cached typed entry (the re-gather realloc + rebuild eviction path, and the engine-group lifetime rides the entry)", () => {
         const entry = {
             engineCache: new Map([[0, {} as GPUBindGroup]]),

--- a/packages/shallot/src/standard/sear/pipelines.ts
+++ b/packages/shallot/src/standard/sear/pipelines.ts
@@ -63,18 +63,18 @@ export function resetPipelineCaches(): void {
     _bgQuant = null;
 }
 
-// ---- the typed pipeline builder (4a-ii-c, the template + its extensions): compiles a `Surface`'s
+// ---- the typed pipeline builder (the template + its extensions): compiles a `Surface`'s
 // `vs`/`fs` TGSL fns against the canonical `engineLayout` (group 0), the typed shadow group (group 1,
 // `shadowLayout` — the atlas passes bind `pointLayout`/`cascadeLayout` there instead), and
-// the surface's own synthesized `layout` (group 2 — `surfaceLayout()`'s $idx(2) synthesis, c-1): the
+// the surface's own synthesized `layout` (group 2 — `surfaceLayout()`'s $idx(2) synthesis): the
 // opaque color / transparent pipelines, the prepass depth + tag pipelines, and the point/cascade
 // shadow-atlas pipelines. A surface in `Surfaces` DRAWS through these in every pass — `record()`
-// consults the typed registry first (the built-in flip, c-3b), and `forward.ts`/`atlas.ts` issue the
+// consults the typed registry first (the built-in flip), and `forward.ts`/`atlas.ts` issue the
 // draws via `.with(pass)` on sear's own render passes. `screen` surfaces project through their own `vs`
 // chunk's `patch.clip` and draw un-culled (d-1); `"clip"` blend and `specialize` are carried for the glTF
 // typed migration.
 //
-// Cached beside the legacy `_compiled` map by name + material variant. `preparePipelines` compiles every
+// Cached by name + material variant. `preparePipelines` compiles every
 // non-specializing `Surfaces` entry and force-unwraps it, so the resolve + the sync
 // `createRenderPipeline` (the
 // 0a/1c spike finding) validate against the real device at warm — a malformed group split, a name
@@ -86,31 +86,31 @@ export interface CompiledSurface {
     layout: SurfaceLayout<Record<string, Binding>>;
     color: TgpuRenderPipeline<d.Vec4f> | null;
     transparent: TgpuRenderPipeline<d.Vec4f> | null;
-    // the prepass pipelines for this typed surface, keyed like the legacy `Compiled.prepass` map
-    // (`laneKey` — `""` the position-only depth pipeline, `"tag"` the id lane); empty for a `blend:
+    // the prepass pipelines for this typed surface (keyed by lane: `""` the position-only depth
+    // pipeline, `"tag"` the id lane); empty for a `blend:
     // "alpha"` surface (a transparent pixel has no single owner, writes no prepass depth, casts nothing —
-    // the same legacy rule `compileVariant` applies). Compiled off `layout.depthVariant` — a DISTINCT
-    // `TgpuBindGroupLayout` object from `layout` (the c-2 caching verdict), so a draw-time bind-group
+    // the same rule `compileVariant` applies). Compiled off `layout.depthVariant` — a DISTINCT
+    // `TgpuBindGroupLayout` object from `layout`, so a draw-time bind-group
     // cache for these needs its own key space, never `layout`'s (`SurfaceGroupEntry.depth`, `record`).
     // the map holds both the depth-only (`Void` output) and the tag-lane (`u32` output) pipeline under one
-    // key space — the same widening the legacy `Compiled.prepass: Map<string, GPURenderPipeline>` uses (a
+    // key space — holding both depth and tag pipelines under a single key namespace (a
     // bare `GPURenderPipeline` has no output type parameter either)
     prepass: Map<string, TgpuRenderPipeline<any>>;
-    // the point/cascade shadow-atlas pipelines (4a-ii-c-3a-3) — the former string shadow pipeline's typed twin. `null` for a
-    // non-instanced surface (only an instanced surface casts, the `castable` law `compileVariant` applies) —
+    // the point/cascade shadow-atlas pipelines — the former string shadow pipeline's typed twin. `null` for a
+    // non-instanced surface (only an instanced surface casts) —
     // never a silent gap, since a non-instanced typed surface has no per-instance `eids`/`transforms` to
     // re-gather against in the first place.
     point: TgpuRenderPipeline<any> | null;
     cascade: TgpuRenderPipeline<any> | null;
     // the single-sample (AA-off) color twin, compiled lazily by `ensureSingle` the first frame a
-    // no-AA camera draws this surface — the legacy `Compiled.single` shape, sync here (typegpu pipeline
+    // no-AA camera draws this surface — compiled here (typegpu pipeline
     // wrappers are cheap; the real resolve+create defers to first draw regardless)
     single: {
         color: TgpuRenderPipeline<d.Vec4f> | null;
         transparent: TgpuRenderPipeline<d.Vec4f> | null;
     } | null;
-    // the fixed inputs `ensureSingle` re-compiles the 1× twin from (the legacy `ColorArgs` shape —
-    // the entry fns are reused, so the twin shares the authored vs/fs, differing only in multisample)
+    // the fixed inputs `ensureSingle` re-compiles the 1× twin from; the entry fns are reused, so the
+    // twin shares the authored vs/fs, differing only in multisample
     args: {
         vertex: ReturnType<typeof typedColorVs> | ReturnType<typeof typedVaryingVs>;
         fragment: ReturnType<typeof typedColorFs>;
@@ -123,14 +123,14 @@ export interface CompiledSurface {
 }
 const _compiledTyped = new Map<string, CompiledSurface>();
 
-/** the per-draw group-2 state a typed draw binds (4a-ii-c-3b) — the typed twin of {@link GroupEntry}.
+/** the per-draw group-2 state a typed draw binds — the typed twin of the legacy string pipeline's GroupEntry.
  * `color` builds against `layout` (the 16 B main stream at the `vertices` slot); opaque depth/atlas
  * groups use the DISTINCT `layout.depthVariant` object (the 8 B position stream), while clipped groups
  * use the full layout/main stream because their fragment cutoff consumes material UVs. `point`/`cascade`
- * swap the `eids` lane to that atlas's re-gathered packed list (the legacy `eidsSwap`). View rides group
+ * swap the `eids` lane to that atlas's re-gathered packed list. View rides group
  * 0 per slot, so this state is slot-independent — one
- * instance per draw. `engineCache` holds the draw's engine group-0 instances per view slot (lazy, the
- * legacy `colorCache`/`prepassCache` lifetime: entry-scoped so a quant-buffer churn — a glTF import's
+ * instance per draw. `engineCache` holds the draw's engine group-0 instances per view slot (lazy,
+ * entry-scoped so a quant-buffer churn — a glTF import's
  * per-import buffers — drops the old groups with the overwritten entry, never a module map keyed on
  * buffer identity that grows for the app's life). `atlasG0` is its prebuilt slot-0 instance the
  * shadow-atlas passes bind (slot 0's View buffer as an unread placeholder — the atlas VS projects by
@@ -201,7 +201,7 @@ export function engineGroup(
 
 // a background reads no mesh, but `engineLayout` (the shared group-0 instance the Backgrounds lock
 // names) still carries the `meshQuant` slot — a one-record placeholder buffer fills it, never read (the
-// slot-0 View placeholder precedent, `record`'s eidsSwap)
+// slot-0 View placeholder precedent)
 let _bgQuant: GPUBuffer | null = null;
 
 /** the never-read `meshQuant` placeholder a typed background's engine group binds. */
@@ -422,7 +422,7 @@ function typedColorVs(surface: AnySurface, clip = false, suffix = clip ? "Clip" 
  * the typed color-pass fragment entry: fills the four `sear/engine.ts` shading-seam privateVars exactly
  * as the raw scaffold's `fragmentBody` does (`sunVisibility` via a real {@link sampleSunShadow} call —
  * matching the raw path's inline sample — `fragWorld`, `fragCoord`, `pointScale`), builds the surface's
- * `fsCtxSchema` context (`uv`/`localPos` cross for real from the vs — c-3), and returns the surface's own
+ * `fsCtxSchema` context (`uv`/`localPos` cross for real from the vs), and returns the surface's own
  * `fs` chunk's result verbatim (sear's `col` return,
  * unwrapped — a typed `fs` already returns `vec4f`, no lane locals: the prepass tag/depth lanes are a
  * separate pipeline, still unported).
@@ -481,7 +481,7 @@ function typedColorFs(surface: AnySurface) {
             // structurally satisfy (a TS quirk over a generic-default index signature, not a real type
             // error) — the escape is the same shape as the `layout.$` cast above.
             //
-            // `uv`/`localPos` now cross for real (c-3) — resolved from the vs's own interpolated output,
+            // `uv`/`localPos` now cross for real — resolved from the vs's own interpolated output,
             // not a zero-fill stand-in.
             const ctx = CtxSchema({
                 eid: input.eid,
@@ -499,8 +499,8 @@ function typedColorFs(surface: AnySurface) {
 /**
  * the position-only typed prepass vertex entry (empty lane set — the shadow map's own shape too): pulls
  * the 8 B position-only vertex from the surface's `layout.depthVariant` (a DISTINCT `TgpuBindGroupLayout`
- * instance from `layout` — the c-2 caching verdict), decodes position alone (normal defaults `+Z`, uv `0`
- * — the raw prepass's own shape, `pass === "prepass"` in `codegen.ts`'s the former string pipeline), applies the
+ * instance from `layout`), decodes position alone (normal defaults `+Z`, uv `0`
+ * — the raw prepass's own shape, `pass === "prepass"` in codegen.ts's the former string pipeline), applies the
  * standard instance transform, then splices the surface's own `vs` chunk when present. Inlined rather than
  * factored through a shared helper (probed live: a plain function marked `"use gpu"` can't take a host
  * object like `surface` as an argument — "Shellless functions can only accept arguments representing WGSL
@@ -524,8 +524,7 @@ function typedPrepassVs(surface: AnySurface) {
             const mq = engineLayout.$.meshQuant[meshIdOf(v.y)];
             const localPos = decodePos(v.x, v.y, mq);
             // the raw prepass's own default (`codegen.ts`'s the former string pipeline, `pass === "prepass"`) — pinned
-            // for the life of the vs, never touched by the instance transform below (`INSTANCE_VS` mutates
-            // only `world`/`worldNormal`); a `vs` chunk reading `vsIn.localNormal` must see this default,
+            // for the life of the vs, never touched by the instance transform below; a `vs` chunk reading `vsIn.localNormal` must see this default,
             // not the transformed `worldNormal` (a real bug caught in review — passing `worldNormal` here
             // silently fed world-space data into a field the raw path documents as local-space)
             const localNormal = d.vec3f(0, 0, 1);
@@ -800,7 +799,7 @@ function varyingClipFs(surface: AnySurface, tag: boolean) {
 }
 
 /**
- * the varyings-carrying typed color/prepass vertex entry (4a-ii-c-3a, the varyings mechanism lock): TGSL has
+ * the varyings-carrying typed color/prepass vertex entry (the varyings mechanism): TGSL has
  * no object-spread and no dynamic-key struct construction, so a shared "use gpu" body can't vary its
  * return shape per surface — a surface declaring `varyings` gets its own **WGSL-bodied copier**, distinct
  * from a fixed shared body. The copier does the real vertex math (vertex pull, quantized decode,
@@ -808,7 +807,7 @@ function varyingClipFs(surface: AnySurface, tag: boolean) {
  * raw fn, its `out.<varying> = patched.<varying>;` lines JS-string-templated from `Object.keys(surface.
  * varyings)` (never through the transpiler). The thin entry stays real TGSL (typegpu's own header/
  * location machinery) and only binds + returns the copier's result — `const r = copier(...); return r;`,
- * since a direct return hits "Cannot resolve struct cast" (the c-1/c-2 API laws, probed live via
+ * since a direct return hits "Cannot resolve struct cast" (probed live via
  * `tgpu.resolve` before this landed).
  */
 function typedVaryingVs(surface: AnySurface, clip = false, suffix = clip ? "Clip" : "") {
@@ -827,9 +826,8 @@ function typedVaryingVs(surface: AnySurface, clip = false, suffix = clip ? "Clip
     const hasVs = !!vsFn;
     const fragmentFields = fragmentInterstage(surface);
     const instanced = typedInstanced(surface);
-    // a `screen` surface's own projection is the patch's `clip` lane (the former string pipeline's `out.clip =
-    // clipPos`); everything else projects `view.viewProj * world` after the chunk, so displacing `world`
-    // still projects
+    // a `screen` surface's own projection is the patch's `clip` lane; everything else projects
+    // `view.viewProj * world` after the chunk, so displacing `world` still projects
     const screen = !!surface.screen;
     const layout = surface.layout;
     const OutStruct = d
@@ -1274,9 +1272,9 @@ function typedVaryingTagFs(surface: AnySurface) {
 
 /**
  * compile a `Surface`'s color-pass pipeline(s): the opaque `color` pipeline, or — for a `blend:
- * "alpha"` surface (c-3) — the single blended `transparent` pipeline instead (the legacy `colorPipelines`
- * split: exactly one of the two compiles, never both, matching the raw path's "one non-opaque pipeline"
- * shape). Cached by name + material variant plus exact source-surface/layout identity, so replacing a
+ * "alpha"` surface — the single blended `transparent` pipeline instead (exactly one of the two
+ * compiles, never both, matching the raw path's "one non-opaque pipeline" shape). Cached by name +
+ * material variant plus exact source-surface/layout identity, so replacing a
  * registry entry after warm cannot inherit the previous owner's pipelines. A `screen` surface projects
  * through its own `vs` chunk (`patch.clip`) and rasterizes un-culled; `"clip"` and a surface's
  * `specialize` factory are resolved here for the glTF typed migration.
@@ -1380,7 +1378,7 @@ export function compileVariant<
 
 /**
  * compile a typed surface's single-sample (AA-off) color twin, once, the first frame a no-AA camera
- * draws it — the legacy {@link ensureSingle}'s typed twin, sync (the wrapper is cheap; the real
+ * draws it — the typed twin of the legacy string pipeline's pattern (the wrapper is cheap; the real
  * resolve+create lands at the twin's first draw). Reuses the compiled entry fns, so only
  * `multisample.count` differs.
  */
@@ -1423,7 +1421,7 @@ export function ensureSingle(t: CompiledSurface): void {
 }
 
 /**
- * compile a `Surface`'s prepass pipelines (4a-ii-c-3a-2): the position-only depth pipeline (key `""`,
+ * compile a `Surface`'s prepass pipelines: the position-only depth pipeline (key `""`,
  * vertex-only except for a `clip` surface's cutoff fragment) and the id-lane pipeline (key `"tag"`, the
  * raw `COLOR_LANES` id lane). Opaque depth-only surfaces compile off `layout.depthVariant`; clipped
  * surfaces execute their authored cutoff and therefore use the full layout/main vertex stream. An
@@ -1496,13 +1494,12 @@ function compileTypedPrepass(
 }
 
 /**
- * the shared typed point/cascade fragment entry (4a-ii-c-3a-3): the tile-seam discard alone, the former string shadow pipeline's
- * `fsPoint` twin — clamped to `layout.depthVariant` position + the `tileBox` varying its matching vs writes.
+ * the shared typed point/cascade fragment entry: the tile-seam discard alone — clamped to
+ * `layout.depthVariant` position + the `tileBox` varying its matching vs writes.
  * Atlas-size-independent (the vs bakes the atlas scale into `tileBox` already), so ONE instance serves every
- * typed surface's point pipeline AND every typed surface's cascade pipeline (the raw path's `fsPoint` is
- * textually identical between the two atlases too — only the VS's rect-index formula + atlas constant
- * differ, `codegen.ts`'s the former string shadow pipeline). A `clip` surface uses the wider per-surface fragment below so
- * the same material cutoff holes its atlas depth.
+ * typed surface's point pipeline AND every typed surface's cascade pipeline (the VS's rect-index formula
+ * and atlas constants differ per atlas, from codegen.ts). A `clip` surface uses the wider per-surface
+ * fragment below so the same material cutoff holes its atlas depth.
  */
 const typedShadowFs = tgpu
     .fragmentFn({
@@ -1520,14 +1517,14 @@ const typedShadowFs = tgpu
     .$name("shadowAtlasFs");
 
 /**
- * the typed point/cascade shadow-atlas vertex entry (4a-ii-c-3a-3): the former string shadow pipeline's VS, pinned
+ * the typed point/cascade shadow-atlas vertex entry: the former string shadow pipeline's VS, pinned
  * statement-for-statement — pulls the 8 B position-only vertex from `layout.depthVariant` (the
  * `typedPrepassVs` shape), reads the re-gathered `(combo << COMBO_SHIFT) | eid` packed instance at the
  * surface's `eids` lane, applies the instance transform, splices the surface's own `vs` chunk when present,
  * then projects by that combo's tile-folded viewProj (`shadowLayout.$.faceVP.m[combo]`) and computes the
  * `tileBox` seam-discard bounds from `shadowLayout.$.tileRects` (indexed `slot·6+face` for the point atlas,
- * `slot` alone for the cascade atlas — the former string shadow pipeline's `rectExpr` split) scaled by the atlas's pixel
- * size. Only an **instanced** surface reaches here (only `eids`+`transforms` gives a per-instance member to
+ * `slot` alone for the cascade atlas — indexed differently per atlas) scaled by the atlas's pixel size.
+ * Only an **instanced** surface reaches here (only `eids`+`transforms` gives a per-instance member to
  * re-gather against) — `compileTypedShadow` gates the call, so this never runs for a non-instanced surface.
  */
 function typedShadowVs(
@@ -1941,9 +1938,8 @@ function clipShadowFs(surface: AnySurface) {
 }
 
 /**
- * compile a `Surface`'s point + cascade shadow-atlas pipelines (4a-ii-c-3a-3) — `null` for a
- * non-instanced or `screen` surface (only an instanced, non-`screen` surface casts — the raw `castable`
- * law `compileVariant` applies, `!surface.screen && instanced` — a 2D overlay has no atlas placement).
+ * compile a `Surface`'s point + cascade shadow-atlas pipelines — `null` for a non-instanced or
+ * `screen` surface (only an instanced, non-`screen` surface casts — a 2D overlay has no atlas placement).
  * Opaque surfaces share {@link typedShadowFs}; clipped surfaces use their wider cutoff
  * vertex/fragment pair. Each closes over its own `pointLayout` / `cascadeLayout` group-1 and its
  * own atlas pixel size (the
@@ -2127,10 +2123,9 @@ export function prepassWgsl(surface: AnySurface, variant = 0): { "": string; tag
     };
 }
 
-// ---- the typed `Backgrounds` contract's pipeline builder (4a-ii-c-3a-4, the Backgrounds bindings lock):
+// ---- the typed `Backgrounds` contract's pipeline builder (the Backgrounds bindings lock):
 // the Surfaces contract minus mesh machinery, same group scheme. Group 0 = the shared `engineLayout`
-// instance (the color pass's own — `BG_BASE` dies on the typed path, matching the raw path's own group-0
-// sharing note in `compileBackground`'s docblock); group 1 = `shadowLayout`, declared-but-unused via
+// instance (the color pass's own); group 1 = `shadowLayout`, declared-but-unused via
 // the `forcedZero` scope-forcing precedent (preserving `compileBackground`'s documented group-count-
 // compatibility reason: a bg pipeline with only group 0 would drop group 1 for the blend draws that follow
 // in the same pass); group 2 = the background's own bindings, through `contract.ts`'s `bgLayout` — the
@@ -2144,9 +2139,9 @@ type AnyBackground = Background<Record<string, Binding>>;
 /**
  * the engine-owned fullscreen-triangle vertex entry every typed background shares — no per-background
  * variance (no mesh, no varyings, per the Backgrounds bindings lock), so ONE instance serves every typed
- * background's pipeline. Statement-for-statement the former string background pipeline's raw `vs` (codegen.ts): the three
- * corners come from `@builtin(vertex_index)` alone, emitted at the reverse-Z far plane (clip z = 0) so
- * {@link compileBackground}'s `depthCompare: "greater-equal"` + no-depth-write test admits only
+ * background's pipeline. Statement-for-statement the former string background pipeline's raw vs (codegen.ts):
+ * the three corners come from `@builtin(vertex_index)` alone, emitted at the reverse-Z far plane (clip z = 0)
+ * so {@link compileBackground}'s `depthCompare: "greater-equal"` + no-depth-write test admits only
  * un-rendered pixels.
  */
 const typedBgVs = tgpu
@@ -2161,12 +2156,11 @@ const typedBgVs = tgpu
 
 /**
  * a typed background's fragment entry: reconstructs the normalized world-space view ray `dir` from
- * `@builtin(position)` + `engineLayout`'s `view.invViewProj` — operand-for-operand the former string background pipeline's raw
- * reconstruct (codegen.ts), not an interstage varying (gpu.md rule 9) — forces `shadowLayout`'s
- * group-1 bindings into scope via the `forcedZero` fold (`typedColorFs`'s precedent, same reason:
- * `sampleSunShadow`/`pointShadowOf`'s free names are invisible to `tgpu.resolve`'s call-graph walk
- * otherwise), then calls the background's own `fs` chunk and wraps its `vec3f` result opaque (`vec4f(col,
- * 1)`, the former string background pipeline's own contract).
+ * `@builtin(position)` + `engineLayout`'s `view.invViewProj` — operand-for-operand the former string
+ * background pipeline's raw reconstruct (codegen.ts), not an interstage varying (gpu.md rule 9) — forces
+ * `shadowLayout`'s group-1 bindings into scope via the `forcedZero` fold (`typedColorFs`'s precedent, same
+ * reason: `sampleSunShadow`/`pointShadowOf`'s free names are invisible to `tgpu.resolve`'s call-graph walk
+ * otherwise), then calls the background's own `fs` chunk and wraps its `vec3f` result opaque (`vec4f(col, 1)`).
  */
 function typedBgFs(bg: AnyBackground) {
     return tgpu
@@ -2204,7 +2198,7 @@ function typedBgFs(bg: AnyBackground) {
 }
 
 /** a compiled typed background: the 4× MSAA + single-sample twins (a camera binds whichever its
- *  `Camera.antialias` selects — `CompiledBg`'s raw twin). */
+ *  `Camera.antialias` selects). */
 export interface CompiledBackground {
     /** exact registry spec + layout this pipeline/group state was derived from. */
     owner: AnyBackground;

--- a/packages/shallot/src/standard/sear/shadows.ts
+++ b/packages/shallot/src/standard/sear/shadows.ts
@@ -1026,7 +1026,7 @@ export function destroyPointShadows(state: State): void {
 }
 
 /** forget the cached combo camera eids on a (re)build: the prior State owns its own teardown, a fresh
- * one recreates lazily (the same lifecycle-reset as {@link resetShadowCamera}) */
+ * one recreates lazily */
 export function resetPointShadows(): void {
     _comboEids = [];
     _capWarned = false;

--- a/packages/shallot/src/standard/tumble/compose.ts
+++ b/packages/shallot/src/standard/tumble/compose.ts
@@ -22,7 +22,7 @@ export function nlerpShortest(
 }
 
 /** the render scale mapping a `Body`'s collider to its unit render mesh (avbd/step.ts `COMPOSE_PASS_WGSL`,
- *  physics.md "Storage + the Body / Transform contract"): box/hull → `2·halfExtents`, sphere → uniform
+ *  avbd.md "Storage + the Body / Transform contract"): box/hull → `2·halfExtents`, sphere → uniform
  *  `2·radius`, capsule → `(2·radius, halfExtents.y + radius, 2·radius)` (the caps distort under a
  *  non-proportional ratio — render-only; the collider stays exact). */
 export function renderScale(

--- a/packages/shallot/src/standard/tumble/engine/body.ts
+++ b/packages/shallot/src/standard/tumble/engine/body.ts
@@ -4,7 +4,7 @@
 // solver velocity/delta state (b3BodyState, only in the awake set's bodyStates column). Static and
 // sleeping bodies have a sim but no state.
 //
-// fround discipline per the README. This file holds the types + accessors; the
+// fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity". This file holds the types + accessors; the
 // create/destroy/setType/mass machinery is appended below.
 
 import { NULL_INDEX, swapRemove } from "./array";

--- a/packages/shallot/src/standard/tumble/engine/broadphase.ts
+++ b/packages/shallot/src/standard/tumble/engine/broadphase.ts
@@ -1,12 +1,6 @@
 // Broad-phase — a port of Box3D's src/broad_phase.c (Erin Catto, MIT), the container over three
 // dynamic trees (static / kinematic / dynamic) plus the move buffer that records which proxies
 // changed this step, in deterministic insertion order.
-//
-// Stage-5 scope: the trees, proxy lifecycle, and the move buffer (bit-set-mirrors-array invariant).
-// The pair-finding half — b3PairQueryCallback / b3FindPairsTask / b3UpdateBroadPhasePairs and the
-// pairSet — is world-coupled (shapes, bodies, contacts, filters, sensors, joints) and ports at the
-// lifecycle/solver stages (7/8) where those types exist, alongside contact creation. It composes
-// from the tree Query already implemented here; building it now would need stub world types.
 
 import { GrowVec } from "./array";
 import { type BitSet, clearBit, createBitSet, getBit, setBitGrow } from "./bitset";
@@ -17,8 +11,7 @@ import { createSet, type HashSet } from "./table";
 import type { DynamicTree } from "./tree";
 import * as tree from "./tree";
 
-// b3BodyType. Local for now; hoists to lifecycle at stage 7. Static must be 0 so the proxy-key
-// pack/unpack (2-bit type) round-trips.
+// b3BodyType. Static must be 0 so the proxy-key pack/unpack (2-bit type) round-trips.
 export const BodyType = {
     Static: 0,
     Kinematic: 1,

--- a/packages/shallot/src/standard/tumble/engine/contact.ts
+++ b/packages/shallot/src/standard/tumble/engine/contact.ts
@@ -3,9 +3,8 @@
 // keyed (contactId << 1 | edgeIndex). Contacts are born non-touching; touching is discovered during
 // the step, which links islands and moves the contact into the constraint graph.
 //
-// Ported from Box3D's contact.c (Erin Catto, MIT). Deterministic shape
-// ordering. No contact is actually created before the solver stage (pair finding runs in step), so
-// the manifold + graph paths here are seamed to the solver stage. fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
+// Deterministic shape ordering. Contacts are created during pair finding, and the manifold + graph paths
+// integrate with the solver stage. fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { NULL_INDEX, swapRemove } from "./array";
 import { type Body, BodyFlags, wakeBody } from "./body";

--- a/packages/shallot/src/standard/tumble/engine/contact.ts
+++ b/packages/shallot/src/standard/tumble/engine/contact.ts
@@ -3,9 +3,9 @@
 // keyed (contactId << 1 | edgeIndex). Contacts are born non-touching; touching is discovered during
 // the step, which links islands and moves the contact into the constraint graph.
 //
-// Stage 7 (lifecycle) ports the create/destroy/register machinery and the deterministic shape
+// Ported from Box3D's contact.c (Erin Catto, MIT). Deterministic shape
 // ordering. No contact is actually created before the solver stage (pair finding runs in step), so
-// the manifold + graph paths here are seamed to the solver stage. fround discipline per the README.
+// the manifold + graph paths here are seamed to the solver stage. fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { NULL_INDEX, swapRemove } from "./array";
 import { type Body, BodyFlags, wakeBody } from "./body";

--- a/packages/shallot/src/standard/tumble/engine/core.ts
+++ b/packages/shallot/src/standard/tumble/engine/core.ts
@@ -1,10 +1,10 @@
 // World-scoped physical constants and the length-unit base. Ported from Box3D's constants.h /
-// core.h (Erin Catto, MIT). fround discipline per the README.
+// core.h (Erin Catto, MIT). fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 //
 // Box3D scales its length-based constants by a settable length-unit (b3SetLengthUnitsPerMeter).
-// The port fixes the unit at the default 1.0 — every fixture is generated at 1.0, and stages 1-6
-// already bake `0.005` etc. as literals. A settable unit is a scoped follow-on: it would have to
-// sweep every module's constant at once, and no stage exercises a non-unit world. So the derived
+// The port fixes the unit at the default 1.0 — every fixture is generated at 1.0, and existing
+// modules already bake `0.005` etc. as literals. A settable unit is a scoped follow-on: it would have to
+// sweep every module's constant at once, and no implementation exercises a non-unit world. So the derived
 // constants below are the final, correct values for the locked scope, not a lesser stopgap.
 
 import { f32 } from "./math";

--- a/packages/shallot/src/standard/tumble/engine/distance.ts
+++ b/packages/shallot/src/standard/tumble/engine/distance.ts
@@ -1,6 +1,6 @@
 // GJK distance, shape casting, and conservative-advancement time of impact.
 // Ported op-for-op from Box3D's distance.c (Erin Catto, MIT; portions by Dirk Gregorius).
-// fround discipline + scalar-branch mirroring per the README.
+// fround discipline + scalar-branch mirroring per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 //
 // The whole query runs in shape A's frame using the relative pose of B in A, keeping the math
 // near the local origin. Results stay in frame A.

--- a/packages/shallot/src/standard/tumble/engine/graph.ts
+++ b/packages/shallot/src/standard/tumble/engine/graph.ts
@@ -8,10 +8,7 @@
 // (`convexContacts`). A color's `bodySet` tracks which bodies it already constrains (unused on the
 // overflow color, which imposes no sharing limit).
 //
-// FORCE_OVERFLOW mirrors C's `#if B3_FORCE_OVERFLOW` parity knob: when set, every constraint routes
-// to the overflow color and the coloring bit sets go unused — the shape the port shipped against the
-// force-overflow fixtures. It flips to false with the default-config fixture migration (the colored,
-// wide solve). The transient per-step constraint arrays live in wasm columns, not here.
+// The transient per-step constraint arrays live in wasm columns, not here.
 //
 // Coloring is integer-only, so no fround discipline applies here.
 

--- a/packages/shallot/src/standard/tumble/engine/heightfield.ts
+++ b/packages/shallot/src/standard/tumble/engine/heightfield.ts
@@ -7,7 +7,7 @@
 // The C stores the field as one byte blob with offsets into the height/material/flag arrays; the port
 // models it as a plain struct of arrays. The raw bytes are never hashed by the sim (only body/contact
 // state is), so the representation is free — the compression, the flag bits, and the query's triangle-
-// visit order are what must stay bit-exact. fround discipline per the README.
+// visit order are what must stay bit-exact. fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { LINEAR_SLOP, MAX_AABB_MARGIN, OVERLAP_SLOP } from "./core";
 import {

--- a/packages/shallot/src/standard/tumble/engine/hull.ts
+++ b/packages/shallot/src/standard/tumble/engine/hull.ts
@@ -1,6 +1,6 @@
 // Convex hulls: quickhull builder, baking (weld/merge/reduction), mass properties, box/cylinder
 // generators. Ported op-for-op from Box3D's hull.c (Erin Catto; Dirk Gregorius contributed, MIT).
-// fround discipline per the README.
+// fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 //
 // The C builder carves all working memory from one block with pointer-based intrusive lists and
 // free lists for edge/face recycling. In TS the pointers are object references and the free lists

--- a/packages/shallot/src/standard/tumble/engine/island.ts
+++ b/packages/shallot/src/standard/tumble/engine/island.ts
@@ -3,11 +3,8 @@
 // in an island. Contacts/joints are stored as links carrying both body ids inline so the split
 // pass never touches b3Contact/b3Joint.
 //
-// Stage 7 (lifecycle) ports create/destroy — a body gets an island on creation — plus the contact
-// unlink that contact destroy needs. Stage 9 (islands+sleeping) adds merge (when a contact links two
-// islands), contact linking (b3LinkContact), and the union-find split (b3SplitIsland) that runs when a
-// touching contact stops. Joints (the join/split joint halves) are stage 10; island.joints is always
-// empty here. Validation is compiled out in the fixture build, so b3ValidateIsland is a no-op.
+// Persistent islands hold connected awake bodies. Contacts and joints are linked/unlinked as they form
+// and break. Validation is compiled out in the fixture build, so b3ValidateIsland is a no-op.
 
 import { NULL_INDEX, swapRemove } from "./array";
 import type { Contact } from "./contact";
@@ -163,7 +160,7 @@ function mergeIslands(world: WorldState, islandIdA: number, islandIdB: number): 
         bigIsland.contacts.push(link);
     }
 
-    // Migrate joints from smaller island to larger island (stage 10; always empty here)
+    // Migrate joints from smaller island to larger island
     for (let i = 0; i < smallIsland.joints.length; ++i) {
         const link = smallIsland.joints[i];
         const joint = world.joints[link.jointId];
@@ -358,7 +355,7 @@ export function splitIsland(world: WorldState, baseId: number): void {
         }
     }
 
-    // Union over joints, tracking per-component joint counts (stage 10; always empty here).
+    // Union over joints, tracking per-component joint counts.
     for (let i = 0; i < baseJointCount; ++i) {
         const bodyA = bodies[baseJoints[i].bodyIdA];
         const bodyB = bodies[baseJoints[i].bodyIdB];
@@ -434,7 +431,7 @@ export function splitIsland(world: WorldState, baseId: number): void {
         targetIsland.contacts.push(link);
     }
 
-    // Assign joints to the island of their bodies (stage 10; always empty here).
+    // Assign joints to the island of their bodies.
     for (let i = 0; i < baseJointCount; ++i) {
         const link = baseJoints[i];
         const joint = world.joints[link.jointId];

--- a/packages/shallot/src/standard/tumble/engine/island.ts
+++ b/packages/shallot/src/standard/tumble/engine/island.ts
@@ -3,8 +3,7 @@
 // in an island. Contacts/joints are stored as links carrying both body ids inline so the split
 // pass never touches b3Contact/b3Joint.
 //
-// Persistent islands hold connected awake bodies. Contacts and joints are linked/unlinked as they form
-// and break. Validation is compiled out in the fixture build, so b3ValidateIsland is a no-op.
+// Contacts and joints are linked/unlinked as they form and break. Validation is compiled out in the fixture build, so b3ValidateIsland is a no-op.
 
 import { NULL_INDEX, swapRemove } from "./array";
 import type { Contact } from "./contact";

--- a/packages/shallot/src/standard/tumble/engine/math.ts
+++ b/packages/shallot/src/standard/tumble/engine/math.ts
@@ -191,9 +191,7 @@ export function computeCosSin(radians: number): CosSin {
     return { cosine: f32(c * invMag), sine: f32(s * invMag) };
 }
 
-/** @deprecated use computeCosSin */
 export const sin = (radians: number): number => computeCosSin(radians).sine;
-/** @deprecated use computeCosSin */
 export const cos = (radians: number): number => computeCosSin(radians).cosine;
 
 // --- vec3 -----------------------------------------------------------------------------------

--- a/packages/shallot/src/standard/tumble/engine/mesh.ts
+++ b/packages/shallot/src/standard/tumble/engine/mesh.ts
@@ -5,7 +5,7 @@
 // The C stores the mesh as one byte blob with offsets into node/vertex/triangle/material/flag arrays
 // (SIMD-aligned bitfield nodes); the port models it as a plain struct of arrays. The raw bytes are
 // never hashed by the sim, so the representation is free to change — only the BVH build order and the
-// query's triangle-visit order are load-bearing for bit-exactness. fround discipline per the README.
+// query's triangle-visit order are load-bearing for bit-exactness. fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { HUGE, LINEAR_SLOP, OVERLAP_SLOP } from "./core";
 import {

--- a/packages/shallot/src/standard/tumble/engine/mover.ts
+++ b/packages/shallot/src/standard/tumble/engine/mover.ts
@@ -1,6 +1,6 @@
 // Character mover: the plane solver that pushes a capsule mover out of a set of collision planes,
 // and the velocity clip that projects motion along them. Ported op-for-op from Box3D's mover.c
-// (Erin Catto, MIT). fround discipline per the README.
+// (Erin Catto, MIT). fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 //
 // The collision planes fed here come from b3CollideMover (collideMover in shape.ts), which gathers a
 // b3PlaneResult per touched shape. The caller turns those into b3CollisionPlanes (adding a pushLimit

--- a/packages/shallot/src/standard/tumble/engine/pairs.ts
+++ b/packages/shallot/src/standard/tumble/engine/pairs.ts
@@ -10,7 +10,7 @@
 // surviving filters (self-body / sensor / shouldShapesCollide / joint walk) over the returned
 // candidates and creates the contacts. A found compound leaf stays on the TS path: the kernel emits a
 // placeholder, and TS maps the query bounds into the compound's local frame and recurses its inner
-// tree, each overlapping child a candidate with its child index. fround per the README.
+// tree, each overlapping child a candidate with its child index. fround per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { intVec, NULL_INDEX } from "./array";
 import { type Body, getBodyTransformQuick } from "./body";

--- a/packages/shallot/src/standard/tumble/engine/sensor.ts
+++ b/packages/shallot/src/standard/tumble/engine/sensor.ts
@@ -5,7 +5,7 @@
 //
 // Single-threaded and serial: the C's per-worker sensor task + the event-publish pass collapse into
 // one loop, and the eventBits optimization drops out (a sensor whose overlaps didn't change emits no
-// events regardless, so the diff always runs). fround discipline per the README.
+// events regardless, so the diff always runs). fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { NULL_INDEX } from "./array";
 import { getBodyTransformQuick } from "./body";

--- a/packages/shallot/src/standard/tumble/engine/shape.ts
+++ b/packages/shallot/src/standard/tumble/engine/shape.ts
@@ -3,7 +3,7 @@
 // body through a doubly-linked shape list and to the broad-phase through a proxy key.
 //
 // Sphere/capsule/hull/mesh/height-field/compound shapes are ported: create/destroy, mass/AABB/extent/
-// centroid, the proxy, and materials. fround discipline per the README.
+// centroid, the proxy, and materials. fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { NULL_INDEX } from "./array";
 import { type Body, getBodyTransformQuick, updateBodyMassData } from "./body";

--- a/packages/shallot/src/standard/tumble/engine/softness.ts
+++ b/packages/shallot/src/standard/tumble/engine/softness.ts
@@ -1,6 +1,6 @@
 // Soft-constraint coefficients (Box3D's b3Softness / b3MakeSoft, Erin Catto, MIT). Extracted into
 // its own leaf module (math-only) so both the contact solver and the joints can pull it without an
-// import cycle through body.ts. fround discipline per the README.
+// import cycle through body.ts. fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { f32, PI } from "./math";
 

--- a/packages/shallot/src/standard/tumble/engine/solverset.ts
+++ b/packages/shallot/src/standard/tumble/engine/solverset.ts
@@ -3,10 +3,9 @@
 // disabled, awake, and one set per sleeping island group. A body's sim lives in its set's bodySims
 // column; the awake set additionally holds a bodyStates column and the live islands.
 //
-// Ported from Box3D's solver_set.c (Erin Catto, MIT). Handles destroy/wake/transferBody — the transfers reachable from body
-// create/destroy/setType. trySleepIsland (the sleep transition) and
-// completes wake by transferring touching contacts back to the graph (via graph.ts). transferJoint
-// moves a joint's sim between sets (used by setType). MergeSolverSets stays seamed for the joints stage.
+// Handles destroy/wake/transferBody — the transfers reachable from body create/destroy/setType. trySleepIsland
+// (the sleep transition) handles wake completion by transferring touching contacts back to the graph (via graph.ts).
+// transferJoint moves a joint's sim between sets (used by setType).
 
 import { NULL_INDEX, swapRemove } from "./array";
 import {

--- a/packages/shallot/src/standard/tumble/engine/solverset.ts
+++ b/packages/shallot/src/standard/tumble/engine/solverset.ts
@@ -3,8 +3,8 @@
 // disabled, awake, and one set per sleeping island group. A body's sim lives in its set's bodySims
 // column; the awake set additionally holds a bodyStates column and the live islands.
 //
-// Stage 7 (lifecycle) ports destroy/wake/transferBody — the transfers reachable from body
-// create/destroy/setType. Stage 9 (islands+sleeping) adds trySleepIsland (the sleep transition) and
+// Ported from Box3D's solver_set.c (Erin Catto, MIT). Handles destroy/wake/transferBody — the transfers reachable from body
+// create/destroy/setType. trySleepIsland (the sleep transition) and
 // completes wake by transferring touching contacts back to the graph (via graph.ts). transferJoint
 // moves a joint's sim between sets (used by setType). MergeSolverSets stays seamed for the joints stage.
 

--- a/packages/shallot/src/standard/tumble/engine/step.ts
+++ b/packages/shallot/src/standard/tumble/engine/step.ts
@@ -3,7 +3,7 @@
 // hash (the regression contract) is taken by the caller after the step returns.
 //
 // No recording. Single-threaded and serial, so the parallel task orchestration collapses to
-// straight-line calls. fround discipline per the README.
+// straight-line calls. fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { claimResident, reserveBodies } from "./bodycolumns";
 import { collide } from "./collide";

--- a/packages/shallot/src/standard/tumble/engine/triangle_manifold.ts
+++ b/packages/shallot/src/standard/tumble/engine/triangle_manifold.ts
@@ -1,7 +1,7 @@
 // Triangle narrowphase — ports triangle_manifold.c from Box3D (Erin Catto, MIT). Sphere/capsule/
 // hull versus a single triangle, producing a manifold in the primary shape's local frame. These
 // feed the mesh/height-field multi-manifold driver (mesh_contact). The hull path reuses the SAT
-// cache and the shared clip/query helpers from manifold.ts. fround discipline per the README.
+// cache and the shared clip/query helpers from manifold.ts. fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import { type DistanceInput, emptyCache, type SimplexCache, shapeDistance } from "./distance";
 import type { Capsule, Sphere } from "./geometry";

--- a/packages/shallot/src/standard/tumble/engine/world.ts
+++ b/packages/shallot/src/standard/tumble/engine/world.ts
@@ -3,9 +3,7 @@
 // array of records; the hot payload lives in solver sets. Worlds live in a fixed registry so a
 // stale world id (to a destroyed, possibly recycled, world) is detected by a generation mismatch.
 //
-// Stage 7 (lifecycle) ports create/destroy/validity/counters and the hull database. The step, the
-// constraint graph, sensors, recording, and threading are later stages; their world state is added
-// as those stages land. fround discipline per the README.
+// Ported from Box3D's physics_world.c (Erin Catto, MIT). fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import type { Body } from "./body";
 import { type BodyStore, createBodyStore, releaseResident } from "./bodycolumns";

--- a/packages/shallot/src/standard/tumble/engine/world.ts
+++ b/packages/shallot/src/standard/tumble/engine/world.ts
@@ -3,7 +3,7 @@
 // array of records; the hot payload lives in solver sets. Worlds live in a fixed registry so a
 // stale world id (to a destroyed, possibly recycled, world) is detected by a generation mismatch.
 //
-// Ported from Box3D's physics_world.c (Erin Catto, MIT). fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
+// fround discipline per .claude/rules/tumble.md § "The contract: bit-exact f32 parity".
 
 import type { Body } from "./body";
 import { type BodyStore, createBodyStore, releaseResident } from "./bodycolumns";

--- a/packages/shallot/src/standard/tumble/lifecycle.test.ts
+++ b/packages/shallot/src/standard/tumble/lifecycle.test.ts
@@ -16,8 +16,7 @@ import { Slab } from "../slab";
 import { shutdown } from "./engine";
 import { Tumble, TumblePlugin } from "./index";
 
-// World lifecycle conformance (specs/tumble-shallot.md "World lifecycle is exclusive and disposal is
-// mandatory"): the wasm kernel is a singleton with ONE resident region, so a leaked world on a rebuild is a
+// World lifecycle conformance: the wasm kernel is a singleton with ONE resident region, so a leaked world on a rebuild is a
 // hard failure, not a slow leak — the build→step→dispose ×2 roster entry this file is. No device needed:
 // TumblePlugin's own warm() never touches Compute (CPU-native), so this runs at the fast `bun test` tier —
 // bypasses `build()`/`app()` (register + Slab.collect + the lifecycle hooks directly), the orbit.test.ts shape.

--- a/packages/shallot/src/standard/tumble/tumble.test.ts
+++ b/packages/shallot/src/standard/tumble/tumble.test.ts
@@ -518,7 +518,7 @@ describe("Tumble.body handle accessor", () => {
 
 describe("same-update destroy+create realias", () => {
     test("a box destroyed and a sphere created at the recycled eid marshals the new body", async () => {
-        // the same-update destroy+create identity bug (tumble.md "Eid presence is not identity"): a box
+        // the same-update destroy+create identity bug (tumble.md "The wasm world is a singleton — dispose is load-bearing"): a box
         // is marshaled, then destroyed and its eid recycled by a NEW sphere Body in one update. SyncSystem
         // keys create/destroy on presence alone, so it neither sweeps the eid (it still has Body) nor
         // re-marshals it (it's still in `bodies`) — the old box handle survives entirely. The fix (1b)
@@ -863,7 +863,12 @@ describe("compose covers static bodies", () => {
             Physics.backend?.compose(undefined as unknown as GPUCommandEncoder, buffer, 1);
             expect(writes.get(box * 48)).toBeDefined();
             const still = writes.get(floor * 48);
-            if (still) expect(still[1]).toBeCloseTo(-0.1); // if reported, it's still the spawn pose
+            if (still) {
+                expect(still[1]).toBeCloseTo(-0.1); // if reported, it's still the spawn pose
+            } else {
+                // floor is static and not moving, so compose may or may not report it
+                expect(still).toBeUndefined();
+            }
         } finally {
             compute.device = priorDevice;
         }


### PR DESCRIPTION
- **audit-comment-sweep: burn down false comments in tumble, sear, avbd, standard**
- **audit-comment-sweep: fix duplicated attribution and broken grammar from the sweep**
