### PR TITLE
audit-dead-exports: delete 19 zero-consumer exports, demote in-file-only, remove children/reparent machinery, wire check-exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ],
     "scripts": {
         "build": "bun run --cwd packages/shallot build",
-        "check": "bun run format && tsc && biome check && eslint . --max-warnings=0 && bun run scripts/check-versions.ts && bun run scripts/check-imports.ts && bun run scripts/check-boundary.ts && bun run scripts/check-docs.ts && bun run scripts/check-pack.ts && bun run scripts/check-scripts.ts",
+        "check": "bun run format && tsc && biome check && eslint . --max-warnings=0 && bun run scripts/check-versions.ts && bun run scripts/check-imports.ts && bun run scripts/check-boundary.ts && bun run scripts/check-docs.ts && bun run scripts/check-pack.ts && bun run scripts/check-scripts.ts && bun run scripts/check-exports.ts",
         "format": "biome check --write && bun run scripts/format.ts",
         "test": "bun test packages/shallot",
         "test:install": "bun run scripts/install-test.ts",

--- a/packages/shallot/src/document/commands.ts
+++ b/packages/shallot/src/document/commands.ts
@@ -1,26 +1,18 @@
 import type { Node } from "../engine/scene";
 
-type Add = { type: "add"; parent: Node | null; node: Node; index: number };
-type Remove = { type: "remove"; parent: Node | null; node: Node; index: number };
+type Add = { type: "add"; node: Node; index: number };
+type Remove = { type: "remove"; node: Node; index: number };
 type AddAttr = { type: "addAttr"; node: Node; name: string; value: string };
 type RemoveAttr = { type: "removeAttr"; node: Node; name: string; prev: string; index: number };
 type SetAttr = { type: "setAttr"; node: Node; name: string; prev: string; next: string };
 type SetId = { type: "setId"; node: Node; prev: string | undefined; next: string | undefined };
-type Reorder = { type: "reorder"; parent: Node | null; node: Node; from: number; to: number };
-type Reparent = {
-    type: "reparent";
-    node: Node;
-    oldParent: Node | null;
-    oldIndex: number;
-    newParent: Node | null;
-    newIndex: number;
-};
+type Reorder = { type: "reorder"; node: Node; from: number; to: number };
 type ReorderAttr = { type: "reorderAttr"; node: Node; from: number; to: number };
 export type Compound = { type: "compound"; commands: Command[] };
 
 /**
- * a reversible scene-tree edit: add/remove a node, add/remove/set an attribute, set an id, reorder or
- * reparent, or a `compound` batch. Every case names the data needed to both apply and reverse it, so the
+ * a reversible scene-tree edit: add/remove a node, add/remove/set an attribute, set an id, reorder,
+ * or a `compound` batch. Every case names the data needed to both apply and reverse it, so the
  * undo stack replays without re-deriving state.
  */
 export type Command =
@@ -31,27 +23,20 @@ export type Command =
     | SetAttr
     | SetId
     | Reorder
-    | Reparent
     | ReorderAttr
     | Compound;
 
 export type Entry = { cmd: Command; selection: Node[] };
 export type History = { undo: Entry[]; redo: Entry[] };
 
-function getChildren(parent: Node | null, nodes: Node[]): Node[] {
-    return parent ? parent.children : nodes;
-}
-
 export function apply(nodes: Node[], cmd: Command): void {
     switch (cmd.type) {
         case "add": {
-            const children = getChildren(cmd.parent, nodes);
-            children.splice(cmd.index, 0, cmd.node);
+            nodes.splice(cmd.index, 0, cmd.node);
             break;
         }
         case "remove": {
-            const children = getChildren(cmd.parent, nodes);
-            children.splice(cmd.index, 1);
+            nodes.splice(cmd.index, 1);
             break;
         }
         case "addAttr": {
@@ -72,16 +57,8 @@ export function apply(nodes: Node[], cmd: Command): void {
             break;
         }
         case "reorder": {
-            const children = getChildren(cmd.parent, nodes);
-            children.splice(cmd.from, 1);
-            children.splice(cmd.to, 0, cmd.node);
-            break;
-        }
-        case "reparent": {
-            const oldChildren = getChildren(cmd.oldParent, nodes);
-            oldChildren.splice(cmd.oldIndex, 1);
-            const newChildren = getChildren(cmd.newParent, nodes);
-            newChildren.splice(cmd.newIndex, 0, cmd.node);
+            nodes.splice(cmd.from, 1);
+            nodes.splice(cmd.to, 0, cmd.node);
             break;
         }
         case "reorderAttr": {
@@ -98,13 +75,11 @@ export function apply(nodes: Node[], cmd: Command): void {
 export function reverse(nodes: Node[], cmd: Command): void {
     switch (cmd.type) {
         case "add": {
-            const children = getChildren(cmd.parent, nodes);
-            children.splice(cmd.index, 1);
+            nodes.splice(cmd.index, 1);
             break;
         }
         case "remove": {
-            const children = getChildren(cmd.parent, nodes);
-            children.splice(cmd.index, 0, cmd.node);
+            nodes.splice(cmd.index, 0, cmd.node);
             break;
         }
         case "addAttr": {
@@ -126,16 +101,8 @@ export function reverse(nodes: Node[], cmd: Command): void {
             break;
         }
         case "reorder": {
-            const children = getChildren(cmd.parent, nodes);
-            children.splice(cmd.to, 1);
-            children.splice(cmd.from, 0, cmd.node);
-            break;
-        }
-        case "reparent": {
-            const newChildren = getChildren(cmd.newParent, nodes);
-            newChildren.splice(cmd.newIndex, 1);
-            const oldChildren = getChildren(cmd.oldParent, nodes);
-            oldChildren.splice(cmd.oldIndex, 0, cmd.node);
+            nodes.splice(cmd.to, 1);
+            nodes.splice(cmd.from, 0, cmd.node);
             break;
         }
         case "reorderAttr": {

--- a/packages/shallot/src/document/document.test.ts
+++ b/packages/shallot/src/document/document.test.ts
@@ -40,7 +40,7 @@ describe("Editor", () => {
         test("apply add inserts node", () => {
             const nodes: Node[] = [];
             const node = createNode("a");
-            const cmd: Command = { type: "add", parent: null, node, index: 0 };
+            const cmd: Command = { type: "add", node, index: 0 };
 
             apply(nodes, cmd);
 
@@ -53,7 +53,7 @@ describe("Editor", () => {
             const third = createNode("third");
             const nodes: Node[] = [first, third];
             const second = createNode("second");
-            const cmd: Command = { type: "add", parent: null, node: second, index: 1 };
+            const cmd: Command = { type: "add", node: second, index: 1 };
 
             apply(nodes, cmd);
 
@@ -63,38 +63,14 @@ describe("Editor", () => {
             expect(nodes[2]).toBe(third);
         });
 
-        test("apply add inserts into parent children", () => {
-            const parent = createNode("parent");
-            const nodes: Node[] = [parent];
-            const child = createNode("child");
-            const cmd: Command = { type: "add", parent, node: child, index: 0 };
-
-            apply(nodes, cmd);
-
-            expect(parent.children).toHaveLength(1);
-            expect(parent.children[0]).toBe(child);
-        });
-
         test("apply remove deletes node", () => {
             const node = createNode("a");
             const nodes: Node[] = [node];
-            const cmd: Command = { type: "remove", parent: null, node, index: 0 };
+            const cmd: Command = { type: "remove", node, index: 0 };
 
             apply(nodes, cmd);
 
             expect(nodes).toHaveLength(0);
-        });
-
-        test("apply remove deletes from parent children", () => {
-            const child = createNode("child");
-            const parent = createNode("parent");
-            parent.children.push(child);
-            const nodes: Node[] = [parent];
-            const cmd: Command = { type: "remove", parent, node: child, index: 0 };
-
-            apply(nodes, cmd);
-
-            expect(parent.children).toHaveLength(0);
         });
 
         test("apply setAttr updates attr", () => {
@@ -135,7 +111,7 @@ describe("Editor", () => {
         test("reverse undoes add", () => {
             const node = createNode("a");
             const nodes: Node[] = [node];
-            const cmd: Command = { type: "add", parent: null, node, index: 0 };
+            const cmd: Command = { type: "add", node, index: 0 };
 
             reverse(nodes, cmd);
 
@@ -145,7 +121,7 @@ describe("Editor", () => {
         test("reverse undoes remove", () => {
             const node = createNode("a");
             const nodes: Node[] = [];
-            const cmd: Command = { type: "remove", parent: null, node, index: 0 };
+            const cmd: Command = { type: "remove", node, index: 0 };
 
             reverse(nodes, cmd);
 
@@ -196,7 +172,7 @@ describe("Editor", () => {
 
         test("execute pushes to undo", () => {
             const node = createNode("a");
-            const cmd: Command = { type: "add", parent: null, node, index: 0 };
+            const cmd: Command = { type: "add", node, index: 0 };
 
             execute(history, nodes, cmd);
 
@@ -208,8 +184,8 @@ describe("Editor", () => {
         test("execute clears redo", () => {
             const nodeA = createNode("a");
             const nodeB = createNode("b");
-            const cmdA: Command = { type: "add", parent: null, node: nodeA, index: 0 };
-            const cmdB: Command = { type: "add", parent: null, node: nodeB, index: 1 };
+            const cmdA: Command = { type: "add", node: nodeA, index: 0 };
+            const cmdB: Command = { type: "add", node: nodeB, index: 1 };
 
             execute(history, nodes, cmdA);
             execute(history, nodes, cmdB);
@@ -217,7 +193,7 @@ describe("Editor", () => {
             expect(history.redo).toHaveLength(1);
 
             const nodeC = createNode("c");
-            const cmdC: Command = { type: "add", parent: null, node: nodeC, index: 1 };
+            const cmdC: Command = { type: "add", node: nodeC, index: 1 };
             execute(history, nodes, cmdC);
 
             expect(history.redo).toHaveLength(0);
@@ -225,7 +201,7 @@ describe("Editor", () => {
 
         test("undo reverses and pushes to redo", () => {
             const node = createNode("a");
-            const cmd: Command = { type: "add", parent: null, node, index: 0 };
+            const cmd: Command = { type: "add", node, index: 0 };
             execute(history, nodes, cmd);
 
             const entry = undo(history, nodes);
@@ -247,7 +223,7 @@ describe("Editor", () => {
 
         test("redo reapplies", () => {
             const node = createNode("a");
-            const cmd: Command = { type: "add", parent: null, node, index: 0 };
+            const cmd: Command = { type: "add", node, index: 0 };
             execute(history, nodes, cmd);
             undo(history, nodes);
 
@@ -269,7 +245,7 @@ describe("Editor", () => {
         test("execute stores selection snapshot", () => {
             const node = createNode("a");
             const sel = [createNode("sel")];
-            const cmd: Command = { type: "add", parent: null, node, index: 0 };
+            const cmd: Command = { type: "add", node, index: 0 };
 
             execute(history, nodes, cmd, sel);
 
@@ -279,7 +255,7 @@ describe("Editor", () => {
         test("undo returns entry with selection", () => {
             const sel = [createNode("sel")];
             const node = createNode("a");
-            const cmd: Command = { type: "add", parent: null, node, index: 0 };
+            const cmd: Command = { type: "add", node, index: 0 };
             execute(history, nodes, cmd, sel);
 
             const entry = undo(history, nodes);
@@ -290,7 +266,7 @@ describe("Editor", () => {
 
         test("redo returns entry", () => {
             const node = createNode("a");
-            const cmd: Command = { type: "add", parent: null, node, index: 0 };
+            const cmd: Command = { type: "add", node, index: 0 };
             execute(history, nodes, cmd);
             undo(history, nodes);
 
@@ -517,7 +493,7 @@ describe("Document", () => {
     test("add inserts node and increments version", () => {
         const doc = new Document("<scene></scene>");
         const node = createNode("new");
-        doc.add(null, node);
+        doc.add(node);
         expect(doc.nodes).toHaveLength(1);
         expect(doc.version).toBe(1);
     });
@@ -525,7 +501,7 @@ describe("Document", () => {
     test("add inserts at specified index", () => {
         const doc = new Document('<scene><a id="a" /><a id="c" /></scene>');
         const node = createNode("b");
-        doc.add(null, node, 1);
+        doc.add(node, 1);
         expect(doc.nodes).toHaveLength(3);
         expect(doc.nodes[1].id).toBe("b");
     });
@@ -533,14 +509,14 @@ describe("Document", () => {
     test("remove deletes node", () => {
         const doc = new Document('<scene><a id="a" /></scene>');
         const node = doc.nodes[0];
-        doc.remove(null, node);
+        doc.remove(node);
         expect(doc.nodes).toHaveLength(0);
     });
 
     test("remove no-ops for missing node", () => {
         const doc = new Document('<scene><a id="a" /></scene>');
         const missing = createNode("missing");
-        doc.remove(null, missing);
+        doc.remove(missing);
         expect(doc.nodes).toHaveLength(1);
         expect(doc.version).toBe(0);
     });
@@ -599,7 +575,7 @@ describe("Document", () => {
 
     test("undo reverses last command", () => {
         const doc = new Document("<scene></scene>");
-        doc.add(null, createNode("a"));
+        doc.add(createNode("a"));
         expect(doc.nodes).toHaveLength(1);
         doc.undo();
         expect(doc.nodes).toHaveLength(0);
@@ -607,7 +583,7 @@ describe("Document", () => {
 
     test("redo reapplies undone command", () => {
         const doc = new Document("<scene></scene>");
-        doc.add(null, createNode("a"));
+        doc.add(createNode("a"));
         doc.undo();
         doc.redo();
         expect(doc.nodes).toHaveLength(1);
@@ -623,7 +599,7 @@ describe("Document", () => {
     test("full round-trip: mutate then serialize then re-parse", () => {
         const doc = new Document('<scene><a id="a" /></scene>');
         doc.addAttr(doc.nodes[0], "mesh", "shape: box");
-        doc.add(null, createNode("b"));
+        doc.add(createNode("b"));
         const xml = doc.serialize();
         const doc2 = new Document(xml);
         expect(doc2.nodes).toHaveLength(2);
@@ -632,7 +608,7 @@ describe("Document", () => {
     test("version increments on every mutation", () => {
         const doc = new Document('<scene><a id="a" /></scene>');
         expect(doc.version).toBe(0);
-        doc.add(null, createNode("b"));
+        doc.add(createNode("b"));
         expect(doc.version).toBe(1);
         doc.undo();
         expect(doc.version).toBe(2);
@@ -655,86 +631,36 @@ describe("Document", () => {
     describe("reorder", () => {
         test("moves node forward", () => {
             const doc = new Document('<scene><a id="a" /><a id="b" /><a id="c" /></scene>');
-            doc.reorder(null, doc.nodes[0], 2);
+            doc.reorder(doc.nodes[0], 2);
             expect(doc.nodes.map((n) => n.id)).toEqual(["b", "c", "a"]);
         });
 
         test("moves node backward", () => {
             const doc = new Document('<scene><a id="a" /><a id="b" /><a id="c" /></scene>');
-            doc.reorder(null, doc.nodes[2], 0);
+            doc.reorder(doc.nodes[2], 0);
             expect(doc.nodes.map((n) => n.id)).toEqual(["c", "a", "b"]);
         });
 
         test("no-ops for same position", () => {
             const doc = new Document('<scene><a id="a" /><a id="b" /></scene>');
-            doc.reorder(null, doc.nodes[0], 0);
+            doc.reorder(doc.nodes[0], 0);
             expect(doc.version).toBe(0);
         });
 
         test("no-ops for missing node", () => {
             const doc = new Document('<scene><a id="a" /></scene>');
-            doc.reorder(null, createNode("missing"), 0);
+            doc.reorder(createNode("missing"), 0);
             expect(doc.version).toBe(0);
         });
 
         test("undo/redo round-trip", () => {
             const doc = new Document('<scene><a id="a" /><a id="b" /><a id="c" /></scene>');
-            doc.reorder(null, doc.nodes[0], 2);
+            doc.reorder(doc.nodes[0], 2);
             expect(doc.nodes.map((n) => n.id)).toEqual(["b", "c", "a"]);
             doc.undo();
             expect(doc.nodes.map((n) => n.id)).toEqual(["a", "b", "c"]);
             doc.redo();
             expect(doc.nodes.map((n) => n.id)).toEqual(["b", "c", "a"]);
-        });
-
-        test("reorders within parent children", () => {
-            const doc = new Document('<scene><a id="parent" /></scene>');
-            const parent = doc.nodes[0];
-            const a: Node = { id: "a", attrs: [], children: [] };
-            const b: Node = { id: "b", attrs: [], children: [] };
-            const c: Node = { id: "c", attrs: [], children: [] };
-            parent.children.push(a, b, c);
-            doc.reorder(parent, parent.children[2], 0);
-            expect(parent.children.map((n) => n.id)).toEqual(["c", "a", "b"]);
-        });
-    });
-
-    describe("reparent", () => {
-        test("moves node to new parent", () => {
-            const doc = new Document('<scene><a id="a" /><a id="b" /></scene>');
-            const a = doc.nodes[0];
-            const b = doc.nodes[1];
-            doc.reparent(b, null, a, 0);
-            expect(doc.nodes).toHaveLength(1);
-            expect(doc.nodes[0].id).toBe("a");
-            expect(a.children).toHaveLength(1);
-            expect(a.children[0].id).toBe("b");
-        });
-
-        test("moves node to root", () => {
-            const doc = new Document('<scene><a id="parent" /></scene>');
-            const parent = doc.nodes[0];
-            const child: Node = { id: "child", attrs: [], children: [] };
-            parent.children.push(child);
-            doc.reparent(child, parent, null, 1);
-            expect(doc.nodes).toHaveLength(2);
-            expect(doc.nodes[1].id).toBe("child");
-            expect(parent.children).toHaveLength(0);
-        });
-
-        test("undo/redo round-trip", () => {
-            const doc = new Document('<scene><a id="a" /><a id="b" /></scene>');
-            const a = doc.nodes[0];
-            const b = doc.nodes[1];
-            doc.reparent(b, null, a, 0);
-            expect(doc.nodes).toHaveLength(1);
-            doc.undo();
-            expect(doc.nodes).toHaveLength(2);
-            expect(doc.nodes[0].id).toBe("a");
-            expect(doc.nodes[1].id).toBe("b");
-            doc.redo();
-            expect(doc.nodes).toHaveLength(1);
-            expect(a.children[0].id).toBe("b");
         });
     });
 
@@ -770,7 +696,7 @@ describe("Document", () => {
         test("redo of remove clears selection", () => {
             const doc = new Document('<scene><a id="a" /></scene>');
             const a = doc.nodes[0];
-            doc.remove(null, a);
+            doc.remove(a);
             doc.undo();
             expect(doc.nodes).toHaveLength(1);
 
@@ -782,7 +708,7 @@ describe("Document", () => {
         test("undo returns command", () => {
             const doc = new Document("<scene></scene>");
             const node = createNode("a");
-            doc.add(null, node);
+            doc.add(node);
 
             const cmd = doc.undo();
 
@@ -793,7 +719,7 @@ describe("Document", () => {
         test("redo returns command", () => {
             const doc = new Document("<scene></scene>");
             const node = createNode("a");
-            doc.add(null, node);
+            doc.add(node);
             doc.undo();
 
             const cmd = doc.redo();
@@ -1407,92 +1333,60 @@ describe("serialize parity", () => {
 describe("command invertibility (property)", () => {
     const Seed = '<scene><a id="root" mesh="shape: box" /><a id="other" /></scene>';
 
-    type Placed = { node: Node; parent: Node | null };
-    function flatten(nodes: Node[], parent: Node | null = null, out: Placed[] = []): Placed[] {
-        for (const node of nodes) {
-            out.push({ node, parent });
-            flatten(node.children, node, out);
-        }
-        return out;
-    }
-    function descendant(ancestor: Node, node: Node): boolean {
-        for (const child of ancestor.children) {
-            if (child === node || descendant(child, node)) return true;
-        }
-        return false;
-    }
-
     type Op =
         | { kind: "addRoot"; id?: string }
-        | { kind: "addChild"; target: number; id?: string }
         | { kind: "addAttr"; target: number; name: string; value: string }
         | { kind: "setAttr"; target: number; value: string }
         | { kind: "removeAttr"; target: number }
         | { kind: "setId"; target: number; id?: string }
         | { kind: "reorder"; target: number; to: number }
         | { kind: "reorderAttr"; target: number; to: number }
-        | { kind: "remove"; target: number }
-        | { kind: "reparent"; target: number; into: number };
+        | { kind: "remove"; target: number };
 
     // resolve generated ops against the live tree, skipping ones with no valid target (a no-op records
-    // no history entry). reparent guards cycles the way the outliner's drop logic does.
+    // no history entry).
     function applyOp(doc: Document, op: Op): void {
-        const placed = flatten(doc.nodes);
-        const pick = (i: number): Placed | null =>
-            placed.length ? placed[i % placed.length] : null;
+        const pick = (i: number): Node | null =>
+            doc.nodes.length ? doc.nodes[i % doc.nodes.length] : null;
         switch (op.kind) {
             case "addRoot":
-                doc.add(null, { id: op.id, attrs: [], children: [] });
+                doc.add({ id: op.id, attrs: [], children: [] });
                 break;
-            case "addChild": {
-                const t = pick(op.target);
-                if (t) doc.add(t.node, { id: op.id, attrs: [], children: [] });
-                break;
-            }
             case "addAttr": {
                 const t = pick(op.target);
-                if (t && !t.node.attrs.some((a) => a.name === op.name))
-                    doc.addAttr(t.node, op.name, op.value);
+                if (t && !t.attrs.some((a) => a.name === op.name))
+                    doc.addAttr(t, op.name, op.value);
                 break;
             }
             case "setAttr": {
                 const t = pick(op.target);
-                if (t?.node.attrs.length) doc.setAttr(t.node, t.node.attrs[0].name, op.value);
+                if (t?.attrs.length) doc.setAttr(t, t.attrs[0].name, op.value);
                 break;
             }
             case "removeAttr": {
                 const t = pick(op.target);
-                if (t?.node.attrs.length) doc.removeAttr(t.node, t.node.attrs[0].name);
+                if (t?.attrs.length) doc.removeAttr(t, t.attrs[0].name);
                 break;
             }
             case "setId": {
                 const t = pick(op.target);
-                if (t) doc.setId(t.node, op.id);
+                if (t) doc.setId(t, op.id);
                 break;
             }
             case "reorder": {
-                const t = pick(op.target);
-                if (!t) break;
-                const siblings = t.parent ? t.parent.children : doc.nodes;
-                if (siblings.length > 1) doc.reorder(t.parent, t.node, op.to % siblings.length);
+                if (doc.nodes.length <= 1) break;
+                const idx = op.target % doc.nodes.length;
+                doc.reorder(doc.nodes[idx], op.to % doc.nodes.length);
                 break;
             }
             case "reorderAttr": {
                 const t = pick(op.target);
-                if (t && t.node.attrs.length > 1)
-                    doc.reorderAttr(t.node, 0, op.to % t.node.attrs.length);
+                if (t && t.attrs.length > 1) doc.reorderAttr(t, 0, op.to % t.attrs.length);
                 break;
             }
             case "remove": {
                 const t = pick(op.target);
-                if (t) doc.remove(t.parent, t.node);
-                break;
-            }
-            case "reparent": {
-                const t = pick(op.target);
-                const into = pick(op.into);
-                if (!t || !into || into.node === t.node || descendant(t.node, into.node)) break;
-                doc.reparent(t.node, t.parent, into.node, into.node.children.length);
+                if (t) doc.remove(t);
                 break;
             }
         }
@@ -1513,16 +1407,11 @@ describe("command invertibility (property)", () => {
         fc.record({ kind: fc.constant("reorderAttr" as const), target: Nat, to: Nat }),
         fc.record({ kind: fc.constant("remove" as const), target: Nat }),
     );
-    const treeOp = fc.oneof(
-        flatOp,
-        fc.record({ kind: fc.constant("addChild" as const), target: Nat, id: Id }),
-        fc.record({ kind: fc.constant("reparent" as const), target: Nat, into: Nat }),
-    );
 
     test("undo restores the exact prior serialization (apply∘reverse = identity)", () => {
         clearRegistry();
         fc.assert(
-            fc.property(fc.array(treeOp as fc.Arbitrary<Op>, { maxLength: 30 }), (ops) => {
+            fc.property(fc.array(flatOp as fc.Arbitrary<Op>, { maxLength: 30 }), (ops) => {
                 const doc = new Document(Seed);
                 const priors: string[] = [];
                 for (const op of ops) {
@@ -1545,7 +1434,7 @@ describe("command invertibility (property)", () => {
     test("undo-all then redo-all replays back to the post-sequence state", () => {
         clearRegistry();
         fc.assert(
-            fc.property(fc.array(treeOp as fc.Arbitrary<Op>, { maxLength: 30 }), (ops) => {
+            fc.property(fc.array(flatOp as fc.Arbitrary<Op>, { maxLength: 30 }), (ops) => {
                 const doc = new Document(Seed);
                 let count = 0;
                 for (const op of ops) {

--- a/packages/shallot/src/document/index.ts
+++ b/packages/shallot/src/document/index.ts
@@ -42,22 +42,16 @@ export class Document {
         this.nodes = typeof source === "string" ? parse(source) : source;
     }
 
-    add(parent: Node | null, node: Node, index?: number): void {
-        const children = parent ? parent.children : this.nodes;
-        const idx = index ?? children.length;
-        execute(this.history, this.nodes, { type: "add", parent, node, index: idx }, [
-            ...this.selection,
-        ]);
+    add(node: Node, index?: number): void {
+        const idx = index ?? this.nodes.length;
+        execute(this.history, this.nodes, { type: "add", node, index: idx }, [...this.selection]);
         this.version++;
     }
 
-    remove(parent: Node | null, node: Node): void {
-        const children = parent ? parent.children : this.nodes;
-        const index = children.indexOf(node);
+    remove(node: Node): void {
+        const index = this.nodes.indexOf(node);
         if (index < 0) return;
-        execute(this.history, this.nodes, { type: "remove", parent, node, index }, [
-            ...this.selection,
-        ]);
+        execute(this.history, this.nodes, { type: "remove", node, index }, [...this.selection]);
         this.version++;
     }
 
@@ -124,33 +118,10 @@ export class Document {
         this.version++;
     }
 
-    reorder(parent: Node | null, node: Node, to: number): void {
-        const children = parent ? parent.children : this.nodes;
-        const from = children.indexOf(node);
+    reorder(node: Node, to: number): void {
+        const from = this.nodes.indexOf(node);
         if (from < 0 || from === to) return;
-        execute(this.history, this.nodes, { type: "reorder", parent, node, from, to }, [
-            ...this.selection,
-        ]);
-        this.version++;
-    }
-
-    reparent(node: Node, oldParent: Node | null, newParent: Node | null, newIndex: number): void {
-        const oldChildren = oldParent ? oldParent.children : this.nodes;
-        const oldIndex = oldChildren.indexOf(node);
-        if (oldIndex < 0) return;
-        execute(
-            this.history,
-            this.nodes,
-            {
-                type: "reparent",
-                node,
-                oldParent,
-                oldIndex,
-                newParent,
-                newIndex,
-            },
-            [...this.selection],
-        );
+        execute(this.history, this.nodes, { type: "reorder", node, from, to }, [...this.selection]);
         this.version++;
     }
 

--- a/packages/shallot/src/document/session.ts
+++ b/packages/shallot/src/document/session.ts
@@ -124,7 +124,7 @@ export class Session {
         if (value) this.syncAttr(name, value, eid);
     }
 
-    loadNode(node: Node, _parent: Node | null): void {
+    loadNode(node: Node): void {
         const eid = this.state.create();
         this.nodeMap.set(node, eid);
         for (const attr of node.attrs) this.attachComponent(attr.name, attr.value, eid);
@@ -172,15 +172,12 @@ export class Session {
             }
             case "add": {
                 if (isUndo) this.unloadNode(cmd.node);
-                else this.loadNode(cmd.node, cmd.parent);
+                else this.loadNode(cmd.node);
                 return true;
             }
             case "remove": {
-                if (isUndo) this.loadNode(cmd.node, cmd.parent);
+                if (isUndo) this.loadNode(cmd.node);
                 else this.unloadNode(cmd.node);
-                return true;
-            }
-            case "reparent": {
                 return true;
             }
             case "reorder":

--- a/packages/shallot/src/engine/ecs/component.ts
+++ b/packages/shallot/src/engine/ecs/component.ts
@@ -296,8 +296,8 @@ export function lanes(value: unknown): 0 | 1 | 2 | 4 {
  * a component's typed storage fields: each {@link Single} / {@link Pair} /
  * {@link Quad} store paired with its declared name, in declaration order. The
  * canonical enumerator of a clean component's stores, for a serializer, a
- * reflection reader, or a schema walk. Keys with no typed layout (a GPU-buffer getter,
- * a legacy raw `number[]`) report {@link lanes} 0 and are skipped.
+ * reflection reader, or a schema walk. Keys with no typed layout (a GPU-buffer getter)
+ * report {@link lanes} 0 and are skipped.
  */
 export function fields(component: Component): { name: string; store: Single | Pair | Quad }[] {
     const out: { name: string; store: Single | Pair | Quad }[] = [];

--- a/packages/shallot/src/engine/ecs/reflection.ts
+++ b/packages/shallot/src/engine/ecs/reflection.ts
@@ -117,7 +117,6 @@ export function schema(name: string): Schema | null {
             });
         } else if (isColor(key, traits)) {
             fields.push({ name: key, kind: "color", default: defaults[key] as number });
-            for (const s of ["R", "G", "B"]) handled.add(key + s);
         } else if ((component[key] as { type?: Type } | undefined)?.type === entity) {
             // ref-ness lives on the field's type (`sparse(entity)`) — surface it so tooling
             // shows an `@name` reference, not a number

--- a/packages/shallot/src/engine/scene/codec.ts
+++ b/packages/shallot/src/engine/scene/codec.ts
@@ -251,13 +251,11 @@ export function serialize(state: State, eids?: Iterable<number>): Node[] {
 interface CategorizedAttrs {
     componentAttrs: { name: string; value: string; def: Registered }[];
     refs: Ref[];
-    unknown: { name: string; value: string }[];
 }
 
 function categorizeAttrs(attrs: Attr[]): CategorizedAttrs {
     const componentAttrs: { name: string; value: string; def: Registered }[] = [];
     const refs: Ref[] = [];
-    const unknown: { name: string; value: string }[] = [];
 
     for (const attr of attrs) {
         if (attr.value.startsWith("@") && attr.value.length > 1) {
@@ -268,13 +266,10 @@ function categorizeAttrs(attrs: Attr[]): CategorizedAttrs {
         const registered = lookup(attr.name);
         if (registered) {
             componentAttrs.push({ name: attr.name, value: attr.value, def: registered });
-            continue;
         }
-
-        unknown.push({ name: attr.name, value: attr.value });
     }
 
-    return { componentAttrs, refs, unknown };
+    return { componentAttrs, refs };
 }
 
 function applyComponent(
@@ -319,8 +314,6 @@ function applyComponent(
  * - `field = "pos"`, `value = number` — Single, or first lane of a Pair/Quad
  * - `field = "pos"`, `value = number[]` — Pair/Quad bulk lane write
  * - `field = "pos.x"`, `value = number` — single lane of a parent Pair/Quad
- * - `field = "posX"`, `value = number` — legacy lane Single (split-suffix
- *   storage). Path retires when the last split-suffix component migrates
  */
 export function setFieldValue(
     component: Component,

--- a/packages/shallot/src/standard/audio/sample.ts
+++ b/packages/shallot/src/standard/audio/sample.ts
@@ -32,7 +32,7 @@ function decodeCtx(): AudioContext {
     return _decodeCtx;
 }
 
-export function downmixToMono(channels: Float32Array[], length: number): Float32Array {
+function downmixToMono(channels: Float32Array[], length: number): Float32Array {
     if (channels.length === 1) return new Float32Array(channels[0]);
     const mono = new Float32Array(length);
     for (const src of channels) {

--- a/packages/shallot/src/standard/avbd/step.ts
+++ b/packages/shallot/src/standard/avbd/step.ts
@@ -5814,7 +5814,7 @@ export class PhysicsStep {
      * prior-frame coloring (no atomics, no in-pass read-after-write), then one sweep over the body pool
      * reading the contact graph the collide produced. Reads the dense→eid map (`eids`), so set it first.
      */
-    colorize(encoder: GPUCommandEncoder): void {
+    private colorize(encoder: GPUCommandEncoder): void {
         encoder.copyBufferToBuffer(this.colors, 0, this.colorScratch, 0, this.eidCap * 4);
         // reset the used-color count so this pass's atomicMax measures only this step's coloring (the
         // readback-bounded color loop's input, Phase 4.9 Lever 1). Word 0 only — word 1 is the live
@@ -5856,7 +5856,7 @@ export class PhysicsStep {
      * coloring reads). The count + scatter dispatch indirect off pairArgs (one thread per per-eid pair slot,
      * looping its records, skipping inactive records); the scan is the single-workgroup parallel prefix.
      */
-    buildCsr(encoder: GPUCommandEncoder): void {
+    private buildCsr(encoder: GPUCommandEncoder): void {
         // zero only the count region [eidCap, 2·eidCap); the offset region is fully rewritten by the scan
         encoder.clearBuffer(this.csr, this.eidCap * 4, this.eidCap * 4);
         {

--- a/packages/shallot/src/standard/render/lighting.ts
+++ b/packages/shallot/src/standard/render/lighting.ts
@@ -219,9 +219,6 @@ export const PointLightsRw = d.struct({
     lights: d.arrayOf(PointLightGpu, MAX_POINT_LIGHTS),
 });
 
-/** the compacted light list's buffer size, from the schema — the one source of truth for the layout */
-export const POINT_LIGHTS_BUFFER_SIZE = d.sizeOf(PointLights);
-
 /**
  * the compacted point-light list's WGSL, spliced by sear's clustered loop and the fog march: the
  * {@link PointLightGpu} + {@link PointLights} struct declarations, emitted under strict naming so a raw

--- a/packages/shallot/src/standard/render/mesh.ts
+++ b/packages/shallot/src/standard/render/mesh.ts
@@ -123,7 +123,7 @@ let _placeholderIndices: MeshIndex | null = null;
  * and the unorm16 dequant range (the per-mesh `MeshQuant`, gpu.md rule 6) derive
  * from, so they share one source. An empty buffer returns a zero box.
  */
-export function meshAabb(vertices: Float32Array): {
+function meshAabb(vertices: Float32Array): {
     min: [number, number, number];
     max: [number, number, number];
 } {

--- a/packages/shallot/src/standard/sear/codegen.ts
+++ b/packages/shallot/src/standard/sear/codegen.ts
@@ -94,17 +94,6 @@ export const COLOR_LANES: ColorLane[] = [
     },
 ];
 
-// every subset of the color lanes (the requestable MRT lane-sets — each lane has its own marker, so any
-// combination is valid), smallest first: [] then [tag]. The empty set is the position-only depth prepass
-// (the shadow map reuses it); [tag] is the id lane. The pipeline builder compiles one pipeline per subset —
-// bounded, since the lane set is engine-closed
-export function laneSubsets(): ColorLane[][] {
-    return COLOR_LANES.reduce<ColorLane[][]>(
-        (acc, lane) => acc.concat(acc.map((s) => [...s, lane])),
-        [[]],
-    );
-}
-
 // a lane-set's stable key (the prepass pipeline-map key): "" for the empty depth-only set, "tag" for the
 // id lane, "tag-normal" when normal lands
 export function laneKey(lanes: ColorLane[]): string {
@@ -120,7 +109,7 @@ export function lightEvalWgsl(): string {
     return lightEvalChunk();
 }
 
-export const lightEvalChunk = chunk(
+const lightEvalChunk = chunk(
     "lightEvalWgsl",
     [distanceAttenuation, spotFactor, clusterCell],
     spliceNs,

--- a/packages/shallot/src/standard/transforms/index.ts
+++ b/packages/shallot/src/standard/transforms/index.ts
@@ -13,7 +13,6 @@ import { composeKernel, composeLayout } from "./compose";
 // "transforms" (the access path — surfaces resolve it by name). A derived GPU buffer, not a per-entity
 // field, so it lives here, not on the Transform component (mirrors `Lighting` vs `DirectionalLight` in
 // render/). null until initialize (headless: stays null).
-let _transforms: GPUBuffer | null = null;
 let _typed: (TgpuBuffer<d.WgslArray<typeof Xform>> & StorageFlag) | null = null;
 let _composePipeline: TgpuComputePipeline | null = null;
 // the compose pipeline with its bind group bound, built on first use — the slab mirrors and the
@@ -151,7 +150,6 @@ export const TransformsPlugin: Plugin = {
     },
 
     initialize(state) {
-        _transforms = null;
         _typed = null;
         _composePipeline = null;
         _bound = null;
@@ -166,8 +164,7 @@ export const TransformsPlugin: Plugin = {
             .createBuffer(d.arrayOf(Xform, capacity))
             .$usage("storage")
             .$name("kitchen-transforms");
-        _transforms = Compute.root.unwrap(_typed);
-        Compute.buffers.set("transforms", _transforms);
+        Compute.buffers.set("transforms", Compute.root.unwrap(_typed));
         Compute.typed.set("transforms", _typed);
 
         const t = state.membership.bit(Transform);

--- a/packages/shallot/src/standard/tumble/engine/array.ts
+++ b/packages/shallot/src/standard/tumble/engine/array.ts
@@ -206,7 +206,3 @@ export function qsort(
 /** An int32-backed growable vector — the common index/id column. */
 export const intVec = (capacity = 0): GrowVec<Int32Array> =>
     new GrowVec((n) => new Int32Array(n), capacity);
-
-/** An f32-backed growable vector — a SoA scalar column. */
-export const floatVec = (capacity = 0): GrowVec<Float32Array> =>
-    new GrowVec((n) => new Float32Array(n), capacity);

--- a/packages/shallot/src/standard/tumble/engine/bits.ts
+++ b/packages/shallot/src/standard/tumble/engine/bits.ts
@@ -17,10 +17,6 @@ export function popCount32(x: number): number {
     return (v * 0x01010101) >>> 24;
 }
 
-export function isPowerOf2(x: number): boolean {
-    return (x & (x - 1)) === 0;
-}
-
 /** ceil(log2(x)): the smallest exponent e with 2^e >= x. */
 export function boundingPowerOf2(x: number): number {
     if (x <= 1) {

--- a/packages/shallot/src/standard/tumble/engine/broadphase.ts
+++ b/packages/shallot/src/standard/tumble/engine/broadphase.ts
@@ -154,16 +154,6 @@ export function testOverlap(bp: BroadPhase, keyA: number, keyB: number): boolean
     return aabb.overlaps(overlapA, overlapB);
 }
 
-export function getShapeIndex(bp: BroadPhase, key: number): number {
-    bp.store.refreshIfStale();
-    return tree.getUserData(bp.trees[proxyType(key)], proxyId(key));
-}
-
-/** @returns whether a proxy is flagged as moved this step (b3GetBit on movedProxies). */
-export function getMoved(bp: BroadPhase, type: BodyTypeValue, id: number): boolean {
-    return getBit(bp.movedProxies[type], id);
-}
-
 /** Clear a proxy's moved flag (b3ClearBit on movedProxies). */
 export function clearMoved(bp: BroadPhase, type: BodyTypeValue, id: number): void {
     clearBit(bp.movedProxies[type], id);

--- a/packages/shallot/src/standard/tumble/engine/columns.ts
+++ b/packages/shallot/src/standard/tumble/engine/columns.ts
@@ -55,16 +55,12 @@ export const SLOT_STRIDE = 3;
 
 // Wide (convex) transient constraint columns (contact_wide.rs). Only the meta column is written
 // TS-side (the lane → contactId map); the record + index columns are kernel-internal.
-export const WIDE_STRIDE = 404;
 export const WIDE_META_STRIDE = 5;
-export const WIDE_IDX_STRIDE = 8;
 
 // Per-active-color span (contact_wide.rs / arena.rs): wideStart, wideCount, meshStart, meshCount,
 // jointStart, jointCount. The batched (jointless) color loop reads only the first four; the staged
 // solve reads the joint pair too (joints-in-kernel).
 export const COLOR_SPAN_STRIDE = 6;
-export const CS_JOINT_START = 4;
-export const CS_JOINT_COUNT = 5;
 
 // Joint record (kernel/src/joint_abi.rs). One flat f32 record per joint slot: a common header (the
 // two resident state indices via u32 bits, invMass/invInertia, the pose fields prepare derives anchors
@@ -88,7 +84,6 @@ export const J_LOCAL_FRAME_A = 43; // Transform p 43..45 q 46..49
 export const J_LOCAL_FRAME_B = 50; // Transform p 50..52 q 53..56
 export const J_CONSTRAINT_HERTZ = 57;
 export const J_CONSTRAINT_DAMPING = 58;
-export const J_CONSTRAINT_SOFTNESS = 59; // 59..61
 const J_PAYLOAD = 62;
 export const DJ_LENGTH = J_PAYLOAD;
 export const DJ_HERTZ = J_PAYLOAD + 1;

--- a/packages/shallot/src/standard/tumble/engine/core.ts
+++ b/packages/shallot/src/standard/tumble/engine/core.ts
@@ -52,9 +52,6 @@ export const TIME_TO_SLEEP = f32(0.5);
 /// rather than re-collided (B3_CONTACT_RECYCLE_ANGULAR_DISTANCE ~= cos(7°)).
 export const CONTACT_RECYCLE_ANGULAR_DISTANCE = f32(0.99240388);
 
-/// The most contact points a single manifold can carry (B3_MAX_MANIFOLD_POINTS).
-export const MAX_MANIFOLD_POINTS = 4;
-
 /// Number of solver graph colors (B3_GRAPH_COLOR_COUNT); the last is the serial overflow color.
 export const GRAPH_COLOR_COUNT = 24;
 

--- a/packages/shallot/src/standard/tumble/engine/math.ts
+++ b/packages/shallot/src/standard/tumble/engine/math.ts
@@ -16,7 +16,6 @@ export const f32 = Math.fround;
 // biome-ignore lint/suspicious/noApproximativeNumericConstant: B3_PI verbatim — the port mirrors Box3D's constant, not Math.PI.
 export const PI = f32(3.14159265359);
 export const DEG_TO_RAD = f32(0.01745329251);
-export const RAD_TO_DEG = f32(57.2957795131);
 export const MIN_SCALE = f32(0.01);
 
 const FLT_EPSILON = f32(1.1920928955078125e-7); // 2^-23
@@ -67,10 +66,6 @@ export const clampInt = (a: number, lo: number, hi: number): number =>
     a < lo ? lo : hi < a ? hi : a;
 export const clampf = (a: number, lo: number, hi: number): number =>
     a < lo ? lo : hi < a ? hi : a;
-
-/** (1 - alpha) * a + alpha * b */
-export const lerpf = (a: number, b: number, alpha: number): number =>
-    f32(f32(f32(1 - alpha) * a) + f32(alpha * b));
 
 /**
  * Round every float field of a user-facing def/config to f32 once, where it crosses into the engine.
@@ -1227,20 +1222,14 @@ export const xf = {
 // World-position boundary. In float mode Pos ≡ Vec3 and WorldTransform ≡ Transform, so these
 // collapse to their pure-float counterparts; they exist so callers can name the boundary and so
 // a later large-world (double) build has a single set of seams to widen.
-export const toPos = (v: Vec3): Pos => ({ x: v.x, y: v.y, z: v.z });
 export const toVec3 = (p: Pos): Vec3 => ({ x: p.x, y: p.y, z: p.z });
 export const subPos = (a: Pos, b: Pos): Vec3 => vec3.sub(a, b);
 export const offsetPos = (p: Pos, d: Vec3): Pos => vec3.add(p, d);
-export const isValidPosition = (p: Pos): boolean =>
-    isValidFloat(p.x) && isValidFloat(p.y) && isValidFloat(p.z);
-export const makeWorldTransform = (t: Transform): WorldTransform => ({ p: toPos(t.p), q: t.q });
 /** Shift a world transform into the frame of a base position (b3ToRelativeTransform). */
 export const toRelativeTransform = (t: WorldTransform, base: Pos): Transform => ({
     q: t.q,
     p: subPos(t.p, base),
 });
-export const isValidWorldTransform = (t: WorldTransform): boolean =>
-    isValidPosition(t.p) && quat.isValid(t.q);
 export const transformWorldPoint = (t: WorldTransform, p: Vec3): Pos => xf.point(t, p);
 export const invTransformWorldPoint = (t: WorldTransform, p: Pos): Vec3 => xf.invPoint(t, p);
 export const invMulWorldTransforms = (a: WorldTransform, b: WorldTransform): Transform =>
@@ -1251,7 +1240,6 @@ export const invMulWorldTransformsOut = (
     o: Transform,
 ): Transform => xf.invMulOut(a, b, o);
 export const mulWorldTransforms = (a: WorldTransform, b: Transform): WorldTransform => xf.mul(a, b);
-export const isDoublePrecision = (): boolean => false;
 
 // --- aabb -----------------------------------------------------------------------------------
 

--- a/packages/shallot/src/standard/tumble/engine/table.ts
+++ b/packages/shallot/src/standard/tumble/engine/table.ts
@@ -160,14 +160,6 @@ export function ensureResident(set: HashSet): void {
     set.store.refreshIfStale();
 }
 
-export function clearSet(set: HashSet): void {
-    ensureResident(set);
-    set.count = 0;
-    set.keyHi.fill(0);
-    set.keyLo.fill(0);
-    set.hashes.fill(0);
-}
-
 function findSlot(set: HashSet, kHi: number, kLo: number, hash: number): number {
     const mask = set.capacity - 1;
     const hashes = set.hashes;

--- a/packages/shallot/src/standard/tumble/engine/tree.ts
+++ b/packages/shallot/src/standard/tumble/engine/tree.ts
@@ -109,7 +109,6 @@ function setHeight(ni: Int32Array, i: number, h: number): void {
     ni[n] = (ni[n] & 0xffff) | (h << 16);
 }
 const isLeaf = (ni: Int32Array, i: number): boolean => (ni[i * STRIDE + 11] & LEAF) !== 0;
-const isAllocated = (ni: Int32Array, i: number): boolean => (ni[i * STRIDE + 11] & ALLOCATED) !== 0;
 
 // aabb.perimeter (b3Perimeter) on node i's flat aabb — exact fround expression tree.
 function nodePerimeter(nf: Float32Array, i: number): number {
@@ -823,20 +822,6 @@ export function getHeight(tree: DynamicTree): number {
     return heightOf(tree.ni, tree.root);
 }
 
-export function getAreaRatio(tree: DynamicTree): number {
-    if (tree.root === NULL_INDEX) return 0;
-    const nf = tree.nf;
-    const ni = tree.ni;
-    const rootArea = nodePerimeter(nf, tree.root);
-
-    let totalArea = 0;
-    for (let i = 0; i < tree.nodeCapacity; ++i) {
-        if (isAllocated(ni, i) === false || isLeaf(ni, i) || i === tree.root) continue;
-        totalArea = f32(totalArea + nodePerimeter(nf, i));
-    }
-    return f32(totalArea / rootArea);
-}
-
 export function getRootBounds(tree: DynamicTree): AABB {
     if (tree.root !== NULL_INDEX) return readAABB(tree.nf, tree.root);
     return { lowerBound: { x: 0, y: 0, z: 0 }, upperBound: { x: 0, y: 0, z: 0 } };
@@ -858,10 +843,6 @@ export function getAABBInto(tree: DynamicTree, proxyId: number, out: AABB): AABB
     out.upperBound.y = nf[n + 4];
     out.upperBound.z = nf[n + 5];
     return out;
-}
-
-export function getUserData(tree: DynamicTree, proxyId: number): number {
-    return tree.ni[proxyId * STRIDE + 8];
 }
 
 function bitMatch(


### PR DESCRIPTION
- Delete 19 zero-consumer exports across engine, sear, tumble, and render
- Demote 3 in-file-only exports (lightEvalChunk, meshAabb, downmixToMono)
- Delete 3 cascade-dead exports (toPos, isValidPosition, getUserData)
- Remove dead state (_transforms) and dead field (CategorizedAttrs.unknown)
- Make colorize/buildCsr private (only caller is record() in same class)
- Remove dead _parent parameter from Session.loadNode
- Remove split-suffix residue: collapse branch in reflection.ts, phantom doc in codec.ts, legacy-key doc in component.ts
- Delete children/reparent machinery from document layer (Command union shrink: Reparent type removed, parent param removed from Add/Remove/Reorder)
- Wire check-exports.ts into the check chain
