### PR TITLE
shallot roads/overlay substrate

### DIFF
--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -1,18 +1,32 @@
 import type { Plugin, System } from "@dylanebert/shallot";
 import { Meshes } from "@dylanebert/shallot/render/core";
+import { capturePoints, type ScreenPoint, TRANSITION_TOLERANCE_PX, worldToScreen } from "./capture";
 import { gate } from "./gate";
 import type { Check } from "./harness";
+import { overlayIdle } from "./terrain/terrain";
 
 // The roads showcase's boot orchestration, as a plugin (a manifest project has no `main.ts` entry) —
 // the same shape as voxel's `boot.ts`. Terrain generation itself runs inside `terrain.ts`'s own `warm()`
 // (the grid's topology is fixed, so there's no separate "wait for buffers, then generate" step the way
-// voxel's carve-capable mesher needs); this plugin's only job is installing the device gate once the
-// terrain mesh is registered. `mode: always` so the poll runs in edit mode too, not just play.
+// voxel's carve-capable mesher needs); this plugin's only job is installing the device gate + the capture
+// bridge once the terrain mesh is registered. `mode: always` so the poll runs in edit mode too, not just
+// play.
 
 declare global {
     interface Window {
         // the device gate, driven by the project's own Playwright on a real GPU (test/roads.spec.ts).
         __roadsGate?: () => Promise<Check[]>;
+        // the pixel-probe capture's world→screen bridge (capture.ts), its on-road/off-road world points
+        // (real generated terrain height), and an overlay-drained poll — all real ECS/GPU state Playwright
+        // can't compute itself.
+        __roadsProbe?: (points: ReadonlyArray<readonly [number, number, number]>) => ScreenPoint[];
+        __roadsCapturePoints?: () => ReturnType<typeof capturePoints>;
+        __roadsOverlayIdle?: () => boolean;
+        // a plain re-export of capture.ts's derived constant — never imported directly into the Playwright
+        // driver (this project's src/ runs in the browser via the dev server; a direct Node-side import of
+        // it pulls in the published `@dylanebert/shallot` package graph under Playwright's own loader,
+        // which chokes on the package's `exports` map — `test/roads.spec.ts` stays bridge-only).
+        __roadsTransitionTolerancePx?: number;
     }
 }
 
@@ -29,9 +43,17 @@ const BootSystem: System = {
         if (!armed || !Meshes.get("terrain")) return;
         armed = false;
         window.__roadsGate = () => gate();
+        window.__roadsProbe = (points) => worldToScreen(points);
+        window.__roadsCapturePoints = () => capturePoints();
+        window.__roadsOverlayIdle = () => overlayIdle();
+        window.__roadsTransitionTolerancePx = TRANSITION_TOLERANCE_PX;
     },
     dispose() {
         delete window.__roadsGate;
+        delete window.__roadsProbe;
+        delete window.__roadsCapturePoints;
+        delete window.__roadsOverlayIdle;
+        delete window.__roadsTransitionTolerancePx;
     },
 };
 

--- a/examples/showcase/roads/src/capture.test.ts
+++ b/examples/showcase/roads/src/capture.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { TRANSITION_TOLERANCE_PX } from "./capture";
+
+describe("TRANSITION_TOLERANCE_PX", () => {
+    test("is a small positive pixel bound, not a fraction or a huge slack", () => {
+        // the mechanism argument (capture.ts's docstring) puts the formula's own band at ~0.5 px; the
+        // constant should sit within a small integer multiple of that, not an order of magnitude off in
+        // either direction (too tight would fail on ordinary filtering slop, too loose stops catching a
+        // genuinely soft/misregistered edge — the exact defect this gate exists to find).
+        expect(TRANSITION_TOLERANCE_PX).toBeGreaterThan(0);
+        expect(TRANSITION_TOLERANCE_PX).toBeLessThanOrEqual(4);
+    });
+});

--- a/examples/showcase/roads/src/capture.ts
+++ b/examples/showcase/roads/src/capture.ts
@@ -1,6 +1,7 @@
 import { computeViewProj, Views } from "@dylanebert/shallot/render/core";
 import { decodePos } from "@dylanebert/shallot/utils/core";
 import { OFF_ROAD_POINT, ON_ROAD_POINT } from "./overlay/stroke";
+import { COVERAGE_BAND_PX } from "./overlay/tiles";
 import { TERRAIN_QUANT } from "./terrain/generate";
 import { gridX, gridZ, VERTS } from "./terrain/grid";
 import { readVertices } from "./terrain/terrain";
