### PR TITLE
shallot-roads: scaffold roads showcase, GPU FBM terrain

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -264,6 +264,17 @@
         "@playwright/test": "^1.58.2",
       },
     },
+    "examples/showcase/roads": {
+      "name": "roads",
+      "version": "0.0.0",
+      "dependencies": {
+        "@dylanebert/shallot": "workspace:*",
+        "typegpu": "~0.12.0",
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.58.2",
+      },
+    },
     "examples/showcase/sandbox": {
       "name": "sandbox",
       "version": "0.0.0",
@@ -820,6 +831,8 @@
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "respond-to-input": ["respond-to-input@workspace:examples/recipes/respond-to-input"],
+
+    "roads": ["roads@workspace:examples/showcase/roads"],
 
     "rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
 

--- a/examples/showcase/roads/package.json
+++ b/examples/showcase/roads/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "roads",
+    "version": "0.0.0",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "test": "bun test --cwd ../../.. ./examples/showcase/roads/src",
+        "gate": "playwright test"
+    },
+    "dependencies": {
+        "@dylanebert/shallot": "workspace:*",
+        "typegpu": "~0.12.0"
+    },
+    "devDependencies": {
+        "@playwright/test": "^1.58.2"
+    }
+}

--- a/examples/showcase/roads/playwright.config.ts
+++ b/examples/showcase/roads/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from "@playwright/test";
+
+// The roads showcase's own browser driver — bring-your-own, as a real user would. shallot exports no
+// Playwright harness (bun ships `bun test` and tells you to bring Playwright); the reusable part is the
+// gate logic in `src/gate.ts`, written against the published surface. The web server is `shallot dev` (the
+// standalone runtime, no editor), so the gate runs against the same path a user opens. This is full device
+// testing: it needs a capable WebGPU GPU. In WSL the only adapter is software (llvmpipe), which fails
+// shallot's device floor, so the gate is display-gated there — the same posture `bun run flows` takes.
+
+const PORT = 3101;
+const URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+    testDir: "./test",
+    fullyParallel: false,
+    workers: 1,
+    reporter: [["list"]],
+    timeout: 120_000,
+    webServer: {
+        // standalone `shallot dev` over this project's manifest — `bunx` resolves the installed CLI. A cold
+        // first vite build can run past 60s in CI; the warm cache serves in ~1s.
+        command: `bunx shallot dev . --port ${PORT} --strict-port`,
+        url: URL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 180_000,
+    },
+    use: {
+        baseURL: URL,
+        channel: "chrome",
+        launchOptions: {
+            args: [
+                "--enable-unsafe-webgpu",
+                "--enable-features=WebGPUDeveloperFeatures",
+                "--enable-dawn-features=allow_unsafe_apis",
+            ],
+        },
+    },
+});

--- a/examples/showcase/roads/public/icon.svg
+++ b/examples/showcase/roads/public/icon.svg
@@ -1,0 +1,20 @@
+<svg id="Shallot" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80">
+  <title>shallot icon</title>
+
+  <defs>
+    <radialGradient id="baseGradient" cx="35%" cy="30%" r="70%" fx="25%" fy="20%">
+      <stop offset="0%" stop-color="#F5D4B8"/>
+      <stop offset="45%" stop-color="#E8A86B"/>
+      <stop offset="100%" stop-color="#B87654"/>
+    </radialGradient>
+  </defs>
+
+  <g transform="rotate(35 40.0 40.0)">
+    <path id="Background" d="M40,2 C44,10 66,28 66,46 C66,60 48,70 40,78 C32,70 14,60 14,46 C14,28 36,10 40,2 Z" fill="#E8A86B"/>
+    <path id="CloveLeft" d="M40,6 C37,14 22,28 20,44 C20,52 28,62 36,70 C34,58 26,46 26,38 C26,26 38,12 40,6 Z" fill="#D49560"/>
+    <path id="CloveRight" d="M40,6 C43,14 58,28 60,44 C60,52 52,62 44,70 C46,58 54,46 54,38 C54,26 42,12 40,6 Z" fill="#D49560"/>
+    <path id="CenterCrease" d="M40,8 C40,20 40,50 40,72" stroke="#6B4230" stroke-width="1" stroke-opacity="0.4" fill="none" stroke-linecap="round"/>
+    <path id="BottomEdge" d="M40,78 C48,70 66,60 66,46 C61,58 44,70 40,73 Z" fill="#D49560"/>
+    <path id="Outline" d="M40,2 C44,10 66,28 66,46 C66,60 48,70 40,78 C32,70 14,60 14,46 C14,28 36,10 40,2 Z" fill="none" stroke="#6B4230" stroke-width="2"/>
+  </g>
+</svg>

