### PR TITLE
audit dead exports/1

### DIFF
--- a/packages/shallot/tests/check-exports.test.ts
+++ b/packages/shallot/tests/check-exports.test.ts
@@ -3,12 +3,15 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+    computeEntryFiles,
+    computePublicSurface,
     extractDirectExports,
     extractImports,
     extractReExports,
     findDeadExports,
     isTestFile,
     resolveSpecifier,
+    stripComments,
 } from "../../../scripts/check-exports";
 
 // Fixture trees live under the OS tmpdir, never the repo — `--root`-style isolation so a
@@ -46,6 +49,44 @@ describe("isTestFile", () => {
     test("passes non-test files", () => {
         expect(isTestFile("foo.ts")).toBe(false);
         expect(isTestFile("foo.spec.ts")).toBe(false);
+    });
+});
+
+describe("stripComments", () => {
+    test("strips line comments", () => {
+        const content = "const x = 1; // comment\nconst y = 2;";
+        const stripped = stripComments(content);
+        expect(stripped).toBe("const x = 1; \nconst y = 2;");
+    });
+
+    test("strips block comments including JSDoc", () => {
+        const content =
+            "/**\n * @example\n * export const config = 1;\n */\nexport const real = 2;";
+        const stripped = stripComments(content);
+        expect(stripped).toBe("\n\n\n\nexport const real = 2;");
+    });
+
+    test("preserves string literals containing // or /*", () => {
+        const content = 'const url = "http://example.com";\nconst path = "a/*b";';
+        const stripped = stripComments(content);
+        expect(stripped).toBe('const url = "http://example.com";\nconst path = "a/*b";');
+    });
+
+    test("does not match export const inside a JSDoc @example block", () => {
+        const content = `
+/**
+ * @example
+ * \`\`\`
+ * export const config: Config = { plugins: [] };
+ * \`\`\`
+ */
+export const TumblePlugin: Plugin = { name: "Tumble" };
+`;
+        const stripped = stripComments(content);
+        const exports = extractDirectExports(stripped);
+        const names = exports.map((e) => e.name);
+        expect(names).toContain("TumblePlugin");
+        expect(names).not.toContain("config");
     });
 });
 
@@ -103,26 +144,6 @@ export type { Foo };
 `;
         const exports = extractDirectExports(content);
         expect(exports.map((e) => e.name)).toEqual(["Foo"]);
-    });
-
-    test("does not match export const inside a JSDoc @example block", () => {
-        // A known limitation of regex-based parsing: `export const config` inside a JSDoc
-        // @example code block is matched as a real export. This test documents the limitation
-        // so a future fix (AST-based parsing) can flip it to false.
-        const content = `
-/**
- * @example
- * \`\`\`
- * export const config: Config = { plugins: [] };
- * \`\`\`
- */
-export const TumblePlugin: Plugin = { name: "Tumble" };
-`;
-        const exports = extractDirectExports(content);
-        const names = exports.map((e) => e.name);
-        expect(names).toContain("TumblePlugin");
-        // limitation: `config` is falsely captured from the JSDoc example
-        expect(names).toContain("config");
     });
 });
 
@@ -279,6 +300,89 @@ describe("resolveSpecifier", () => {
     });
 });
 
+describe("computeEntryFiles", () => {
+    test("resolves named entry points to file paths", () => {
+        const root = fixture({
+            "packages/shallot/src/index.ts": "export const foo = 1;",
+            "packages/shallot/src/extras/index.ts": "export const bar = 2;",
+            "packages/shallot/package.json": JSON.stringify({
+                exports: {
+                    ".": "./src/index.ts",
+                    "./extras": "./src/extras/index.ts",
+                    "./src/*": "./src/*",
+                },
+            }),
+        });
+        const entries = computeEntryFiles(root, {
+            ".": "./src/index.ts",
+            "./extras": "./src/extras/index.ts",
+            "./src/*": "./src/*",
+        });
+        expect(entries.sort()).toEqual(
+            ["packages/shallot/src/index.ts", "packages/shallot/src/extras/index.ts"].sort(),
+        );
+    });
+
+    test("ignores the ./src/* wildcard escape hatch", () => {
+        const root = fixture({
+            "packages/shallot/src/index.ts": "export const foo = 1;",
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+        });
+        const entries = computeEntryFiles(root, {
+            ".": "./src/index.ts",
+            "./src/*": "./src/*",
+        });
+        expect(entries).toEqual(["packages/shallot/src/index.ts"]);
+    });
+});
+
+describe("computePublicSurface", () => {
+    test("star re-export makes all direct exports of the source public", () => {
+        const directExports = new Map([
+            ["packages/shallot/src/index.ts", new Set(["reExportedFn"])],
+            ["packages/shallot/src/module.ts", new Set(["reExportedFn", "notReExported"])],
+        ]);
+        const reExports = new Map<string, { names: string[] | "*"; sourceFile: string }[]>([
+            [
+                "packages/shallot/src/index.ts",
+                [{ names: "*" as const, sourceFile: "packages/shallot/src/module.ts" }],
+            ],
+        ]);
+        const surface = computePublicSurface(
+            ["packages/shallot/src/index.ts"],
+            directExports,
+            reExports,
+        );
+        // star re-export: all direct exports of module.ts are public
+        expect(surface.has("packages/shallot/src/module.ts::reExportedFn")).toBe(true);
+        expect(surface.has("packages/shallot/src/module.ts::notReExported")).toBe(true);
+        // the barrel's own direct export is also public
+        expect(surface.has("packages/shallot/src/index.ts::reExportedFn")).toBe(true);
+    });
+
+    test("named re-export makes only the named symbol public, not siblings", () => {
+        const directExports = new Map([
+            ["packages/shallot/src/index.ts", new Set<string>()],
+            ["packages/shallot/src/module.ts", new Set(["foo", "bar"])],
+        ]);
+        const reExports = new Map([
+            [
+                "packages/shallot/src/index.ts",
+                [{ names: ["foo"], sourceFile: "packages/shallot/src/module.ts" }],
+            ],
+        ]);
+        const surface = computePublicSurface(
+            ["packages/shallot/src/index.ts"],
+            directExports,
+            reExports,
+        );
+        expect(surface.has("packages/shallot/src/module.ts::foo")).toBe(true);
+        expect(surface.has("packages/shallot/src/module.ts::bar")).toBe(false);
+    });
+});
+
 describe("findDeadExports — red-first proof", () => {
     test("flags a planted zero-consumer export and does not flag a live one", async () => {
         const root = fixture({
@@ -294,7 +398,8 @@ export function inFileFn(): number { return inFileFn(); }
 import { liveFn } from "./module";
 liveFn();
 `,
-            "packages/shallot/src/index.ts": `export * from "./module";`,
+            // index re-exports liveFn (public surface) but NOT deadFn or inFileFn
+            "packages/shallot/src/index.ts": `export { liveFn } from "./module";`,
         });
 
         const dead = await findDeadExports(root);
@@ -331,7 +436,8 @@ prodFn();
 import { testOnlyFn } from "../src/module";
 testOnlyFn();
 `,
-            "packages/shallot/src/index.ts": `export * from "./module";`,
+            // index re-exports prodFn (public) but NOT testOnlyFn
+            "packages/shallot/src/index.ts": `export { prodFn } from "./module";`,
         });
 
         const dead = await findDeadExports(root);
@@ -353,6 +459,7 @@ testOnlyFn();
             "packages/shallot/src/module.ts": `
 export function barrelFn(): number { return 0; }
 `,
+            // barrelFn is on the public surface (star re-exported from entry point) AND consumed
             "packages/shallot/src/index.ts": `export * from "./module";`,
             "packages/shallot/src/consumer.ts": `
 import { barrelFn } from "./index";