@@ -95,7 +96,7 @@ export async function capturePoints(): Promise<{
 /**
  * the derived antialiasing-band screen-pixel tolerance for the capture's boundary-transition probe.
  *
- * The governing mechanism is the fs's own coverage formula (`terrain.ts`): `fw = 0.5·fwidth(dist) + ε`,
+ * The governing mechanism is the fs's own coverage formula (`terrain.ts`): `fw = COVERAGE_BAND_PX·fwidth(dist) + ε`,
  * `coverage = clamp(0.5 − dist/fw, 0, 1)`. Coverage leaves `[0, 1]` exactly when `dist/fw` leaves
  * `[−0.5, 0.5]` — i.e. when `dist` moves by `fw ≈ 0.5·fwidth(dist)` — and `fwidth` is *defined* as the
  * change in its argument over one screen pixel (`|ddx| + |ddy|`), so the coverage band is designed to span
@@ -103,9 +104,9 @@ export async function capturePoints(): Promise<{
  * self-scaling property is the whole point of fwidth-thresholded AA, Green SIGGRAPH 2007 — a texel-size
  * bound converted through the camera's fov/depth would be the *wrong* quantity, and reads far too tight
  * whenever the atlas is minified, the common case at this showcase's camera distance). This constant
- * allows a further ×4 over that ~0.5 px formula band for what the formula doesn't model: the `ε` softening
+ * is that band ×4 — imported, not restated, so the two can't drift — allowing for what the formula doesn't model: the `ε` softening
  * term, the atlas sampler's own bilinear interpolation (one more texel-to-texel blend before `fwidth` ever
  * measures it), and discrete-pixel sampling slop in the probe itself — a fixed multiple of the mechanism's
  * own band, not a value fitted to one observed capture.
  */
-export const TRANSITION_TOLERANCE_PX = 2;
+export const TRANSITION_TOLERANCE_PX = COVERAGE_BAND_PX * 4;

--- a/examples/showcase/roads/src/capture.ts
+++ b/examples/showcase/roads/src/capture.ts
@@ -1,0 +1,111 @@
+import { computeViewProj, Views } from "@dylanebert/shallot/render/core";
+import { decodePos } from "@dylanebert/shallot/utils/core";
+import { OFF_ROAD_POINT, ON_ROAD_POINT } from "./overlay/stroke";
+import { TERRAIN_QUANT } from "./terrain/generate";
+import { gridX, gridZ, VERTS } from "./terrain/grid";
+import { readVertices } from "./terrain/terrain";
+
+// The device gate's world→screen bridge for the pixel-probe capture (the spec's flagged-risk validation,
+// stage 4's own arm — `checks.md`: the fs composite is observable only in the rendered frame). Rather than
+// hand-deriving the orbit camera's trig in the Playwright driver, this reads the *real* live viewProj the
+// renderer itself uses (`computeViewProj`, `@dylanebert/shallot/render/core`) — so the mapping can't drift
+// from whatever the scene's orbit distance/pitch/fov actually are, and the driver never re-implements
+// camera math it doesn't own.
+
+/** a world point's screen position as a fraction of the canvas (0,0 = top-left, 1,1 = bottom-right) — the
+ *  unit `test/roads.spec.ts` multiplies by the captured screenshot's own pixel dimensions, so the mapping
+ *  is DPR-independent. `depth` is the point's view-space depth (the clip w component, equal to view-space
+ *  depth for this engine's perspective matrix, `engine/utils/math.ts`), carried for diagnostics — it plays
+ *  no role in {@link TRANSITION_TOLERANCE_PX}, which is depth-independent by construction (see its doc). */
+export interface ScreenPoint {
+    x: number;
+    y: number;
+    depth: number;
+}
+
+const _vp = new Float32Array(16);
+
+/** the eid of the canvas-presenting camera — never a plain `state.query([Camera])`/`state.only([Camera])`,
+ *  since a casting light's pooled shadow camera (cascade/point-combo) also carries the `Camera` component
+ *  (`sear/shadows.ts`'s `attachView`), so a scene with one shadow-casting light already has more than one
+ *  `Camera`-tagged entity (measured: `state.only` warned "found multiple" the first time this ran against
+ *  this scene's directional-light shadow). {@link Views} is the real disambiguator: only the display
+ *  camera's entry carries a live `canvas` (a shadow camera's view is off-screen, `attachView`). */
+function cameraEid(): number {
+    for (const [eid, view] of Views) {
+        if (view.canvas) return eid;
+    }
+    throw new Error("capture: no canvas-presenting camera in Views");
+}
+
+function canvasElement(): HTMLCanvasElement {
+    const canvas = document.querySelector("canvas");
+    if (!canvas) throw new Error("capture: no canvas element");
+    return canvas;
+}
+
+/** project `points` (world x, y, z) through the scene's canvas-presenting camera into normalized screen
+ *  fractions + view-space depth. Throws if no such camera or canvas exists — a capture with neither has
+ *  nothing to probe. */
+export function worldToScreen(
+    points: ReadonlyArray<readonly [x: number, y: number, z: number]>,
+): ScreenPoint[] {
+    const eid = cameraEid();
+    const canvas = canvasElement();
+    const aspect = canvas.width / canvas.height;
+    computeViewProj(eid, aspect, _vp);
+    return points.map(([x, y, z]) => {
+        // column-major mat4 × vec4(x, y, z, 1) (engine/utils/math.ts's convention)
+        const cx = _vp[0] * x + _vp[4] * y + _vp[8] * z + _vp[12];
+        const cy = _vp[1] * x + _vp[5] * y + _vp[9] * z + _vp[13];
+        const cw = _vp[3] * x + _vp[7] * y + _vp[11] * z + _vp[15];
+        const ndcX = cx / cw;
+        const ndcY = cy / cw;
+        // NDC is y-up in [-1,1]; screen space is y-down in [0,1] — flip.
+        return { x: ndcX * 0.5 + 0.5, y: 1 - (ndcY * 0.5 + 0.5), depth: cw };
+    });
+}
+
+/** one grid-aligned world (x, z) → its full 3D world point, height read from the real generated vertex
+ *  stream (`readVertices`, `terrain.ts`) rather than re-deriving the noise function in JS — {@link gridX}/
+ *  {@link gridZ} require an exact grid column, which `overlay/stroke.ts`'s ON_ROAD_POINT/OFF_ROAD_POINT are
+ *  built to be. */
+async function withHeight(x: number, z: number): Promise<[x: number, y: number, z: number]> {
+    const raw = await readVertices();
+    const ix = gridX(x);
+    const iz = gridZ(z);
+    const idx = iz * VERTS + ix;
+    const y = decodePos(raw[idx * 4], raw[idx * 4 + 1], TERRAIN_QUANT).y;
+    return [x, y, z];
+}
+
+/** the capture gate's fixed on-road/off-road world probe points, heights read from the live generated
+ *  terrain (`overlay/stroke.ts`'s ON_ROAD_POINT/OFF_ROAD_POINT). */
+export async function capturePoints(): Promise<{
+    onRoad: [number, number, number];
+    offRoad: [number, number, number];
+}> {
+    const [onRoad, offRoad] = await Promise.all([
+        withHeight(...ON_ROAD_POINT),
+        withHeight(...OFF_ROAD_POINT),
+    ]);
+    return { onRoad, offRoad };
+}
+
+/**
+ * the derived antialiasing-band screen-pixel tolerance for the capture's boundary-transition probe.
+ *
+ * The governing mechanism is the fs's own coverage formula (`terrain.ts`): `fw = 0.5·fwidth(dist) + ε`,
+ * `coverage = clamp(0.5 − dist/fw, 0, 1)`. Coverage leaves `[0, 1]` exactly when `dist/fw` leaves
+ * `[−0.5, 0.5]` — i.e. when `dist` moves by `fw ≈ 0.5·fwidth(dist)` — and `fwidth` is *defined* as the
+ * change in its argument over one screen pixel (`|ddx| + |ddy|`), so the coverage band is designed to span
+ * **about half a screen pixel**, independent of world scale, texel density, or camera distance (that
+ * self-scaling property is the whole point of fwidth-thresholded AA, Green SIGGRAPH 2007 — a texel-size
+ * bound converted through the camera's fov/depth would be the *wrong* quantity, and reads far too tight
+ * whenever the atlas is minified, the common case at this showcase's camera distance). This constant
+ * allows a further ×4 over that ~0.5 px formula band for what the formula doesn't model: the `ε` softening
+ * term, the atlas sampler's own bilinear interpolation (one more texel-to-texel blend before `fwidth` ever
+ * measures it), and discrete-pixel sampling slop in the probe itself — a fixed multiple of the mechanism's
+ * own band, not a value fitted to one observed capture.
+ */
+export const TRANSITION_TOLERANCE_PX = 2;

--- a/examples/showcase/roads/src/overlay/atlas.ts
+++ b/examples/showcase/roads/src/overlay/atlas.ts
@@ -1,0 +1,173 @@
+import { Compute, type State } from "@dylanebert/shallot";
+import type { MeshBinding } from "@dylanebert/shallot/render/core";
+import type { StorageFlag, TgpuBuffer } from "typegpu";
+import * as d from "typegpu/data";
+import { allocate, drain } from "./queue";
+import {
+    ALBEDO_BYTES_PER_TEXEL,
+    ALBEDO_FORMAT,
+    ATLAS_LAYERS,
+    DIST_BYTES_PER_TEXEL,
+    DIST_FORMAT,
+    dirtyTiles,
+    type Rect,
+    THROTTLE,
+    TILE_COUNT,
+    TILE_RES,
+    tileCoordOf,
+} from "./tiles";
+
+// The overlay atlas's GPU state: two texture-2d-arrays (albedo + boundary distance, `tiles.ts`'s formats)
+// sized to {@link ATLAS_LAYERS} — smaller than {@link TILE_COUNT}, the "small indirection" the spec's
+// Approach names — plus the indirection storage buffer the terrain fs (`terrain/terrain.ts`) looks tile id
+// up in. A tile's layer is allocated the first time it's marked dirty (never evicted — out of scope, see
+// tiles.ts); `redraw` drains the dirty queue at a fixed per-frame throttle, so a burst of edits (this
+// stage's hand-authored stroke, or a future full network regeneration) never stalls one frame with every
+// tile's `writeTexture` call at once.
+
+/** the indirection buffer's declared element schema: `array<i32, TILE_COUNT>` — negative = unallocated
+ *  (`terrain.ts`'s fs reads `< 0` as "no overlay here"). Exported so the surface layout and this module's
+ *  own typed buffer agree on one schema, never two independently-constructed `d.arrayOf` calls. */
+export const Indirection = d.arrayOf(d.i32, TILE_COUNT);
+
+let albedoTex: GPUTexture | null = null;
+let distTex: GPUTexture | null = null;
+let sampler: GPUSampler | null = null;
+let indirectionRaw: GPUBuffer | null = null;
+let indirectionTyped: (TgpuBuffer<typeof Indirection> & StorageFlag) | null = null;
+
+// the indirection table's CPU mirror (so allocateLayer can read "already resident?" without a GPU
+// readback) + the free-running layer counter. Reset at warm.
+const indirectionCpu = new Int32Array(TILE_COUNT).fill(-1);
+let nextLayer = 0;
+
+// the dirty queue: an array (FIFO order — earliest marks redraw first) + a parallel Set for O(1)
+// de-duplication (`markDirty` called twice for the same tile before it drains must not double-queue it).
+const pending: number[] = [];
+const pendingSet = new Set<number>();
+
+function teardown(): void {
+    albedoTex?.destroy();
+    distTex?.destroy();
+    indirectionRaw?.destroy();
+    albedoTex = null;
+    distTex = null;
+    sampler = null;
+    indirectionRaw = null;
+    indirectionTyped = null;
+    indirectionCpu.fill(-1);
+    nextLayer = 0;
+    pending.length = 0;
+    pendingSet.clear();
+}
+
+/** allocate the atlas's GPU resources — textures, sampler, indirection buffer, all cleared to "no tile
+ *  resident". Ties cleanup to `state.onDispose` (the same in-place-rebuild-safe pattern `terrain.ts` uses). */
+export function warm(state: State): void {
+    teardown();
+    state.onDispose(teardown);
+    const { device, root } = Compute;
+
+    albedoTex = device.createTexture({
+        label: "overlay-albedo",
+        size: { width: TILE_RES, height: TILE_RES, depthOrArrayLayers: ATLAS_LAYERS },
+        format: ALBEDO_FORMAT,
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    distTex = device.createTexture({
+        label: "overlay-dist",
+        size: { width: TILE_RES, height: TILE_RES, depthOrArrayLayers: ATLAS_LAYERS },
+        format: DIST_FORMAT,
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    // clamp-to-edge: an indirection miss reads coverage 0 (see terrain.ts), but a resident tile's own edge
+    // texels must never sample a neighbour layer's content — array layers don't share address space, so
+    // this only guards the tile's own uv range degenerating past [0,1] at the antialiased boundary.
+    sampler = device.createSampler({
+        label: "overlay-samp",
+        magFilter: "linear",
+        minFilter: "linear",
+        addressModeU: "clamp-to-edge",
+        addressModeV: "clamp-to-edge",
+    });
+    indirectionRaw = device.createBuffer({
+        label: "overlay-indirection",
+        size: TILE_COUNT * 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    indirectionCpu.fill(-1);
+    device.queue.writeBuffer(indirectionRaw, 0, indirectionCpu as Int32Array<ArrayBuffer>);
+    indirectionTyped = root.createBuffer(Indirection, indirectionRaw).$usage("storage");
+    nextLayer = 0;
+    pending.length = 0;
+    pendingSet.clear();
+}
+
+/** the terrain mesh's `bindings` override for the four overlay entries the surface layout declares
+ *  (`terrain.ts`). Reads live GPU resource identities — the renderer resolves a texture binding to a view
+ *  each frame, so no bind group here needs manual (re)construction. */
+export function bindings(): Record<string, MeshBinding> {
+    if (!albedoTex || !distTex || !sampler || !indirectionTyped) {
+        throw new Error("overlay atlas: bindings() read before warm()");
+    }
+    return {
+        albedo: albedoTex,
+        dist: distTex,
+        overlaySamp: sampler,
+        indirection: indirectionTyped,
+    };
+}
+
+/** mark every tile `rect` overlaps dirty (`tiles.ts`'s analytic dirty set) — idempotent: a tile already
+ *  pending isn't re-queued. */
+export function markDirty(rect: Rect): void {
+    for (const id of dirtyTiles(rect)) {
+        if (pendingSet.has(id)) continue;
+        pendingSet.add(id);
+        pending.push(id);
+    }
+}
+
+/** a tile's packed content: tightly-packed row-major albedo (rgba8unorm) + distance (r8unorm) buffers,
+ *  `tiles.ts`'s `texelOffset` addressing — `stroke.ts`'s `packStrokeTile` is this stage's producer. */
+export type TilePacker = (tx: number, tz: number) => { albedo: Uint8Array; dist: Uint8Array };
+
+/**
+ * drain up to {@link THROTTLE} pending dirty tiles: allocate each one's atlas layer, write its content via
+ * `pack`, and flush the changed indirection entries. Returns the number of tiles redrawn — 0 once the
+ * queue is empty, so a caller (the per-frame `OverlaySystem`, `terrain.ts`) can poll it every frame with no
+ * extra bookkeeping.
+ */
+export function redraw(pack: TilePacker): number {
+    if (!albedoTex || !distTex || !indirectionRaw) return 0;
+    const ids = drain(pending, pendingSet, THROTTLE);
+    if (ids.length === 0) return 0;
+    const { device } = Compute;
+    for (const id of ids) {
+        const alloc = allocate(indirectionCpu, id, nextLayer, ATLAS_LAYERS);
+        nextLayer = alloc.nextLayer;
+        const layer = alloc.layer;
+        const [tx, tz] = tileCoordOf(id);
+        const { albedo, dist } = pack(tx, tz);
+        device.queue.writeTexture(
+            { texture: albedoTex, origin: { x: 0, y: 0, z: layer } },
+            albedo as Uint8Array<ArrayBuffer>,
+            { bytesPerRow: TILE_RES * ALBEDO_BYTES_PER_TEXEL, rowsPerImage: TILE_RES },
+            { width: TILE_RES, height: TILE_RES, depthOrArrayLayers: 1 },
+        );
+        device.queue.writeTexture(
+            { texture: distTex, origin: { x: 0, y: 0, z: layer } },
+            dist as Uint8Array<ArrayBuffer>,
+            { bytesPerRow: TILE_RES * DIST_BYTES_PER_TEXEL, rowsPerImage: TILE_RES },
+            { width: TILE_RES, height: TILE_RES, depthOrArrayLayers: 1 },
+        );
+        device.queue.writeBuffer(indirectionRaw, id * 4, new Int32Array([layer]));
+    }
+    return ids.length;
+}
+
+/** whether every marked tile has drained through {@link redraw} — the boot path polls this so the
+ *  hand-authored stroke is fully resident before the device gate's capture reads the frame. */
+export function idle(): boolean {
+    return pending.length === 0;
+}

--- a/examples/showcase/roads/src/overlay/queue.test.ts
+++ b/examples/showcase/roads/src/overlay/queue.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { allocate, drain } from "./queue";
+import { ATLAS_LAYERS, THROTTLE } from "./tiles";
+
+describe("drain — the per-frame throttle", () => {
+    test("never pops more than the throttle, even with a larger backlog", () => {
+        const pending = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        const set = new Set(pending);
+        const popped = drain(pending, set, THROTTLE);
+        expect(popped.length).toBe(THROTTLE);
+        expect(pending.length).toBe(10 - THROTTLE);
+        // every popped id left both the array and the de-dup set
+        for (const id of popped) {
+            expect(pending).not.toContain(id);
+            expect(set.has(id)).toBe(false);
+        }
+    });
+
+    test("pops FIFO — oldest marks redraw first", () => {
+        const pending = [10, 20, 30];
+        const set = new Set(pending);
+        expect(drain(pending, set, 2)).toEqual([10, 20]);
+        expect(pending).toEqual([30]);
+    });
+
+    test("a backlog under the throttle drains fully in one call, leaving nothing pending", () => {
+        const pending = [1, 2, 3];
+        const set = new Set(pending);
+        const popped = drain(pending, set, THROTTLE);
+        expect(popped).toEqual([1, 2, 3]);
+        expect(pending.length).toBe(0);
+        expect(set.size).toBe(0);
+    });
+
+    test("a burst larger than ATLAS_LAYERS still drains at exactly THROTTLE per call — the throttle bounds redraws, not capacity", () => {
+        const pending = Array.from({ length: ATLAS_LAYERS + 20 }, (_, i) => i);
+        const set = new Set(pending);
+        let calls = 0;
+        while (pending.length > 0) {
+            expect(drain(pending, set, THROTTLE).length).toBeLessThanOrEqual(THROTTLE);
+            calls++;
+            if (calls > pending.length + ATLAS_LAYERS + 20)
+                throw new Error("drain never converged");
+        }
+        expect(calls).toBe(Math.ceil((ATLAS_LAYERS + 20) / THROTTLE));
+    });
+});
+
+describe("allocate — atlas layer assignment", () => {
+    test("assigns sequential layers to fresh tiles, writing the CPU indirection mirror in place", () => {
+        const cpu = new Int32Array(8).fill(-1);
+        const a = allocate(cpu, 3, 0, 8);
+        expect(a).toEqual({ layer: 0, nextLayer: 1 });
+        expect(cpu[3]).toBe(0);
+        const b = allocate(cpu, 5, a.nextLayer, 8);
+        expect(b).toEqual({ layer: 1, nextLayer: 2 });
+        expect(cpu[5]).toBe(1);
+    });
+
+    test("returns the existing layer for an already-resident tile, counter unchanged", () => {
+        const cpu = new Int32Array(8).fill(-1);
+        const first = allocate(cpu, 2, 0, 8);
+        const again = allocate(cpu, 2, first.nextLayer, 8);
+        expect(again).toEqual({ layer: first.layer, nextLayer: first.nextLayer });
+    });
+
+    test("throws rather than silently wrapping or evicting once capacity is exhausted", () => {
+        const cpu = new Int32Array(4).fill(-1);
+        let next = 0;
+        for (let i = 0; i < 2; i++) next = allocate(cpu, i, next, 2).nextLayer;
+        expect(() => allocate(cpu, 2, next, 2)).toThrow(/capacity exceeded/);
+    });
+});

--- a/examples/showcase/roads/src/overlay/queue.ts
+++ b/examples/showcase/roads/src/overlay/queue.ts
@@ -1,0 +1,54 @@
+// The overlay atlas's two pure, device-free mechanisms — split out of atlas.ts so the per-frame throttle
+// and the layer-allocation policy are `bun test`-reachable without a GPU (`atlas.ts`'s `redraw` calls both,
+// then does the real `writeTexture`/`writeBuffer` work these functions never touch).
+
+/**
+ * pop up to `n` ids off the front of `pending` (FIFO — oldest mark redraws first), removing each from
+ * `pendingSet` too. Mutates both in place (the same queue+set pair `atlas.ts` owns across frames) and
+ * returns the popped ids. Never pops more than `pending.length` has, so the caller's "how many did I
+ * redraw this frame" is just the returned array's length.
+ *
+ * @example drain([1, 2, 3, 4], new Set([1, 2, 3, 4]), 2) // → [1, 2], pending left with [3, 4]
+ */
+export function drain(pending: number[], pendingSet: Set<number>, n: number): number[] {
+    const count = Math.min(n, pending.length);
+    const ids: number[] = [];
+    for (let i = 0; i < count; i++) {
+        const id = pending.shift() as number;
+        pendingSet.delete(id);
+        ids.push(id);
+    }
+    return ids;
+}
+
+/** a resident-or-newly-assigned atlas layer for tile `id`, plus the free-running counter's next value. */
+export interface Allocation {
+    layer: number;
+    nextLayer: number;
+}
+
+/**
+ * resolve tile `id`'s atlas layer against the indirection CPU mirror `cpu` (negative = unallocated):
+ * already resident → its existing layer, unchanged counter; otherwise the next free layer, `cpu[id]`
+ * written in place. Throws when `nextLayer` would exceed `capacity` rather than silently overwriting a
+ * resident layer or wrapping the counter (`coding.md`'s Robust clause — no plausible-fallback substitute
+ * for a real capacity limit).
+ *
+ * @example allocate(new Int32Array(4).fill(-1), 2, 0, 4) // → { layer: 0, nextLayer: 1 }, cpu[2] === 0
+ */
+export function allocate(
+    cpu: Int32Array,
+    id: number,
+    nextLayer: number,
+    capacity: number,
+): Allocation {
+    const existing = cpu[id];
+    if (existing >= 0) return { layer: existing, nextLayer };
+    if (nextLayer >= capacity) {
+        throw new Error(
+            `overlay atlas: capacity exceeded (${capacity} layers) allocating tile ${id}`,
+        );
+    }
+    cpu[id] = nextLayer;
+    return { layer: nextLayer, nextLayer: nextLayer + 1 };
+}

--- a/examples/showcase/roads/src/overlay/stroke.test.ts
+++ b/examples/showcase/roads/src/overlay/stroke.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import {
+    OFF_ROAD_POINT,
+    ON_ROAD_POINT,
+    packStrokeTile,
+    ROAD_ALBEDO,
+    STROKE_HALF_WIDTH,
+    strokeDistance,
+    strokeRect,
+} from "./stroke";
+import { DIST_RANGE, decodeDist, dirtyTiles, TEXEL_SIZE, tileId, tileOrigin } from "./tiles";
+
+describe("strokeDistance", () => {
+    test("is negative at the centreline and positive well outside the road", () => {
+        expect(strokeDistance(0, 0)).toBeLessThan(0);
+        expect(strokeDistance(0, 50)).toBeGreaterThan(0);
+    });
+
+    test("is exactly -STROKE_HALF_WIDTH... 0 at the edge, by construction", () => {
+        // at x=0 the segment's closest point is (0,0), so distance to the road edge is |z| - halfWidth
+        expect(strokeDistance(0, STROKE_HALF_WIDTH)).toBeCloseTo(0, 10);
+        expect(strokeDistance(0, STROKE_HALF_WIDTH + 1)).toBeCloseTo(1, 10);
+    });
+
+    test("ON_ROAD_POINT and OFF_ROAD_POINT classify as their names say", () => {
+        expect(strokeDistance(...ON_ROAD_POINT)).toBeLessThan(0);
+        expect(strokeDistance(...OFF_ROAD_POINT)).toBeGreaterThan(0);
+    });
+});
+
+describe("strokeRect → dirtyTiles", () => {
+    test("the stroke's dirty set is the pair of tile rows straddling Z=0, none elsewhere", () => {
+        // the stroke's ±4 m width straddles the tz=7/tz=8 boundary at Z=0 (tile z ranges are
+        // [tz*64-512, tz*64-512+64), so tz=7 covers [-64,0) and tz=8 covers [0,64)) — exactly two rows, not
+        // one, since the road is centred exactly on a tile edge.
+        const ids = dirtyTiles(strokeRect());
+        expect(ids.length).toBeGreaterThan(0);
+        const rows = new Set(ids.map((id) => Math.floor(id / 16)));
+        expect(rows).toEqual(new Set([7, 8]));
+    });
+
+    test("the dirty column span matches the stroke's ±150 m length", () => {
+        const ids = dirtyTiles(strokeRect());
+        const cols = ids.map((id) => id % 16);
+        // ±150 m from the origin (world half 512) → world x in [362, 662) maps to tx in [5, 10]
+        expect(Math.min(...cols)).toBe(5);
+        expect(Math.max(...cols)).toBe(10);
+    });
+});
+
+describe("packStrokeTile — the seeded-tile readback oracle", () => {
+    test("packs a known pattern into the tile straddling the stroke's centre, read back byte-exact", () => {
+        // the tile whose corner sits at the world origin — squarely under the stroke's centreline
+        // (STROKE_Z=0) and well inside its ±150 m length.
+        const tx = 8;
+        const tz = 8;
+        expect(dirtyTiles(strokeRect())).toContain(tileId(tx, tz));
+        const { albedo, dist } = packStrokeTile(tx, tz);
+
+        // independent re-derivation: recompute the expected texel content at a handful of coordinates by
+        // hand-walking the tile's own world origin and texel size, never calling packStrokeTile's internal
+        // texelOffset — an agreement check against the same formula would only prove self-consistency
+        // (checks.md), so this reads the origin from tileOrigin (a different module function) and computes
+        // the byte offset with an inline formula.
+        const [ox, oz] = tileOrigin(tx, tz);
+        const probes: Array<[number, number]> = [
+            [0, 0],
+            [256, 256], // tile centre
+            [511, 0],
+            [0, 511],
+        ];
+        for (const [px, py] of probes) {
+            const worldX = ox + (px + 0.5) * TEXEL_SIZE;
+            const worldZ = oz + (py + 0.5) * TEXEL_SIZE;
+            // clamped the same way encodeDist saturates — this test's own independent clamp, not a call
+            // into encodeDist, since the far probes here land well outside ±DIST_RANGE
+            const expectedDist = Math.max(
+                -DIST_RANGE,
+                Math.min(DIST_RANGE, strokeDistance(worldX, worldZ)),
+            );
+
+            const distByteOffset = py * 512 + px; // r8unorm: 1 byte/texel, independent stride formula
+            const gotDist = decodeDist(dist[distByteOffset]);
+            const step = (2 * DIST_RANGE) / 255; // quantization step
+            expect(Math.abs(gotDist - expectedDist)).toBeLessThanOrEqual(step / 2 + 1e-6);
+
+            const albedoByteOffset = (py * 512 + px) * 4;
+            expect(albedo[albedoByteOffset]).toBe(Math.round(ROAD_ALBEDO[0] * 255));
+            expect(albedo[albedoByteOffset + 1]).toBe(Math.round(ROAD_ALBEDO[1] * 255));
+            expect(albedo[albedoByteOffset + 2]).toBe(Math.round(ROAD_ALBEDO[2] * 255));
+            expect(albedo[albedoByteOffset + 3]).toBe(255);
+        }
+    });
+
+    test("a tile far from the stroke encodes uniformly-outside distance", () => {
+        const { dist } = packStrokeTile(0, 15); // far corner, no overlap with the centre-row stroke
+        // every texel should decode to (near-)saturated outside distance — a broad sample, not exhaustive
+        for (let i = 0; i < dist.length; i += 997) {
+            expect(decodeDist(dist[i])).toBeGreaterThan(0.5);
+        }
+    });
+});

--- a/examples/showcase/roads/src/overlay/stroke.ts
+++ b/examples/showcase/roads/src/overlay/stroke.ts
@@ -1,0 +1,94 @@
+import {
+    ALBEDO_BYTES_PER_TEXEL,
+    DIST_BYTES_PER_TEXEL,
+    encodeDist,
+    type Rect,
+    TEXEL_SIZE,
+    TILE_RES,
+    texelOffset,
+    tileOrigin,
+} from "./tiles";
+
+// The stage's hand-authored "known pattern": a single straight road-width stroke, standing in for the real
+// stroke document a later stage authors (spec's Approach step 5 — "Road rasterizer" owns polylines/stamps
+// and a compute rasterizer). Stage 4's job is the substrate (atlas + indirection + composite + dirty/
+// redraw), so this is deliberately the simplest shape that exercises every layer of it: a pure
+// distance-to-segment function (the same primitive the real rasterizer will differential-test against,
+// `checks.md`'s two-independent-derivations shape for stage 5) plus a CPU-side packer that stands in for
+// the TGSL compute rasterizer stage 5 builds.
+//
+// Run along +X through the world origin at Z=0 (grid.ts centres the terrain there, and `heightAt(0, 0)` is
+// the one analytically known height on the seeded surface — an exact perlin-lattice point samples zero
+// gradient contribution at every octave, so `GROUND_LEVEL + fbm2(0,0)*RELIEF === GROUND_LEVEL` regardless
+// of seed — useful for a fixed-camera capture that needs a real world height with no device readback).
+// HALF_WIDTH is one grid cell (grid.ts's SPACING) so an on-road/off-road probe pair can sit on exact grid
+// vertices too (test/roads.spec.ts's capture arm reads their heights via `readVertices`).
+export const STROKE_HALF_LENGTH = 150; // metres either side of the origin
+export const STROKE_HALF_WIDTH = 4; // metres — matches terrain/grid.ts's SPACING
+export const STROKE_Z = 0;
+
+// dark asphalt, the same "not sampled from real materials, just a legible showcase color" spirit as
+// terrain.ts's grass/rock/snow constants.
+export const ROAD_ALBEDO: readonly [number, number, number] = [0.05, 0.05, 0.06];
+
+/** signed distance in world metres from (x, z) to the stroke's road edge — negative inside the road,
+ *  positive outside, zero at the boundary. The primitive stage 5's differential oracle will re-derive
+ *  independently against a GPU rasterization of the same shape (`checks.md`'s two-derivations discipline);
+ *  here it's the one source both the CPU packer and this stage's unit tests read. */
+export function strokeDistance(x: number, z: number): number {
+    const clampedX = Math.max(-STROKE_HALF_LENGTH, Math.min(STROKE_HALF_LENGTH, x));
+    const dx = x - clampedX;
+    const dz = z - STROKE_Z;
+    const toSegment = Math.hypot(dx, dz);
+    return toSegment - STROKE_HALF_WIDTH;
+}
+
+/** the stroke's world-space dirty bounds — its width/length AABB plus a one-texel margin so the
+ *  fwidth-antialiased edge (terrain.ts's fs) never samples a texel outside the written region. Feeds
+ *  `dirtyTiles` (tiles.ts). */
+export function strokeRect(): Rect {
+    const margin = TEXEL_SIZE;
+    return {
+        minX: -STROKE_HALF_LENGTH - STROKE_HALF_WIDTH - margin,
+        maxX: STROKE_HALF_LENGTH + STROKE_HALF_WIDTH + margin,
+        minZ: STROKE_Z - STROKE_HALF_WIDTH - margin,
+        maxZ: STROKE_Z + STROKE_HALF_WIDTH + margin,
+    };
+}
+
+/** pack one tile's albedo + distance content for the stroke pattern — the CPU write-path `atlas.ts` calls
+ *  per dirty tile. Every texel gets a distance sample (so a tile far from the stroke still encodes "clearly
+ *  outside"); albedo is only meaningful where distance is negative, but is written everywhere too (cheap,
+ *  and the fs never reads it past the coverage the distance channel derives). */
+export function packStrokeTile(tx: number, tz: number): { albedo: Uint8Array; dist: Uint8Array } {
+    const [ox, oz] = tileOrigin(tx, tz);
+    const albedo = new Uint8Array(TILE_RES * TILE_RES * ALBEDO_BYTES_PER_TEXEL);
+    const dist = new Uint8Array(TILE_RES * TILE_RES * DIST_BYTES_PER_TEXEL);
+    for (let y = 0; y < TILE_RES; y++) {
+        const worldZ = oz + (y + 0.5) * TEXEL_SIZE;
+        for (let x = 0; x < TILE_RES; x++) {
+            const worldX = ox + (x + 0.5) * TEXEL_SIZE;
+            const d = strokeDistance(worldX, worldZ);
+            const distAt = texelOffset(x, y, DIST_BYTES_PER_TEXEL);
+            dist[distAt] = encodeDist(d);
+            const albedoAt = texelOffset(x, y, ALBEDO_BYTES_PER_TEXEL);
+            albedo[albedoAt] = Math.round(ROAD_ALBEDO[0] * 255);
+            albedo[albedoAt + 1] = Math.round(ROAD_ALBEDO[1] * 255);
+            albedo[albedoAt + 2] = Math.round(ROAD_ALBEDO[2] * 255);
+            albedo[albedoAt + 3] = 255;
+        }
+    }
+    return { albedo, dist };
+}
+
+/** a world point guaranteed inside the stroke — the capture gate's on-road probe. Sits at the origin
+ *  (analytically zero height, see the module header) with a lateral margin from either edge for the
+ *  antialiased boundary. */
+export const ON_ROAD_POINT: readonly [x: number, z: number] = [0, STROKE_Z];
+
+/** a world point guaranteed outside the stroke, one grid cell (grid.ts SPACING) beyond the road edge —
+ *  the capture gate's off-road probe, also grid-aligned for an exact `readVertices` height. */
+export const OFF_ROAD_POINT: readonly [x: number, z: number] = [
+    0,
+    STROKE_Z + STROKE_HALF_WIDTH + 4,
+];

--- a/examples/showcase/roads/src/overlay/tiles.test.ts
+++ b/examples/showcase/roads/src/overlay/tiles.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { WORLD_HALF } from "../terrain/grid";
+import {
+    DIST_RANGE,
+    decodeDist,
+    dirtyTiles,
+    encodeDist,
+    TILE_COUNT,
+    TILE_RES,
+    TILE_SIZE,
+    TILES_PER_SIDE,
+    texelOffset,
+    tileId,
+    tileOf,
+} from "./tiles";
+
+describe("tile addressing", () => {
+    test("tileId is row-major over tx within tz, matching TILES_PER_SIDE", () => {
+        expect(tileId(0, 0)).toBe(0);
+        expect(tileId(1, 0)).toBe(1);
+        expect(tileId(0, 1)).toBe(TILES_PER_SIDE);
+        expect(tileId(TILES_PER_SIDE - 1, TILES_PER_SIDE - 1)).toBe(TILE_COUNT - 1);
+    });
+
+    test("tileOf maps the world origin to the grid's centre tile", () => {
+        // the grid centres on the origin (grid.ts), so (0, 0) sits at the boundary between the two centre
+        // tiles on each axis — tileOf floors, landing on the tile whose min corner is the origin.
+        expect(tileOf(0, 0)).toEqual([TILES_PER_SIDE / 2, TILES_PER_SIDE / 2]);
+    });
+
+    test("tileOf clamps the far edge into the last tile column, not one past it", () => {
+        expect(tileOf(WORLD_HALF, WORLD_HALF)).toEqual([TILES_PER_SIDE - 1, TILES_PER_SIDE - 1]);
+        expect(tileOf(-WORLD_HALF, -WORLD_HALF)).toEqual([0, 0]);
+    });
+});
+
+describe("dirtyTiles — the dirty-set oracle", () => {
+    // an independent hand-derivation of the analytic tile set, walking the full grid by its own formula
+    // rather than calling dirtyTiles' own tileOf/tileId — checks.md's "an agreement check between two
+    // things one author wrote from one document tests the document's self-consistency, never its truth":
+    // this derives the set a different way (world-space overlap of each tile's known footprint) so the two
+    // can actually disagree if either has a bug.
+    function handDerivedDirtySet(minX: number, minZ: number, maxX: number, maxZ: number): number[] {
+        const out: number[] = [];
+        for (let tz = 0; tz < TILES_PER_SIDE; tz++) {
+            const tileMinZ = tz * TILE_SIZE - WORLD_HALF;
+            const tileMaxZ = tileMinZ + TILE_SIZE;
+            if (tileMaxZ <= minZ || tileMinZ >= maxZ) continue;
+            for (let tx = 0; tx < TILES_PER_SIDE; tx++) {
+                const tileMinX = tx * TILE_SIZE - WORLD_HALF;
+                const tileMaxX = tileMinX + TILE_SIZE;
+                if (tileMaxX <= minX || tileMinX >= maxX) continue;
+                out.push(tz * TILES_PER_SIDE + tx);
+            }
+        }
+        return out;
+    }
+
+    test("a rect straddling the origin returns exactly the four tiles meeting there", () => {
+        const rect = { minX: -1, minZ: -1, maxX: 1, maxZ: 1 };
+        const got = dirtyTiles(rect).sort((a, b) => a - b);
+        const want = handDerivedDirtySet(rect.minX, rect.minZ, rect.maxX, rect.maxZ).sort(
+            (a, b) => a - b,
+        );
+        expect(got).toEqual(want);
+        expect(got.length).toBe(4);
+    });
+
+    test("a rect fully inside one tile returns exactly that tile", () => {
+        const rect = { minX: 10, minZ: 10, maxX: 12, maxZ: 12 };
+        const got = dirtyTiles(rect);
+        const want = handDerivedDirtySet(rect.minX, rect.minZ, rect.maxX, rect.maxZ);
+        expect(got).toEqual(want);
+        expect(got.length).toBe(1);
+    });
+
+    test("a rect spanning a 3×2 tile block matches the hand-derived set, clamped at the grid edge", () => {
+        // deliberately overruns past the -Z/-X edge to exercise the clamp arm too
+        const rect = {
+            minX: -WORLD_HALF - 50,
+            minZ: -WORLD_HALF - 50,
+            maxX: -WORLD_HALF + 100,
+            maxZ: -WORLD_HALF + 70,
+        };
+        const got = dirtyTiles(rect).sort((a, b) => a - b);
+        const want = handDerivedDirtySet(rect.minX, rect.minZ, rect.maxX, rect.maxZ).sort(
+            (a, b) => a - b,
+        );
+        expect(got).toEqual(want);
+    });
+
+    test("redrawing only touches the tiles the edit rect overlaps — a disjoint rect returns a disjoint set", () => {
+        const near = dirtyTiles({ minX: -5, minZ: -5, maxX: 5, maxZ: 5 });
+        const far = dirtyTiles({ minX: 200, minZ: 200, maxX: 205, maxZ: 205 });
+        for (const id of far) expect(near).not.toContain(id);
+    });
+});
+
+describe("distance codec round trip (the CPU↔GPU byte boundary)", () => {
+    test("encode → decode recovers the original value within one quantization step", () => {
+        const step = (2 * DIST_RANGE) / 255;
+        for (const metres of [-1, -0.5, -0.1, 0, 0.1, 0.37, 0.999, 1]) {
+            const round = decodeDist(encodeDist(metres));
+            expect(Math.abs(round - metres)).toBeLessThanOrEqual(step / 2 + 1e-9);
+        }
+    });
+
+    test("clamps outside ±DIST_RANGE to the saturated bytes", () => {
+        expect(encodeDist(5)).toBe(255);
+        expect(encodeDist(-5)).toBe(0);
+    });
+
+    test("zero distance encodes to the midpoint byte", () => {
+        expect(encodeDist(0)).toBe(Math.round(0.5 * 255));
+    });
+});
+
+describe("texelOffset — an independent stride derivation", () => {
+    test("matches a hand-walked row-major byte count for a handful of texels", () => {
+        // independent of texelOffset's own (y * TILE_RES + x) * bpt formula: walk texels in the same
+        // row-major order one at a time, incrementing a running byte counter, and compare.
+        const bpt = 4;
+        const probes: Array<[number, number]> = [
+            [0, 0],
+            [1, 0],
+            [0, 1],
+            [TILE_RES - 1, 0],
+            [0, TILE_RES - 1],
+            [TILE_RES - 1, TILE_RES - 1],
+        ];
+        for (const [px, py] of probes) {
+            let counted = 0;
+            outer: for (let y = 0; y < TILE_RES; y++) {
+                for (let x = 0; x < TILE_RES; x++) {
+                    if (x === px && y === py) break outer;
+                    counted += bpt;
+                }
+            }
+            expect(texelOffset(px, py, bpt)).toBe(counted);
+        }
+    });
+});

--- a/examples/showcase/roads/src/overlay/tiles.ts
+++ b/examples/showcase/roads/src/overlay/tiles.ts
@@ -1,0 +1,117 @@
+import { WORLD_EXTENT, WORLD_HALF } from "../terrain/grid";
+
+// The overlay's fixed world-space tile grid: pure addressing + packing math, no GPU/engine imports (the
+// same device-free split terrain/grid.ts and terrain/noise.ts use) — `bun test` exercises every formula
+// here without a device (testing.md's logic tier). `atlas.ts` is the GPU-resident half that consumes it.
+//
+// Tile size: 64 m (spec-given, matching Anno's own 512² tile precedent). 1024 m / 64 m = 16 tiles/side
+// exactly (grid.ts's WORLD_EXTENT), so the tile grid tiles the terrain footprint with no partial edge tile
+// — a round number a reader can check, not a fit. Atlas resolution: 512² texels/tile (Anno precedent,
+// spec's Locked decision) — one row is 512 texels regardless of TILE_SIZE, so a texel is
+// TILE_SIZE / TILE_RES = 0.125 m, the sub-texel-crisp unit the fwidth-thresholded distance channel
+// (terrain.ts's fs) reads against.
+
+export const TILE_SIZE = 64; // world metres per tile side
+export const TILE_RES = 512; // atlas texels per tile side (Anno's 512² slices)
+export const TEXEL_SIZE = TILE_SIZE / TILE_RES; // world metres per atlas texel (0.125 m)
+
+export const TILES_PER_SIDE = WORLD_EXTENT / TILE_SIZE; // 16
+export const TILE_COUNT = TILES_PER_SIDE * TILES_PER_SIDE; // 256
+
+// Atlas capacity: smaller than TILE_COUNT (the "small indirection" the spec's Approach names — every
+// unwritten tile costs no atlas layer, only an indirection slot). A layer is allocated the first time a
+// tile is marked dirty and never evicted (residency/eviction is the explicitly out-of-scope "tier above" —
+// this world is small enough that the spec's own argument against full VT paging applies to overlay
+// capacity too). Sized off the redraw throttle below: ATLAS_LAYERS = 8 × THROTTLE gives 8 fully-throttled
+// frames of sustained new-tile allocation before capacity is reached — well past stage 6's "a handful of
+// roads + one carpark" network, which (a few hundred metres of centreline over 64 m tiles) touches on the
+// order of ten tiles. Exceeding it is a fail-loud error (atlas.ts), not silent eviction — a residue for a
+// later stage if the network ever grows past this working set.
+export const THROTTLE = 8; // dirty-tile redraws (writeTexture calls) per frame
+export const ATLAS_LAYERS = 8 * THROTTLE; // 64
+
+export const ALBEDO_FORMAT = "rgba8unorm" as const;
+export const ALBEDO_BYTES_PER_TEXEL = 4;
+// the boundary-distance channel: a signed distance in world metres, quantized to r8unorm (one byte/texel —
+// no float16 pack/unpack boundary to get wrong). DIST_RANGE clamps the encoded range to ±1 m: the
+// fwidth-thresholded composite (terrain.ts) only ever reads distance within a few texels of its zero
+// crossing (0.125 m/texel × a handful of texels), so saturating the unorm range at ±1 m spends every
+// quantization step (2 m / 255 ≈ 0.0078 m ≈ 0.06 texel) where the antialiasing actually samples, instead of
+// wasting range on interior distances no reader needs precisely.
+export const DIST_FORMAT = "r8unorm" as const;
+export const DIST_BYTES_PER_TEXEL = 1;
+export const DIST_RANGE = 1; // metres, half-range
+
+/** encode a signed world-metre distance to its r8unorm byte — the CPU write-path's half of the codec
+ *  `terrain.ts`'s fs decodes (`(sampled - 0.5) * 2 * DIST_RANGE`), read back verbatim by unorm sampling. */
+export function encodeDist(metres: number): number {
+    const clamped = Math.max(-DIST_RANGE, Math.min(DIST_RANGE, metres));
+    const unit = clamped / (2 * DIST_RANGE) + 0.5; // → [0, 1]
+    return Math.round(unit * 255);
+}
+
+/** the exact inverse of {@link encodeDist} — the CPU-side check reads a packed byte back through this
+ *  rather than re-deriving encode's arithmetic, so the readback oracle exercises a real round trip. */
+export function decodeDist(byte: number): number {
+    return ((byte / 255 - 0.5) * 2 * DIST_RANGE) as number;
+}
+
+/** tile grid column (tx, tz) → flat tile id, row-major over tx within tz — the same convention
+ *  `grid.ts`'s `vertexIndex` uses for the mesh grid, and the id the fs's indirection lookup and this
+ *  module's `dirtyTiles` both address by. */
+export function tileId(tx: number, tz: number): number {
+    return tz * TILES_PER_SIDE + tx;
+}
+
+export function tileCoordOf(id: number): [tx: number, tz: number] {
+    return [id % TILES_PER_SIDE, Math.floor(id / TILES_PER_SIDE)];
+}
+
+/** world (x, z) → the tile column that contains it, clamped to the grid (a point exactly on the far edge,
+ *  `x === WORLD_HALF`, would otherwise floor to `TILES_PER_SIDE`, one past the last column). */
+export function tileOf(x: number, z: number): [tx: number, tz: number] {
+    const tx = Math.min(TILES_PER_SIDE - 1, Math.max(0, Math.floor((x + WORLD_HALF) / TILE_SIZE)));
+    const tz = Math.min(TILES_PER_SIDE - 1, Math.max(0, Math.floor((z + WORLD_HALF) / TILE_SIZE)));
+    return [tx, tz];
+}
+
+/** an axis-aligned world-space edit region — a stroke's dirty bounds, in world metres. */
+export interface Rect {
+    minX: number;
+    minZ: number;
+    maxX: number;
+    maxZ: number;
+}
+
+/**
+ * the analytic dirty-tile set for an edit rect: every tile column whose 64 m footprint overlaps `rect`,
+ * clamped to the grid, sorted ascending by {@link tileId}. Pure — `atlas.ts`'s `markDirty` is a thin
+ * GPU-side wrapper over this.
+ *
+ * @example dirtyTiles({ minX: -10, minZ: -10, maxX: 10, maxZ: 10 }) // the four tiles meeting at the origin
+ */
+export function dirtyTiles(rect: Rect): number[] {
+    const [tx0, tz0] = tileOf(rect.minX, rect.minZ);
+    const [tx1, tz1] = tileOf(rect.maxX, rect.maxZ);
+    const loTx = Math.min(tx0, tx1);
+    const hiTx = Math.max(tx0, tx1);
+    const loTz = Math.min(tz0, tz1);
+    const hiTz = Math.max(tz0, tz1);
+    const out: number[] = [];
+    for (let tz = loTz; tz <= hiTz; tz++) {
+        for (let tx = loTx; tx <= hiTx; tx++) out.push(tileId(tx, tz));
+    }
+    return out;
+}
+
+/** a tile column's world-space origin (its minX/minZ corner) — the offset a texel-local (u, v) is added to. */
+export function tileOrigin(tx: number, tz: number): [x: number, z: number] {
+    return [tx * TILE_SIZE - WORLD_HALF, tz * TILE_SIZE - WORLD_HALF];
+}
+
+/** byte offset of texel (x, y)'s first channel within one tile's tightly packed row-major buffer — no
+ *  WebGPU copy-alignment padding (that padding is `atlas.ts`'s `writeTexture` call's own concern, not the
+ *  CPU pattern buffer's). */
+export function texelOffset(x: number, y: number, bytesPerTexel: number): number {
+    return (y * TILE_RES + x) * bytesPerTexel;
+}

--- a/examples/showcase/roads/src/overlay/tiles.ts
+++ b/examples/showcase/roads/src/overlay/tiles.ts
@@ -42,6 +42,14 @@ export const DIST_FORMAT = "r8unorm" as const;
 export const DIST_BYTES_PER_TEXEL = 1;
 export const DIST_RANGE = 1; // metres, half-range
 
+// the fwidth-thresholded coverage band's half-width, in screen pixels: the fs's `fw = COVERAGE_BAND_PX *
+// fwidth(dist)` coefficient (terrain.ts). `fwidth` is the change in its argument over one screen pixel, and
+// coverage leaves [0, 1] exactly when `dist` moves by `fw` — so this coefficient *is* the band width the
+// composite antialiases over, and the capture gate's pixel tolerance is a fixed multiple of it
+// (capture.ts's TRANSITION_TOLERANCE_PX). Two readers, one value: the shader can't import a JS constant
+// through TGSL's resolver, but it can be *interpolated* into it, which is what terrain.ts does.
+export const COVERAGE_BAND_PX = 0.5;
+
 /** encode a signed world-metre distance to its r8unorm byte — the CPU write-path's half of the codec
  *  `terrain.ts`'s fs decodes (`(sampled - 0.5) * 2 * DIST_RANGE`), read back verbatim by unorm sampling. */
 export function encodeDist(metres: number): number {

--- a/examples/showcase/roads/src/terrain/grid.ts
+++ b/examples/showcase/roads/src/terrain/grid.ts
@@ -26,13 +26,24 @@ export const GridVertices = d.arrayOf(d.vec4u, VERTEX_COUNT);
 export const GridPosition = d.arrayOf(d.vec2u, VERTEX_COUNT);
 export const GridIndices = d.arrayOf(d.u32, INDEX_COUNT);
 
-/** grid column (ix, iz) → world (x, z), centred on the origin. The inverse a reader would need lives
- *  nowhere yet (stage 1 has no picking) — added when a later stage needs it. */
+/** grid column (ix, iz) → world (x, z), centred on the origin. */
 export function worldX(ix: number): number {
     return (ix - HALF) * SPACING;
 }
 export function worldZ(iz: number): number {
     return (iz - HALF) * SPACING;
+}
+
+/** the inverse of {@link worldX}/{@link worldZ} — a grid-aligned world (x, z) → its exact column (ix, iz),
+ *  used by the overlay capture gate (`capture.ts`) to read a probe point's real generated height off
+ *  `readVertices()` rather than re-deriving the noise function in JS. `Math.round` rather than a plain
+ *  divide since a caller passing an exact multiple of SPACING can still land a hair off an integer to
+ *  floating-point error. */
+export function gridX(x: number): number {
+    return Math.round(x / SPACING) + HALF;
+}
+export function gridZ(z: number): number {
+    return Math.round(z / SPACING) + HALF;
 }
 
 /** grid column (ix, iz) → flat vertex index, row-major over x within z. The GPU kernel and this CPU

--- a/examples/showcase/roads/src/terrain/terrain.test.ts
+++ b/examples/showcase/roads/src/terrain/terrain.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { body, flat } from "../../../../../packages/shallot/tests/wgsl";
-import { DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
+import { COVERAGE_BAND_PX, DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
 import { terrainFsWgsl } from "./terrain";
 
 // The overlay composite's structural gate — the device-free seam this stage's `bun test` relies on for the
@@ -55,6 +55,10 @@ describe("terrain fs — overlay composite", () => {
         const fs = flat(body(wgsl, "fn terrainFs"));
         expect(fs).toContain(`* ${DIST_RANGE}f`);
         expect(fs).toContain("fwidth(");
+        // the coverage band's own coefficient, not just that fwidth appears: capture.ts derives
+        // TRANSITION_TOLERANCE_PX as a multiple of COVERAGE_BAND_PX, so a shader-side drift in this
+        // factor silently widens the band the capture gate's tolerance was sized against.
+        expect(fs).toMatch(new RegExp(`fwidth\\(dist_\\d*\\) \\* ${COVERAGE_BAND_PX}f`));
         // Green 2007's alpha-tested-magnification form, masked by the residency select above (an
         // unallocated tile's coverage is forced to 0 regardless of what garbage the clamped-layer sample
         // returns) — never a branch, per the uniform-control-flow test above.

--- a/examples/showcase/roads/src/terrain/terrain.test.ts
+++ b/examples/showcase/roads/src/terrain/terrain.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { body, flat } from "../../../../../packages/shallot/tests/wgsl";
+import { DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
+import { terrainFsWgsl } from "./terrain";
+
+// The overlay composite's structural gate — the device-free seam this stage's `bun test` relies on for the
+// fs's atlas-sampling half (`testing.md`'s ladder: CPU-callable/resolved-WGSL first, never a bound
+// device). The composite's actual pixel output is the capture gate's own arm (`gate.ts`/`test/roads.spec.ts`)
+// — checks.md's "layers are a granularity": the compute-write half is proven by the seeded-tile readback
+// oracle (`overlay/stroke.test.ts`), this half by resolution + the capture, neither alone.
+
+describe("terrain fs — overlay composite", () => {
+    const wgsl = terrainFsWgsl();
+
+    test("declares the four overlay bindings the surface layout adds", () => {
+        expect(flat(wgsl)).toContain(
+            "@group(2) @binding(3) var<storage, read> indirection: array<i32>;",
+        );
+        expect(wgsl).toContain("var albedo: texture_2d_array<f32>;");
+        expect(wgsl).toContain("var dist: texture_2d_array<f32>;");
+        expect(wgsl).toContain("var overlaySamp: sampler;");
+    });
+
+    test("addresses the tile grid from world (x, z) using the documented constants", () => {
+        const fs = flat(body(wgsl, "fn terrainFs"));
+        expect(fs).toContain(
+            `(ctx.world.x + ${TILE_SIZE * (TILES_PER_SIDE / 2)}f) / ${TILE_SIZE}f`,
+        );
+        expect(fs).toContain(
+            `(ctx.world.z + ${TILE_SIZE * (TILES_PER_SIDE / 2)}f) / ${TILE_SIZE}f`,
+        );
+        expect(fs).toMatch(/clamp\(i32\(floor\(.*\)\), 0i, \d+i\)/);
+        expect(fs).toContain(`(tz * ${TILES_PER_SIDE}i) + tx`);
+    });
+
+    test("looks the tile up in the indirection buffer, never inside a per-fragment branch around the sample", () => {
+        // textureSample computes screen-space derivatives, so WGSL requires uniform control flow — a
+        // per-fragment `if (layer >= 0)` guard around it is a real-GPU compile rejection ("must only be
+        // called from uniform control flow"), caught red-handed by the device gate. The fix is unconditional
+        // sampling + a `select`-masked contribution instead of a branch; this test pins that shape stays.
+        const fs = flat(body(wgsl, "fn terrainFs"));
+        expect(fs).toContain("let layer = indirection[u32(tileIdx)];");
+        expect(fs).not.toMatch(/if\s*\(\(layer/);
+        expect(fs).toContain("let layerU = u32(max(layer, 0i));");
+        expect(fs).toMatch(/select\(0f, 1f, \(layer >= 0i\)\)/);
+    });
+
+    test("samples both atlas arrays unconditionally, by the same tile-local uv and clamped layer", () => {
+        const fs = flat(body(wgsl, "fn terrainFs"));
+        expect(fs).toContain("textureSample(dist, overlaySamp, uv, layerU)");
+        expect(fs).toContain("textureSample(albedo, overlaySamp, uv, layerU)");
+    });
+
+    test("decodes the distance channel with the documented DIST_RANGE, thresholds coverage with fwidth, and masks it by residency", () => {
+        const fs = flat(body(wgsl, "fn terrainFs"));
+        expect(fs).toContain(`* ${DIST_RANGE}f`);
+        expect(fs).toContain("fwidth(");
+        // Green 2007's alpha-tested-magnification form, masked by the residency select above (an
+        // unallocated tile's coverage is forced to 0 regardless of what garbage the clamped-layer sample
+        // returns) — never a branch, per the uniform-control-flow test above.
+        expect(fs).toMatch(/clamp\(\(0\.5f - \(dist_\d* \/ fw\)\), 0f, 1f\) \* resident/);
+    });
+
+    test("composites the overlay over the base color by coverage — never a second draw", () => {
+        const fs = flat(body(wgsl, "fn terrainFs"));
+        expect(fs).toContain("color = mix(color, overlay, coverage);");
+        expect(wgsl.match(/fn terrainFs\(/g)?.length).toBe(1); // exactly one fs entry — no second pass
+    });
+});

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -1,21 +1,24 @@
 // The terrain mesh + surface: registers the fixed W×H grid (grid.ts) as a `Meshes`/`Draws` entry whose
 // vertex content the height kernel (generate.ts) fills, and a custom sear surface that shades the result
-// from slope + height alone — no textures, no splat map (the spec's stage-1 boundary). This is the
-// showcase's road-carrying ground plane; the overlay that will carry the road network rides on top of
-// this surface starting stage 2 (`shallot-roads` spec, "Overlay substrate").
+// from slope + height alone, then composites one overlay sample over that base by coverage (the road
+// network's substrate, `../overlay/` — same-surface sampling, no second draw, no depth bias: the spec's
+// Locked decision).
 //
 // Unlike voxel's mesher, the index list here never changes (grid.ts's `gridIndices` is a pure function
 // of the fixed cell count) — so it's authored once on the CPU and uploaded once, and the mesh is
 // registered once at warm, not re-emitted every frame. `warm`/`dispose` still exist (not a one-shot
 // `initialize`) because GPU buffers need a live device, which only exists once RenderPlugin has warmed.
 
-import { Compute, type Plugin, RenderPlugin, type State } from "@dylanebert/shallot";
+import { Compute, type Plugin, RenderPlugin, type State, type System } from "@dylanebert/shallot";
 import { DrawIndexedIndirect, Draws, type Mesh, Meshes } from "@dylanebert/shallot/render/core";
 import { fsCtxSchema, lit, registerSurface, surfaceLayout } from "@dylanebert/shallot/sear/core";
 import { MeshQuant } from "@dylanebert/shallot/utils/core";
 import tgpu from "typegpu";
 import * as d from "typegpu/data";
 import * as std from "typegpu/std";
+import * as overlayAtlas from "../overlay/atlas";
+import { packStrokeTile, strokeRect } from "../overlay/stroke";
+import { DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
 import { bindTerrainKernel, generate, TERRAIN_QUANT } from "./generate";
 import {
     GridIndices,
@@ -24,6 +27,7 @@ import {
     gridIndices,
     INDEX_COUNT,
     VERTEX_COUNT,
+    WORLD_HALF,
 } from "./grid";
 
 export { generate } from "./generate";
@@ -38,7 +42,12 @@ const ROCK_SLOPE_HI = 0.92;
 const SNOW_HEIGHT_LO = 0.55; // fraction of the [GROUND_LEVEL, GROUND_LEVEL + RELIEF] band
 const SNOW_HEIGHT_HI = 0.8;
 
-const terrainSurfaceLayout = surfaceLayout({});
+const terrainSurfaceLayout = surfaceLayout({
+    albedo: { type: "texture-2d-array" },
+    dist: { type: "texture-2d-array" },
+    overlaySamp: { type: "sampler" },
+    indirection: { type: "storage", element: d.i32 },
+});
 
 const terrainFs = tgpu.fn(
     [fsCtxSchema()],
@@ -55,10 +64,62 @@ const terrainFs = tgpu.fn(
 
     const heightT = std.clamp(ctx.world.y / d.f32(TERRAIN_QUANT.posScale.y * 0.5), 0, 1);
     const snowBlend = std.smoothstep(d.f32(SNOW_HEIGHT_LO), d.f32(SNOW_HEIGHT_HI), heightT);
-    const color = std.mix(base, snow, snowBlend);
+    let color = std.mix(base, snow, snowBlend);
+
+    // the overlay composite: world (x, z) → tile column → indirection lookup → one atlas sample, coverage
+    // thresholded from the stored signed distance with fwidth (Green, SIGGRAPH 2007 — the sub-texel-crisp
+    // edge the spec's Locked decision names). Same-surface: no second draw, no depth bias.
+    const tx = std.clamp(
+        d.i32(std.floor((ctx.world.x + d.f32(WORLD_HALF)) / d.f32(TILE_SIZE))),
+        0,
+        d.i32(TILES_PER_SIDE - 1),
+    );
+    const tz = std.clamp(
+        d.i32(std.floor((ctx.world.z + d.f32(WORLD_HALF)) / d.f32(TILE_SIZE))),
+        0,
+        d.i32(TILES_PER_SIDE - 1),
+    );
+    const tileIdx = tz * d.i32(TILES_PER_SIDE) + tx;
+    const layer = terrainSurfaceLayout.$.indirection[d.u32(tileIdx)];
+    // `textureSample` computes screen-space derivatives (mip/anisotropy), so WGSL requires it run in
+    // *uniform* control flow — a per-fragment `if (layer >= 0)` branch (layer varies with world position,
+    // non-uniform across the wavefront) makes the compiler reject the call outright ("must only be called
+    // from uniform control flow", caught by the device gate's real-GPU pipeline compile). The fix is the
+    // standard one: always sample, at a clamped-valid layer index, then zero the *contribution* via
+    // `select` instead of skipping the sample.
+    const layerU = d.u32(std.max(layer, 0));
+    const localX = ctx.world.x + d.f32(WORLD_HALF) - d.f32(tx) * d.f32(TILE_SIZE);
+    const localZ = ctx.world.z + d.f32(WORLD_HALF) - d.f32(tz) * d.f32(TILE_SIZE);
+    const uv = d.vec2f(localX / d.f32(TILE_SIZE), localZ / d.f32(TILE_SIZE));
+    const distSample = std.textureSample(
+        terrainSurfaceLayout.$.dist,
+        terrainSurfaceLayout.$.overlaySamp,
+        uv,
+        layerU,
+    ).x;
+    const overlay = std.textureSample(
+        terrainSurfaceLayout.$.albedo,
+        terrainSurfaceLayout.$.overlaySamp,
+        uv,
+        layerU,
+    ).xyz;
+    // decode the r8unorm distance channel back to a signed world-metre distance — the fs's half of the
+    // codec overlay/tiles.ts's encodeDist writes (kept in sync by hand: DIST_RANGE is the one shared
+    // constant both sides read; TGSL can't call a plain JS helper, so this stays inline).
+    const dist = (distSample - d.f32(0.5)) * d.f32(2) * d.f32(DIST_RANGE);
+    const fw = std.fwidth(dist) * d.f32(0.5) + d.f32(1e-5);
+    const resident = std.select(d.f32(0), d.f32(1), layer >= 0);
+    const coverage = std.clamp(d.f32(0.5) - dist / fw, 0, 1) * resident;
+    color = std.mix(color, overlay, coverage);
 
     return d.vec4f(lit(color, ctx.worldNormal), 1);
 });
+
+/** the emitted terrain fs WGSL — the device-free structural seam the overlay composite tests resolve
+ *  (`terrain.test.ts`, the `generate.test.ts`/`noise.test.ts` idiom). */
+export function terrainFsWgsl(): string {
+    return tgpu.resolve([terrainFs], { names: "strict" });
+}
 
 /** the terrain mesh's local-space bounding sphere: the grid's XZ half-extent + the relief's half-height,
  *  centred at the mesh centroid — an analytic AABB→sphere, not a scan (the grid isn't uploaded to the
@@ -99,6 +160,7 @@ async function warm(state: State): Promise<void> {
     // `Plugin.dispose` only fires on `App.dispose`, never on a direct `state.dispose()` (the path an
     // in-place rebuild takes) — tie cleanup to the State itself so both paths clear these buffers.
     state.onDispose(teardown);
+    overlayAtlas.warm(state); // its own teardown/onDispose registration, the same pattern
     const { device, root } = Compute;
 
     const verticesRaw = device.createBuffer({
@@ -157,13 +219,36 @@ async function warm(state: State): Promise<void> {
         indexCount: INDEX_COUNT,
         bounds: terrainBounds(),
         dynamic: true, // content (not topology) is compute-rewritten on reseed — a stale BLAS would cast wrong
+        bindings: overlayAtlas.bindings(), // the four overlay entries terrainSurfaceLayout declares
     };
     Meshes.register(mesh);
     Draws.register({ name: "terrain", surface: "terrain", mesh: "terrain", args: { indirect } });
 
+    // the stage's hand-authored known pattern (overlay/stroke.ts) — stands in for a real stroke document
+    // (stage 5). Marking it dirty here (not per-frame) means one redraw burst at warm, not a repeated mark.
+    overlayAtlas.markDirty(strokeRect());
+
     bindTerrainKernel(vertices, position);
     if (state.signal.aborted) return;
     await generate(SEED);
+}
+
+/** drain the overlay's per-frame dirty-tile throttle (`overlay/atlas.ts`'s `redraw`) — this stage's only
+ *  producer is the hand-authored stroke, so `packStrokeTile` stands in for the real stroke-document
+ *  rasterizer (stage 5). Exported so the device gate can assert draining actually happened. */
+const OverlayRedrawSystem: System = {
+    name: "roads-overlay-redraw",
+    group: "simulation",
+    annotations: { mode: "always" },
+    update() {
+        overlayAtlas.redraw(packStrokeTile);
+    },
+};
+
+/** whether every marked overlay tile has drained through the atlas — the device gate polls this before
+ *  its capture reads the frame (`gate.ts`). */
+export function overlayIdle(): boolean {
+    return overlayAtlas.idle();
 }
 
 /** one-shot GPU→CPU readback of the whole main vertex stream — the device gate's own arm (gate.ts): a
@@ -191,6 +276,7 @@ export async function readVertices(): Promise<Uint32Array> {
 const TerrainPlugin: Plugin = {
     name: "Terrain",
     dependencies: [RenderPlugin],
+    systems: [OverlayRedrawSystem],
     initialize(state) {
         registerSurface(state, { name: "terrain", layout: terrainSurfaceLayout, fs: terrainFs });
     },

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -18,7 +18,7 @@ import * as d from "typegpu/data";
 import * as std from "typegpu/std";
 import * as overlayAtlas from "../overlay/atlas";
 import { packStrokeTile, strokeRect } from "../overlay/stroke";
-import { DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
+import { COVERAGE_BAND_PX, DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
 import { bindTerrainKernel, generate, TERRAIN_QUANT } from "./generate";
 import {
     GridIndices,
@@ -107,7 +107,7 @@ const terrainFs = tgpu.fn(
     // codec overlay/tiles.ts's encodeDist writes (kept in sync by hand: DIST_RANGE is the one shared
     // constant both sides read; TGSL can't call a plain JS helper, so this stays inline).
     const dist = (distSample - d.f32(0.5)) * d.f32(2) * d.f32(DIST_RANGE);
-    const fw = std.fwidth(dist) * d.f32(0.5) + d.f32(1e-5);
+    const fw = std.fwidth(dist) * d.f32(COVERAGE_BAND_PX) + d.f32(1e-5);
     const resident = std.select(d.f32(0), d.f32(1), layer >= 0);
     const coverage = std.clamp(d.f32(0.5) - dist / fw, 0, 1) * resident;
     color = std.mix(color, overlay, coverage);

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -11,6 +11,12 @@ interface Check {
     detail: string;
 }
 
+interface ScreenPoint {
+    x: number;
+    y: number;
+    depth: number;
+}
+
 // Software rasterizers by the name they report in `GPUAdapterInfo`: Chromium's SwiftShader, Mesa's two,
 // and D3D's WARP. Deliberately a name list rather than a capability probe — SwiftShader clears shallot's
 // whole base floor (all three `BASE_FEATURES` plus 10 storage buffers per stage, measured under WSL
@@ -62,4 +68,112 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
     for (const c of checks) {
         expect(c.pass, `${c.name}: ${c.detail}`).toBe(true);
     }
+
+    // Phase 2: the overlay substrate's own flagged-risk validation (spec's Locked decision) — a real
+    // captured frame, machine-read, with the hand-authored stroke (overlay/stroke.ts). The compute-write
+    // half is proven device-free (overlay/stroke.test.ts's seeded-tile readback oracle); this is the fs
+    // composite's own arm, observable only in the rendered frame (checks.md: layers are a granularity).
+    await page.waitForFunction(
+        () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
+        null,
+        { timeout: 10_000 },
+    );
+
+    const { onRoad, offRoad } = (await page.evaluate(() =>
+        (
+            window as unknown as {
+                __roadsCapturePoints: () => Promise<{
+                    onRoad: [number, number, number];
+                    offRoad: [number, number, number];
+                }>;
+            }
+        ).__roadsCapturePoints(),
+    )) as { onRoad: [number, number, number]; offRoad: [number, number, number] };
+
+    const [onRoadScreen, offRoadScreen] = (await page.evaluate(
+        (points) =>
+            (
+                window as unknown as {
+                    __roadsProbe: (pts: [number, number, number][]) => ScreenPoint[];
+                }
+            ).__roadsProbe(points),
+        [onRoad, offRoad],
+    )) as ScreenPoint[];
+
+    const screenshot = await page.screenshot();
+    const capture = await page.evaluate(
+        async ({ base64, onRoadScreen, offRoadScreen, tolerancePx }) => {
+            const binary = atob(base64);
+            const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+            const bitmap = await createImageBitmap(new Blob([bytes], { type: "image/png" }));
+            const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+            const context = canvas.getContext("2d");
+            if (!context) throw new Error("roads capture: 2D screenshot context unavailable");
+            context.drawImage(bitmap, 0, 0);
+            const data = context.getImageData(0, 0, bitmap.width, bitmap.height).data;
+
+            const luminanceAt = (fracX: number, fracY: number): number => {
+                const x = Math.min(bitmap.width - 1, Math.max(0, Math.round(fracX * bitmap.width)));
+                const y = Math.min(
+                    bitmap.height - 1,
+                    Math.max(0, Math.round(fracY * bitmap.height)),
+                );
+                const at = (y * bitmap.width + x) * 4;
+                return 0.3 * data[at] + 0.59 * data[at + 1] + 0.11 * data[at + 2];
+            };
+
+            const onRoadLum = luminanceAt(onRoadScreen.x, onRoadScreen.y);
+            const offRoadLum = luminanceAt(offRoadScreen.x, offRoadScreen.y);
+
+            // walk pixels along the on-road → off-road screen segment; the transition band is the run of
+            // consecutive samples whose luminance sits strictly between the two endpoints (not at either
+            // plateau) — its pixel length is what the derived tolerance bounds.
+            const dxPx = (offRoadScreen.x - onRoadScreen.x) * bitmap.width;
+            const dyPx = (offRoadScreen.y - onRoadScreen.y) * bitmap.height;
+            const spanPx = Math.hypot(dxPx, dyPx);
+            const steps = Math.max(8, Math.ceil(spanPx * 2)); // ≥2 samples/pixel along the segment
+            const lo = Math.min(onRoadLum, offRoadLum);
+            const hi = Math.max(onRoadLum, offRoadLum);
+            const band = hi - lo;
+            const plateau = band * 0.1; // within 10% of an endpoint counts as "at" that endpoint
+            let transitionSamples = 0;
+            for (let i = 0; i <= steps; i++) {
+                const t = i / steps;
+                const fx = onRoadScreen.x + (offRoadScreen.x - onRoadScreen.x) * t;
+                const fy = onRoadScreen.y + (offRoadScreen.y - onRoadScreen.y) * t;
+                const lum = luminanceAt(fx, fy);
+                if (lum > lo + plateau && lum < hi - plateau) transitionSamples++;
+            }
+            const transitionPx = (transitionSamples / steps) * spanPx;
+
+            return { onRoadLum, offRoadLum, transitionPx, spanPx, tolerancePx };
+        },
+        {
+            base64: screenshot.toString("base64"),
+            onRoadScreen,
+            offRoadScreen,
+            tolerancePx: await page.evaluate(
+                () =>
+                    (window as unknown as { __roadsTransitionTolerancePx: number })
+                        .__roadsTransitionTolerancePx,
+            ),
+        },
+    );
+
+    // on-road classifies as road albedo (dark, low-chroma asphalt), off-road as terrain (brighter grass) —
+    // a luminance ratio, not a fixed RGB band, since ambient/directional lighting scales both pixels by
+    // roughly the same local factor: the albedo constants alone put road/grass luminance at ≈0.40 (asphalt
+    // [0.05,0.05,0.06] vs grass [0.09,0.16,0.05] through the same 0.3/0.59/0.11 weights terrain.ts's `lit`
+    // uses), so 0.75 leaves comfortable margin while still ruling out "no overlay reached the frame".
+    expect(
+        capture.onRoadLum,
+        `on-road ${capture.onRoadLum.toFixed(1)} vs off-road ${capture.offRoadLum.toFixed(1)}`,
+    ).toBeLessThan(capture.offRoadLum * 0.75);
+
+    expect(
+        capture.transitionPx,
+        `boundary transition ${capture.transitionPx.toFixed(2)}px over a ${capture.spanPx.toFixed(2)}px probe span (tolerance ${capture.tolerancePx}px)`,
+    ).toBeLessThanOrEqual(capture.tolerancePx);
+
+    expect(errors, errors.join("\n")).toEqual([]);
 });


### PR DESCRIPTION
- **shallot-roads: overlay substrate — tile atlas, indirection, fs composite, capture gate**
- **shallot-roads: single-source the coverage band the capture tolerance derives from**
