### PR TITLE
audit comment sweep/stage 3

### DIFF
--- a/packages/shallot/src/extras/gltf/live.ts
+++ b/packages/shallot/src/extras/gltf/live.ts
@@ -57,7 +57,7 @@ const LiveCtx = fsCtxSchema();
 // read to resolution time (see standard/sear/pipelines.ts's `typedVaryingVs` for the same fix in full).
 const liveBound = liveLayout.$;
 
-// The dynamic vec4 lane reads are the one WGSL-bodied leaf the 4a lock names. The surface itself is still
+// The dynamic vec4 lane reads are the one WGSL-bodied leaf this surface needs. The surface itself is still
 // a typed fn: schemas own every argument/resource and `$uses` binds the raw body's free names.
 const liveVs = tgpu
     .fn(

--- a/packages/shallot/src/extras/lines/surface.ts
+++ b/packages/shallot/src/extras/lines/surface.ts
@@ -1,5 +1,5 @@
 // The `lines` sear surface: the segment schema, its group-2 layout, and the screen-space quad expansion
-// as TGSL. Sibling of `index.ts` because that module holds the ECS/system/plugin half (2a: kernels live
+// as TGSL. Sibling of `index.ts` because that module holds the ECS/system/plugin half (kernels live
 // beside, not inside, registry code); the CPU staging + upload live in `segments.ts`.
 //
 // `localPos.xy` carries the quad corner: x = t (0 start, 1 end), y = edge (-1, +1). The surface is
@@ -126,7 +126,7 @@ export const lineVs = tgpu
         // the array-element read is a pointer, not a copy — wrap in the element schema
         const seg = Segment(lineLayout.$.lineSegments[vsIn.iid]);
         // `view.viewProj` is re-read rather than bound to a local: a uniform-aliased local emits WGSL
-        // pointer form (2c), the shape Metal's compiler is watched on
+        // pointer form, the shape Metal's compiler is watched on
         const q = lineQuad(
             std.mul(engineLayout.$.view.viewProj, d.vec4f(seg.a, 1)),
             std.mul(engineLayout.$.view.viewProj, d.vec4f(seg.b, 1)),

--- a/packages/shallot/src/extras/skin/live.ts
+++ b/packages/shallot/src/extras/skin/live.ts
@@ -722,7 +722,7 @@ export const skinParamsWgsl = chunk("skinParamsWgsl", [SkinParams], spliceNs);
 // the per-instance tint — WGSL-bodied, because it reads `skinData` and `skin` as module-scope globals the
 // *consumer* declares by name (the relocatable contract every live-skin surface shares) and calls the
 // sear-spliced `unpackLdrColor`. A TGSL body has no spelling for either until the surface contract itself
-// is typed (4a).
+// is typed.
 const liveTint = tgpu
     .fn(
         [d.u32],

--- a/packages/shallot/src/extras/text/glyph.ts
+++ b/packages/shallot/src/extras/text/glyph.ts
@@ -60,7 +60,7 @@ export const sdfToSignedDistance = tgpu.fn(
     const a = std.select(sdf, 1 - sdf, sdf > 0.5);
     const absDist = (1 - std.pow(2 * a, 1 / SDF_EXPONENT)) * maxDimension;
     // f32-typed rails: a bare `1` / `-1` transpiles i32 and lands an implicit conversion in the emitted
-    // WGSL (the integer-literal law, spec Approach 2a)
+    // WGSL (the integer-literal law)
     return absDist * std.select(d.f32(1), d.f32(-1), sdf > 0.5);
 });
 

--- a/packages/shallot/src/extras/text/sdf.ts
+++ b/packages/shallot/src/extras/text/sdf.ts
@@ -368,7 +368,7 @@ export class SDFGenerator {
     begin(): void {
         // built here, drawn from `flush` microseconds later, so there is no force-compile forcer: a
         // `precompile` thunk drains after warm, long after these draws already went out (the load-path
-        // blit's refuted precompile, spec Approach 2a)
+        // blit's refuted precompile)
         this._pipelines = pipelines();
         this.ensureIntermediateTexture();
         this._pending = [];

--- a/packages/shallot/src/standard/avbd/step.test.ts
+++ b/packages/shallot/src/standard/avbd/step.test.ts
@@ -307,8 +307,8 @@ test("joint-dual references its own-group counters binding (the forcing touch)",
 });
 
 // The shared factory's contactContrib/springContrib/jointContrib/solvePose are the typed primal's (and
-// solve-lds's) real pipeline consumer since 2b — this pins that the roRo-bound instance the CPU
-// differential exercises also resolves cleanly standalone (the "author once" mandate).
+// solve-lds's) real pipeline consumer now that both are typed pipelines — this pins that the roRo-bound
+// instance the CPU differential exercises also resolves cleanly standalone (the "author once" mandate).
 test("the shared factory's primal-side functions resolve standalone (CPU-differential-testable)", () => {
     for (const fn of [
         solverRoRo.contactForce,
@@ -376,7 +376,7 @@ test("solve-lds resolves the whole iters × colors block as one workgroup-reside
 // The shared chunks (Mat3/CForce/Contrib/Sol/NewPose) are authored exactly once and closed over per
 // reader set (contactMath/contribMath/dualMath/jointDualMath) — every pass that calls into them must emit
 // byte-identical struct text, never an independent raw copy that could drift from the typed one (the
-// defect class the interim two-copy state at 2a was sanctioned to avoid for exactly one sub-stage).
+// defect class the interim two-copy state was sanctioned to avoid only for one transitional stage).
 test("the shared solver structs emit byte-identical text in every pass that uses them", () => {
     const allThree = {
         dual: stepWgsl.dual(),

--- a/packages/shallot/src/standard/avbd/step.ts
+++ b/packages/shallot/src/standard/avbd/step.ts
@@ -365,8 +365,8 @@ const B_ROUND: u32 = ${B_ROUND}u;
 
 // ── the shared solver bindings, one layout per storage access-mode combination ─────────────────────────
 // `params` + `bodies` + `pairContacts` are what nearly every kernel binds, so they live in ONE shared
-// layout at group 1 and every kernel's own I/O keeps group 0 (the 3a `nodeLayout` shape, bind-by-layout-
-// object). WGSL access mode is part of a binding's type, so a read-only reader and a read-write writer
+// layout at group 1 and every kernel's own I/O keeps group 0 (the same bind-by-layout-object shape
+// `nodeLayout` uses elsewhere). WGSL access mode is part of a binding's type, so a read-only reader and a read-write writer
 // need distinct layouts — hence one variant per (bodies, pairContacts) access pair, and the accessors
 // below are FACTORIES over the variant (one authored accessor re-emits per
 // layout). A variant's chunks carry their own `Namespace`, so every variant emits the shared math + the
@@ -772,9 +772,9 @@ const roRw = accessors("readonly", "mutable");
 const rwRw = accessors("mutable", "mutable");
 
 // ── the shared solver factory ──────────────────────────────────────────────────────────────────────
-// MAT3 / CONTACT_FORCE / JOINT_REC ported to TGSL fns, parameterized by a pose-reader set (the 1c
-// factory-closure law: one authored kernel re-emits per reader set — storage readers now, 2b adds the
-// LDS set solve-lds shadows bPos/bQuat with). Unlike the typed kernels below, these are plain `tgpu.fn`
+// MAT3 / CONTACT_FORCE / JOINT_REC ported to TGSL fns, parameterized by a pose-reader set (the
+// factory-closure law: one authored kernel re-emits per reader set — storage readers, and the LDS
+// set solve-lds shadows bPos/bQuat with). Unlike the typed kernels below, these are plain `tgpu.fn`
 // definitions with no manual chunk()/ns bookkeeping: nothing here produces standalone spliced WGSL text
 // the way the raw *PassWgsl() functions do, so `tgpu.resolve([kernel], {names:"strict"})` — one clean
 // call per consuming kernel — walks the whole call graph itself with no forcing needed.
@@ -782,7 +782,7 @@ const rwRw = accessors("mutable", "mutable");
 /**
  * the persistent per-joint record group's index. `jointRecords` needs its own bind group — solve-lds
  * sits exactly at the 10-storage floor within group 0 + the shared solver group, so a third binding has
- * nowhere else to go. joint-init / joint-dual (this stage) and 2b's primal / solve-lds all bind it here.
+ * nowhere else to go. joint-init / joint-dual (this stage) and primal / solve-lds all bind it here.
  * @internal
  */
 export const JOINT_GROUP = 2;
@@ -948,15 +948,15 @@ export function jointAccessors(access: Access) {
     };
 }
 
-/** joint records read-only — 2b's primal / solve-lds. */
+/** joint records read-only — used by primal / solve-lds. */
 export const jointRo = jointAccessors("readonly");
 /** joint records read-write — this stage's joint-init / joint-dual. */
 export const jointRw = jointAccessors("mutable");
 
 /**
  * the primal / solve-lds own-group bindings ({@link solvePose}'s CSR adjacency + authored constraints) —
- * not consumed by any 2a pipeline (primal / solve-lds stay raw this stage), but `solvePose` /
- * `jointContrib` need concrete bindings to resolve + CPU-differential now. 2b's typed primal / solve-lds
+ * not consumed by the raw pipeline (primal / solve-lds stay raw at this point), but `solvePose` /
+ * `jointContrib` need concrete bindings to resolve + CPU-differential now. The typed primal / solve-lds
  * reuse this layout unchanged.
  * @internal
  */
@@ -1248,7 +1248,7 @@ const solve6 = tgpu
     .$name("solve6");
 
 /**
- * the shared contact stamp over one pose-reader set (storage readers this stage; 2b's LDS set repeats
+ * the shared contact stamp over one pose-reader set (storage readers this stage; the LDS set repeats
  * this factory call with solve-lds's workgroup-memory readers instead). @internal
  */
 export function contactMath(A: ReturnType<typeof accessors>) {
@@ -1515,7 +1515,7 @@ export function contribMath(
 
     /** the per-body primal step: stamp `bid`'s CSR contacts + authored constraints into one 6×6 block
      *  system, add the inertial term, LDLᵀ-solve, integrate. Pose reads go through `A.bPos`/`A.bQuat`, so
-     *  the composing kernel picks the backing — storage for the typed primal (2b), workgroup memory for
+     *  the composing kernel picks the backing — storage for the typed primal, workgroup memory for
      *  solve-lds's LDS reader set. Differential-tested on CPU against the f64 oracle math. */
     const solvePose = tgpu
         .fn(
@@ -1576,7 +1576,7 @@ export function contribMath(
 const STICK_THRESH = 1.0e-5;
 
 /**
- * one pair slot's dual update (manifold.ts updateDual), shared by the standalone dual pass and 2b's
+ * one pair slot's dual update (manifold.ts updateDual), shared by the standalone dual pass and the
  * LDS-resident kernel: loop its `CONTACTS_PER_PAIR` records, dual-update each active one in place.
  * @internal
  */
@@ -1631,7 +1631,7 @@ export function dualMath(
 }
 
 /**
- * one joint's dual update (joint.ts updateJointDual), shared by the standalone joint-dual pass and 2b's
+ * one joint's dual update (joint.ts updateJointDual), shared by the standalone joint-dual pass and the
  * LDS-resident kernel. The rigid (∞-stiffness) rows store λ ← K·C + λ; both row triples ramp the penalty
  * by β|C|, clamped to `PENALTY_MAX`.
  * @internal
@@ -1823,7 +1823,7 @@ const aabbKernel = tgpu
 // the block write are one source of truth — the small-N O(n²) scan differs ONLY in how it enumerates
 // candidates, the precondition for warmstart carrying across a regime flip (identical blocks). Broadphase
 // (descent) and broadphase-small (scan) each declare their own group-0 layout (different extra bindings —
-// `nodes` vs `prims`), so this factory closes over whichever layout its caller passes — the 1c
+// `nodes` vs `prims`), so this factory closes over whichever layout its caller passes — the
 // factory-closure law, applied to a group-0 layout rather than the shared solver group.
 const NbrArr = d.arrayOf(d.u32, PAIRS_PER_BODY);
 const Nd2Arr = d.arrayOf(d.f32, PAIRS_PER_BODY);
@@ -4467,9 +4467,9 @@ export class PhysicsStep {
             .with(roRo.layout, this._sharedBG.roRo);
         // a typed pipeline is created synchronously, so Dawn defers its shader compile to the first
         // dispatch — a first-frame hitch where the raw passes' `createComputePipelineAsync` compiled at
-        // build. Force it at warm with a 0-workgroup dispatch, the shipped drain (1a). Both groups are
+        // build. Force it at warm with a 0-workgroup dispatch, the shipped drain. Both groups are
         // already bound here, so the drain's bound-nothing guard is inert — a forcer that allocates its
-        // own buffers must return the *dispatch* for that guard to fire (2a).
+        // own buffers must return the *dispatch* for that guard to fire.
         register(`${this._scope}-aabb`, () => {
             this._aabbPipe.dispatchWorkgroups(0);
             return this._aabbPipe;

--- a/packages/shallot/src/standard/bvh/traverse.ts
+++ b/packages/shallot/src/standard/bvh/traverse.ts
@@ -112,7 +112,7 @@ export const BvhHit = d
     .$name("BvhHit");
 
 // The four node readers — WGSL-bodied, because `nodes` is a module-scope global the *consumer*
-// declares by name (the relocatable contract; no TGSL spelling until that contract is typed, 4a).
+// declares by name (the relocatable contract; no TGSL spelling until that contract is typed).
 const bvhNodeMin = tgpu
     .fn(
         [d.u32],

--- a/packages/shallot/src/standard/fog/index.ts
+++ b/packages/shallot/src/standard/fog/index.ts
@@ -84,7 +84,7 @@ let _lights: { keys: (GPUBuffer | GPUTextureView | GPUSampler)[]; group: LightsG
 
 // per-camera group 0 (scene / depth / output / view / fog), cached per eid on the `sceneTransform` read +
 // write + the depth view (all three reallocate only on a resize, so the group rebuilds then, not every
-// frame) and the view slot (the per-slot View buffer it binds — Approach 4a's per-slot-buffer design)
+// frame) and the view slot (the per-slot View buffer it binds — a per-slot-buffer design)
 const _views = new Map<
     number,
     {

--- a/packages/shallot/src/standard/fog/pipeline.test.ts
+++ b/packages/shallot/src/standard/fog/pipeline.test.ts
@@ -5,7 +5,7 @@ import { fogLayout0, fogLayout1, fogWgsl } from "./pipeline";
 // The fog march's typed layouts + kernel, resolved device-free — the `outlineWgsl`/`glazeWgsl` shape. These
 // pin the structure the pipeline gates can't cheaply reach: the group-0/group-1 binding shapes, the six
 // shadow-only bindings forced into scope despite no direct `layout.$.x` access in the kernel body, and the
-// idiv audit (0a's probe found the fog kernel needs none). Numerics are the bench's job
+// idiv audit (a probe found the fog kernel needs none). Numerics are the bench's job
 // (`bun bench --scenario render --param mode=fog`); this is what the GPU can't tell us about cheaply.
 describe("fog bind-group layouts", () => {
     test("group 0 has the five per-camera entries at distinct indices", () => {

--- a/packages/shallot/src/standard/render/contract.ts
+++ b/packages/shallot/src/standard/render/contract.ts
@@ -5,7 +5,7 @@
 // to **group 2** (engine 0 / shadow-or-atlas 1 / surface 2) — `surfaceLayout()`'s `$idx(SURFACE_GROUP)`. The
 // `vertices` slot is pass-variant (color pass reads the 16 B main stream, prepass/shadow the 8 B
 // position-only stream, same physical slot) — `surfaceLayout()` synthesizes both variants; typegpu resolves only
-// what a given shader actually calls, so carrying the unused variant's declaration costs nothing (the 2b
+// what a given shader actually calls, so carrying the unused variant's declaration costs nothing (the
 // "layout is a superset of what one shader declares" precedent, `engine.test.ts`).
 
 import type { TgpuBindGroupLayout, TgpuFn } from "typegpu";

--- a/packages/shallot/src/standard/render/index.ts
+++ b/packages/shallot/src/standard/render/index.ts
@@ -215,7 +215,7 @@ export const BeginFrameSystem: System = {
         Render.viewCount = count;
         // per-slot writer: only shading slots ([0, shadeCount)) ever bind a real View buffer — the
         // point/cascade atlas passes bind slot 0's buffer as an unread placeholder — so a depth-only slot
-        // gets no write at all (design lock, Approach 4a). Each write sources VIEW_BYTES from the same
+        // gets no write at all (design lock). Each write sources VIEW_BYTES from the same
         // per-slot viewStaging subrange the pack loop above always wrote
         const viewFloats = VIEW_BYTES / 4;
         for (let slot = 0; slot < Render.shadeCount; slot++) {

--- a/packages/shallot/src/standard/sear/atlas.ts
+++ b/packages/shallot/src/standard/sear/atlas.ts
@@ -683,8 +683,8 @@ export function renderPointShadows(frameDraws: { draw: Draw; r: Recorded }[]): v
     cpass.end();
 
     // one pass into the whole atlas — one indirect draw per casting mesh, the VS placing each re-gathered
-    // instance into its combo's tile. The point VS projects by faceVP (not view), so the bound View buffer
-    // (slot 0's, `record`'s eidsSwap) is an unread placeholder
+    // instance into its combo's tile. The point VS projects by faceVP (not view), so the View buffer bound
+    // at slot 0 is an unread placeholder
     const pass = encoder.beginRenderPass({
         label: "sear-pointshadow",
         timestampWrites: Compute.span?.("sear:pointshadow"),

--- a/packages/shallot/src/standard/sear/engine.test.ts
+++ b/packages/shallot/src/standard/sear/engine.test.ts
@@ -31,7 +31,7 @@ describe("engine scaffold", () => {
     // `frame` and `meshQuant` are group-0 entries the scaffold never reads (the vertex decode reads
     // meshQuant, not the shading scaffold), so typegpu's
     // resolve — which emits only what's called — declares none of their WGSL: the layout is a superset
-    // of what any one shader declares (the 2b precedent).
+    // of what any one shader declares.
     test("binds the five group-0 resources it actually reads, by their typed-layout names", () => {
         expect(flatWgsl).toMatch(/var<uniform> view: View;/);
         expect(flatWgsl).toMatch(/var<uniform> lighting: Lighting;/);

--- a/packages/shallot/src/standard/sear/pipelines.ts
+++ b/packages/shallot/src/standard/sear/pipelines.ts
@@ -2300,7 +2300,7 @@ export async function preparePipelines(): Promise<void> {
     // force each typed pipeline's memo at warm (`root.unwrap` runs the resolve + the sync
     // `createRenderPipeline`) — typegpu defers both to first use, which would otherwise land mid-frame
     // on the first draw and hide a resolution/validation error until then (the force-compile-at-warm
-    // lock, Approach 0a)
+    // lock)
     for (const surface of Surfaces) {
         if (surface.specialize) continue;
         const t = compileVariant(surface);

--- a/packages/shallot/src/standard/tumble/engine/bodycolumns.ts
+++ b/packages/shallot/src/standard/tumble/engine/bodycolumns.ts
@@ -1,6 +1,6 @@
 // The persistent body region (kernel/src/bodies.rs) — the awake body columns held resident across
-// steps, first in the kernel's linear memory: velocity/delta `state` + `flags` (4a.2) and the
-// integrate/finalize `sim`/`fin`/`sim2` fields (4a.3). The solver runs directly over these columns
+// steps, first in the kernel's linear memory: velocity/delta `state` + `flags` and the
+// integrate/finalize `sim`/`fin`/`sim2` fields. The solver runs directly over these columns
 // (the kernel phases alias `LAYOUT[STATE]`/`LAYOUT[SIM]`/etc here), so a step no longer marshals the
 // body in and reads it back out — the column is the single source of truth. This module owns the
 // grow-only sizing (the region tracks the total-body high-water so it never shrinks with the churny
@@ -314,7 +314,7 @@ class ResidentBodyState implements BodyState {
 
 /**
  * A `BodySim` (b3BodySim) backed by record `i` of the resident sim/fin/sim2 columns rather than a plain
- * object (4a.3), so no per-step marshal runs. Vector/quaternion/matrix getters return fresh objects
+ * object, so no per-step marshal runs. Vector/quaternion/matrix getters return fresh objects
  * (plain-object semantics — in-place sub-field writes on the caller side become whole-field setter
  * assignments); scalar getters return the raw slot (no allocation). Reads go through `store.simF` etc
  * on every access so a grow's re-derivation is transparent. Index-fixed like {@link ResidentBodyState}:

--- a/packages/shallot/src/standard/tumble/engine/columns.ts
+++ b/packages/shallot/src/standard/tumble/engine/columns.ts
@@ -24,7 +24,7 @@ export function writeMat3(col: Float32Array, o: number, m: Mat3): void {
     col[o + 8] = m.cz.z;
 }
 
-// Body columns (body.rs + bodies.rs). All resident in the persistent body region (4a) — the awake
+// Body columns (body.rs + bodies.rs). All resident in the persistent body region — the awake
 // `BodySim`/`BodyState` are offset-backed views over them (bodycolumns.ts), so no per-step marshal.
 export const STATE_STRIDE = 16;
 /** Live f32 fields in a state record; slots STATE_LIVE..STATE_STRIDE are alignment padding. */
@@ -245,7 +245,7 @@ export const D_XF_B = 10; // p3 + q4
 export const D_GEOM_A = 17; // ≤7 slots
 export const D_GEOM_B = 24; // ≤7 slots
 
-// Contact-recycle input record (arena.rs `RECYCLE_STRIDE`, 4b.3c). All u32: contactId, the two bodies'
+// Contact-recycle input record (arena.rs `RECYCLE_STRIDE`). All u32: contactId, the two bodies'
 // awake localIndices (resident-column records), the two shapeIds (fat-AABB column records), and a bits
 // word (bit0 eligible, bit1 wasTouching). The kernel reads the bodies' transforms/centers/extents and
 // the cached pose from the resident columns; only these indices + bits cross per contact.
@@ -273,7 +273,7 @@ const JOINT = 15;
 const N_COLS = 16;
 
 /** The column views the TS side reads or writes. The body columns (`state`/`flags`/`sim`/`fin`) are
- * resident (4a) — held across steps in the body region and viewed through the `BodySim`/`BodyState`
+ * resident — held across steps in the body region and viewed through the `BodySim`/`BodyState`
  * views (bodycolumns.ts), not here. The transient constraint columns (cc/mc/mcp) and the persistent
  * directory/pool are kernel-internal. */
 export type Columns = {

--- a/packages/shallot/src/standard/tumble/engine/fataabbcolumns.test.ts
+++ b/packages/shallot/src/standard/tumble/engine/fataabbcolumns.test.ts
@@ -1,4 +1,4 @@
-// 4b.3a / T4 — the resident fat-AABB column mirrors each shape's fatAABB. Every TS site that writes
+// The resident fat-AABB column mirrors each shape's fatAABB. Every TS site that writes
 // `shape.fatAABB` mirrors it into the column inline (create, refit commit, CCD, moves), so the column the
 // in-kernel recycle + finalize escape tests read stays current with no step-top flush. This exercises the
 // whole write path end-to-end: a static shape written once at create (never refits), dynamic shapes refit

--- a/packages/shallot/src/standard/tumble/engine/fataabbcolumns.ts
+++ b/packages/shallot/src/standard/tumble/engine/fataabbcolumns.ts
@@ -1,9 +1,9 @@
 // The persistent fat-AABB region (kernel/src/fataabb.rs) — one enlarged broad-phase AABB per shape,
-// held resident in the kernel's linear memory so the in-kernel recycle loop (4b) can test contact
+// held resident in the kernel's linear memory so the in-kernel recycle loop can test contact
 // overlap without a per-step marshal. A second low persistent region, directly above the body region;
 // keyed by shapeId (grow-on-createShape), so — unlike the body region — no record migration: a shape's
 // slot is fixed for its life. This module owns the grow-only sizing to the shape high-water; the write
-// (at refit) and the kernel read land in 4b.3.
+// (at refit) and the kernel read happen outside this module.
 //
 // A region grow relocates the manifold + geometry regions above it (kernel-side, in place) and, like
 // any memory.grow, detaches every typed-array view — so callers refresh the stores over the relocated
@@ -36,7 +36,7 @@ export function reserveFatAabb(shapeCount: number): boolean {
 
 /**
  * A typed-array view over the resident fat-AABB column plus the shapeId-keyed write. One per world.
- * The column is the source the in-kernel recycle overlap test (4b.3c) and the in-kernel finalize refit's
+ * The column is the source the in-kernel recycle overlap test and the in-kernel finalize refit's
  * escape test read; every TS site that writes `shape.fatAABB` mirrors it here inline (create, user
  * moves, the CCD/fast paths, the finalize commit). Re-derives its view whenever a grow detaches it.
  */

--- a/packages/shallot/src/standard/tumble/engine/jointcolumns.ts
+++ b/packages/shallot/src/standard/tumble/engine/jointcolumns.ts
@@ -4,7 +4,7 @@
 // + softness in `prepare`, so this only copies the raw body-sim inputs + config + the persistent
 // impulses (no arithmetic — bit-exact by construction against the serial prepare's identical inputs).
 //
-// All eight solver joint types are wired (3b template + 3c). Filter joints carry a header-only no-op
+// All eight solver joint types are wired. Filter joints carry a header-only no-op
 // record (a collision filter has no solve), so every awake joint type is kernel-resident and
 // `writeRecord`'s throw is unreachable for an awake joint.
 

--- a/packages/shallot/src/standard/tumble/engine/kernel.test.ts
+++ b/packages/shallot/src/standard/tumble/engine/kernel.test.ts
@@ -41,7 +41,7 @@ test("wasm-simd128 kernel loads and runs f32x4 over shared memory", async () => 
 // (reserve → write inputs through the views → run the export shim → read outputs back), and assert
 // bit-for-bit against the committed C gold. This exercises the arena layout, the layoutPtr header, the
 // view derivation, and the finalize shim — everything between TS and the gold-verified Rust arithmetic.
-// Body `state` is resident (4a.2), so it's driven through the body store over the persistent region
+// Body `state` is resident, so it's driven through the body store over the persistent region
 // (which `reserveBodies` establishes and `arena::reserve` aliases `LAYOUT[STATE]` at), not `cols`.
 const _b = new ArrayBuffer(4);
 const _f = new Float32Array(_b);
@@ -101,12 +101,12 @@ test("finalize export shim matches the C gold over shared columns", async () => 
     }
 });
 
-// Geometry-columns gate (3c.2b): upload the convex hulls from the committed manifold gold into the
+// Geometry-columns gate: upload the convex hulls from the committed manifold gold into the
 // kernel's static geometry columns, then run the hull-hull narrowphase over those column-backed hulls
 // in wasm (`collideHullsGeo`) and assert the manifold bit-for-bit against the same gold the native
 // Vec-backed path verifies. This exercises the whole geometry read path — the reserveGeometry layout,
 // the TS upload (geocolumns.ts), the wasm reinterpret into the HullData view, and every pool the
-// narrowphase touches (points, vertices, edges, faces, planes, center) — the seed of 3c.3's dispatch.
+// narrowphase touches (points, vertices, edges, faces, planes, center) — the seed of the convex-dispatch gate below.
 type GoldVec = [string, string, string];
 type GoldHull = {
     center: GoldVec;
@@ -214,14 +214,14 @@ test("collideHullsGeo matches the manifold gold over the static geometry columns
     }
 });
 
-// Convex dispatch gate (3c.3.a): drive `dispatchConvex` over the full column stack the live collide will
+// Convex dispatch gate: drive `dispatchConvex` over the full column stack the live collide will
 // use — the static geometry pools (hulls), the persistent manifold pool (warm-start in/out), the folded
 // GJK/SAT cache — for every convex pair type in the convex-manifold gold, and assert the mapped
 // persistent manifold bit-for-bit against the same gold the native `compute_convex_manifold` path
 // verifies. Mirrors the native `check_scene`: two runs per scene (cold: no old points; warm: old points
 // seeded so impulses carry by feature id), each from a cold cache (fresh store per run). This isolates the
 // dispatch column marshaling + pool↔manifold round-trip + cache read/write from the live restructure
-// (3c.3.b). Inert until then (nothing calls `dispatchConvex` in the live path).
+// the live restructure. Inert until then (nothing calls `dispatchConvex` in the live path).
 type GoldSphere = { center: GoldVec; radius: string };
 type GoldCapsule = { center1: GoldVec; center2: GoldVec; radius: string };
 type GoldXf = { p: GoldVec; q: [string, string, string, string] };
@@ -381,11 +381,11 @@ test("dispatchConvex maps the convex-manifold gold through the geometry + manifo
     }
 });
 
-// Persistent manifold columns gate (3c.2c.ii): the store's allocator + wasm region + view protocol.
+// Persistent manifold columns gate: the store's allocator + wasm region + view protocol.
 // Proves the ABI end-to-end — reserve, block allocation, the mixed f32/u32 aliasing on both columns,
 // free-list recycling, and (the load-bearing bit) that a directory grow which shifts the pool base
 // memmoves live pool data in place so every block keeps its element offset across the `memory.grow`
-// detach. Inert in the live solve until 3c.2c.iii, so the fixture gate is unaffected; this test is the
+// detach. Inert in the live solve until the pool-backed views land, so the fixture gate is unaffected; this test is the
 // standing proof the storage round-trips.
 test("persistent manifold store round-trips and preserves data across a directory grow", async () => {
     await init({ threads: 0 });
@@ -463,7 +463,7 @@ test("persistent manifold store round-trips and preserves data across a director
     readManifold(base1 + 1, 128, "block1[1] after pool grow");
 });
 
-// Pool-backed manifold views gate (3c.2c.iii): the `Manifold`/`ManifoldPoint` accessors the narrowphase
+// Pool-backed manifold views gate: the `Manifold`/`ManifoldPoint` accessors the narrowphase
 // writes and the solver/events read. Proves every header + point field round-trips through the pool
 // (incl. the signed `triangleIndex` i32 alias and the `persisted` bool), and that views re-fetched over
 // a contact's block after a pool grow read the same data. All values are exactly f32-representable.
@@ -525,7 +525,7 @@ test("pool-backed manifold views round-trip every field across a grow", async ()
     check("after pool grow");
 });
 
-// Persistent body region relocation gate (4a.1): the body region sits first in linear memory, so its
+// Persistent body region relocation gate: the body region sits first in linear memory, so its
 // own growth shifts the manifold + geometry regions above it. Prove the kernel relocates them in place
 // — one overlapping memmove of the whole span + a static rebase — so a live contact's warm-start
 // manifold and an interned hull's geometry survive a body-region grow bit-for-bit. This is the only
@@ -544,7 +544,7 @@ test("a body-region grow relocates the manifold + geometry regions in place", as
     k.reserveManifolds(8, 8);
     k.reserveGeometry(2, 4, 4, 4);
 
-    // The body region owns live columns too (4a.2): STATE stays at the region base across a grow, but
+    // The body region owns live columns too: STATE stays at the region base across a grow, but
     // FLAGS shifts up as capacity grows, so its contents must be copied. Mark record 5 in both and
     // assert they survive at the (re-derived) offsets — the DYNAMIC-flag-loss regression that made the
     // solver stop writing velocity back once a scene crossed the 16-body cap.
@@ -609,7 +609,7 @@ test("a body-region grow relocates the manifold + geometry regions in place", as
     expect(new Uint32Array(buf(), bl1[4], 6)[5]).toBe(markFlags);
 });
 
-// Persistent fat-AABB region relocation gate (4b.1): a second low persistent region, above the body
+// Persistent fat-AABB region relocation gate: a second low persistent region, above the body
 // region and below the manifold region. Prove both directions — its own grow relocates the manifold +
 // geometry regions above it in place (its own single base-anchored column staying put), and a body
 // region grow below shifts the whole fat-AABB region up with everything above it. Wasm-only, like the

--- a/packages/shallot/src/standard/tumble/engine/kernel.ts
+++ b/packages/shallot/src/standard/tumble/engine/kernel.ts
@@ -36,7 +36,7 @@ export type Kernel = {
     layoutPtr(): number;
 
     // Persistent body columns (kernel/src/bodies.rs) — the awake body state held resident across
-    // steps (4a), first in linear memory. `reserveBodies` sizes the region to the total-body
+    // steps, first in linear memory. `reserveBodies` sizes the region to the total-body
     // high-water (grow-only), relocating the manifold + geometry regions above it in place on a grow;
     // `bodyLayoutPtr` returns the byte-offset header TS derives its column views from (bodycolumns.ts).
     reserveBodies(cap: number): number;
@@ -46,7 +46,7 @@ export type Kernel = {
     bodyCap(): number;
 
     // Persistent fat-AABB column (kernel/src/fataabb.rs) — one enlarged broad-phase AABB per shape,
-    // held resident so the in-kernel recycle loop (4b) tests contact overlap without a marshal. A second
+    // held resident so the in-kernel recycle loop tests contact overlap without a marshal. A second
     // low persistent region above the body region; `reserveFatAabb` sizes it to the shape high-water
     // (grow-only), relocating the manifold + geometry regions above it on a grow. `fatAabbLayoutPtr`
     // returns the byte-offset header TS derives its view from (fataabbcolumns.ts); `fatAabbCap` is the
@@ -100,7 +100,7 @@ export type Kernel = {
     // read by the convex narrowphase. `reserveGeometry` lays out the pools (before the solver columns)
     // for the given totals; `geoLayoutPtr` returns the byte-offset header TS writes the hulls through
     // (geocolumns.ts). `collideHullsGeo` runs the hull-hull narrowphase over two column-backed hulls,
-    // writing the manifold to the buffer at `geoOutPtr` — the 3c.2b geometry-read verification.
+    // writing the manifold to the buffer at `geoOutPtr` — the geometry-read verification.
     reserveGeometry(hulls: number, verts: number, edges: number, faces: number): void;
     geoLayoutPtr(): number;
 
@@ -124,7 +124,7 @@ export type Kernel = {
     ): number;
     geoOutPtr(): number;
 
-    // Convex narrowphase batched dispatch (kernel/src/arena.rs, 3c.3). `reserveDispatch` lays out the
+    // Convex narrowphase batched dispatch (kernel/src/arena.rs). `reserveDispatch` lays out the
     // per-record input + output columns (at the solver base, consumed within collide); the collect pass
     // writes the input through `dispatchPtr`, `dispatchConvex` runs `compute_convex_manifold` per record
     // over the geometry + manifold columns, and the finish pass reads the touching flags at `dispatchOutPtr`.
@@ -133,7 +133,7 @@ export type Kernel = {
     dispatchOutPtr(): number;
     dispatchConvex(count: number): void;
 
-    // Contact-recycle batched pass (kernel/src/arena.rs, 4b.3c). `reserveRecycle` lays out the per-record
+    // Contact-recycle batched pass (kernel/src/arena.rs). `reserveRecycle` lays out the per-record
     // input + output columns (at the solver base, consumed within collide, before the convex dispatch);
     // the collide walk writes the input through `recyclePtr`, `dispatchRecycle` runs box3d's recycle branch
     // per record over the resident body + fat-AABB + manifold columns, and the finish pass reads each

--- a/packages/shallot/src/standard/tumble/engine/manifoldstore.ts
+++ b/packages/shallot/src/standard/tumble/engine/manifoldstore.ts
@@ -1,7 +1,7 @@
 // The persistent contact-manifold store — the warm-start state that survives across steps, held
 // column-resident in the kernel's linear memory (kernel/src/manifolds.rs) instead of as JS objects on
 // each contact. TS owns the allocator + lifecycle because the mesh narrowphase is TS and the convex one
-// is the kernel (3c.3), so allocation can't live on one side of the FFI; the kernel just reads/writes
+// is the kernel, so allocation can't live on one side of the FFI; the kernel just reads/writes
 // manifold data at the offsets this store hands out.
 //
 // Two columns, mirroring box3d's `b3Contact.manifolds` heap array:
@@ -22,7 +22,7 @@ import { f32, type Mat3, mat3, type Quat, type Transform, type Vec3, vec3 } from
  * indexA, indexB, hit (0..11) — plus the convex narrowphase's persistent GJK/SAT cache union (12..21,
  * `DIR_CACHE`) and the in-kernel recycle loop's cached relative pose (22..36, `DIR_CACHED_*`), both
  * folded here to share the directory's contactId key + grow-in-place lifecycle. TS never reads/writes
- * the recycle tail — the kernel recycle pass owns it (4b.3c). */
+ * the recycle tail — the kernel recycle pass owns it. */
 export const DIR_STRIDE = 37;
 /** First slot of the convex cache union within a directory record (kernel `DIR_CACHE`). */
 const DIR_CACHE = 12;

--- a/packages/shallot/src/standard/tumble/tumble.test.ts
+++ b/packages/shallot/src/standard/tumble/tumble.test.ts
@@ -521,7 +521,7 @@ describe("same-update destroy+create realias", () => {
         // the same-update destroy+create identity bug (tumble.md "The wasm world is a singleton — dispose is load-bearing"): a box
         // is marshaled, then destroyed and its eid recycled by a NEW sphere Body in one update. SyncSystem
         // keys create/destroy on presence alone, so it neither sweeps the eid (it still has Body) nor
-        // re-marshals it (it's still in `bodies`) — the old box handle survives entirely. The fix (1b)
+        // re-marshals it (it's still in `bodies`) — the old box handle survives entirely. The fix
         // compares `state.stamp(eid)` against the stored stamp and rebinds on mismatch.
         clear();
         const state = new State();


### PR DESCRIPTION
- **audit-comment-sweep: stage 3 — residual bare-digit-letter stage-ID comments**
- **audit-comment-sweep: drop the last dead-symbol comment reference**