@@ -377,7 +484,8 @@ export function unusedNs(): number { return 0; }
 import * as ns from "./module";
 ns.usedNs();
 `,
-            "packages/shallot/src/index.ts": `export * from "./module";`,
+            // index re-exports usedNs (public) but NOT unusedNs
+            "packages/shallot/src/index.ts": `export { usedNs } from "./module";`,
         });
 
         const dead = await findDeadExports(root);
@@ -398,7 +506,8 @@ ns.usedNs();
 export function allowedDead(): number { return 0; }
 export function notAllowed(): number { return 0; }
 `,
-            "packages/shallot/src/index.ts": `export * from "./module";`,
+            // neither is re-exported from the entry point
+            "packages/shallot/src/index.ts": `export const other = 1;`,
         });
 
         const dead = await findDeadExports(root, [
@@ -420,10 +529,115 @@ export function liveFn(): number { return 1; }
 import { liveFn } from "./module";
 liveFn();
 `,
+            // liveFn is both consumed AND on the public surface
             "packages/shallot/src/index.ts": `export * from "./module";`,
         });
 
         const dead = await findDeadExports(root);
         expect(dead).toHaveLength(0);
+    });
+
+    // --- New semantics: public surface exclusion ---
+
+    test("a symbol with zero in-repo consumers but re-exported from a declared entry point is NOT flagged", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function publicFn(): number { return 0; }
+export function deadFn(): number { return 0; }
+`,
+            // index.ts re-exports publicFn but NOT deadFn
+            "packages/shallot/src/index.ts": `export { publicFn } from "./module";`,
+        });
+
+        const dead = await findDeadExports(root);
+        const names = dead.map((d) => d.name);
+
+        // publicFn is on the public surface (re-exported from the `.` entry point) → NOT flagged
+        expect(names).not.toContain("publicFn");
+
+        // deadFn is NOT on the public surface → flagged as zero-consumer
+        expect(names).toContain("deadFn");
+        expect(dead.find((d) => d.name === "deadFn")!.category).toBe("zero-consumer");
+    });
+
+    test("a symbol re-exported through a star barrel chain from an entry point is NOT flagged", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: {
+                    ".": "./src/index.ts",
+                    "./extras": "./src/extras/index.ts",
+                    "./src/*": "./src/*",
+                },
+            }),
+            "packages/shallot/src/mod.ts": `
+export function deepFn(): number { return 0; }
+`,
+            "packages/shallot/src/extras/index.ts": `export * from "../mod";`,
+            "packages/shallot/src/index.ts": `export * from "./mod";`,
+        });
+
+        const dead = await findDeadExports(root);
+        // deepFn is reachable from both `.` and `./extras` entry points via star re-exports → NOT flagged
+        expect(dead.find((d) => d.name === "deepFn")).toBeUndefined();
+    });
+
+    test("the ./src/* wildcard is ignored: a symbol only reachable through it IS flagged", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function wildcardOnly(): number { return 0; }
+`,
+            // index.ts does NOT re-export from module — module is only reachable via ./src/*
+            "packages/shallot/src/index.ts": `export const other = 1;`,
+        });
+
+        const dead = await findDeadExports(root);
+        // wildcardOnly is only reachable through ./src/* which is ignored → flagged
+        const found = dead.find((d) => d.name === "wildcardOnly");
+        expect(found).toBeDefined();
+        expect(found!.category).toBe("zero-consumer");
+    });
+
+    test("JSDoc @example reference is not counted as a consumer or export", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+/**
+ * @example
+ * \`\`\`
+ * export const config = { foo: 1 };
+ * \`\`\`
+ */
+export function realFn(): number { return 0; }
+export function deadFn(): number { return 0; }
+`,
+            "packages/shallot/src/consumer.ts": `
+// realFn is used here, but deadFn is only mentioned in a comment
+import { realFn } from "./module";
+realFn();
+// deadFn is mentioned here but not imported
+`,
+            // index re-exports realFn (public) but NOT deadFn
+            "packages/shallot/src/index.ts": `export { realFn } from "./module";`,
+        });
+
+        const dead = await findDeadExports(root);
+        const names = dead.map((d) => d.name);
+
+        // realFn is consumed → not flagged
+        expect(names).not.toContain("realFn");
+
+        // deadFn is not consumed (comment mention doesn't count) → flagged
+        expect(names).toContain("deadFn");
+
+        // `config` from the JSDoc @example is not a real export → not in the output at all
+        expect(names).not.toContain("config");
     });
 });