--- a/examples/showcase/roads/public/scenes/roads.scene
+++ b/examples/showcase/roads/public/scenes/roads.scene
@@ -1,0 +1,20 @@
+<scene>
+    <!-- the declarative environment for the roads terrain showcase: ambient + a casting sun, and a plain
+         orbit camera. The heightfield grid is a non-Part producer built in code (terrain/terrain.ts), so
+         only the lights + camera live here. -->
+    <a ambient-light />
+    <a directional-light shadow="distance: 1200" />
+
+    <!-- orbit camera framing the ~1 km² grid (terrain/grid.ts: 1024 m × 1024 m, centred on the world
+         origin — the grid's own centring). distance/max-distance are sized to the terrain's footprint
+         the same way voxel sizes its orbit to the voxel grid: the orbit defaults (distance 10 / max 30)
+         would frame a speck of a 1024 m field and clamp on first zoom. min-distance drops low enough to
+         read ground-level detail near the camera. clear-color is a daytime sky (sRGB hex). The sun shadow
+         distance (above) covers the grid so terrain self-shadows across its relief. -->
+    <a
+        camera="clear-color: 0x78a7ff"
+        sear
+        orbit="distance: 900; max-distance: 2500; min-distance: 10; pitch: 0.5"
+        transform
+    />
+</scene>

--- a/examples/showcase/roads/shallot.json
+++ b/examples/showcase/roads/shallot.json
@@ -1,0 +1,11 @@
+{
+  "scene": "scenes/roads.scene",
+  "plugins": {
+    "Part": false,
+    "Orbit": true,
+    "Mirror": true,
+    "Profile": true,
+    "Terrain": "./src/terrain/terrain",
+    "RoadsBoot": "./src/boot"
+  }
+}

--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -1,0 +1,43 @@
+import type { Plugin, System } from "@dylanebert/shallot";
+import { Meshes } from "@dylanebert/shallot/render/core";
+import { gate } from "./gate";
+import type { Check } from "./harness";
+
+// The roads showcase's boot orchestration, as a plugin (a manifest project has no `main.ts` entry) —
+// the same shape as voxel's `boot.ts`. Terrain generation itself runs inside `terrain.ts`'s own `warm()`
+// (the grid's topology is fixed, so there's no separate "wait for buffers, then generate" step the way
+// voxel's carve-capable mesher needs); this plugin's only job is installing the device gate once the
+// terrain mesh is registered. `mode: always` so the poll runs in edit mode too, not just play.
+
+declare global {
+    interface Window {
+        // the device gate, driven by the project's own Playwright on a real GPU (test/roads.spec.ts).
+        __roadsGate?: () => Promise<Check[]>;
+    }
+}
+
+let armed = true;
+
+const BootSystem: System = {
+    name: "roads-boot",
+    group: "simulation",
+    annotations: { mode: "always" },
+    setup() {
+        armed = true; // setup runs once per State build — re-arm so a rebuild re-installs the gate
+    },
+    update() {
+        if (!armed || !Meshes.get("terrain")) return;
+        armed = false;
+        window.__roadsGate = () => gate();
+    },
+    dispose() {
+        delete window.__roadsGate;
+    },
+};
+
+const RoadsBootPlugin: Plugin = {
+    name: "RoadsBoot",
+    systems: [BootSystem],
+};
+
+export default RoadsBootPlugin;

--- a/examples/showcase/roads/src/gate.ts
+++ b/examples/showcase/roads/src/gate.ts
@@ -1,0 +1,93 @@
+import { decodePos } from "@dylanebert/shallot/utils/core";
+import type { Check } from "./harness";
+import { TERRAIN_QUANT } from "./terrain/generate";
+import { VERTEX_COUNT } from "./terrain/grid";
+import { RELIEF } from "./terrain/noise";
+import { generate, readVertices, SEED } from "./terrain/terrain";
+
+// The terrain generator's correctness gate — the seed-determinism readback the spec's Validation names
+// ("Overlay correctness"/"Rasterizer fidelity" are later stages; this stage's own arm is the height
+// kernel's seed determinism, run on the real device). It's the showcase dogfooding its own testing:
+// published-`@dylanebert/shallot` surface + this project's own lib + driver, no reach into any repo
+// harness. `boot.ts` exposes it on `window.__roadsGate`; the project's own Playwright
+// (`test/roads.spec.ts`) drives it on a GPU.
+//
+// `bun test ./src` (noise.test.ts, grid.test.ts, generate.test.ts) covers the device-free half: the
+// permutation table's seed determinism, the WGSL structural resolve, and the grid-topology oracle
+// (`testing.md`'s observation ladder — never bind a device in `bun test`). This gate covers the one thing
+// only a real device can show: that two GPU dispatches at the same seed actually produce byte-identical
+// vertex content, and two different seeds don't.
+
+const GATE_SEED_A = 0x0072_6f61; // "roa" — a fixed seed independent of the live terrain's SEED (boot.ts)
+const GATE_SEED_B = 0x0064_7332; // "ds2"
+
+/** the per-column surface-height standard deviation, decoded from the raw vertex stream via the
+ *  published {@link decodePos} — the same decode sear's vertex pull uses, so this reads exactly what the
+ *  renderer will read. Samples every 8th vertex (a stride, not the full 66k) since the stat only needs
+ *  enough points to detect "flat vs rolling", not a full census. */
+function heightStd(raw: Uint32Array): number {
+    const stride = 8;
+    let sum = 0;
+    let sumSq = 0;
+    let n = 0;
+    for (let i = 0; i < VERTEX_COUNT; i += stride) {
+        const w0 = raw[i * 4];
+        const w1 = raw[i * 4 + 1];
+        const y = decodePos(w0, w1, TERRAIN_QUANT).y;
+        sum += y;
+        sumSq += y * y;
+        n++;
+    }
+    const mean = sum / n;
+    return Math.sqrt(Math.max(0, sumSq / n - mean * mean));
+}
+
+function equalStream(a: Uint32Array, b: Uint32Array): boolean {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+}
+
+/** run the terrain generator's gate against the live device, restoring the boot seed's terrain when done. */
+export async function gate(): Promise<Check[]> {
+    const checks: Check[] = [];
+
+    await generate(GATE_SEED_A);
+    const first = await readVertices();
+    checks.push({
+        name: "vertex-stream-size",
+        pass: first.length === VERTEX_COUNT * 4,
+        detail: `${first.length} u32 words (expected ${VERTEX_COUNT * 4})`,
+    });
+
+    await generate(GATE_SEED_A);
+    const repeat = await readVertices();
+    checks.push({
+        name: "deterministic",
+        pass: equalStream(first, repeat),
+        detail: "seed → bit-identical vertex stream across two runs",
+    });
+
+    await generate(GATE_SEED_B);
+    const reseeded = await readVertices();
+    checks.push({
+        name: "reseed-changes",
+        pass: !equalStream(first, reseeded),
+        detail: "a different seed produces a different vertex stream",
+    });
+
+    // the relief floor: a 5-octave zero-mean fbm's surface std is ≳ 0.1·RELIEF (voxel's `noise.ts`
+    // derives the same bound for its heightmap — the octave/persistence pair is identical here), so
+    // halving it for seed-to-seed variation gives a not-flat floor with ~2× margin, not a tuned threshold.
+    const std = heightStd(reseeded);
+    const reliefFloor = RELIEF * 0.05;
+    checks.push({
+        name: "relief",
+        pass: std > reliefFloor,
+        detail: `surface-height std ${std.toFixed(2)} > ${reliefFloor.toFixed(2)} (rolling, not flat)`,
+    });
+
+    // restore the boot seed's terrain for the live view.
+    await generate(SEED);
+    return checks;
+}

--- a/examples/showcase/roads/src/harness.ts
+++ b/examples/showcase/roads/src/harness.ts
@@ -1,0 +1,31 @@
+import { Compute, type Mirror } from "@dylanebert/shallot";
+
+// The project's own tiny test/boot helpers — published-surface-only (no reach into the repo harness),
+// the same shape as voxel's `src/harness.ts`. {@link Check} is the gate's verdict shape, read by
+// `window.__roadsGate`.
+
+export interface Check {
+    name: string;
+    pass: boolean;
+    detail: string;
+}
+
+/** await `n` animation frames — lets the running render loop advance a known amount. */
+export function frames(n: number): Promise<void> {
+    return new Promise((resolve) => {
+        let i = 0;
+        const tick = () => (++i >= n ? resolve() : requestAnimationFrame(tick));
+        requestAnimationFrame(tick);
+    });
+}
+
+// Mirror is 1-2 frames stale by design (a staging ring + async map). After mutating state the GPU reads,
+// wait until a snapshot encoded *after* now lands, so a readback reflects the new state. Bounded — a stuck
+// map resolves to the loop cap.
+export async function settle(m: Mirror, max = 120): Promise<void> {
+    const target = Compute.frame + 2;
+    for (let i = 0; i < max; i++) {
+        await frames(1);
+        if (m.snapshot && m.snapshot.frame >= target) return;
+    }
+}

--- a/examples/showcase/roads/src/terrain/generate.test.ts
+++ b/examples/showcase/roads/src/terrain/generate.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+    body,
+    flat,
+    integerDiscipline,
+    noIntegerDivision,
+} from "../../../../../packages/shallot/tests/wgsl";
+import { heightKernelWgsl } from "./generate";
+import { HALF, SPACING, VERTS } from "./grid";
+
+// The height kernel's structural gate — the device-free seam this stage's `bun test` relies on for the
+// GPU dispatch (`testing.md`'s ladder rung (a)/(b): CPU-callable TGSL + exact resolved WGSL, never a
+// bound device). The kernel's own seed-determinism *readback* runs on the real device instead
+// (`gate.ts`, driven by `test/roads.spec.ts`) — the split voxel's `generate.test.ts`/`gate.ts` also make.
+
+describe("height kernel reference", () => {
+    const wgsl = heightKernelWgsl();
+
+    test("resolves the complete noise, encode, and storage graph", () => {
+        for (const helper of [
+            "grad2",
+            "perlin2",
+            "fbm2",
+            "heightAt",
+            "encodePos",
+            "encodeUv",
+            "octEncodeNormal",
+        ]) {
+            expect(wgsl).toContain(`fn ${helper}(`);
+        }
+        expect(flat(wgsl)).toContain(
+            "@group(0) @binding(0) var<storage, read> perm_1: array<u32, 512>;",
+        );
+        expect(wgsl.match(/var<storage/g)?.length).toBeGreaterThanOrEqual(3); // perm + vertices + position
+    });
+
+    test("dispatches one thread per vertex, with a bounds guard at the fence-post edge", () => {
+        const kernel = flat(body(wgsl, "@compute"));
+        expect(kernel).toContain("@workgroup_size(8, 8, 1)");
+        expect(kernel).toContain(`gid_1.x >= ${VERTS}u`);
+        expect(kernel).toContain(`gid_1.y >= ${VERTS}u`);
+        integerDiscipline(kernel);
+        noIntegerDivision(kernel);
+    });
+
+    test("samples the surface at its own column and its four neighbours (the finite-difference normal)", () => {
+        const kernel = flat(body(wgsl, "@compute"));
+        expect(kernel.match(/heightAt\(/g)?.length).toBe(5);
+    });
+
+    test("addresses the fixed grid's world position from the documented HALF/SPACING constants", () => {
+        const kernel = flat(body(wgsl, "@compute"));
+        expect(kernel).toContain(`(f32(ix) - ${HALF}f) * ${SPACING}f`);
+        expect(kernel).toContain(`(f32(iz) - ${HALF}f) * ${SPACING}f`);
+    });
+});

--- a/examples/showcase/roads/src/terrain/generate.ts
+++ b/examples/showcase/roads/src/terrain/generate.ts
@@ -1,0 +1,182 @@
+// GPU heightfield terrain generation. A TGSL compute pass writes the quantized vertex streams directly,
+// one thread per grid vertex: no intermediate density volume, no atomic append — the grid's topology
+// (grid.ts) is fixed and data-independent, so each thread owns exactly one output slot
+// (`vertexIndex(ix, iz)`, grid.ts) and there's no race to arbitrate. This is voxel's mesher simplified by
+// the one fact a heightfield has that a voxel volume doesn't: the vertex/index count is known up front.
+//
+// Each thread samples {@link heightAt} at its own column and its four neighbours (a finite-difference
+// normal — the standard heightfield trick: for `y = h(x, z)`, `normal = normalize(-∂h/∂x, 1, -∂h/∂z)`),
+// then writes the encoded position + oct-normal directly into the mesh's quantized main + position
+// streams (gpu.md rule 6) via the published `encodePos`/`encodeUv`/`octEncodeNormal` codecs — the same
+// producer-writes-quantized-storage-directly pattern voxel's `emitKernel` uses.
+
+import { Compute } from "@dylanebert/shallot";
+import { precompile, precompileScope } from "@dylanebert/shallot/runtime";
+import {
+    encodePos,
+    encodeUv,
+    type MeshQuant,
+    octEncodeNormal,
+} from "@dylanebert/shallot/utils/core";
+import tgpu, { type StorageFlag, type TgpuBuffer } from "typegpu";
+import * as d from "typegpu/data";
+import * as std from "typegpu/std";
+import { GridPosition, GridVertices, HALF, SPACING, VERTS } from "./grid";
+import { GROUND_LEVEL, heightAt, makePermutation, noiseLayout, PermData, RELIEF } from "./noise";
+
+const WORLD_HALF = ((VERTS - 1) / 2) * SPACING;
+const WORLD_EXTENT = (VERTS - 1) * SPACING;
+
+/** the terrain mesh's analytic AABB (grid.ts's world extent × the noise-derived height band), the
+ *  {@link MeshQuant} table both the generator (encode) and sear (decode) dequantize against. One source:
+ *  a scale change to either the grid spacing or the relief amplitude updates this automatically. */
+export const TERRAIN_QUANT: d.Infer<typeof MeshQuant> = {
+    posOffset: d.vec4f(-WORLD_HALF, GROUND_LEVEL - RELIEF, -WORLD_HALF, 0),
+    posScale: d.vec4f(WORLD_EXTENT, 2 * RELIEF, WORLD_EXTENT, 0),
+    uvScale: d.vec4f(0, 0, 0, 0),
+};
+
+const WG = 8; // 8×8 = 64 threads per workgroup, one 2D dispatch over the fixed vertex grid
+const DISPATCH = { x: Math.ceil(VERTS / WG), y: Math.ceil(VERTS / WG) };
+
+const terrainLayout = tgpu.bindGroupLayout({
+    vertices: { storage: GridVertices, access: "mutable" },
+    position: { storage: GridPosition, access: "mutable" },
+});
+
+const heightKernel = tgpu
+    .computeFn({
+        workgroupSize: [WG, WG, 1],
+        in: { gid: d.builtin.globalInvocationId },
+    })((input) => {
+        "use gpu";
+        const gid = input.gid;
+        if (gid.x >= d.u32(VERTS) || gid.y >= d.u32(VERTS)) return;
+
+        const ix = gid.x;
+        const iz = gid.y;
+        const x = (d.f32(ix) - d.f32(HALF)) * d.f32(SPACING);
+        const z = (d.f32(iz) - d.f32(HALF)) * d.f32(SPACING);
+        const eps = d.f32(SPACING);
+
+        const y = heightAt(x, z);
+        const yx0 = heightAt(x - eps, z);
+        const yx1 = heightAt(x + eps, z);
+        const yz0 = heightAt(x, z - eps);
+        const yz1 = heightAt(x, z + eps);
+        const normal = std.normalize(
+            d.vec3f(
+                -(yx1 - yx0) / (d.f32(2.0) * eps),
+                d.f32(1.0),
+                -(yz1 - yz0) / (d.f32(2.0) * eps),
+            ),
+        );
+
+        const idx = iz * d.u32(VERTS) + ix;
+        const octN = octEncodeNormal(normal);
+        const uvw = encodeUv(d.vec2f(0, 0), TERRAIN_QUANT);
+        const m = encodePos(d.vec3f(x, y, z), d.u32(0), TERRAIN_QUANT);
+        terrainLayout.$.vertices[idx] = d.vec4u(m.x, m.y, octN, uvw);
+        terrainLayout.$.position[idx] = d.vec2u(m.x, m.y);
+    })
+    .$name("terrain-height-kernel");
+
+/** the emitted height-kernel WGSL — the device-free structural seam the terrain tests resolve. */
+export function heightKernelWgsl(): string {
+    return tgpu.resolve([octEncodeNormal, encodePos, encodeUv, heightKernel], { names: "strict" });
+}
+
+type TerrainRoot = typeof Compute.root;
+type TerrainPipeline = ReturnType<TerrainRoot["createComputePipeline"]>;
+type PermBuffer = TgpuBuffer<typeof PermData> & StorageFlag;
+
+let pipeline: TerrainPipeline | null = null;
+let bindGroup: ReturnType<TerrainRoot["createBindGroup"]> | null = null;
+let permRaw: GPUBuffer | null = null;
+let warmed = false;
+let tail = Promise.resolve();
+
+/** wire the height kernel to the mesh's live vertex/position buffers — called once from `terrain.ts`'s
+ *  `warm()`, after the mesh buffers exist. */
+export function bindTerrainKernel(
+    vertices: TgpuBuffer<typeof GridVertices> & StorageFlag,
+    position: TgpuBuffer<typeof GridPosition> & StorageFlag,
+): void {
+    const { root } = Compute;
+    pipeline = root.createComputePipeline({ compute: heightKernel }).$name("terrain-generate");
+    bindGroup = root.createBindGroup(terrainLayout, { vertices, position });
+    warmed = false;
+}
+
+async function run(seed: number): Promise<void> {
+    if (!pipeline || !bindGroup) throw new Error("terrain: generate before bindTerrainKernel");
+    const activePipeline = pipeline;
+    const activeBindGroup = bindGroup;
+    const { device, root } = Compute;
+
+    if (!warmed) {
+        const warmLabel = precompileScope("terrain-generate");
+        const owned: { raw: GPUBuffer | null } = { raw: null };
+        try {
+            await precompile(warmLabel, () => {
+                owned.raw = device.createBuffer({
+                    label: `${warmLabel}-perm`,
+                    size: d.sizeOf(PermData),
+                    usage: GPUBufferUsage.STORAGE,
+                });
+                const warmPerm = root.createBuffer(PermData, owned.raw).$usage("storage");
+                const noiseGroup = root.createBindGroup(noiseLayout, { perm: warmPerm });
+                const enc = device.createCommandEncoder({ label: warmLabel });
+                const pass = enc.beginComputePass({ label: warmLabel });
+                activePipeline
+                    .with(noiseGroup)
+                    .with(activeBindGroup)
+                    .with(pass)
+                    .dispatchWorkgroups(0);
+                pass.end();
+                device.queue.submit([enc.finish()]);
+                return activePipeline;
+            });
+        } finally {
+            owned.raw?.destroy();
+        }
+        warmed = true;
+    }
+
+    const perm = makePermutation(seed);
+    const nextRaw = device.createBuffer({
+        label: "terrain-perm",
+        size: perm.byteLength,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    try {
+        const nextPerm: PermBuffer = root.createBuffer(PermData, nextRaw).$usage("storage");
+        device.queue.writeBuffer(nextRaw, 0, perm as Uint32Array<ArrayBuffer>);
+        const noiseGroup = root.createBindGroup(noiseLayout, { perm: nextPerm });
+        const enc = device.createCommandEncoder({ label: "terrain-generate" });
+        const pass = enc.beginComputePass({ label: "terrain-generate" });
+        activePipeline
+            .with(noiseGroup)
+            .with(activeBindGroup)
+            .with(pass)
+            .dispatchWorkgroups(DISPATCH.x, DISPATCH.y, 1);
+        pass.end();
+        device.queue.submit([enc.finish()]);
+    } catch (cause) {
+        nextRaw.destroy();
+        throw cause;
+    }
+    permRaw?.destroy();
+    permRaw = nextRaw;
+}
+
+/** regenerate the terrain's height + normal for `seed`, serialized behind the prior call so two
+ *  overlapping reseeds (F9 spam, the gate's back-to-back regenerate calls) never interleave dispatches. */
+export function generate(seed: number): Promise<void> {
+    const result = tail.then(
+        () => run(seed),
+        () => run(seed),
+    );
+    tail = result.catch(() => {});
+    return result;
+}

--- a/examples/showcase/roads/src/terrain/grid.test.ts
+++ b/examples/showcase/roads/src/terrain/grid.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import {
+    CELLS,
+    gridIndices,
+    HALF,
+    INDEX_COUNT,
+    SPACING,
+    VERTEX_COUNT,
+    VERTS,
+    vertexIndex,
+    worldX,
+    worldZ,
+} from "./grid";
+
+// The mesh-topology oracle: the fixed W×H grid's vertex/index counts and index list are pure functions of
+// `CELLS`, derivable by hand for a small grid and checked against `gridIndices()` here, then relied on
+// (not re-derived) for the full-size counts. `generate.test.ts`'s WGSL structural check pins the GPU
+// kernel writes at the same `vertexIndex` addressing this file pins on the CPU side.
+
+describe("grid dimensions", () => {
+    test("vertex/index counts derive from CELLS (fence-post + two triangles per quad)", () => {
+        expect(VERTS).toBe(CELLS + 1);
+        expect(VERTEX_COUNT).toBe(VERTS * VERTS);
+        expect(INDEX_COUNT).toBe(CELLS * CELLS * 6);
+        expect(HALF).toBe(CELLS / 2);
+    });
+
+    test("the grid centres exactly on the world origin", () => {
+        expect(worldX(0)).toBe(-HALF * SPACING);
+        expect(worldX(VERTS - 1)).toBe(HALF * SPACING);
+        expect(worldX(HALF)).toBe(0);
+        expect(worldZ(HALF)).toBe(0);
+    });
+});
+
+describe("vertexIndex addressing", () => {
+    test("row-major over x within z, spanning exactly [0, VERTEX_COUNT)", () => {
+        expect(vertexIndex(0, 0)).toBe(0);
+        expect(vertexIndex(1, 0)).toBe(1);
+        expect(vertexIndex(0, 1)).toBe(VERTS);
+        expect(vertexIndex(VERTS - 1, VERTS - 1)).toBe(VERTEX_COUNT - 1);
+    });
+});
+
+describe("gridIndices", () => {
+    test("a 1×1 cell grid emits one quad, CCW-up-facing, from its four corners", () => {
+        // corners: 0=(0,0) 1=(1,0) 2=(0,1) 3=(1,1) — a single quad, verts = 2
+        const idx = gridIndices(1);
+        expect(idx.length).toBe(6);
+        expect(Array.from(idx)).toEqual([0, 2, 1, 1, 2, 3]);
+    });
+
+    test("a 2×2 cell grid emits four quads over a 3×3 vertex fence-post, index count = 24", () => {
+        const cells = 2;
+        const idx = gridIndices(cells);
+        expect(idx.length).toBe(cells * cells * 6);
+
+        // hand-derive the same four quads by the documented corner formula and compare directly —
+        // an independent derivation of the same rule, not a call into gridIndices itself.
+        const verts = cells + 1;
+        const expected: number[] = [];
+        for (let iz = 0; iz < cells; iz++) {
+            for (let ix = 0; ix < cells; ix++) {
+                const i0 = iz * verts + ix;
+                const i1 = i0 + 1;
+                const i2 = i0 + verts;
+                const i3 = i2 + 1;
+                expected.push(i0, i2, i1, i1, i2, i3);
+            }
+        }
+        expect(Array.from(idx)).toEqual(expected);
+
+        // every index stays within the fence-post vertex count, and each of the 9 vertices is referenced
+        // by at least one triangle (no orphan corner).
+        const seen = new Set<number>();
+        for (const i of idx) {
+            expect(i).toBeGreaterThanOrEqual(0);
+            expect(i).toBeLessThan(verts * verts);
+            seen.add(i);
+        }
+        expect(seen.size).toBe(verts * verts);
+    });
+
+    test("the full-size grid (CELLS) matches the documented counts", () => {
+        expect(gridIndices().length).toBe(INDEX_COUNT);
+    });
+});

--- a/examples/showcase/roads/src/terrain/grid.ts
+++ b/examples/showcase/roads/src/terrain/grid.ts
@@ -1,0 +1,72 @@
+import * as d from "typegpu/data";
+
+// The terrain grid's addressing + world scale — a fixed-topology XZ vertex grid, not voxel's 3D density
+// field. A heightfield needs only one height sample per (x, z) column, so the mesh is a flat W×H quad
+// grid displaced in Y, not a volumetric field marched into faces.
+//
+// Scale: 256×256 quads at 4 m spacing → a 1024 m × 1024 m footprint (~1.05 km²), matching the spec's
+// "~1 km² showcase scale" (the voxel-example spirit: round numbers a reader can check, not a tuned
+// figure). 4 m spacing keeps the vertex count small (257×257 = 66,049 verts, well under any storage-
+// binding pressure) while staying fine enough to read the rolling hills at showcase camera distances —
+// a road's own texel density is stage 3's problem, not this stage's. CELLS must be even so the grid
+// centres exactly on the world origin (HALF is a whole number of cells).
+
+export const SPACING = 4; // world metres per grid cell
+export const CELLS = 256; // quads per side
+export const VERTS = CELLS + 1; // vertices per side (fence-post)
+export const HALF = CELLS / 2; // cells from centre to edge
+
+export const VERTEX_COUNT = VERTS * VERTS;
+export const INDEX_COUNT = CELLS * CELLS * 6;
+
+export const WORLD_EXTENT = CELLS * SPACING; // metres per side (1024)
+export const WORLD_HALF = WORLD_EXTENT / 2;
+
+export const GridVertices = d.arrayOf(d.vec4u, VERTEX_COUNT);
+export const GridPosition = d.arrayOf(d.vec2u, VERTEX_COUNT);
+export const GridIndices = d.arrayOf(d.u32, INDEX_COUNT);
+
+/** grid column (ix, iz) → world (x, z), centred on the origin. The inverse a reader would need lives
+ *  nowhere yet (stage 1 has no picking) — added when a later stage needs it. */
+export function worldX(ix: number): number {
+    return (ix - HALF) * SPACING;
+}
+export function worldZ(iz: number): number {
+    return (iz - HALF) * SPACING;
+}
+
+/** grid column (ix, iz) → flat vertex index, row-major over x within z. The GPU kernel and this CPU
+ *  twin share the same formula (the mesh-topology oracle asserts they can't drift). */
+export function vertexIndex(ix: number, iz: number): number {
+    return iz * VERTS + ix;
+}
+
+/**
+ * the CPU-built index buffer for the fixed W×H quad grid — pure function of {@link CELLS}, no dependency
+ * on generated heights (unlike voxel's mesher, the triangle list here is data-independent, so it's
+ * authored once on the CPU and uploaded once, never recomputed on the GPU).
+ *
+ * Winding: each quad (ix, iz) splits into (i0, i2, i1) and (i1, i2, i3) where i0..i3 are its four
+ * corners in row-major order. For p0=(x,y,z), p1=(x+1,y,z), p2=(x,y,z+1): cross(p2-p0, p1-p0) = (0,1,0)
+ * — that triangle order faces +Y (up), the convention sear expects for a front-facing ground plane.
+ */
+export function gridIndices(cells = CELLS): Uint32Array {
+    const verts = cells + 1;
+    const out = new Uint32Array(cells * cells * 6);
+    let k = 0;
+    for (let iz = 0; iz < cells; iz++) {
+        for (let ix = 0; ix < cells; ix++) {
+            const i0 = iz * verts + ix;
+            const i1 = i0 + 1;
+            const i2 = i0 + verts;
+            const i3 = i2 + 1;
+            out[k++] = i0;
+            out[k++] = i2;
+            out[k++] = i1;
+            out[k++] = i1;
+            out[k++] = i2;
+            out[k++] = i3;
+        }
+    }
+    return out;
+}

--- a/examples/showcase/roads/src/terrain/noise.test.ts
+++ b/examples/showcase/roads/src/terrain/noise.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { body, flat } from "../../../../../packages/shallot/tests/wgsl";
+import { GROUND_LEVEL, HFREQ, makePermutation, noiseWgsl, RELIEF } from "./noise";
+
+describe("makePermutation", () => {
+    // the seed → identical terrain determinism (validated end-to-end on the GPU in the roads gate) rests
+    // on the permutation table being deterministic in its seed. These pin that CPU-side foundation —
+    // `testing.md`'s observation ladder never binds a device in `bun test`.
+
+    test("is deterministic in the seed", () => {
+        expect(makePermutation(1337)).toEqual(makePermutation(1337));
+    });
+
+    test("differs across seeds", () => {
+        expect(makePermutation(1)).not.toEqual(makePermutation(2));
+    });
+
+    test("first half is a permutation of 0..255, second half doubles it", () => {
+        const perm = makePermutation(42);
+        expect(perm.length).toBe(512);
+        const seen = new Set<number>();
+        for (let i = 0; i < 256; i++) {
+            expect(perm[i]).toBeGreaterThanOrEqual(0);
+            expect(perm[i]).toBeLessThan(256);
+            expect(perm[i + 256]).toBe(perm[i]); // doubled so lattice hashes never wrap
+            seen.add(perm[i]);
+        }
+        expect(seen.size).toBe(256); // every value 0..255 appears exactly once
+    });
+});
+
+describe("emitted WGSL", () => {
+    test("preserves the f32 gradient evaluation and FBM recurrence", () => {
+        const wgsl = noiseWgsl();
+        const grad = flat(body(wgsl, "fn grad2"));
+        expect(grad).toBe(
+            "fn grad2(hash: u32, x: f32, y: f32) -> f32 { let h = (hash & 7u); " +
+                "var gx = 0f; var gy = 0f; " +
+                "if ((h == 0u)) { gx = 1f; gy = 0f; } " +
+                "if ((h == 1u)) { gx = -1f; gy = 0f; } " +
+                "if ((h == 2u)) { gx = 0f; gy = 1f; } " +
+                "if ((h == 3u)) { gx = 0f; gy = -1f; } " +
+                "if ((h == 4u)) { gx = 0.7071067690849304f; gy = 0.7071067690849304f; } " +
+                "if ((h == 5u)) { gx = -0.7071067690849304f; gy = 0.7071067690849304f; } " +
+                "if ((h == 6u)) { gx = 0.7071067690849304f; gy = -0.7071067690849304f; } " +
+                "if ((h == 7u)) { gx = -0.7071067690849304f; gy = -0.7071067690849304f; } " +
+                "return ((gx * x) + (gy * y)); }",
+        );
+
+        const perlin = flat(body(wgsl, "fn perlin2"));
+        expect(perlin).toBe(
+            "fn perlin2(p: vec2f) -> f32 { " +
+                "let x = p.x; let y = p.y; let fx = floor(x); let fy = floor(y); " +
+                "let X = u32((i32(fx) & 255i)); let Y = u32((i32(fy) & 255i)); " +
+                "let xf = (x - fx); let yf = (y - fy); " +
+                "let u = (((xf * xf) * xf) * ((xf * ((xf * 6f) - 15f)) + 10f)); " +
+                "let v = (((yf * yf) * yf) * ((yf * ((yf * 6f) - 15f)) + 10f)); " +
+                "let perm = (&perm_1); let A = ((*perm)[X] + Y); " +
+                "let B = ((*perm)[(X + 1u)] + Y); let v00 = grad2((*perm)[A], xf, yf); " +
+                "let v10 = grad2((*perm)[B], (xf - 1f), yf); " +
+                "let v01 = grad2((*perm)[(A + 1u)], xf, (yf - 1f)); " +
+                "let v11 = grad2((*perm)[(B + 1u)], (xf - 1f), (yf - 1f)); " +
+                "return mix(mix(v00, v10, u), mix(v01, v11, u), v); }",
+        );
+
+        const fbm = flat(body(wgsl, "fn fbm2"));
+        expect(fbm).toBe(
+            "fn fbm2(p: vec2f) -> f32 { var amp = 1f; var freq = 1f; var sum = 0f; " +
+                "var norm = 0f; var i = 0u; for (; (i < 5u); i = (i + 1u)) { " +
+                "sum = (sum + (perlin2((p * freq)) * amp)); norm = (norm + amp); " +
+                "amp = (amp * 0.5f); freq = (freq * 2f); } return (sum / norm); }",
+        );
+    });
+
+    test("heightAt bakes this project's own frequency/relief/ground constants", () => {
+        const wgsl = noiseWgsl();
+        const height = flat(body(wgsl, "fn heightAt"));
+        // HFREQ round-trips through an f32 literal (0.003 has no exact binary fraction), so the emitted
+        // WGSL carries the f32-rounded value, not the JS source literal — read, not guessed.
+        expect(height).toBe(
+            `fn heightAt(x: f32, z: f32) -> f32 { return (${GROUND_LEVEL}f + ` +
+                `(fbm2((vec2f(x, z) * ${Math.fround(HFREQ)}f)) * ${RELIEF}f)); }`,
+        );
+    });
+});

--- a/examples/showcase/roads/src/terrain/noise.ts
+++ b/examples/showcase/roads/src/terrain/noise.ts
@@ -1,0 +1,168 @@
+// The pure terrain-height primitives: the seeded permutation table + the layered 2D perlin/fbm WGSL —
+// the same technique voxel's `noise.ts` uses for its heightmap generator, reused here directly on world
+// (x, z) metres instead of voxel grid cells. No engine/GPU imports, so `bun test` exercises the
+// determinism foundation device-free — the GPU dispatch that consumes this lives in generate.ts.
+//
+// Showcase examples don't import each other's `src/` (examples.md: each is a self-contained project), so
+// this is its own copy of the perlin/fbm/permutation shape, not a shared import from voxel.
+
+import tgpu from "typegpu";
+import * as d from "typegpu/data";
+import * as std from "typegpu/std";
+
+// heightmap knobs, in world units (metres), since the terrain kernel samples world position directly —
+// unlike voxel, which samples grid-cell coordinates. HFREQ's period (1/HFREQ ≈ 330 m) puts about three
+// broad hills across the 1024 m field (grid.ts); RELIEF is the vertical amplitude in metres (|fbm2| ≤ 1
+// ⇒ height ∈ GROUND_LEVEL ± RELIEF) — gentle rolling hills, not mountains, the showcase's "readable at
+// street level" brief.
+export const HFREQ = 0.003;
+export const RELIEF = 40;
+const OCTAVES = 5; // baked into fbm2 below — broad shapes + medium hills + fine detail
+const PERSISTENCE = d.f32(0.5); // each octave's amplitude vs the last
+const LACUNARITY = d.f32(2.0); // each octave's frequency vs the last
+export const GROUND_LEVEL = 0; // terrain centred on world Y=0 (the grid's own XZ centring, grid.ts)
+
+const PERM_SIZE = 256;
+const SQRT1_2 = d.f32(Math.SQRT1_2);
+const NEG_SQRT1_2 = d.f32(-Math.SQRT1_2);
+export const PermData = d.arrayOf(d.u32, PERM_SIZE * 2);
+
+export const noiseLayout = tgpu.bindGroupLayout({
+    perm: { storage: PermData, access: "readonly" },
+});
+
+function mulberry32(seed: number): () => number {
+    let s = seed >>> 0;
+    return () => {
+        s = (s + 0x6d2b79f5) | 0;
+        let t = s;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+/** seeded length-512 doubled permutation table — Fisher-Yates over 0..255, concatenated with itself so the
+ *  perlin lattice hashes (`perm[A + 1]`, up to index 511) never wrap. Deterministic in `seed`. */
+export function makePermutation(seed: number): Uint32Array {
+    const rng = mulberry32(seed);
+    const base = new Uint32Array(PERM_SIZE);
+    for (let i = 0; i < PERM_SIZE; i++) base[i] = i;
+    for (let i = PERM_SIZE - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1));
+        const tmp = base[i];
+        base[i] = base[j];
+        base[j] = tmp;
+    }
+    const perm = new Uint32Array(PERM_SIZE * 2);
+    perm.set(base);
+    perm.set(base, PERM_SIZE);
+    return perm;
+}
+
+/**
+ * TGSL mirror of the 2D improved-noise gradient lattice. The binding comes from {@link noiseLayout},
+ * so the generator can resolve the noise helpers through the same schema-backed layout.
+ */
+export const grad2 = tgpu.fn(
+    [d.u32, d.f32, d.f32],
+    d.f32,
+)((hash, x, y) => {
+    "use gpu";
+    const h = hash & d.u32(7);
+    let gx = d.f32(0.0);
+    let gy = d.f32(0.0);
+    if (h === d.u32(0)) {
+        gx = d.f32(1.0);
+        gy = d.f32(0.0);
+    }
+    if (h === d.u32(1)) {
+        gx = d.f32(-1.0);
+        gy = d.f32(0.0);
+    }
+    if (h === d.u32(2)) {
+        gx = d.f32(0.0);
+        gy = d.f32(1.0);
+    }
+    if (h === d.u32(3)) {
+        gx = d.f32(0.0);
+        gy = d.f32(-1.0);
+    }
+    if (h === d.u32(4)) {
+        gx = SQRT1_2;
+        gy = SQRT1_2;
+    }
+    if (h === d.u32(5)) {
+        gx = NEG_SQRT1_2;
+        gy = SQRT1_2;
+    }
+    if (h === d.u32(6)) {
+        gx = SQRT1_2;
+        gy = NEG_SQRT1_2;
+    }
+    if (h === d.u32(7)) {
+        gx = NEG_SQRT1_2;
+        gy = NEG_SQRT1_2;
+    }
+    return gx * x + gy * y;
+});
+
+export const perlin2 = tgpu.fn(
+    [d.vec2f],
+    d.f32,
+)((p) => {
+    "use gpu";
+    const x = p.x;
+    const y = p.y;
+    const fx = std.floor(x);
+    const fy = std.floor(y);
+    const X = d.u32(d.i32(fx) & d.i32(255));
+    const Y = d.u32(d.i32(fy) & d.i32(255));
+    const xf = x - fx;
+    const yf = y - fy;
+    const u = xf * xf * xf * (xf * (xf * d.f32(6.0) - d.f32(15.0)) + d.f32(10.0));
+    const v = yf * yf * yf * (yf * (yf * d.f32(6.0) - d.f32(15.0)) + d.f32(10.0));
+    const perm = noiseLayout.$.perm;
+    const A = perm[X] + Y;
+    const B = perm[X + d.u32(1)] + Y;
+    const v00 = grad2(perm[A], xf, yf);
+    const v10 = grad2(perm[B], xf - d.f32(1.0), yf);
+    const v01 = grad2(perm[A + d.u32(1)], xf, yf - d.f32(1.0));
+    const v11 = grad2(perm[B + d.u32(1)], xf - d.f32(1.0), yf - d.f32(1.0));
+    return std.mix(std.mix(v00, v10, u), std.mix(v01, v11, u), v);
+});
+
+export const fbm2 = tgpu.fn(
+    [d.vec2f],
+    d.f32,
+)((p) => {
+    "use gpu";
+    let amp = d.f32(1.0);
+    let freq = d.f32(1.0);
+    let sum = d.f32(0.0);
+    let norm = d.f32(0.0);
+    let i = d.u32(0);
+    for (; i < d.u32(OCTAVES); i = i + d.u32(1)) {
+        sum = sum + perlin2(std.mul(p, freq)) * amp;
+        norm = norm + amp;
+        amp = amp * PERSISTENCE;
+        freq = freq * LACUNARITY;
+    }
+    return sum / norm;
+});
+
+/** height at world (x, z): `GROUND_LEVEL + fbm2((x, z) · HFREQ) · RELIEF` — the terrain's own surface
+ *  function, sampled by the generator kernel both at a vertex and at its four neighbours (for the
+ *  finite-difference normal). Bound through {@link noiseLayout} like {@link perlin2}. */
+export const heightAt = tgpu.fn(
+    [d.f32, d.f32],
+    d.f32,
+)((x, z) => {
+    "use gpu";
+    return d.f32(GROUND_LEVEL) + fbm2(std.mul(d.vec2f(x, z), d.f32(HFREQ))) * d.f32(RELIEF);
+});
+
+/** the emitted perlin/fbm/height WGSL — the device-free structural seam the terrain tests resolve. */
+export function noiseWgsl(): string {
+    return tgpu.resolve([grad2, perlin2, fbm2, heightAt], { names: "strict" });
+}

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -1,0 +1,201 @@
+// The terrain mesh + surface: registers the fixed W×H grid (grid.ts) as a `Meshes`/`Draws` entry whose
+// vertex content the height kernel (generate.ts) fills, and a custom sear surface that shades the result
+// from slope + height alone — no textures, no splat map (the spec's stage-1 boundary). This is the
+// showcase's road-carrying ground plane; the overlay that will carry the road network rides on top of
+// this surface starting stage 2 (`shallot-roads` spec, "Overlay substrate").
+//
+// Unlike voxel's mesher, the index list here never changes (grid.ts's `gridIndices` is a pure function
+// of the fixed cell count) — so it's authored once on the CPU and uploaded once, and the mesh is
+// registered once at warm, not re-emitted every frame. `warm`/`dispose` still exist (not a one-shot
+// `initialize`) because GPU buffers need a live device, which only exists once RenderPlugin has warmed.
+
+import { Compute, type Plugin, RenderPlugin, type State } from "@dylanebert/shallot";
+import { DrawIndexedIndirect, Draws, type Mesh, Meshes } from "@dylanebert/shallot/render/core";
+import { fsCtxSchema, lit, registerSurface, surfaceLayout } from "@dylanebert/shallot/sear/core";
+import { MeshQuant } from "@dylanebert/shallot/utils/core";
+import tgpu from "typegpu";
+import * as d from "typegpu/data";
+import * as std from "typegpu/std";
+import { bindTerrainKernel, generate, TERRAIN_QUANT } from "./generate";
+import {
+    GridIndices,
+    GridPosition,
+    GridVertices,
+    gridIndices,
+    INDEX_COUNT,
+    VERTEX_COUNT,
+} from "./grid";
+
+export { generate } from "./generate";
+
+export const SEED = 1337;
+
+// slope/height blend thresholds — grass on flat low ground, rock where it steepens, snow above the
+// relief's upper band. `slope` is `dot(worldNormal, up)`: 1 = flat, 0 = vertical. Fractions of RELIEF
+// (generate.ts / noise.ts), not absolute metres, so the bands scale automatically if RELIEF changes.
+const ROCK_SLOPE_LO = 0.7;
+const ROCK_SLOPE_HI = 0.92;
+const SNOW_HEIGHT_LO = 0.55; // fraction of the [GROUND_LEVEL, GROUND_LEVEL + RELIEF] band
+const SNOW_HEIGHT_HI = 0.8;
+
+const terrainSurfaceLayout = surfaceLayout({});
+
+const terrainFs = tgpu.fn(
+    [fsCtxSchema()],
+    d.vec4f,
+)((ctx) => {
+    "use gpu";
+    const grass = d.vec3f(0.09, 0.16, 0.05);
+    const rock = d.vec3f(0.12, 0.11, 0.1);
+    const snow = d.vec3f(0.55, 0.58, 0.62);
+
+    const slope = std.dot(ctx.worldNormal, d.vec3f(0, 1, 0));
+    const rockBlend = 1 - std.smoothstep(d.f32(ROCK_SLOPE_LO), d.f32(ROCK_SLOPE_HI), slope);
+    const base = std.mix(grass, rock, rockBlend);
+
+    const heightT = std.clamp(ctx.world.y / d.f32(TERRAIN_QUANT.posScale.y * 0.5), 0, 1);
+    const snowBlend = std.smoothstep(d.f32(SNOW_HEIGHT_LO), d.f32(SNOW_HEIGHT_HI), heightT);
+    const color = std.mix(base, snow, snowBlend);
+
+    return d.vec4f(lit(color, ctx.worldNormal), 1);
+});
+
+/** the terrain mesh's local-space bounding sphere: the grid's XZ half-extent + the relief's half-height,
+ *  centred at the mesh centroid — an analytic AABB→sphere, not a scan (the grid isn't uploaded to the
+ *  CPU to compute one). */
+function terrainBounds(): [number, number, number, number] {
+    const cx = TERRAIN_QUANT.posOffset.x + TERRAIN_QUANT.posScale.x * 0.5;
+    const cy = TERRAIN_QUANT.posOffset.y + TERRAIN_QUANT.posScale.y * 0.5;
+    const cz = TERRAIN_QUANT.posOffset.z + TERRAIN_QUANT.posScale.z * 0.5;
+    const hx = TERRAIN_QUANT.posScale.x * 0.5;
+    const hy = TERRAIN_QUANT.posScale.y * 0.5;
+    const hz = TERRAIN_QUANT.posScale.z * 0.5;
+    const radius = Math.sqrt(hx * hx + hy * hy + hz * hz);
+    return [cx, cy, cz, radius];
+}
+
+let buffers: {
+    verticesRaw: GPUBuffer;
+    positionRaw: GPUBuffer;
+    quantRaw: GPUBuffer;
+    indicesRaw: GPUBuffer;
+    indirectRaw: GPUBuffer;
+} | null = null;
+
+function teardown(): void {
+    if (!buffers) return;
+    Meshes.delete("terrain");
+    Draws.delete("terrain");
+    buffers.verticesRaw.destroy();
+    buffers.positionRaw.destroy();
+    buffers.quantRaw.destroy();
+    buffers.indicesRaw.destroy();
+    buffers.indirectRaw.destroy();
+    buffers = null;
+}
+
+async function warm(state: State): Promise<void> {
+    teardown(); // a rebuild (HMR) re-warms — clear the prior generation's buffers first
+    // `Plugin.dispose` only fires on `App.dispose`, never on a direct `state.dispose()` (the path an
+    // in-place rebuild takes) — tie cleanup to the State itself so both paths clear these buffers.
+    state.onDispose(teardown);
+    const { device, root } = Compute;
+
+    const verticesRaw = device.createBuffer({
+        label: "terrain-main",
+        // COPY_SRC so the device gate's seed-determinism check (gate.ts) can read the generated stream back.
+        size: VERTEX_COUNT * 16,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    const positionRaw = device.createBuffer({
+        label: "terrain-pos",
+        size: VERTEX_COUNT * 8,
+        usage: GPUBufferUsage.STORAGE,
+    });
+    const quantRaw = device.createBuffer({
+        label: "terrain-quant",
+        size: d.sizeOf(MeshQuant),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    const indicesRaw = device.createBuffer({
+        label: "terrain-indices",
+        size: INDEX_COUNT * 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
+    });
+    const indirectRaw = device.createBuffer({
+        label: "terrain-indirect",
+        size: 20,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST,
+    });
+    buffers = { verticesRaw, positionRaw, quantRaw, indicesRaw, indirectRaw };
+
+    device.queue.writeBuffer(indicesRaw, 0, gridIndices() as Uint32Array<ArrayBuffer>);
+
+    const vertices = root.createBuffer(GridVertices, verticesRaw).$usage("storage");
+    const position = root.createBuffer(GridPosition, positionRaw).$usage("storage");
+    const quant = root.createBuffer(d.arrayOf(MeshQuant, 1), quantRaw).$usage("storage");
+    quant.write([TERRAIN_QUANT]);
+    const indices = root.createBuffer(GridIndices, indicesRaw).$usage("storage", "index");
+    const indirect = root
+        .createBuffer(DrawIndexedIndirect, indirectRaw)
+        .$usage("storage", "indirect");
+    indirect.write({
+        indexCount: INDEX_COUNT,
+        instanceCount: 1,
+        firstIndex: 0,
+        baseVertex: 0,
+        firstInstance: 0,
+    });
+
+    const mesh: Mesh = {
+        name: "terrain",
+        vertices,
+        position,
+        quant,
+        indices,
+        indexBase: 0,
+        indexCount: INDEX_COUNT,
+        bounds: terrainBounds(),
+        dynamic: true, // content (not topology) is compute-rewritten on reseed — a stale BLAS would cast wrong
+    };
+    Meshes.register(mesh);
+    Draws.register({ name: "terrain", surface: "terrain", mesh: "terrain", args: { indirect } });
+
+    bindTerrainKernel(vertices, position);
+    if (state.signal.aborted) return;
+    await generate(SEED);
+}
+
+/** one-shot GPU→CPU readback of the whole main vertex stream — the device gate's own arm (gate.ts): a
+ *  regenerate-and-compare check needs the actual GPU output, not a re-derivation of it. Mirrors voxel's
+ *  `readGrid()`; an assert-only bridge, never a per-frame readback. */
+export async function readVertices(): Promise<Uint32Array> {
+    if (!buffers) throw new Error("terrain: readVertices before the mesh buffers exist");
+    const { device } = Compute;
+    const size = VERTEX_COUNT * 16;
+    const staging = device.createBuffer({
+        label: "terrain-readback",
+        size,
+        usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    });
+    const enc = device.createCommandEncoder({ label: "terrain-readback" });
+    enc.copyBufferToBuffer(buffers.verticesRaw, 0, staging, 0, size);
+    device.queue.submit([enc.finish()]);
+    await staging.mapAsync(GPUMapMode.READ);
+    const out = new Uint32Array(staging.getMappedRange().slice(0));
+    staging.unmap();
+    staging.destroy();
+    return out;
+}
+
+const TerrainPlugin: Plugin = {
+    name: "Terrain",
+    dependencies: [RenderPlugin],
+    initialize(state) {
+        registerSurface(state, { name: "terrain", layout: terrainSurfaceLayout, fs: terrainFs });
+    },
+    warm,
+    dispose: teardown,
+};
+
+export default TerrainPlugin;

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -1,0 +1,65 @@
+import { expect, type Page, test } from "@playwright/test";
+
+// Drive the terrain generator's device gate: load the app, wait for it to warm and expose
+// `window.__roadsGate`, run it on the real GPU, and assert every check passes (and the page raised no
+// error). The checks themselves live in `src/gate.ts` against the published surface — this driver is the
+// only part Playwright touches. One session, phases within one test (the Playwright structure rule).
+
+interface Check {
+    name: string;
+    pass: boolean;
+    detail: string;
+}
+
+// Software rasterizers by the name they report in `GPUAdapterInfo`: Chromium's SwiftShader, Mesa's two,
+// and D3D's WARP. Deliberately a name list rather than a capability probe — SwiftShader clears shallot's
+// whole base floor (all three `BASE_FEATURES` plus 10 storage buffers per stage, measured under WSL
+// 2026-08-10), so nothing about the floor distinguishes it, and it is only the *execution* that dies.
+// Bias narrow: an unlisted software adapter re-crashes loudly, while an over-broad pattern would skip this
+// gate on real hardware and report green having tested nothing.
+const SOFTWARE = /swiftshader|llvmpipe|lavapipe|warp|basic render/i;
+
+/** the adapter's self-reported identity, or `""` when the browser hands out none. */
+const adapterName = (page: Page): Promise<string> =>
+    page.evaluate(async () => {
+        const adapter = await navigator.gpu?.requestAdapter();
+        if (!adapter) return "";
+        const { vendor, architecture, device, description } = adapter.info;
+        return [vendor, architecture, device, description].filter(Boolean).join(" ");
+    });
+
+test("terrain generator gate — sized, deterministic, reseeds, not flat (real GPU)", async ({
+    page,
+}) => {
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    // standalone runtime — the gate only touches GPU buffers, no editor/scene writes.
+    await page.goto("/");
+
+    // Full device testing: the generator needs a real GPU. Probe before waiting on the boot hook, because
+    // on a software adapter the app never installs it and the wait burns its full 120 s before failing —
+    // display-gated the same way `shallot verify`'s callers are, so a GPU-less host skips instead of reds.
+    const adapter = await adapterName(page);
+    console.log(`roads gate adapter: ${adapter || "none offered"}`);
+    test.skip(
+        adapter === "" || SOFTWARE.test(adapter),
+        `no real-GPU adapter (${adapter || "none offered"})`,
+    );
+
+    // the boot plugin installs the hook once the terrain mesh is registered (see boot.ts). A cold vite
+    // build is slower than the warm path, so allow longer than steady-state needs.
+    await page.waitForFunction(() => typeof window.__roadsGate === "function", null, {
+        timeout: 120_000,
+    });
+
+    const checks = (await page.evaluate(() =>
+        (window as unknown as { __roadsGate: () => Promise<Check[]> }).__roadsGate(),
+    )) as Check[];
+
+    expect(errors, errors.join("\n")).toEqual([]);
+    expect(checks.length).toBeGreaterThan(0);
+    for (const c of checks) {
+        expect(c.pass, `${c.name}: ${c.detail}`).toBe(true);
+    }
+});

--- a/examples/showcase/roads/tsconfig.json
+++ b/examples/showcase/roads/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../../tsconfig.json"
+}


### PR DESCRIPTION
Fixed 257x257-vertex grid (1024m x 1024m), compute-authored quantized
vertex stream (one thread per vertex, no atomics), slope/height sear
surface, orbit camera. Mirrors voxel's project shape (boot.ts,
window.__roadsGate, own Playwright spec, bun test over src).