--- a/packages/shallot/tests/check-exports.test.ts
+++ b/packages/shallot/tests/check-exports.test.ts
@@ -1,0 +1,429 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    extractDirectExports,
+    extractImports,
+    extractReExports,
+    findDeadExports,
+    isTestFile,
+    resolveSpecifier,
+} from "../../../scripts/check-exports";
+
+// Fixture trees live under the OS tmpdir, never the repo — `--root`-style isolation so a
+// planted dead export never touches a tracked file. Each test gets its own dir; cleaned up after.
+
+const roots: string[] = [];
+
+function fixture(files: Record<string, string>): string {
+    const dir = mkdtempSync(join(tmpdir(), "check-exports-"));
+    roots.push(dir);
+    for (const [rel, content] of Object.entries(files)) {
+        const full = join(dir, rel);
+        mkdirSync(join(full, ".."), { recursive: true });
+        writeFileSync(full, content);
+    }
+    return dir;
+}
+
+afterEach(() => {
+    while (roots.length > 0) {
+        const dir = roots.pop();
+        if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+});
+
+describe("isTestFile", () => {
+    test("identifies test suffixes", () => {
+        expect(isTestFile("foo.test.ts")).toBe(true);
+        expect(isTestFile("foo.oracle.ts")).toBe(true);
+        expect(isTestFile("foo.lab.ts")).toBe(true);
+        expect(isTestFile("foo.probes.ts")).toBe(true);
+        expect(isTestFile("foo.tier.ts")).toBe(true);
+    });
+
+    test("passes non-test files", () => {
+        expect(isTestFile("foo.ts")).toBe(false);
+        expect(isTestFile("foo.spec.ts")).toBe(false);
+    });
+});
+
+describe("extractDirectExports", () => {
+    test("captures function, const, class, type, interface, enum", () => {
+        const content = `
+export function foo() {}
+export const bar = 1;
+export let baz = 2;
+export class Qux {}
+export type Foo = number;
+export interface Bar {}
+export enum Baz { A, B }
+`;
+        const exports = extractDirectExports(content);
+        const names = exports.map((e) => e.name).sort();
+        expect(names).toEqual(["Bar", "Baz", "Foo", "Qux", "bar", "baz", "foo"]);
+    });
+
+    test("captures export { name } without from (re-export of local symbols)", () => {
+        const content = `
+const internal = 1;
+export { internal };
+`;
+        const exports = extractDirectExports(content);
+        expect(exports.map((e) => e.name)).toEqual(["internal"]);
+        expect(exports[0].kind).toBe("re-export");
+    });
+
+    test("does not capture export { name } from (that is a re-export, not a direct export)", () => {
+        const content = `export { foo } from "./module";`;
+        const exports = extractDirectExports(content);
+        expect(exports).toHaveLength(0);
+    });
+
+    test("does not capture export * from", () => {
+        const content = `export * from "./module";`;
+        const exports = extractDirectExports(content);
+        expect(exports).toHaveLength(0);
+    });
+
+    test("does not double-count a name captured by both a keyword export and export { }", () => {
+        const content = `
+export const foo = 1;
+export { foo };
+`;
+        const exports = extractDirectExports(content);
+        expect(exports.filter((e) => e.name === "foo")).toHaveLength(1);
+    });
+
+    test("handles export type { name } without from", () => {
+        const content = `
+type Foo = number;
+export type { Foo };
+`;
+        const exports = extractDirectExports(content);
+        expect(exports.map((e) => e.name)).toEqual(["Foo"]);
+    });
+
+    test("does not match export const inside a JSDoc @example block", () => {
+        // A known limitation of regex-based parsing: `export const config` inside a JSDoc
+        // @example code block is matched as a real export. This test documents the limitation
+        // so a future fix (AST-based parsing) can flip it to false.
+        const content = `
+/**
+ * @example
+ * \`\`\`
+ * export const config: Config = { plugins: [] };
+ * \`\`\`
+ */
+export const TumblePlugin: Plugin = { name: "Tumble" };
+`;
+        const exports = extractDirectExports(content);
+        const names = exports.map((e) => e.name);
+        expect(names).toContain("TumblePlugin");
+        // limitation: `config` is falsely captured from the JSDoc example
+        expect(names).toContain("config");
+    });
+});
+
+describe("extractReExports", () => {
+    test("captures export * from", () => {
+        const reExports = extractReExports('export * from "./module";');
+        expect(reExports).toHaveLength(1);
+        expect(reExports[0].names).toBe("*");
+        expect(reExports[0].source).toBe("./module");
+    });
+
+    test("captures export { name } from", () => {
+        const reExports = extractReExports('export { foo, bar } from "./module";');
+        expect(reExports).toHaveLength(1);
+        expect(reExports[0].names).toEqual(["foo", "bar"]);
+        expect(reExports[0].source).toBe("./module");
+    });
+
+    test("captures export type { name } from", () => {
+        const reExports = extractReExports('export type { Foo } from "./module";');
+        expect(reExports).toHaveLength(1);
+        expect(reExports[0].names).toEqual(["Foo"]);
+    });
+
+    test("handles multiline export { } from", () => {
+        const content = `export {
+    foo,
+    bar,
+} from "./module";`;
+        const reExports = extractReExports(content);
+        expect(reExports).toHaveLength(1);
+        expect(reExports[0].names).toEqual(["foo", "bar"]);
+    });
+
+    test("strips type modifier on individual names", () => {
+        const reExports = extractReExports('export { foo, type Bar } from "./module";');
+        expect(reExports[0].names).toEqual(["foo", "Bar"]);
+    });
+});
+
+describe("extractImports", () => {
+    test("captures named imports", () => {
+        const imports = extractImports('import { foo, bar } from "./module";');
+        expect(imports).toHaveLength(1);
+        expect(imports[0].names).toEqual(["foo", "bar"]);
+        expect(imports[0].specifier).toBe("./module");
+    });
+
+    test("captures type-only named imports", () => {
+        const imports = extractImports('import type { Foo } from "./module";');
+        expect(imports[0].names).toEqual(["Foo"]);
+    });
+
+    test("strips type modifier on individual names", () => {
+        const imports = extractImports('import { foo, type Bar } from "./module";');
+        expect(imports[0].names).toEqual(["foo", "Bar"]);
+    });
+
+    test("captures default import", () => {
+        const imports = extractImports('import foo from "./module";');
+        expect(imports[0].names).toEqual(["foo"]);
+    });
+
+    test("captures mixed default + named import", () => {
+        const imports = extractImports('import foo, { bar } from "./module";');
+        expect(imports[0].names).toEqual(["foo", "bar"]);
+    });
+
+    test("captures namespace import with namespace name", () => {
+        const imports = extractImports('import * as ns from "./module";');
+        expect(imports).toHaveLength(1);
+        expect(imports[0].names).toEqual(["*"]);
+        expect(imports[0].namespace).toBe("ns");
+    });
+
+    test("strips alias from imported name (source name before `as`)", () => {
+        const imports = extractImports('import { foo as bar } from "./module";');
+        expect(imports[0].names).toEqual(["foo"]);
+    });
+});
+
+describe("resolveSpecifier", () => {
+    test("resolves a relative import to a .ts file", () => {
+        const root = fixture({
+            "packages/shallot/src/module.ts": "export const foo = 1;",
+            "packages/shallot/src/consumer.ts": 'import { foo } from "./module";',
+            "packages/shallot/package.json": JSON.stringify({ exports: {} }),
+        });
+        const resolved = resolveSpecifier("packages/shallot/src/consumer.ts", "./module", root, {});
+        expect(resolved).toBe("packages/shallot/src/module.ts");
+    });
+
+    test("resolves a relative import to an index.ts", () => {
+        const root = fixture({
+            "packages/shallot/src/mod/index.ts": "export const foo = 1;",
+            "packages/shallot/src/consumer.ts": 'import { foo } from "./mod";',
+            "packages/shallot/package.json": JSON.stringify({ exports: {} }),
+        });
+        const resolved = resolveSpecifier("packages/shallot/src/consumer.ts", "./mod", root, {});
+        expect(resolved).toBe("packages/shallot/src/mod/index.ts");
+    });
+
+    test("resolves a package import through the exports map", () => {
+        const root = fixture({
+            "packages/shallot/src/index.ts": "export const foo = 1;",
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts" },
+            }),
+        });
+        const resolved = resolveSpecifier("examples/app/src/app.ts", "@dylanebert/shallot", root, {
+            ".": "./src/index.ts",
+        });
+        expect(resolved).toBe("packages/shallot/src/index.ts");
+    });
+
+    test("resolves a package subpath through the exports map", () => {
+        const root = fixture({
+            "packages/shallot/src/extras/index.ts": "export const foo = 1;",
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { "./extras": "./src/extras/index.ts" },
+            }),
+        });
+        const resolved = resolveSpecifier(
+            "examples/app/src/app.ts",
+            "@dylanebert/shallot/extras",
+            root,
+            { "./extras": "./src/extras/index.ts" },
+        );
+        expect(resolved).toBe("packages/shallot/src/extras/index.ts");
+    });
+
+    test("resolves a wildcard ./src/* export", () => {
+        const root = fixture({
+            "packages/shallot/src/engine/ecs/reflection.ts": "export const foo = 1;",
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { "./src/*": "./src/*" },
+            }),
+        });
+        const resolved = resolveSpecifier(
+            "packages/shallot/tests/test.test.ts",
+            "@dylanebert/shallot/src/engine/ecs/reflection",
+            root,
+            { "./src/*": "./src/*" },
+        );
+        expect(resolved).toBe("packages/shallot/src/engine/ecs/reflection.ts");
+    });
+
+    test("returns null for non-package, non-relative specifiers", () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({ exports: {} }),
+        });
+        const resolved = resolveSpecifier("packages/shallot/src/consumer.ts", "typegpu", root, {});
+        expect(resolved).toBeNull();
+    });
+});
+
+describe("findDeadExports — red-first proof", () => {
+    test("flags a planted zero-consumer export and does not flag a live one", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function deadFn(): number { return 0; }
+export function liveFn(): number { return 1; }
+export function inFileFn(): number { return inFileFn(); }
+`,
+            "packages/shallot/src/consumer.ts": `
+import { liveFn } from "./module";
+liveFn();
+`,
+            "packages/shallot/src/index.ts": `export * from "./module";`,
+        });
+
+        const dead = await findDeadExports(root);
+        const names = dead.map((d) => d.name);
+
+        // deadFn has zero consumers and is not referenced in-file → zero-consumer
+        expect(names).toContain("deadFn");
+        const deadFn = dead.find((d) => d.name === "deadFn")!;
+        expect(deadFn.category).toBe("zero-consumer");
+
+        // liveFn is consumed by consumer.ts → not flagged
+        expect(names).not.toContain("liveFn");
+
+        // inFileFn is referenced in-file but not imported externally → in-file-only
+        expect(names).toContain("inFileFn");
+        const inFile = dead.find((d) => d.name === "inFileFn")!;
+        expect(inFile.category).toBe("in-file-only");
+    });
+
+    test("flags a test-only export (consumed only by a .test.ts file)", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function testOnlyFn(): number { return 0; }
+export function prodFn(): number { return 1; }
+`,
+            "packages/shallot/src/consumer.ts": `
+import { prodFn } from "./module";
+prodFn();
+`,
+            "packages/shallot/tests/test.test.ts": `
+import { testOnlyFn } from "../src/module";
+testOnlyFn();
+`,
+            "packages/shallot/src/index.ts": `export * from "./module";`,
+        });
+
+        const dead = await findDeadExports(root);
+        const testOnly = dead.find((d) => d.name === "testOnlyFn");
+        expect(testOnly).toBeDefined();
+        expect(testOnly!.category).toBe("test-only");
+        expect(testOnly!.testConsumers).toHaveLength(1);
+        expect(testOnly!.testConsumers[0].file).toContain("test.test.ts");
+
+        // prodFn is consumed by a production file → not flagged
+        expect(dead.find((d) => d.name === "prodFn")).toBeUndefined();
+    });
+
+    test("follows barrel re-export chains: a symbol consumed through a barrel is not flagged", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function barrelFn(): number { return 0; }
+`,
+            "packages/shallot/src/index.ts": `export * from "./module";`,
+            "packages/shallot/src/consumer.ts": `
+import { barrelFn } from "./index";
+barrelFn();
+`,
+        });
+
+        const dead = await findDeadExports(root);
+        expect(dead.find((d) => d.name === "barrelFn")).toBeUndefined();
+    });
+
+    test("namespace import only consumes exports actually accessed through the namespace", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function usedNs(): number { return 0; }
+export function unusedNs(): number { return 0; }
+`,
+            "packages/shallot/src/consumer.ts": `
+import * as ns from "./module";
+ns.usedNs();
+`,
+            "packages/shallot/src/index.ts": `export * from "./module";`,
+        });
+
+        const dead = await findDeadExports(root);
+        // usedNs is accessed through ns.usedNs() → not flagged
+        expect(dead.find((d) => d.name === "usedNs")).toBeUndefined();
+        // unusedNs is NOT accessed through the namespace → flagged as zero-consumer
+        const unused = dead.find((d) => d.name === "unusedNs");
+        expect(unused).toBeDefined();
+        expect(unused!.category).toBe("zero-consumer");
+    });
+
+    test("allowlist suppresses a flagged export", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function allowedDead(): number { return 0; }
+export function notAllowed(): number { return 0; }
+`,
+            "packages/shallot/src/index.ts": `export * from "./module";`,
+        });
+
+        const dead = await findDeadExports(root, [
+            { file: "packages/shallot/src/module.ts", name: "allowedDead" },
+        ]);
+        expect(dead.find((d) => d.name === "allowedDead")).toBeUndefined();
+        expect(dead.find((d) => d.name === "notAllowed")).toBeDefined();
+    });
+
+    test("a clean fixture with no dead exports reports empty", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function liveFn(): number { return 1; }
+`,
+            "packages/shallot/src/consumer.ts": `
+import { liveFn } from "./module";
+liveFn();
+`,
+            "packages/shallot/src/index.ts": `export * from "./module";`,
+        });
+
+        const dead = await findDeadExports(root);
+        expect(dead).toHaveLength(0);
+    });
+});

--- a/packages/shallot/tests/check-exports.test.ts
+++ b/packages/shallot/tests/check-exports.test.ts
@@ -11,6 +11,7 @@ import {
     findDeadExports,
     isTestFile,
     resolveSpecifier,
+    shouldFail,
     stripComments,
 } from "../../../scripts/check-exports";
 
@@ -639,5 +640,93 @@ realFn();
 
         // `config` from the JSDoc @example is not a real export → not in the output at all
         expect(names).not.toContain("config");
+    });
+});
+
+describe("exit-condition split — only zero-consumer is fatal", () => {
+    test("shouldFail returns true when zero-consumer is non-empty", () => {
+        const dead = [
+            {
+                file: "a.ts",
+                name: "dead",
+                line: 1,
+                category: "zero-consumer" as const,
+                testConsumers: [],
+            },
+        ];
+        expect(shouldFail(dead)).toBe(true);
+    });
+
+    test("shouldFail returns false when only advisory buckets are non-empty", () => {
+        const dead = [
+            {
+                file: "a.ts",
+                name: "inFile",
+                line: 1,
+                category: "in-file-only" as const,
+                testConsumers: [],
+            },
+            {
+                file: "b.ts",
+                name: "testOnly",
+                line: 2,
+                category: "test-only" as const,
+                testConsumers: [{ file: "t.test.ts", line: 3 }],
+            },
+        ];
+        expect(shouldFail(dead)).toBe(false);
+    });
+
+    test("shouldFail returns false on an empty list", () => {
+        expect(shouldFail([])).toBe(false);
+    });
+
+    test("fixture: advisory buckets non-empty, zero-consumer empty → shouldFail is false (passing case)", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function inFileFn(): number { return inFileFn(); }
+export function testOnlyFn(): number { return 0; }
+`,
+            "packages/shallot/tests/test.test.ts": `
+import { testOnlyFn } from "../src/module";
+testOnlyFn();
+`,
+            // index re-exports neither — both are advisory, zero-consumer is empty
+            "packages/shallot/src/index.ts": `export const other = 1;`,
+        });
+
+        const dead = await findDeadExports(root);
+        // both are flagged but neither is zero-consumer
+        const zeroConsumer = dead.filter((d) => d.category === "zero-consumer");
+        const inFileOnly = dead.filter((d) => d.category === "in-file-only");
+        const testOnly = dead.filter((d) => d.category === "test-only");
+        expect(zeroConsumer).toHaveLength(0);
+        expect(inFileOnly.length).toBeGreaterThan(0);
+        expect(testOnly.length).toBeGreaterThan(0);
+        // the exit decision: advisory-only → pass
+        expect(shouldFail(dead)).toBe(false);
+    });
+
+    test("fixture: non-empty zero-consumer → shouldFail is true (failing case)", async () => {
+        const root = fixture({
+            "packages/shallot/package.json": JSON.stringify({
+                exports: { ".": "./src/index.ts", "./src/*": "./src/*" },
+            }),
+            "packages/shallot/src/module.ts": `
+export function deadFn(): number { return 0; }
+export function inFileFn(): number { return inFileFn(); }
+`,
+            // index re-exports neither
+            "packages/shallot/src/index.ts": `export const other = 1;`,
+        });
+
+        const dead = await findDeadExports(root);
+        const zeroConsumer = dead.filter((d) => d.category === "zero-consumer");
+        expect(zeroConsumer.length).toBeGreaterThan(0);
+        // the exit decision: zero-consumer present → fail
+        expect(shouldFail(dead)).toBe(true);
     });
 });

--- a/scripts/check-exports.ts
+++ b/scripts/check-exports.ts
@@ -1,0 +1,541 @@
+// ts-prune-shaped: for every symbol exported from `packages/shallot/src/**`, determine whether
+// any *external* consumer imports it across `src/`, `examples/`, `scripts/`, and `tests/`.
+// Reports the zero-consumer ones (exported, nobody imports them, not even referenced in-file),
+// the in-file-only ones (exported, referenced within the defining file but not imported
+// externally — exports.md's internal-stays-internal), and the test-only ones (consumed only by
+// test files, zero production consumers). Re-export chains (barrel files) are followed to the
+// original exporter, so a symbol consumed through a barrel is not falsely flagged.
+//
+// `--root <dir>` points the check at an alternate tree (fixture-driven proof; check-scripts.ts
+// and check-boundary.ts carry the same flag for the same reason).
+
+import { existsSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { Glob } from "bun";
+
+const PKG = "@dylanebert/shallot";
+
+// --- Types ------------------------------------------------------------------
+
+export type ExportEntry = {
+    file: string; // path relative to rootDir, forward slashes
+    name: string;
+    line: number;
+    kind: string;
+};
+
+export type DeadExport = {
+    file: string;
+    name: string;
+    line: number;
+    category: "zero-consumer" | "in-file-only" | "test-only";
+    testConsumers: { file: string; line: number }[];
+};
+
+// --- Helpers ----------------------------------------------------------------
+
+export function isTestFile(path: string): boolean {
+    return /\.(test|oracle|lab|probes|tier)\.ts$/.test(path);
+}
+
+export function escapeRegExp(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function lineOf(content: string, offset: number): number {
+    return content.slice(0, offset).split("\n").length;
+}
+
+// --- Export extraction ------------------------------------------------------
+
+// Direct exports: symbols declared with `export` in the file, including `export { name }`
+// without `from` (re-export of local symbols). Re-exports with `from` are handled by
+// extractReExports — they are pass-throughs, not new symbols.
+export function extractDirectExports(content: string): ExportEntry[] {
+    const exports: ExportEntry[] = [];
+
+    const patterns: [RegExp, string][] = [
+        [/export\s+(?:async\s+)?function\s+(\w+)/g, "function"],
+        [/export\s+const\s+(\w+)/g, "const"],
+        [/export\s+let\s+(\w+)/g, "let"],
+        [/export\s+class\s+(\w+)/g, "class"],
+        [/export\s+type\s+(\w+)/g, "type"],
+        [/export\s+interface\s+(\w+)/g, "interface"],
+        [/export\s+enum\s+(\w+)/g, "enum"],
+    ];
+
+    for (const [pattern, kind] of patterns) {
+        for (const m of content.matchAll(pattern)) {
+            if (m.index === undefined) continue;
+            exports.push({ file: "", name: m[1], line: lineOf(content, m.index), kind });
+        }
+    }
+
+    // export { name1, name2 } (without `from` — re-export of local symbols)
+    // also handles export type { name1, name2 } without `from`
+    for (const m of content.matchAll(/export\s+(?:type\s+)?\{([^}]+)\}(?!\s*from\b)/g)) {
+        if (m.index === undefined) continue;
+        const names = m[1]
+            .split(",")
+            .map((s) =>
+                s
+                    .trim()
+                    .replace(/^type\s+/, "")
+                    .split(/\s+as\s+/)[0]
+                    .trim(),
+            )
+            .filter(Boolean);
+        for (const name of names) {
+            if (!exports.some((e) => e.name === name)) {
+                exports.push({ file: "", name, line: lineOf(content, m.index), kind: "re-export" });
+            }
+        }
+    }
+
+    return exports;
+}
+
+export type ReExportEntry = {
+    names: string[] | "*"; // "*" for export * from
+    source: string; // module specifier as written
+};
+
+// Re-exports: export { name } from "..." and export * from "..."
+export function extractReExports(content: string): ReExportEntry[] {
+    const reExports: ReExportEntry[] = [];
+
+    for (const m of content.matchAll(/export\s+\*\s+from\s+["']([^"']+)["']/g)) {
+        reExports.push({ names: "*", source: m[1] });
+    }
+
+    for (const m of content.matchAll(
+        /export\s+(?:type\s+)?\{([^}]+)\}\s*from\s+["']([^"']+)["']/g,
+    )) {
+        const names = m[1]
+            .split(",")
+            .map((s) =>
+                s
+                    .trim()
+                    .replace(/^type\s+/, "")
+                    .split(/\s+as\s+/)[0]
+                    .trim(),
+            )
+            .filter(Boolean);
+        reExports.push({ names, source: m[2] });
+    }
+
+    return reExports;
+}
+
+// --- Import extraction ------------------------------------------------------
+
+export type ImportEntry = {
+    names: string[]; // source names (before `as`); ["*"] for namespace imports
+    specifier: string;
+    line: number;
+    namespace: string | null; // namespace name for `import * as ns from`
+};
+
+export function extractImports(content: string): ImportEntry[] {
+    const imports: ImportEntry[] = [];
+
+    const parseNames = (str: string) =>
+        str
+            .split(",")
+            .map((s) =>
+                s
+                    .trim()
+                    .replace(/^type\s+/, "")
+                    .split(/\s+as\s+/)[0]
+                    .trim(),
+            )
+            .filter(Boolean);
+
+    // import { name1, name2 } from "..." / import type { ... } from "..."
+    for (const m of content.matchAll(
+        /import\s+(?:type\s+)?\{([^}]+)\}\s*from\s+["']([^"']+)["']/g,
+    )) {
+        if (m.index === undefined) continue;
+        imports.push({
+            names: parseNames(m[1]),
+            specifier: m[2],
+            line: lineOf(content, m.index),
+            namespace: null,
+        });
+    }
+
+    // import defaultName, { name1, name2 } from "..."
+    for (const m of content.matchAll(
+        /import\s+(\w+)\s*,\s*(?:type\s+)?\{([^}]+)\}\s*from\s+["']([^"']+)["']/g,
+    )) {
+        if (m.index === undefined) continue;
+        imports.push({
+            names: [m[1], ...parseNames(m[2])],
+            specifier: m[3],
+            line: lineOf(content, m.index),
+            namespace: null,
+        });
+    }
+
+    // import defaultName from "..." (not type-only, not mixed with named)
+    for (const m of content.matchAll(/import\s+(?!type\s)(\w+)\s+from\s+["']([^"']+)["']/g)) {
+        if (m.index === undefined) continue;
+        imports.push({
+            names: [m[1]],
+            specifier: m[2],
+            line: lineOf(content, m.index),
+            namespace: null,
+        });
+    }
+
+    // import type defaultName from "..."
+    for (const m of content.matchAll(/import\s+type\s+(\w+)\s+from\s+["']([^"']+)["']/g)) {
+        if (m.index === undefined) continue;
+        imports.push({
+            names: [m[1]],
+            specifier: m[2],
+            line: lineOf(content, m.index),
+            namespace: null,
+        });
+    }
+
+    // import * as name from "..." / import type * as name from "..."
+    for (const m of content.matchAll(
+        /import\s+(?:type\s+)?\*\s+as\s+(\w+)\s+from\s+["']([^"']+)["']/g,
+    )) {
+        if (m.index === undefined) continue;
+        imports.push({
+            names: ["*"],
+            specifier: m[2],
+            line: lineOf(content, m.index),
+            namespace: m[1],
+        });
+    }
+
+    return imports;
+}
+
+// --- Specifier resolution ---------------------------------------------------
+
+export function resolveSpecifier(
+    fromFile: string,
+    specifier: string,
+    rootDir: string,
+    packageExports: Record<string, unknown>,
+): string | null {
+    if (specifier.startsWith(".")) {
+        const fromDir = dirname(resolve(rootDir, fromFile));
+        const abs = resolve(fromDir, specifier);
+        for (const candidate of [abs + ".ts", join(abs, "index.ts"), abs]) {
+            if (existsSync(candidate)) {
+                return relative(rootDir, candidate).replace(/\\/g, "/");
+            }
+        }
+        return null;
+    }
+
+    if (specifier === PKG || specifier.startsWith(PKG + "/")) {
+        const subpath = specifier === PKG ? "." : `./${specifier.slice(PKG.length + 1)}`;
+        const pkgDir = resolve(rootDir, "packages/shallot");
+
+        const target = (entry: unknown) =>
+            typeof entry === "string" ? entry : (entry as { types?: string })?.types;
+
+        // exact match
+        const exact = packageExports[subpath];
+        if (exact) {
+            const t = target(exact);
+            if (t) {
+                const resolved = resolve(pkgDir, t);
+                if (existsSync(resolved)) return relative(rootDir, resolved).replace(/\\/g, "/");
+            }
+        }
+
+        // wildcard match (e.g. ./src/*)
+        for (const [key, value] of Object.entries(packageExports)) {
+            if (!key.includes("*")) continue;
+            const t = target(value);
+            if (typeof t !== "string" || !t.includes("*")) continue;
+
+            const keyStar = key.indexOf("*");
+            const keyPrefix = key.slice(0, keyStar);
+            const keySuffix = key.slice(keyStar + 1);
+            if (subpath.startsWith(keyPrefix) && subpath.endsWith(keySuffix)) {
+                const captured = subpath.slice(keyPrefix.length, subpath.length - keySuffix.length);
+                const tStar = t.indexOf("*");
+                const resolvedPath = t.slice(0, tStar) + captured + t.slice(tStar + 1);
+                for (const candidate of [
+                    resolve(pkgDir, resolvedPath + ".ts"),
+                    join(resolve(pkgDir, resolvedPath), "index.ts"),
+                    resolve(pkgDir, resolvedPath),
+                ]) {
+                    if (existsSync(candidate))
+                        return relative(rootDir, candidate).replace(/\\/g, "/");
+                }
+            }
+        }
+    }
+
+    return null;
+}
+
+// --- Re-export chain resolution ---------------------------------------------
+
+function resolveExport(
+    file: string,
+    name: string,
+    directExports: Map<string, Set<string>>,
+    reExports: Map<string, { names: string[] | "*"; sourceFile: string }[]>,
+    visited: Set<string>,
+): string | null {
+    if (visited.has(file)) return null;
+    visited.add(file);
+
+    if (directExports.get(file)?.has(name)) return file;
+
+    for (const re of reExports.get(file) ?? []) {
+        if (re.names === "*" || re.names.includes(name)) {
+            const result = resolveExport(re.sourceFile, name, directExports, reExports, visited);
+            if (result) return result;
+        }
+    }
+
+    return null;
+}
+
+// --- In-file usage check ----------------------------------------------------
+
+function isInFileOnly(content: string, name: string): boolean {
+    const pattern = new RegExp(`\\b${escapeRegExp(name)}\\b`, "g");
+    return (content.match(pattern) ?? []).length > 1;
+}
+
+// --- Consumer tracking ------------------------------------------------------
+
+type Consumer = { isTest: boolean; consumerFile: string; consumerLine: number };
+
+function addConsumer(
+    consumed: Map<string, Map<string, Consumer[]>>,
+    file: string,
+    name: string,
+    consumer: Consumer,
+): void {
+    if (!consumed.has(file)) consumed.set(file, new Map());
+    if (!consumed.get(file)!.has(name)) consumed.get(file)!.set(name, []);
+    consumed.get(file)!.get(name)!.push(consumer);
+}
+
+// --- Main -------------------------------------------------------------------
+
+export async function findDeadExports(
+    rootDir: string,
+    allowlist: { file: string; name: string }[] = [],
+): Promise<DeadExport[]> {
+    const srcDir = resolve(rootDir, "packages/shallot/src");
+    const pkgPath = resolve(rootDir, "packages/shallot/package.json");
+    if (!existsSync(pkgPath)) return [];
+    const pkg = (await Bun.file(pkgPath).json()) as { exports?: Record<string, unknown> };
+    const packageExports = pkg.exports ?? {};
+
+    const allowSet = new Set(allowlist.map((a) => `${a.file}::${a.name}`));
+
+    // Step 1: walk source files, extract direct exports and re-exports
+    const directExportsMap = new Map<string, Set<string>>();
+    const reExportsMap = new Map<string, { names: string[] | "*"; sourceFile: string }[]>();
+    const allExports: ExportEntry[] = [];
+    const fileContents = new Map<string, string>();
+
+    const srcGlob = new Glob("**/*.ts");
+    for await (const path of srcGlob.scan({ cwd: srcDir })) {
+        if (isTestFile(path)) continue;
+        const full = resolve(srcDir, path);
+        const content = await Bun.file(full).text();
+        const relPath = relative(rootDir, full).replace(/\\/g, "/");
+        fileContents.set(relPath, content);
+
+        const exports = extractDirectExports(content);
+        for (const e of exports) {
+            e.file = relPath;
+            allExports.push(e);
+        }
+        directExportsMap.set(relPath, new Set(exports.map((e) => e.name)));
+
+        const reExports = extractReExports(content);
+        const resolved: { names: string[] | "*"; sourceFile: string }[] = [];
+        for (const re of reExports) {
+            const sourceFile = resolveSpecifier(relPath, re.source, rootDir, packageExports);
+            if (sourceFile) resolved.push({ names: re.names, sourceFile });
+        }
+        reExportsMap.set(relPath, resolved);
+    }
+
+    // Step 2: walk consumer files, extract imports, resolve to original exporters
+    const consumed = new Map<string, Map<string, Consumer[]>>();
+
+    const consumerDirs = [
+        "packages/shallot/src",
+        "packages/shallot/tests",
+        "packages/shallot/bin",
+        "packages/shallot/scripts",
+        "scripts",
+        "examples",
+        "evals",
+    ];
+
+    for (const dir of consumerDirs) {
+        const full = resolve(rootDir, dir);
+        if (!existsSync(full)) continue;
+        const glob = new Glob("**/*.ts");
+        for await (const path of glob.scan({ cwd: full })) {
+            if (path.includes("node_modules") || path.includes("dist/")) continue;
+
+            const fullPath = resolve(full, path);
+            const content = await Bun.file(fullPath).text();
+            const relPath = relative(rootDir, fullPath).replace(/\\/g, "/");
+            const isTest = isTestFile(relPath);
+
+            const imports = extractImports(content);
+            for (const imp of imports) {
+                const targetFile = resolveSpecifier(
+                    relPath,
+                    imp.specifier,
+                    rootDir,
+                    packageExports,
+                );
+                if (!targetFile) continue;
+                if (targetFile === relPath) continue; // self-import is not external
+
+                for (const name of imp.names) {
+                    if (name === "*") {
+                        // namespace import — only exports actually accessed through the namespace
+                        // (nsName.exportName in the file content) are consumed. A bare `import * as ns`
+                        // that never references ns.foo does not consume any export.
+                        const nsName = imp.namespace;
+                        if (nsName) {
+                            const nsPattern = new RegExp(
+                                `\\b${escapeRegExp(nsName)}\\.(\\w+)`,
+                                "g",
+                            );
+                            for (const m of content.matchAll(nsPattern)) {
+                                const accessedName = m[1];
+                                const original = resolveExport(
+                                    targetFile,
+                                    accessedName,
+                                    directExportsMap,
+                                    reExportsMap,
+                                    new Set(),
+                                );
+                                if (original) {
+                                    addConsumer(consumed, original, accessedName, {
+                                        isTest,
+                                        consumerFile: relPath,
+                                        consumerLine: imp.line,
+                                    });
+                                }
+                            }
+                        }
+                    } else {
+                        const original = resolveExport(
+                            targetFile,
+                            name,
+                            directExportsMap,
+                            reExportsMap,
+                            new Set(),
+                        );
+                        if (original) {
+                            addConsumer(consumed, original, name, {
+                                isTest,
+                                consumerFile: relPath,
+                                consumerLine: imp.line,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Step 3: find dead exports
+    const dead: DeadExport[] = [];
+    for (const e of allExports) {
+        if (allowSet.has(`${e.file}::${e.name}`)) continue;
+
+        const consumers = consumed.get(e.file)?.get(e.name) ?? [];
+        const productionConsumers = consumers.filter((c) => !c.isTest);
+        const testConsumers = consumers.filter((c) => c.isTest);
+
+        if (productionConsumers.length > 0) continue;
+
+        if (testConsumers.length > 0) {
+            dead.push({
+                file: e.file,
+                name: e.name,
+                line: e.line,
+                category: "test-only",
+                testConsumers: testConsumers.map((c) => ({
+                    file: c.consumerFile,
+                    line: c.consumerLine,
+                })),
+            });
+        } else {
+            const content = fileContents.get(e.file) ?? "";
+            const inFile = isInFileOnly(content, e.name);
+            dead.push({
+                file: e.file,
+                name: e.name,
+                line: e.line,
+                category: inFile ? "in-file-only" : "zero-consumer",
+                testConsumers: [],
+            });
+        }
+    }
+
+    return dead;
+}
+
+export async function run(rootDir: string): Promise<{ dead: DeadExport[]; total: number }> {
+    const dead = await findDeadExports(rootDir);
+    return { dead, total: dead.length };
+}
+
+if (import.meta.main) {
+    const rootArgIdx = process.argv.indexOf("--root");
+    const rootDir = resolve(
+        rootArgIdx >= 0 ? process.argv[rootArgIdx + 1] : resolve(import.meta.dir, ".."),
+    );
+
+    const { dead, total } = await run(rootDir);
+
+    if (total > 0) {
+        const byCategory = {
+            "zero-consumer": dead.filter((d) => d.category === "zero-consumer"),
+            "in-file-only": dead.filter((d) => d.category === "in-file-only"),
+            "test-only": dead.filter((d) => d.category === "test-only"),
+        };
+
+        console.error(`✗ ${total} dead export(s):\n`);
+
+        for (const [category, items] of Object.entries(byCategory)) {
+            if (items.length === 0) continue;
+            console.error(`  [${category}] (${items.length}):\n`);
+            for (const d of items) {
+                console.error(`    ${d.file}:${d.line} ${d.name}`);
+                if (d.category === "test-only") {
+                    for (const c of d.testConsumers) {
+                        console.error(`      consumed by: ${c.file}:${c.line}`);
+                    }
+                }
+            }
+            console.error();
+        }
+
+        console.error(
+            "An exported symbol with zero production consumers is dead — demote to internal\n" +
+                "(exports.md internal-stays-internal) or delete. Test-only consumers should reach\n" +
+                "the symbol via the module path, not through a public export.",
+        );
+        process.exit(1);
+    }
+
+    console.log("✓ no dead exports");
+}

--- a/scripts/check-exports.ts
+++ b/scripts/check-exports.ts
@@ -6,6 +6,13 @@
 // test files, zero production consumers). Re-export chains (barrel files) are followed to the
 // original exporter, so a symbol consumed through a barrel is not falsely flagged.
 //
+// **Dead = zero in-repo consumers AND not on the sanctioned public surface** — both clauses.
+// The public surface is the transitive re-export closure of the named entry points in
+// `package.json`'s `exports` map (the curated named entries — `./src/*` is ignored as an escape
+// hatch). A library's public exports legitimately have zero internal consumers, so in-repo
+// reachability alone reports the entire public API as dead. Comments are stripped before
+// scanning so a reference inside a JSDoc `@example` block is not counted as a consumer.
+//
 // `--root <dir>` points the check at an alternate tree (fixture-driven proof; check-scripts.ts
 // and check-boundary.ts carry the same flag for the same reason).
 
@@ -44,6 +51,64 @@ export function escapeRegExp(s: string): string {
 
 function lineOf(content: string, offset: number): number {
     return content.slice(0, offset).split("\n").length;
+}
+
+// Strip line comments (`// ...`) and block comments (`/* ... */`, including JSDoc) while
+// preserving string literals and newlines (for line-number accuracy). A reference inside a
+// JSDoc `@example` block is not a consumer.
+export function stripComments(content: string): string {
+    let result = "";
+    let i = 0;
+    const len = content.length;
+
+    while (i < len) {
+        // String literals — copy through, don't treat // or /* inside them as comments
+        if (content[i] === '"' || content[i] === "'" || content[i] === "`") {
+            const quote = content[i];
+            result += content[i];
+            i++;
+            while (i < len) {
+                if (content[i] === "\\" && i + 1 < len) {
+                    result += content[i] + content[i + 1];
+                    i += 2;
+                    continue;
+                }
+                result += content[i];
+                if (content[i] === quote) {
+                    i++;
+                    break;
+                }
+                i++;
+            }
+            continue;
+        }
+
+        // Line comments — skip to end of line (newline preserved by outer loop)
+        if (content[i] === "/" && i + 1 < len && content[i + 1] === "/") {
+            i += 2;
+            while (i < len && content[i] !== "\n") i++;
+            continue;
+        }
+
+        // Block comments (including JSDoc) — skip, but preserve newlines for line numbers
+        if (content[i] === "/" && i + 1 < len && content[i + 1] === "*") {
+            i += 2;
+            while (i < len) {
+                if (content[i] === "*" && i + 1 < len && content[i + 1] === "/") {
+                    i += 2;
+                    break;
+                }
+                if (content[i] === "\n") result += "\n";
+                i++;
+            }
+            continue;
+        }
+
+        result += content[i];
+        i++;
+    }
+
+    return result;
 }
 
 // --- Export extraction ------------------------------------------------------
@@ -279,6 +344,87 @@ export function resolveSpecifier(
     return null;
 }
 
+// --- Public surface computation --------------------------------------------
+
+// Resolve the named entry points from `package.json`'s `exports` map to file paths relative to
+// rootDir. The `./src/*` wildcard is an escape hatch — ignore it, or every file is nominately
+// reachable and nothing is ever dead.
+export function computeEntryFiles(
+    rootDir: string,
+    packageExports: Record<string, unknown>,
+): string[] {
+    const pkgDir = resolve(rootDir, "packages/shallot");
+    const entryFiles: string[] = [];
+
+    for (const [key, value] of Object.entries(packageExports)) {
+        if (key === "./src/*") continue;
+
+        const target = typeof value === "string" ? value : (value as { types?: string })?.types;
+        if (typeof target !== "string") continue;
+
+        const resolved = resolve(pkgDir, target);
+        if (existsSync(resolved)) {
+            entryFiles.push(relative(rootDir, resolved).replace(/\\/g, "/"));
+        }
+    }
+
+    return entryFiles;
+}
+
+// The transitive re-export closure of the entry points: every (file, name) pair where `name` is
+// directly exported from `file` and reachable from an entry point through re-exports. A star
+// re-export (`export * from`) makes all direct exports of the source file reachable; a named
+// re-export (`export { foo } from`) makes only `foo` reachable, following the chain to the
+// original exporter.
+export function computePublicSurface(
+    entryFiles: string[],
+    directExportsMap: Map<string, Set<string>>,
+    reExportsMap: Map<string, { names: string[] | "*"; sourceFile: string }[]>,
+): Set<string> {
+    const publicSurface = new Set<string>();
+
+    function addReachable(file: string, visited: Set<string>) {
+        if (visited.has(file)) return;
+        visited.add(file);
+
+        for (const name of directExportsMap.get(file) ?? []) {
+            publicSurface.add(`${file}::${name}`);
+        }
+
+        for (const re of reExportsMap.get(file) ?? []) {
+            if (re.names === "*") {
+                addReachable(re.sourceFile, visited);
+            } else {
+                for (const name of re.names) {
+                    addReachableNamed(re.sourceFile, name, new Set());
+                }
+            }
+        }
+    }
+
+    function addReachableNamed(file: string, name: string, visited: Set<string>) {
+        const key = `${file}::${name}`;
+        if (visited.has(key)) return;
+        visited.add(key);
+
+        if (directExportsMap.get(file)?.has(name)) {
+            publicSurface.add(key);
+        }
+
+        for (const re of reExportsMap.get(file) ?? []) {
+            if (re.names === "*" || re.names.includes(name)) {
+                addReachableNamed(re.sourceFile, name, visited);
+            }
+        }
+    }
+
+    for (const entry of entryFiles) {
+        addReachable(entry, new Set());
+    }
+
+    return publicSurface;
+}
+
 // --- Re-export chain resolution ---------------------------------------------
 
 function resolveExport(
@@ -339,7 +485,7 @@ export async function findDeadExports(
 
     const allowSet = new Set(allowlist.map((a) => `${a.file}::${a.name}`));
 
-    // Step 1: walk source files, extract direct exports and re-exports
+    // Step 1: walk source files, extract direct exports and re-exports (comments stripped)
     const directExportsMap = new Map<string, Set<string>>();
     const reExportsMap = new Map<string, { names: string[] | "*"; sourceFile: string }[]>();
     const allExports: ExportEntry[] = [];
@@ -349,7 +495,7 @@ export async function findDeadExports(
     for await (const path of srcGlob.scan({ cwd: srcDir })) {
         if (isTestFile(path)) continue;
         const full = resolve(srcDir, path);
-        const content = await Bun.file(full).text();
+        const content = stripComments(await Bun.file(full).text());
         const relPath = relative(rootDir, full).replace(/\\/g, "/");
         fileContents.set(relPath, content);
 
@@ -369,7 +515,11 @@ export async function findDeadExports(
         reExportsMap.set(relPath, resolved);
     }
 
-    // Step 2: walk consumer files, extract imports, resolve to original exporters
+    // Step 1b: compute the public surface (transitive re-export closure of entry points)
+    const entryFiles = computeEntryFiles(rootDir, packageExports);
+    const publicSurface = computePublicSurface(entryFiles, directExportsMap, reExportsMap);
+
+    // Step 2: walk consumer files, extract imports, resolve to original exporters (comments stripped)
     const consumed = new Map<string, Map<string, Consumer[]>>();
 
     const consumerDirs = [
@@ -390,7 +540,7 @@ export async function findDeadExports(
             if (path.includes("node_modules") || path.includes("dist/")) continue;
 
             const fullPath = resolve(full, path);
-            const content = await Bun.file(fullPath).text();
+            const content = stripComments(await Bun.file(fullPath).text());
             const relPath = relative(rootDir, fullPath).replace(/\\/g, "/");
             const isTest = isTestFile(relPath);
 
@@ -455,10 +605,11 @@ export async function findDeadExports(
         }
     }
 
-    // Step 3: find dead exports
+    // Step 3: find dead exports (zero in-repo consumers AND not on the public surface)
     const dead: DeadExport[] = [];
     for (const e of allExports) {
         if (allowSet.has(`${e.file}::${e.name}`)) continue;
+        if (publicSurface.has(`${e.file}::${e.name}`)) continue;
 
         const consumers = consumed.get(e.file)?.get(e.name) ?? [];
         const productionConsumers = consumers.filter((c) => !c.isTest);

--- a/scripts/check-exports.ts
+++ b/scripts/check-exports.ts
@@ -649,44 +649,79 @@ export async function run(rootDir: string): Promise<{ dead: DeadExport[]; total:
     return { dead, total: dead.length };
 }
 
+// Only the zero-consumer bucket is fatal. in-file-only and test-only are advisory — they carry
+// different remedies (demote / reach via module path) and are reported on every run but do not
+// fail the check. This split lets stage 2 reach exit zero after deleting the zero-consumer set,
+// even while advisory buckets remain non-empty.
+export function shouldFail(dead: DeadExport[]): boolean {
+    return dead.some((d) => d.category === "zero-consumer");
+}
+
 if (import.meta.main) {
     const rootArgIdx = process.argv.indexOf("--root");
     const rootDir = resolve(
         rootArgIdx >= 0 ? process.argv[rootArgIdx + 1] : resolve(import.meta.dir, ".."),
     );
 
-    const { dead, total } = await run(rootDir);
+    const { dead } = await run(rootDir);
 
-    if (total > 0) {
-        const byCategory = {
-            "zero-consumer": dead.filter((d) => d.category === "zero-consumer"),
-            "in-file-only": dead.filter((d) => d.category === "in-file-only"),
-            "test-only": dead.filter((d) => d.category === "test-only"),
-        };
+    const byCategory = {
+        "zero-consumer": dead.filter((d) => d.category === "zero-consumer"),
+        "in-file-only": dead.filter((d) => d.category === "in-file-only"),
+        "test-only": dead.filter((d) => d.category === "test-only"),
+    };
 
-        console.error(`✗ ${total} dead export(s):\n`);
+    const fatal = shouldFail(dead);
+    const advisoryCount = byCategory["in-file-only"].length + byCategory["test-only"].length;
 
-        for (const [category, items] of Object.entries(byCategory)) {
-            if (items.length === 0) continue;
-            console.error(`  [${category}] (${items.length}):\n`);
-            for (const d of items) {
+    // --- Enforced class (zero-consumer) ---
+    if (fatal) {
+        console.error(
+            `✗ ${byCategory["zero-consumer"].length} zero-consumer export(s) — ENFORCED:\n`,
+        );
+        for (const d of byCategory["zero-consumer"]) {
+            console.error(`  ${d.file}:${d.line} ${d.name}`);
+        }
+        console.error();
+    }
+
+    // --- Advisory classes (in-file-only, test-only) — always reported, never fatal ---
+    if (advisoryCount > 0) {
+        console.error(`Advisory (${advisoryCount} total) — NOT enforced:\n`);
+        if (byCategory["in-file-only"].length > 0) {
+            console.error(`  [in-file-only] (${byCategory["in-file-only"].length}):`);
+            for (const d of byCategory["in-file-only"]) {
                 console.error(`    ${d.file}:${d.line} ${d.name}`);
-                if (d.category === "test-only") {
-                    for (const c of d.testConsumers) {
-                        console.error(`      consumed by: ${c.file}:${c.line}`);
-                    }
+            }
+            console.error();
+        }
+        if (byCategory["test-only"].length > 0) {
+            console.error(`  [test-only] (${byCategory["test-only"].length}):`);
+            for (const d of byCategory["test-only"]) {
+                console.error(`    ${d.file}:${d.line} ${d.name}`);
+                for (const c of d.testConsumers) {
+                    console.error(`      consumed by: ${c.file}:${c.line}`);
                 }
             }
             console.error();
         }
+    }
 
+    if (fatal) {
         console.error(
-            "An exported symbol with zero production consumers is dead — demote to internal\n" +
-                "(exports.md internal-stays-internal) or delete. Test-only consumers should reach\n" +
-                "the symbol via the module path, not through a public export.",
+            "zero-consumer is the enforced class — delete the export. in-file-only and\n" +
+                "test-only are advisory: demote to internal (exports.md internal-stays-internal)\n" +
+                "or reach via the module path. They are reported on every run but do not fail\n" +
+                "the check.",
         );
         process.exit(1);
     }
 
-    console.log("✓ no dead exports");
+    console.log("✓ no zero-consumer exports");
+    if (advisoryCount > 0) {
+        console.log(
+            `(${advisoryCount} advisory export(s) reported above — in-file-only and test-only\n` +
+                "are not enforced; see guidance.)",
+        );
+    }
 }


### PR DESCRIPTION
- **audit-dead-exports: add sweep script for zero-consumer exports**
- **audit-dead-exports: fix tier-blindness — subtract public surface, strip comments**
- **audit-dead-exports: only zero-consumer bucket is fatal; advisory buckets stay reported**
