### PR TITLE
shallot roads/rasterizer

### DIFF
--- a/examples/showcase/roads/src/overlay/atlas.ts
+++ b/examples/showcase/roads/src/overlay/atlas.ts
@@ -2,15 +2,13 @@ import { Compute, type State } from "@dylanebert/shallot";
 import type { MeshBinding } from "@dylanebert/shallot/render/core";
 import type { StorageFlag, TgpuBuffer } from "typegpu";
 import * as d from "typegpu/data";
+import { documentDirtyTiles, type StrokeDocument } from "./document";
 import { allocate, drain } from "./queue";
+import { rasterizeTile, warm as rasterizeWarm } from "./rasterize";
 import {
-    ALBEDO_BYTES_PER_TEXEL,
     ALBEDO_FORMAT,
     ATLAS_LAYERS,
-    DIST_BYTES_PER_TEXEL,
     DIST_FORMAT,
-    dirtyTiles,
-    type Rect,
     THROTTLE,
     TILE_COUNT,
     TILE_RES,
@@ -21,9 +19,12 @@ import {
 // sized to {@link ATLAS_LAYERS} — smaller than {@link TILE_COUNT}, the "small indirection" the spec's
 // Approach names — plus the indirection storage buffer the terrain fs (`terrain/terrain.ts`) looks tile id
 // up in. A tile's layer is allocated the first time it's marked dirty (never evicted — out of scope, see
-// tiles.ts); `redraw` drains the dirty queue at a fixed per-frame throttle, so a burst of edits (this
-// stage's hand-authored stroke, or a future full network regeneration) never stalls one frame with every
-// tile's `writeTexture` call at once.
+// tiles.ts); `redraw` drains the dirty queue at a fixed per-frame throttle, so a burst of edits (a hand-
+// authored stroke, or a future full network regeneration) never stalls one frame with every tile's
+// rasterize dispatch at once. Stage 5 moved the per-tile content from a CPU `TilePacker` (`writeTexture`
+// on a JS-computed `Uint8Array`) to `rasterize.ts`'s GPU compute dispatch (`copyBufferToTexture` off a
+// packed storage buffer) — `redraw` below is the seam that changed; `queue.ts`'s `drain`/`allocate` are
+// untouched.
 
 /** the indirection buffer's declared element schema: `array<i32, TILE_COUNT>` — negative = unallocated
  *  (`terrain.ts`'s fs reads `< 0` as "no overlay here"). Exported so the surface layout and this module's
@@ -66,6 +67,7 @@ function teardown(): void {
 export function warm(state: State): void {
     teardown();
     state.onDispose(teardown);
+    rasterizeWarm(state); // its own teardown/onDispose registration, the same pattern
     const { device, root } = Compute;
 
     albedoTex = device.createTexture({
@@ -118,27 +120,23 @@ export function bindings(): Record<string, MeshBinding> {
     };
 }
 
-/** mark every tile `rect` overlaps dirty (`tiles.ts`'s analytic dirty set) — idempotent: a tile already
- *  pending isn't re-queued. */
-export function markDirty(rect: Rect): void {
-    for (const id of dirtyTiles(rect)) {
+/** mark every tile `doc` touches dirty (`document.ts`'s exact per-primitive union, not one bounding rect
+ *  over the whole document) — idempotent: a tile already pending isn't re-queued. */
+export function markDirty(doc: StrokeDocument): void {
+    for (const id of documentDirtyTiles(doc)) {
         if (pendingSet.has(id)) continue;
         pendingSet.add(id);
         pending.push(id);
     }
 }
 
-/** a tile's packed content: tightly-packed row-major albedo (rgba8unorm) + distance (r8unorm) buffers,
- *  `tiles.ts`'s `texelOffset` addressing — `stroke.ts`'s `packStrokeTile` is this stage's producer. */
-export type TilePacker = (tx: number, tz: number) => { albedo: Uint8Array; dist: Uint8Array };
-
 /**
- * drain up to {@link THROTTLE} pending dirty tiles: allocate each one's atlas layer, write its content via
- * `pack`, and flush the changed indirection entries. Returns the number of tiles redrawn — 0 once the
- * queue is empty, so a caller (the per-frame `OverlaySystem`, `terrain.ts`) can poll it every frame with no
- * extra bookkeeping.
+ * drain up to {@link THROTTLE} pending dirty tiles: allocate each one's atlas layer, rasterize `doc`'s
+ * content into it via `rasterize.ts`'s GPU dispatch, and flush the changed indirection entries. Returns
+ * the number of tiles redrawn — 0 once the queue is empty, so a caller (the per-frame `OverlaySystem`,
+ * `terrain.ts`) can poll it every frame with no extra bookkeeping.
  */
-export function redraw(pack: TilePacker): number {
+export function redraw(doc: StrokeDocument): number {
     if (!albedoTex || !distTex || !indirectionRaw) return 0;
     const ids = drain(pending, pendingSet, THROTTLE);
     if (ids.length === 0) return 0;
@@ -148,19 +146,7 @@ export function redraw(pack: TilePacker): number {
         nextLayer = alloc.nextLayer;
         const layer = alloc.layer;
         const [tx, tz] = tileCoordOf(id);
-        const { albedo, dist } = pack(tx, tz);
-        device.queue.writeTexture(
-            { texture: albedoTex, origin: { x: 0, y: 0, z: layer } },
-            albedo as Uint8Array<ArrayBuffer>,
-            { bytesPerRow: TILE_RES * ALBEDO_BYTES_PER_TEXEL, rowsPerImage: TILE_RES },
-            { width: TILE_RES, height: TILE_RES, depthOrArrayLayers: 1 },
-        );
-        device.queue.writeTexture(
-            { texture: distTex, origin: { x: 0, y: 0, z: layer } },
-            dist as Uint8Array<ArrayBuffer>,
-            { bytesPerRow: TILE_RES * DIST_BYTES_PER_TEXEL, rowsPerImage: TILE_RES },
-            { width: TILE_RES, height: TILE_RES, depthOrArrayLayers: 1 },
-        );
+        rasterizeTile(doc, tx, tz, albedoTex, distTex, layer);
         device.queue.writeBuffer(indirectionRaw, id * 4, new Int32Array([layer]));
     }
     return ids.length;

--- a/examples/showcase/roads/src/overlay/document.test.ts
+++ b/examples/showcase/roads/src/overlay/document.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import {
+    documentDirtyTiles,
+    documentDistance,
+    flattenSegments,
+    type PolygonStamp,
+    polygonDistance,
+    type StrokeDocument,
+    segmentDistance,
+} from "./document";
+import { strokeDistance, strokeDocument } from "./stroke";
+
+describe("flattenSegments", () => {
+    test("one polyline with N points yields N-1 segments, in order", () => {
+        const doc: StrokeDocument = {
+            polylines: [
+                {
+                    points: [
+                        [0, 0],
+                        [10, 0],
+                        [10, 10],
+                    ],
+                    halfWidth: 2,
+                },
+            ],
+            polygons: [],
+        };
+        const segs = flattenSegments(doc);
+        expect(segs.length).toBe(2);
+        expect(segs[0]).toEqual({ ax: 0, az: 0, bx: 10, bz: 0, halfWidth: 2 });
+        expect(segs[1]).toEqual({ ax: 10, az: 0, bx: 10, bz: 10, halfWidth: 2 });
+    });
+
+    test("an empty document flattens to no segments", () => {
+        expect(flattenSegments({ polylines: [], polygons: [] })).toEqual([]);
+    });
+});
+
+describe("segmentDistance", () => {
+    const seg = { ax: -10, az: 0, bx: 10, bz: 0, halfWidth: 2 };
+
+    test("negative on the centreline, zero at the edge, positive beyond it", () => {
+        expect(segmentDistance(0, 0, seg)).toBeLessThan(0);
+        expect(segmentDistance(0, 2, seg)).toBeCloseTo(0, 10);
+        expect(segmentDistance(0, 5, seg)).toBeCloseTo(3, 10);
+    });
+
+    test("beyond either endpoint, distance is to the endpoint, not the infinite line", () => {
+        // straight out past B=(10,0): the nearest point on the segment is B itself
+        expect(segmentDistance(15, 0, seg)).toBeCloseTo(5 - 2, 10);
+        // diagonally past A=(-10,0)
+        expect(segmentDistance(-13, 4, seg)).toBeCloseTo(5 - 2, 10);
+    });
+
+    test("a zero-length segment falls back to point distance", () => {
+        const point = { ax: 0, az: 0, bx: 0, bz: 0, halfWidth: 1 };
+        expect(segmentDistance(3, 4, point)).toBeCloseTo(5 - 1, 10);
+    });
+});
+
+describe("polygonDistance", () => {
+    // a 10×10 square centred on the origin
+    const square: PolygonStamp = {
+        points: [
+            [-5, -5],
+            [5, -5],
+            [5, 5],
+            [-5, 5],
+        ],
+    };
+
+    test("negative well inside, positive well outside", () => {
+        expect(polygonDistance(0, 0, square)).toBeLessThan(0);
+        expect(polygonDistance(20, 20, square)).toBeGreaterThan(0);
+    });
+
+    test("magnitude at the centre equals the distance to the nearest edge", () => {
+        expect(polygonDistance(0, 0, square)).toBeCloseTo(-5, 10);
+    });
+
+    test("near-zero right at the boundary", () => {
+        expect(Math.abs(polygonDistance(5, 0, square))).toBeCloseTo(0, 10);
+    });
+});
+
+describe("documentDistance", () => {
+    test("is the minimum over every segment and polygon", () => {
+        const doc: StrokeDocument = {
+            polylines: [
+                {
+                    points: [
+                        [-100, 0],
+                        [100, 0],
+                    ],
+                    halfWidth: 2,
+                },
+            ],
+            polygons: [
+                {
+                    points: [
+                        [40, 40],
+                        [60, 40],
+                        [60, 60],
+                        [40, 60],
+                    ],
+                },
+            ],
+        };
+        // near the polyline, not the polygon
+        expect(documentDistance(0, 0, doc)).toBeCloseTo(-2, 10);
+        // inside the polygon, far from the polyline
+        expect(documentDistance(50, 50, doc)).toBeCloseTo(-10, 10);
+    });
+
+    test("cross-checks stroke.ts's hand-rolled strokeDistance over strokeDocument()", () => {
+        // stroke.ts's strokeDistance is the stage-4 clamped-x formula (only valid for its own fixed
+        // horizontal pattern); documentDistance is the stage-5 general form. They should agree exactly
+        // over strokeDocument()'s one-segment shape, which is the point of keeping both alive.
+        const doc = strokeDocument();
+        const samples: Array<[number, number]> = [
+            [0, 0],
+            [0, 4],
+            [0, 5],
+            [149, 0],
+            [151, 0],
+            [-151, 3],
+            [200, 200],
+        ];
+        for (const [x, z] of samples) {
+            expect(documentDistance(x, z, doc)).toBeCloseTo(strokeDistance(x, z), 10);
+        }
+    });
+});
+
+describe("documentDirtyTiles", () => {
+    test("an empty document throws rather than producing a degenerate set", () => {
+        expect(() => documentDirtyTiles({ polylines: [], polygons: [] })).toThrow();
+    });
+
+    test("matches strokeRect/dirtyTiles' original row/column set for strokeDocument()", () => {
+        // the exact set stroke.test.ts's own "strokeRect → dirtyTiles" describe block pins for the
+        // single-arm pattern — documentDirtyTiles must agree now that it's the live path.
+        const ids = new Set(documentDirtyTiles(strokeDocument()));
+        const rows = new Set([...ids].map((id) => Math.floor(id / 16)));
+        expect(rows).toEqual(new Set([7, 8]));
+        const cols = [...ids].map((id) => id % 16);
+        expect(Math.min(...cols)).toBe(5);
+        expect(Math.max(...cols)).toBe(10);
+    });
+});
+
+describe("only-touched-tiles oracle", () => {
+    // a cross of two thin polylines through the origin: a short arm along X (tz row 7/8, the same
+    // straddle strokeDocument's own pattern hits) and a longer arm along Z (tx col 7/8, but spanning many
+    // more tile rows) — the redrawn tile set must be exactly their union: strictly wider than either arm
+    // alone, so this genuinely tests a union, not one arm subsuming the other, and strictly *not* the
+    // single bounding rect over both arms together (which would also mark the empty tiles between them —
+    // documentDirtyTiles.ts's own header comment names this as the bug it avoids).
+    const cross: StrokeDocument = {
+        polylines: [
+            {
+                points: [
+                    [-96, 0],
+                    [96, 0],
+                ],
+                halfWidth: 1,
+            }, // x in [-97,97] -> tx [6,9], tz {7,8}
+            {
+                points: [
+                    [0, -160],
+                    [0, 160],
+                ],
+                halfWidth: 1,
+            }, // z in [-161,161] -> tz [5,10], tx {7,8}
+        ],
+        polygons: [],
+    };
+
+    test("the redrawn tile set is exactly the per-arm union, nothing more", () => {
+        const ids = new Set(documentDirtyTiles(cross));
+        const expected = new Set<number>();
+        for (let tx = 6; tx <= 9; tx++) for (const tz of [7, 8]) expected.add(tz * 16 + tx);
+        for (let tz = 5; tz <= 10; tz++) for (const tx of [7, 8]) expected.add(tz * 16 + tx);
+        expect(expected.size).toBeGreaterThan(8); // a real union, wider than the horizontal arm alone
+        expect(expected.size).toBeGreaterThan(12); // and wider than the vertical arm alone
+        expect(ids).toEqual(expected);
+    });
+
+    test("a tile far from either arm is not in the set", () => {
+        const ids = new Set(documentDirtyTiles(cross));
+        expect(ids.has(0)).toBe(false); // corner tile, nowhere near the cross
+        expect(ids.has(15)).toBe(false);
+    });
+
+    test("a bounding rect over both arms would over-mark a tile neither arm touches — the property the\n     per-primitive union avoids", () => {
+        // tile (tx=9, tz=5): inside the single AABB spanning both arms (x up to 97, z down to -161) but
+        // outside both arms' own footprints (horizontal arm never reaches tz=5; vertical arm never
+        // reaches tx=9). A single-bounding-rect implementation would incorrectly include it.
+        const id = 5 * 16 + 9;
+        expect(documentDirtyTiles(cross)).not.toContain(id);
+    });
+});

--- a/examples/showcase/roads/src/overlay/document.ts
+++ b/examples/showcase/roads/src/overlay/document.ts
@@ -1,0 +1,161 @@
+import { dirtyTiles, type Rect, TEXEL_SIZE } from "./tiles";
+
+// The stroke document: pure data (polylines + width, polygon stamps) plus the CPU analytic distance math
+// stage 5's differential oracle checks the GPU rasterizer (`rasterize.ts`) against. No GPU/engine
+// imports, so `bun test` exercises every formula here without a device (`testing.md`'s logic tier) — the
+// same device-free split `tiles.ts` and `terrain/noise.ts` use.
+//
+// `segmentDistance` below is deliberately a *different* derivation from `rasterize.ts`'s
+// `segmentDistanceGpu`: this one finds the signed perpendicular offset via a 2D cross product once the
+// projection falls strictly between the endpoints, falling back to the nearer endpoint distance outside
+// that range; `rasterize.ts`'s GPU form instead clamps the projection parameter `t` to [0, 1] and always
+// measures straight-line distance to the clamped point. Same geometric quantity, two independently
+// written code paths — `checks.md`'s rule that an agreement check between two things written from one
+// source tests self-consistency, not correctness.
+
+/** one road-width centreline — consecutive points define its segments, `halfWidth` is constant along its
+ *  whole length (a real network's per-segment width variation is out of this stage's scope). */
+export interface Polyline {
+    readonly points: ReadonlyArray<readonly [number, number]>;
+    readonly halfWidth: number;
+}
+
+/** a filled area stamp (a carpark, a plaza) — its boundary is the polygon edge, no width parameter. */
+export interface PolygonStamp {
+    readonly points: ReadonlyArray<readonly [number, number]>;
+}
+
+/** the rasterizer's whole input: every polyline stroke plus every polygon stamp for one redraw. */
+export interface StrokeDocument {
+    readonly polylines: readonly Polyline[];
+    readonly polygons: readonly PolygonStamp[];
+}
+
+/** one polyline segment, flattened to its own endpoints + width — the unit both the CPU oracle and the
+ *  GPU kernel's per-primitive distance function operate on. */
+export interface Segment {
+    readonly ax: number;
+    readonly az: number;
+    readonly bx: number;
+    readonly bz: number;
+    readonly halfWidth: number;
+}
+
+/** every polyline in `doc`, flattened to its consecutive-point segments — pure data marshaling (not
+ *  distance math), shared by the CPU oracle and the GPU buffer packer alike; sharing this step doesn't
+ *  weaken the differential, since the two sides only diverge in how they measure distance to a segment,
+ *  not in which segments exist. */
+export function flattenSegments(doc: StrokeDocument): Segment[] {
+    const out: Segment[] = [];
+    for (const line of doc.polylines) {
+        for (let i = 0; i < line.points.length - 1; i++) {
+            const [ax, az] = line.points[i];
+            const [bx, bz] = line.points[i + 1];
+            out.push({ ax, az, bx, bz, halfWidth: line.halfWidth });
+        }
+    }
+    return out;
+}
+
+/** signed distance in world metres from (px, pz) to one segment's road edge — negative inside,
+ *  zero at the boundary. Perpendicular-offset-via-cross-product once the projection lands strictly
+ *  between the endpoints, nearer-endpoint distance otherwise — see the module header for why this is a
+ *  different derivation from `rasterize.ts`'s clamped-projection form. */
+export function segmentDistance(px: number, pz: number, seg: Segment): number {
+    const { ax, az, bx, bz, halfWidth } = seg;
+    const abx = bx - ax;
+    const abz = bz - az;
+    const len = Math.hypot(abx, abz);
+    if (len === 0) return Math.hypot(px - ax, pz - az) - halfWidth;
+    const ux = abx / len;
+    const uz = abz / len;
+    const along = (px - ax) * ux + (pz - az) * uz; // signed distance along the segment from A
+    if (along <= 0) return Math.hypot(px - ax, pz - az) - halfWidth;
+    if (along >= len) return Math.hypot(px - bx, pz - bz) - halfWidth;
+    const cross = (px - ax) * uz - (pz - az) * ux; // signed perpendicular offset (2D cross product)
+    return Math.abs(cross) - halfWidth;
+}
+
+/** signed distance in world metres from (px, pz) to a polygon stamp's boundary — negative inside (a
+ *  ray-cast winding test), magnitude the nearest edge distance (each edge a zero-width segment). */
+export function polygonDistance(px: number, pz: number, poly: PolygonStamp): number {
+    const pts = poly.points;
+    let inside = false;
+    let nearestEdge = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < pts.length; i++) {
+        const [ax, az] = pts[i];
+        const [bx, bz] = pts[(i + 1) % pts.length];
+        // standard ray-cast: does the horizontal ray from (px, pz) cross edge (a, b)?
+        if (az > pz !== bz > pz) {
+            const xCross = ax + ((pz - az) / (bz - az)) * (bx - ax);
+            if (px < xCross) inside = !inside;
+        }
+        const edge = segmentDistance(px, pz, { ax, az, bx, bz, halfWidth: 0 });
+        if (edge < nearestEdge) nearestEdge = edge;
+    }
+    return inside ? -nearestEdge : nearestEdge;
+}
+
+/** the document's analytic distance at (px, pz) — the minimum (nearest, most-inside) signed distance
+ *  over every segment and polygon. The CPU half of stage 5's differential oracle. */
+export function documentDistance(px: number, pz: number, doc: StrokeDocument): number {
+    let best = Number.POSITIVE_INFINITY;
+    for (const seg of flattenSegments(doc)) {
+        const d = segmentDistance(px, pz, seg);
+        if (d < best) best = d;
+    }
+    for (const poly of doc.polygons) {
+        const d = polygonDistance(px, pz, poly);
+        if (d < best) best = d;
+    }
+    return best;
+}
+
+const MARGIN = TEXEL_SIZE; // the one-texel margin `stroke.ts`'s `strokeRect` used, so the fwidth-
+// antialiased edge (terrain.ts's fs) never samples a texel this document didn't write.
+
+/** one segment's world-space AABB, expanded by its half-width plus {@link MARGIN}. */
+function segmentRect(seg: Segment): Rect {
+    return {
+        minX: Math.min(seg.ax, seg.bx) - seg.halfWidth - MARGIN,
+        maxX: Math.max(seg.ax, seg.bx) + seg.halfWidth + MARGIN,
+        minZ: Math.min(seg.az, seg.bz) - seg.halfWidth - MARGIN,
+        maxZ: Math.max(seg.az, seg.bz) + seg.halfWidth + MARGIN,
+    };
+}
+
+/** one polygon's point AABB, plus {@link MARGIN}. */
+function polygonRect(poly: PolygonStamp): Rect {
+    let minX = Number.POSITIVE_INFINITY;
+    let minZ = Number.POSITIVE_INFINITY;
+    let maxX = Number.NEGATIVE_INFINITY;
+    let maxZ = Number.NEGATIVE_INFINITY;
+    for (const [x, z] of poly.points) {
+        minX = Math.min(minX, x);
+        maxX = Math.max(maxX, x);
+        minZ = Math.min(minZ, z);
+        maxZ = Math.max(maxZ, z);
+    }
+    return { minX: minX - MARGIN, maxX: maxX + MARGIN, minZ: minZ - MARGIN, maxZ: maxZ + MARGIN };
+}
+
+/**
+ * the document's exact dirty-tile set: the union, over every segment and every polygon *individually*, of
+ * `dirtyTiles` on that one primitive's own AABB (`tiles.ts`). Deliberately not one bounding rect over the
+ * whole document — two primitives far apart would otherwise mark every tile *between* them too, which is
+ * exactly the over-approximation the spec's "only-touched-tiles oracle" (assert the redrawn set equals
+ * the analytic set, not the visual) rules out. Sorted ascending by tile id, de-duplicated. Empty
+ * documents throw — an empty edit (`markDirty` on nothing) is a caller bug, not a valid zero-tile mark.
+ */
+export function documentDirtyTiles(doc: StrokeDocument): number[] {
+    const ids = new Set<number>();
+    for (const seg of flattenSegments(doc))
+        for (const id of dirtyTiles(segmentRect(seg))) ids.add(id);
+    for (const poly of doc.polygons) for (const id of dirtyTiles(polygonRect(poly))) ids.add(id);
+    if (ids.size === 0) {
+        throw new Error(
+            "documentDirtyTiles: an empty document (no polylines or polygons) touches no tile",
+        );
+    }
+    return [...ids].sort((a, b) => a - b);
+}

--- a/examples/showcase/roads/src/overlay/rasterize.test.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import { body, flat, integerDiscipline } from "../../../../../packages/shallot/tests/wgsl";
+import {
+    documentDistance,
+    flattenSegments,
+    type Segment,
+    type StrokeDocument,
+    segmentDistance,
+} from "./document";
+import { encodeDistGpu, rasterizeWgsl, segmentDistanceGpu } from "./rasterize";
+import { DIST_RANGE, decodeDist } from "./tiles";
+
+// Stage 5's differential oracle: `segmentDistanceGpu` (rasterize.ts, clamped-projection form, CPU-called
+// through TypeGPU's dual execution — testing.md's logic tier) against `document.ts`'s `segmentDistance`
+// (perpendicular-offset-via-cross-product form) — two independently written derivations of the same
+// geometric quantity (checks.md). The GPU side is additionally quantized through `encodeDistGpu` +
+// `tiles.ts`'s `decodeDist`, the exact byte round-trip the real kernel's output goes through, so the
+// tolerance is the r8unorm quantization step the spec's Approach names, not a raw-float tolerance.
+const QUANT_STEP = (2 * DIST_RANGE) / 255;
+const TOLERANCE = QUANT_STEP / 2 + 1e-6; // half a quantization step, plus f32-roundoff slack
+
+function mulberry32(seed: number): () => number {
+    let s = seed >>> 0;
+    return () => {
+        s = (s + 0x6d2b79f5) | 0;
+        let t = s;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+describe("differential oracle — segmentDistanceGpu vs document.ts's segmentDistance", () => {
+    test("agree within one quantization step over random segments and sample points", () => {
+        const rng = mulberry32(7);
+        const rand = (lo: number, hi: number) => lo + rng() * (hi - lo);
+        for (let i = 0; i < 200; i++) {
+            const seg: Segment = {
+                ax: rand(-100, 100),
+                az: rand(-100, 100),
+                bx: rand(-100, 100),
+                bz: rand(-100, 100),
+                halfWidth: rand(0.5, 8),
+            };
+            const px = rand(-120, 120);
+            const pz = rand(-120, 120);
+
+            const cpu = segmentDistance(px, pz, seg);
+            const gpuRaw = segmentDistanceGpu(
+                px,
+                pz,
+                seg.ax,
+                seg.az,
+                seg.bx,
+                seg.bz,
+                seg.halfWidth,
+            );
+            const gpuQuantized = decodeDist(encodeDistGpu(gpuRaw));
+            const cpuQuantized = decodeDist(
+                Math.round(
+                    (Math.max(-DIST_RANGE, Math.min(DIST_RANGE, cpu)) / (2 * DIST_RANGE) + 0.5) *
+                        255,
+                ),
+            );
+            expect(Math.abs(gpuQuantized - cpuQuantized)).toBeLessThanOrEqual(TOLERANCE);
+            // and the raw (unquantized) forms agree far tighter — same geometric quantity, f32 roundoff only
+            expect(Math.abs(gpuRaw - cpu)).toBeLessThan(1e-4);
+        }
+    });
+
+    test("a multi-segment reduction over segmentDistanceGpu agrees with documentDistance", () => {
+        // documentDistanceGpu itself reads its segments out of a bound storage buffer
+        // (rasterLayout.$.segments), so it can't be CPU-called without a device (testing.md: "never bind a
+        // device in bun test") — the kernel's reduction loop is instead pinned structurally below
+        // ("emitted WGSL"). This exercises the same reduction (min over every segment's
+        // segmentDistanceGpu) in plain JS, over the same per-primitive kernel math the earlier test
+        // already validated CPU-side.
+        const doc: StrokeDocument = {
+            polylines: [
+                {
+                    points: [
+                        [-50, 0],
+                        [50, 0],
+                    ],
+                    halfWidth: 3,
+                },
+                {
+                    points: [
+                        [0, -50],
+                        [0, 50],
+                    ],
+                    halfWidth: 2,
+                },
+            ],
+            polygons: [],
+        };
+        const samples: Array<[number, number]> = [
+            [0, 0],
+            [10, 10],
+            [-30, 5],
+            [40, 40],
+        ];
+        for (const [px, pz] of samples) {
+            const cpu = documentDistance(px, pz, doc);
+            let gpu = Number.POSITIVE_INFINITY;
+            for (const seg of flattenSegments(doc)) {
+                const d = segmentDistanceGpu(px, pz, seg.ax, seg.az, seg.bx, seg.bz, seg.halfWidth);
+                if (d < gpu) gpu = d;
+            }
+            expect(Math.abs(gpu - cpu)).toBeLessThan(1e-4);
+        }
+    });
+});
+
+describe("determinism", () => {
+    test("segmentDistanceGpu is a pure function of its inputs — repeated calls agree exactly", () => {
+        const a = segmentDistanceGpu(5, 3, -10, 0, 10, 0, 2);
+        const b = segmentDistanceGpu(5, 3, -10, 0, 10, 0, 2);
+        expect(a).toBe(b);
+    });
+
+    test("encodeDistGpu is deterministic and matches tiles.ts's encodeDist within one f32 rounding ULP", () => {
+        for (const m of [-1, -0.5, 0, 0.3333, 0.9, 1]) {
+            const a = encodeDistGpu(m);
+            const b = encodeDistGpu(m);
+            expect(a).toBe(b);
+        }
+    });
+});
+
+describe("emitted WGSL — structural", () => {
+    const wgsl = rasterizeWgsl();
+
+    test("segmentDistanceGpu clamps the projection parameter to [0, 1]", () => {
+        const fn = flat(body(wgsl, "fn segmentDistanceGpu"));
+        expect(fn).toContain("clamp(");
+        expect(fn).toContain("distance(");
+    });
+
+    test("the rasterize kernel dispatches 128×512 threads (GROUPS_PER_SIDE × TILE_RES) at workgroup 8×8", () => {
+        const kernel = flat(body(wgsl, "@compute @workgroup_size(8, 8, 1) fn roadsrasterize"));
+        expect(kernel).toContain("gx >= 128u");
+        expect(kernel).toContain("gy >= 512u");
+    });
+
+    test("every index computation stays unsigned (integerDiscipline)", () => {
+        integerDiscipline(wgsl);
+    });
+
+    test("the kernel packs 4 texels' distance bytes little-endian into one u32", () => {
+        const kernel = flat(body(wgsl, "@compute @workgroup_size(8, 8, 1) fn roadsrasterize"));
+        expect(kernel).toContain("word = (word | (byte << (k * 8u)))");
+    });
+
+    test("albedo is written once per texel with the precomputed constant word, not recomputed per-thread", () => {
+        expect(flat(wgsl)).toContain("const roadAlbedoWord: u32 =");
+        const kernel = flat(body(wgsl, "@compute @workgroup_size(8, 8, 1) fn roadsrasterize"));
+        expect(kernel).toContain("albedoOut[albedoIdx] = roadAlbedoWord");
+    });
+});

--- a/examples/showcase/roads/src/overlay/rasterize.test.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.test.ts
@@ -3,12 +3,19 @@ import { body, flat, integerDiscipline } from "../../../../../packages/shallot/t
 import {
     documentDistance,
     flattenSegments,
+    type PolygonStamp,
+    polygonDistance,
     type Segment,
     type StrokeDocument,
     segmentDistance,
 } from "./document";
-import { encodeDistGpu, rasterizeWgsl, segmentDistanceGpu } from "./rasterize";
-import { DIST_RANGE, decodeDist } from "./tiles";
+import {
+    encodeDistGpu,
+    polygonSignedDistanceGpu,
+    rasterizeWgsl,
+    segmentDistanceGpu,
+} from "./rasterize";
+import { DIST_RANGE, decodeDist, encodeDist, TEXEL_SIZE } from "./tiles";
 
 // Stage 5's differential oracle: `segmentDistanceGpu` (rasterize.ts, clamped-projection form, CPU-called
 // through TypeGPU's dual execution — testing.md's logic tier) against `document.ts`'s `segmentDistance`
@@ -18,6 +25,16 @@ import { DIST_RANGE, decodeDist } from "./tiles";
 // tolerance is the r8unorm quantization step the spec's Approach names, not a raw-float tolerance.
 const QUANT_STEP = (2 * DIST_RANGE) / 255;
 const TOLERANCE = QUANT_STEP / 2 + 1e-6; // half a quantization step, plus f32-roundoff slack
+
+/** the same CPU-side r8unorm quantization `encodeDist`/`encodeDistGpu` both perform, inlined once here
+ *  so both differential oracles (segment, polygon) key off one derivation rather than two copies. */
+function quantizeCpu(metres: number): number {
+    return decodeDist(
+        Math.round(
+            (Math.max(-DIST_RANGE, Math.min(DIST_RANGE, metres)) / (2 * DIST_RANGE) + 0.5) * 255,
+        ),
+    );
+}
 
 function mulberry32(seed: number): () => number {
     let s = seed >>> 0;
@@ -56,25 +73,23 @@ describe("differential oracle — segmentDistanceGpu vs document.ts's segmentDis
                 seg.halfWidth,
             );
             const gpuQuantized = decodeDist(encodeDistGpu(gpuRaw));
-            const cpuQuantized = decodeDist(
-                Math.round(
-                    (Math.max(-DIST_RANGE, Math.min(DIST_RANGE, cpu)) / (2 * DIST_RANGE) + 0.5) *
-                        255,
-                ),
-            );
+            const cpuQuantized = quantizeCpu(cpu);
             expect(Math.abs(gpuQuantized - cpuQuantized)).toBeLessThanOrEqual(TOLERANCE);
             // and the raw (unquantized) forms agree far tighter — same geometric quantity, f32 roundoff only
             expect(Math.abs(gpuRaw - cpu)).toBeLessThan(1e-4);
         }
     });
 
-    test("a multi-segment reduction over segmentDistanceGpu agrees with documentDistance", () => {
-        // documentDistanceGpu itself reads its segments out of a bound storage buffer
-        // (rasterLayout.$.segments), so it can't be CPU-called without a device (testing.md: "never bind a
-        // device in bun test") — the kernel's reduction loop is instead pinned structurally below
-        // ("emitted WGSL"). This exercises the same reduction (min over every segment's
-        // segmentDistanceGpu) in plain JS, over the same per-primitive kernel math the earlier test
-        // already validated CPU-side.
+    test("a multi-primitive (segments + polygons) reduction agrees with documentDistance", () => {
+        // documentDistanceGpu itself reads its segments/polygons out of bound storage buffers
+        // (rasterLayout.$.segments / .polygons / .polyVerts), so it can't be CPU-called without a device
+        // (testing.md: "never bind a device in bun test") — the kernel's reduction loop is instead pinned
+        // structurally below ("emitted WGSL"). This exercises the same reduction (min over every segment's
+        // segmentDistanceGpu AND every polygon's winding+edge reduction) in plain JS, over the same
+        // per-primitive kernel math the earlier tests already validated CPU-side — and, unlike the
+        // segment-only reduction this replaces, carries a non-empty `polygons` array so
+        // `documentDistanceGpu`'s polygon arm is exercised by more than the empty-array default every
+        // other test in this file used.
         const doc: StrokeDocument = {
             polylines: [
                 {
@@ -92,13 +107,24 @@ describe("differential oracle — segmentDistanceGpu vs document.ts's segmentDis
                     halfWidth: 2,
                 },
             ],
-            polygons: [],
+            polygons: [
+                {
+                    points: [
+                        [20, 20],
+                        [35, 20],
+                        [35, 32],
+                        [20, 32],
+                    ],
+                },
+            ],
         };
         const samples: Array<[number, number]> = [
             [0, 0],
             [10, 10],
             [-30, 5],
             [40, 40],
+            [27, 26], // inside the polygon stamp
+            [27, 40], // outside every primitive, nearest the polygon
         ];
         for (const [px, pz] of samples) {
             const cpu = documentDistance(px, pz, doc);
@@ -107,8 +133,86 @@ describe("differential oracle — segmentDistanceGpu vs document.ts's segmentDis
                 const d = segmentDistanceGpu(px, pz, seg.ax, seg.az, seg.bx, seg.bz, seg.halfWidth);
                 if (d < gpu) gpu = d;
             }
+            for (const poly of doc.polygons) {
+                const d = jsPolygonSignedDistance(px, pz, poly.points);
+                if (d < gpu) gpu = d;
+            }
             expect(Math.abs(gpu - cpu)).toBeLessThan(1e-4);
         }
+    });
+});
+
+/**
+ * plain-JS mirror of `polygonDistanceGpu`'s winding + nearest-edge reduction — over `segmentDistanceGpu`
+ * (the same CPU-callable primitive the real reduction calls per edge, `checks.md`'s independent-derivation
+ * rule), finishing with the real, exported `polygonSignedDistanceGpu` for the sign. The reduction loop
+ * (winding parity, nearest-edge min) is a JS reimplementation — like `segmentsDistanceGpu`'s reduction
+ * above, it reads a bound storage array GPU-side and can't be CPU-called directly — but the sign
+ * convention itself, the exact axis a flipped `select` breaks, calls the real kernel code, not a copy.
+ */
+function jsPolygonSignedDistance(
+    px: number,
+    pz: number,
+    pts: ReadonlyArray<readonly [number, number]>,
+): number {
+    let inside = false;
+    let nearestEdge = Number.POSITIVE_INFINITY;
+    for (let i = 0; i < pts.length; i++) {
+        const [ax, az] = pts[i];
+        const [bx, bz] = pts[(i + 1) % pts.length];
+        if (az > pz !== bz > pz) {
+            const xCross = ax + ((pz - az) / (bz - az)) * (bx - ax);
+            if (px < xCross) inside = !inside;
+        }
+        const edge = segmentDistanceGpu(px, pz, ax, az, bx, bz, 0);
+        if (edge < nearestEdge) nearestEdge = edge;
+    }
+    return polygonSignedDistanceGpu(nearestEdge, inside);
+}
+
+describe("differential oracle — polygonDistanceGpu's sign convention vs document.ts's polygonDistance", () => {
+    test("agree within one quantization step over random polygons and sample points", () => {
+        const rng = mulberry32(11);
+        const rand = (lo: number, hi: number) => lo + rng() * (hi - lo);
+        for (let i = 0; i < 150; i++) {
+            const n = 3 + Math.floor(rng() * 5); // 3..7 vertices, roughly convex
+            const cx = rand(-50, 50);
+            const cz = rand(-50, 50);
+            const r = rand(3, 20);
+            const pts: Array<[number, number]> = [];
+            for (let v = 0; v < n; v++) {
+                const a = (v / n) * Math.PI * 2 + rand(-0.2, 0.2);
+                pts.push([cx + Math.cos(a) * r, cz + Math.sin(a) * r]);
+            }
+            const poly: PolygonStamp = { points: pts };
+            const px = rand(-70, 70);
+            const pz = rand(-70, 70);
+
+            const cpu = polygonDistance(px, pz, poly);
+            const gpuRaw = jsPolygonSignedDistance(px, pz, pts);
+            const gpuQuantized = decodeDist(encodeDistGpu(gpuRaw));
+            const cpuQuantized = quantizeCpu(cpu);
+            expect(Math.abs(gpuQuantized - cpuQuantized)).toBeLessThanOrEqual(TOLERANCE);
+            // and the raw (unquantized) forms agree far tighter — same geometric quantity, f32 roundoff only
+            expect(Math.abs(gpuRaw - cpu)).toBeLessThan(1e-4);
+        }
+    });
+
+    test("the sign flips exactly at the boundary: a point moved just inside/outside a square flips sign", () => {
+        const square: Array<[number, number]> = [
+            [-10, -10],
+            [10, -10],
+            [10, 10],
+            [-10, 10],
+        ];
+        const inside = jsPolygonSignedDistance(0, 0, square);
+        const outside = jsPolygonSignedDistance(20, 20, square);
+        expect(inside).toBeLessThan(0);
+        expect(outside).toBeGreaterThan(0);
+        // demonstrated mutation this pins: swapping polygonSignedDistanceGpu's select args would make
+        // `inside` positive and `outside` negative — both assertions above would fail.
+        expect(polygonSignedDistanceGpu(5, false)).toBe(5);
+        expect(polygonSignedDistanceGpu(5, true)).toBe(-5);
     });
 });
 
@@ -119,11 +223,14 @@ describe("determinism", () => {
         expect(a).toBe(b);
     });
 
-    test("encodeDistGpu is deterministic and matches tiles.ts's encodeDist within one f32 rounding ULP", () => {
+    test("encodeDistGpu matches tiles.ts's real encodeDist within one f32 rounding ULP", () => {
+        // the earlier title claimed this comparison without importing or calling tiles.ts's encodeDist —
+        // fixed by actually calling it: the two codecs (TGSL f32 vs plain JS f64) round the same unit
+        // fraction to a byte, so they can differ by at most one rounding step at a bin edge.
         for (const m of [-1, -0.5, 0, 0.3333, 0.9, 1]) {
-            const a = encodeDistGpu(m);
-            const b = encodeDistGpu(m);
-            expect(a).toBe(b);
+            const gpu = encodeDistGpu(m);
+            const cpu = encodeDist(m);
+            expect(Math.abs(gpu - cpu)).toBeLessThanOrEqual(1);
         }
     });
 });
@@ -156,5 +263,91 @@ describe("emitted WGSL — structural", () => {
         expect(flat(wgsl)).toContain("const roadAlbedoWord: u32 =");
         const kernel = flat(body(wgsl, "@compute @workgroup_size(8, 8, 1) fn roadsrasterize"));
         expect(kernel).toContain("albedoOut[albedoIdx] = roadAlbedoWord");
+    });
+
+    describe("texel-group column ↔ world-x ↔ byte-column correspondence", () => {
+        // The `toContain` checks above pin the *shift* (`k * 8u`) — which byte column `k` lands in — but
+        // not which texel `k` actually reads its distance from. A horizontal mirror within the 4-texel
+        // group (`texelX = gx*4 + (3-k)` instead of `gx*4 + k`) leaves every existing structural check
+        // textually unchanged, since it touches neither the packing shift nor the dispatch bounds. Pin it
+        // behaviorally instead: pull the *actual* emitted `texelX`/`worldX` formulas out of the resolved
+        // WGSL and evaluate them for concrete (gx, k) pairs, against an independent hand computation —
+        // gx*GROUP_TEXELS+k for texelX, origin + (texelX+0.5)*TEXEL_SIZE for worldX — so a mutated
+        // formula evaluates to the wrong number here even though it satisfies a bare string match.
+        const kernel = flat(body(wgsl, "@compute @workgroup_size(8, 8, 1) fn roadsrasterize"));
+        const GroupTexels = 4; // rasterize.ts's own module constant — not exported, restated here as
+        // the spec-given "4 x r8 = one u32" fact the module header names, not copied from the source
+
+        /** the RHS expression of `let {name} = <expr>;` in `src`, matched by paren-depth rather than a
+         *  fixed-shape regex — robust to the emitted expression's exact parenthesization. */
+        function extractExpr(src: string, name: string): string {
+            const marker = `let ${name} = `;
+            const start = src.indexOf(marker);
+            expect(start).toBeGreaterThanOrEqual(0);
+            let i = start + marker.length;
+            let depth = 0;
+            const exprStart = i;
+            for (; i < src.length; i++) {
+                const c = src[i];
+                if (c === "(") depth++;
+                else if (c === ")") depth--;
+                else if (c === ";" && depth === 0) break;
+            }
+            return src.slice(exprStart, i);
+        }
+
+        /** evaluate a small WGSL arithmetic expression as JS — strips `u`/`f` numeric suffixes and
+         *  substitutes bare identifiers, then runs it through the JS arithmetic parser via `Function`. The
+         *  expression comes straight out of the resolved WGSL, so this evaluates the kernel's *actual*
+         *  current formula, not an assumption about its shape. */
+        function evalWgslExpr(expr: string, vars: Record<string, number>): number {
+            let js = expr.replace(/(\d+(?:\.\d+)?)[uf]\b/g, "$1");
+            for (const [name, value] of Object.entries(vars)) {
+                js = js.replace(new RegExp(`\\b${name}\\b`, "g"), String(value));
+            }
+            return Function(`"use strict"; return (${js});`)();
+        }
+
+        const texelXExpr = extractExpr(kernel, "texelX");
+        const worldXExpr = extractExpr(kernel, "worldX");
+
+        test("texelX(gx, k) === gx*GROUP_TEXELS + k for every (gx, k), independently hand-computed", () => {
+            for (const gx of [0, 1, 5, 31, 64, 127]) {
+                for (let k = 0; k < GroupTexels; k++) {
+                    const actual = evalWgslExpr(texelXExpr, { gx, k });
+                    expect(actual).toBe(gx * GroupTexels + k);
+                }
+            }
+        });
+
+        test("texelX is strictly increasing in k within one group (rules out any within-group reorder)", () => {
+            for (const gx of [0, 3, 64]) {
+                let prev = Number.NEGATIVE_INFINITY;
+                for (let k = 0; k < GroupTexels; k++) {
+                    const x = evalWgslExpr(texelXExpr, { gx, k });
+                    expect(x).toBeGreaterThan(prev);
+                    prev = x;
+                }
+            }
+        });
+
+        test("worldX(texelX) === origin.x + (texelX + 0.5) * TEXEL_SIZE, chained from the real texelX formula", () => {
+            const origin = { x: -37.5 }; // an arbitrary non-zero tile origin — catches an origin-ignoring bug
+            for (const gx of [0, 7, 96]) {
+                for (let k = 0; k < GroupTexels; k++) {
+                    const texelX = evalWgslExpr(texelXExpr, { gx, k });
+                    const worldExpr = worldXExpr
+                        .replace(/\(\*origin\)\.x/g, String(origin.x))
+                        .replace(/f32\(texelX\)/g, String(texelX));
+                    const actual = evalWgslExpr(worldExpr, {});
+                    const expected = origin.x + (texelX + 0.5) * TEXEL_SIZE;
+                    expect(actual).toBeCloseTo(expected, 9);
+                }
+            }
+        });
+
+        test("the packing expression itself (a cheap structural sentinel, in addition to the eval-based pins above — never the only one, checks.md)", () => {
+            expect(kernel).toContain("let texelX = ((gx * 4u) + k);");
+        });
     });
 });

--- a/examples/showcase/roads/src/overlay/rasterize.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.ts
@@ -93,10 +93,26 @@ const segmentsDistanceGpu = tgpu.fn(
     return best;
 });
 
+/** apply the inside/outside sign convention to a polygon's nearest-edge distance — negative inside,
+ *  positive outside, `inside` decided by ray-cast winding. Factored out of `polygonDistanceGpu` as its
+ *  own pure fn (`checks.md`'s "factor inward") purely so it's CPU-callable with no bound storage:
+ *  `polygonDistanceGpu`'s enclosing reduction reads the shared `polyVerts` buffer and can only run
+ *  inside a real dispatch, but the sign convention itself takes no storage — stage 5's differential
+ *  oracle calls this directly to pin the sign, the exact axis a flipped `select` breaks.
+ * @example polygonSignedDistanceGpu(3, false) // 3 — outside, magnitude unchanged
+ * @example polygonSignedDistanceGpu(3, true) // -3 — inside, negated */
+export const polygonSignedDistanceGpu = tgpu.fn(
+    [d.f32, d.bool],
+    d.f32,
+)((nearestEdge, inside) => {
+    "use gpu";
+    return std.select(nearestEdge, -nearestEdge, inside);
+});
+
 /** one polygon stamp's signed distance at (px, pz) — ray-cast winding for the sign, nearest zero-width
  *  edge distance for the magnitude, reading `poly`'s span out of the shared `polyVerts` buffer. The GPU
  *  twin of `document.ts`'s `polygonDistance`, same construction, independently written GPU-side. */
-const polygonDistanceGpu = tgpu.fn(
+export const polygonDistanceGpu = tgpu.fn(
     [d.f32, d.f32, GpuPolygon],
     d.f32,
 )((px, pz, poly) => {
@@ -114,7 +130,7 @@ const polygonDistanceGpu = tgpu.fn(
         const edge = segmentDistanceGpu(px, pz, a.x, a.y, b.x, b.y, 0);
         if (edge < nearestEdge) nearestEdge = edge;
     }
-    return std.select(nearestEdge, -nearestEdge, inside);
+    return polygonSignedDistanceGpu(nearestEdge, inside);
 });
 
 /** the document's full distance at (px, pz) — the minimum over every segment and every polygon stamp,

--- a/examples/showcase/roads/src/overlay/rasterize.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.ts
@@ -1,0 +1,362 @@
+// The GPU rasterizer: a TGSL compute pass that writes one dirty tile's albedo + boundary-distance content
+// directly from a `StrokeDocument` (`document.ts`) — the real producer `atlas.ts`'s `redraw` calls per
+// drained tile, replacing stage 4's CPU `TilePacker` (`stroke.ts`'s `packStrokeTile`, now a CPU reference
+// kept for its own tests and the cross-check in `document.test.ts`, no longer the live path).
+//
+// Why a storage *buffer*, not `texture_storage_2d<r8unorm, write>`: WebGPU's storage-texture write
+// capability is restricted to a fixed format list (rgba8unorm, the r32/rg32/rgba32 family, rgba16float,
+// …) that does not include r8unorm — `tiles.ts`'s DIST_FORMAT, chosen in stage 4 to spend every
+// quantization step where the fwidth threshold samples. `textureStore` into it would fail pipeline
+// validation. The fix keeps r8unorm as the atlas's sampled format and moves the packing into the kernel
+// itself: one thread per 4-texel group computes all 4 texels' distance, quantizes each to a byte
+// (`encodeDistGpu`, `tiles.ts`'s `encodeDist` reimplemented in TGSL — no shared source, but the same
+// codec `terrain.ts`'s fs decodes), and packs them little-endian into one `u32` — no two threads ever
+// write the same output word, so no atomics. Albedo is rgba8unorm, which *is* storage-writable, but the
+// same one-thread-owns-one-word shape (one thread emits 4 texels' worth of `u32`s) keeps both channels on
+// one dispatch. `encoder.copyBufferToTexture` then moves both packed buffers into the atlas array layer —
+// a GPU-side command, not a CPU readback, so `redraw`'s per-frame throttle stays synchronous exactly as
+// stage 4 left it (`queue.ts`'s `drain`/`allocate` are untouched).
+
+import { Compute, type State } from "@dylanebert/shallot";
+import tgpu from "typegpu";
+import * as d from "typegpu/data";
+import * as std from "typegpu/std";
+import { flattenSegments, type StrokeDocument } from "./document";
+import { ROAD_ALBEDO } from "./stroke";
+import { DIST_RANGE, TEXEL_SIZE, TILE_RES, tileOrigin } from "./tiles";
+
+const GROUP_TEXELS = 4; // texels packed per output distance/index word (4 × r8 = one u32, little-endian)
+const GROUPS_PER_SIDE = TILE_RES / GROUP_TEXELS; // 128 — TILE_RES is a multiple of 4 by construction
+
+const WG = 8;
+const DISPATCH = { x: Math.ceil(GROUPS_PER_SIDE / WG), y: Math.ceil(TILE_RES / WG) };
+
+/** one flattened polyline segment, GPU-side: two endpoints + half-width. */
+const GpuSegment = d.struct({ a: d.vec2f, b: d.vec2f, halfWidth: d.f32 });
+
+/** one polygon stamp's vertex span within the shared `polyVerts` buffer. */
+const GpuPolygon = d.struct({ start: d.u32, count: d.u32 });
+
+const RasterParams = d.struct({
+    tileOrigin: d.vec2f,
+    segmentCount: d.u32,
+    polygonCount: d.u32,
+});
+
+const rasterLayout = tgpu.bindGroupLayout({
+    segments: { storage: d.arrayOf(GpuSegment), access: "readonly" },
+    polygons: { storage: d.arrayOf(GpuPolygon), access: "readonly" },
+    polyVerts: { storage: d.arrayOf(d.vec2f), access: "readonly" },
+    params: { uniform: RasterParams },
+    albedoOut: { storage: d.arrayOf(d.u32), access: "mutable" },
+    distOut: { storage: d.arrayOf(d.u32), access: "mutable" },
+});
+
+/**
+ * point-segment signed distance (minus half-width), the compute kernel's own derivation: clamp the
+ * projection parameter `t` onto [0, 1], measure straight-line distance to the clamped point. CPU-callable
+ * (`testing.md`'s logic tier) so `bun test` exercises this exact math with no device — the GPU half of
+ * stage 5's differential oracle against `document.ts`'s independently-derived `segmentDistance`.
+ * @example segmentDistanceGpu(5, 0, -10, 0, 10, 0, 2) // -2 (on the centreline, inside a 2 m half-width)
+ */
+export const segmentDistanceGpu = tgpu.fn(
+    [d.f32, d.f32, d.f32, d.f32, d.f32, d.f32, d.f32],
+    d.f32,
+)((px, pz, ax, az, bx, bz, halfWidth) => {
+    "use gpu";
+    const abx = bx - ax;
+    const abz = bz - az;
+    const apx = px - ax;
+    const apz = pz - az;
+    const dd = abx * abx + abz * abz;
+    let t = d.f32(0);
+    if (dd > 0) t = std.clamp((apx * abx + apz * abz) / dd, 0, 1);
+    const cx = ax + t * abx;
+    const cz = az + t * abz;
+    return std.distance(d.vec2f(px, pz), d.vec2f(cx, cz)) - halfWidth;
+});
+
+/** the document's segment-only distance at (px, pz) — loops `rasterLayout.$.segments` up to
+ *  `params.segmentCount`, the GPU-side twin of `document.ts`'s `flattenSegments` + minimum. */
+const segmentsDistanceGpu = tgpu.fn(
+    [d.f32, d.f32],
+    d.f32,
+)((px, pz) => {
+    "use gpu";
+    let best = d.f32(3.402823e38); // f32 max — no segment yet
+    let i = d.u32(0);
+    for (; i < rasterLayout.$.params.segmentCount; i = i + d.u32(1)) {
+        const seg = rasterLayout.$.segments[i];
+        const dist = segmentDistanceGpu(px, pz, seg.a.x, seg.a.y, seg.b.x, seg.b.y, seg.halfWidth);
+        if (dist < best) best = dist;
+    }
+    return best;
+});
+
+/** one polygon stamp's signed distance at (px, pz) — ray-cast winding for the sign, nearest zero-width
+ *  edge distance for the magnitude, reading `poly`'s span out of the shared `polyVerts` buffer. The GPU
+ *  twin of `document.ts`'s `polygonDistance`, same construction, independently written GPU-side. */
+const polygonDistanceGpu = tgpu.fn(
+    [d.f32, d.f32, GpuPolygon],
+    d.f32,
+)((px, pz, poly) => {
+    "use gpu";
+    let inside = false;
+    let nearestEdge = d.f32(3.402823e38);
+    let i = d.u32(0);
+    for (; i < poly.count; i = i + d.u32(1)) {
+        const a = rasterLayout.$.polyVerts[poly.start + i];
+        const b = rasterLayout.$.polyVerts[poly.start + ((i + d.u32(1)) % poly.count)];
+        if (a.y > pz !== b.y > pz) {
+            const xCross = a.x + ((pz - a.y) / (b.y - a.y)) * (b.x - a.x);
+            if (px < xCross) inside = !inside;
+        }
+        const edge = segmentDistanceGpu(px, pz, a.x, a.y, b.x, b.y, 0);
+        if (edge < nearestEdge) nearestEdge = edge;
+    }
+    return std.select(nearestEdge, -nearestEdge, inside);
+});
+
+/** the document's full distance at (px, pz) — the minimum over every segment and every polygon stamp,
+ *  the GPU twin of `document.ts`'s `documentDistance`. */
+export const documentDistanceGpu = tgpu.fn(
+    [d.f32, d.f32],
+    d.f32,
+)((px, pz) => {
+    "use gpu";
+    let best = segmentsDistanceGpu(px, pz);
+    let p = d.u32(0);
+    for (; p < rasterLayout.$.params.polygonCount; p = p + d.u32(1)) {
+        const dist = polygonDistanceGpu(px, pz, rasterLayout.$.polygons[p]);
+        if (dist < best) best = dist;
+    }
+    return best;
+});
+
+/** quantize a signed world-metre distance to its r8unorm byte — TGSL reimplementation of `tiles.ts`'s
+ *  `encodeDist` (no shared source: this is what the kernel actually runs; `tiles.ts`'s stays the CPU
+ *  codec the fs's decode and the differential oracle's tolerance both key off). CPU-callable, so the
+ *  oracle can quantize the GPU derivation's raw distance the same way the real kernel would.
+ * @example encodeDistGpu(0) // 128u, the zero crossing */
+export const encodeDistGpu = tgpu.fn(
+    [d.f32],
+    d.u32,
+)((metres) => {
+    "use gpu";
+    const clamped = std.clamp(metres, d.f32(-DIST_RANGE), d.f32(DIST_RANGE));
+    const unit = clamped / d.f32(2 * DIST_RANGE) + d.f32(0.5);
+    return d.u32(std.round(unit * d.f32(255)));
+});
+
+/** pack ROAD_ALBEDO's rgb + full alpha into rgba8unorm's little-endian byte order — every texel gets the
+ *  same word (stage 4's `packStrokeTile` wrote albedo everywhere too: cheap, and the fs never reads it
+ *  past the coverage the distance channel derives). Computed once at module load, not per-thread. */
+function packAlbedoWord(rgb: readonly [number, number, number]): number {
+    const r = Math.round(rgb[0] * 255);
+    const g = Math.round(rgb[1] * 255);
+    const b = Math.round(rgb[2] * 255);
+    return (r | (g << 8) | (b << 16) | (255 << 24)) >>> 0;
+}
+
+const albedoWord = tgpu.const(d.u32, packAlbedoWord(ROAD_ALBEDO)).$name("roadAlbedoWord");
+
+const rasterKernel = tgpu
+    .computeFn({
+        workgroupSize: [WG, WG, 1],
+        in: { gid: d.builtin.globalInvocationId },
+    })((input) => {
+        "use gpu";
+        const gx = input.gid.x; // texel-group column, 0..GROUPS_PER_SIDE-1
+        const gy = input.gid.y; // texel row, 0..TILE_RES-1
+        if (gx >= d.u32(GROUPS_PER_SIDE) || gy >= d.u32(TILE_RES)) return;
+
+        const origin = rasterLayout.$.params.tileOrigin;
+        const worldZ = origin.y + (d.f32(gy) + d.f32(0.5)) * d.f32(TEXEL_SIZE);
+
+        let word = d.u32(0);
+        let k = d.u32(0);
+        for (; k < d.u32(GROUP_TEXELS); k = k + d.u32(1)) {
+            const texelX = gx * d.u32(GROUP_TEXELS) + k;
+            const worldX = origin.x + (d.f32(texelX) + d.f32(0.5)) * d.f32(TEXEL_SIZE);
+            const dist = documentDistanceGpu(worldX, worldZ);
+            const byte = encodeDistGpu(dist);
+            word = word | (byte << (k * d.u32(8)));
+
+            const albedoIdx = gy * d.u32(TILE_RES) + texelX;
+            rasterLayout.$.albedoOut[albedoIdx] = albedoWord.$;
+        }
+        const distIdx = gy * d.u32(GROUPS_PER_SIDE) + gx;
+        rasterLayout.$.distOut[distIdx] = word;
+    })
+    .$name("roads-rasterize");
+
+/** the emitted rasterizer WGSL — the device-free structural seam stage 5's tests resolve. */
+export function rasterizeWgsl(): string {
+    return tgpu.resolve(
+        [
+            segmentDistanceGpu,
+            segmentsDistanceGpu,
+            polygonDistanceGpu,
+            documentDistanceGpu,
+            encodeDistGpu,
+            rasterKernel,
+        ],
+        { names: "strict" },
+    );
+}
+
+type RasterRoot = typeof Compute.root;
+type RasterPipeline = ReturnType<RasterRoot["createComputePipeline"]>;
+
+let pipeline: RasterPipeline | null = null;
+let albedoRaw: GPUBuffer | null = null;
+let distRaw: GPUBuffer | null = null;
+
+const ALBEDO_WORDS = TILE_RES * TILE_RES;
+const DIST_WORDS = TILE_RES * GROUPS_PER_SIDE;
+
+function teardown(): void {
+    albedoRaw?.destroy();
+    distRaw?.destroy();
+    pipeline = null;
+    albedoRaw = null;
+    distRaw = null;
+}
+
+/** allocate the rasterizer's persistent GPU scratch (compute pipeline + the two packed-output buffers,
+ *  sized once for one tile's worth of texels — every tile is the same size, so these are reused across
+ *  every `rasterizeTile` call rather than allocated per redraw). Ties cleanup to `state.onDispose`. */
+export function warm(state: State): void {
+    teardown();
+    state.onDispose(teardown);
+    const { device, root } = Compute;
+    pipeline = root.createComputePipeline({ compute: rasterKernel }).$name("roads-rasterize");
+    albedoRaw = device.createBuffer({
+        label: "roads-raster-albedo",
+        size: ALBEDO_WORDS * 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    distRaw = device.createBuffer({
+        label: "roads-raster-dist",
+        size: DIST_WORDS * 4,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+}
+
+/**
+ * rasterize `doc` into tile (tx, tz)'s content and copy it straight into `albedoTex`/`distTex`'s `layer`
+ * — one compute dispatch + two `copyBufferToTexture` calls, all GPU-side (no CPU readback, so `atlas.ts`'s
+ * `redraw` stays synchronous). The segment/polygon buffers are rebuilt each call, sized to `doc`'s actual
+ * content (the same create-per-call shape `terrain/generate.ts`'s permutation buffer uses) — a redrawn
+ * tile is throttled to a handful per frame (`tiles.ts`'s THROTTLE), so this isn't a hot per-frame path.
+ */
+export function rasterizeTile(
+    doc: StrokeDocument,
+    tx: number,
+    tz: number,
+    albedoTex: GPUTexture,
+    distTex: GPUTexture,
+    layer: number,
+): void {
+    if (!pipeline || !albedoRaw || !distRaw) {
+        throw new Error("rasterize: rasterizeTile before warm()");
+    }
+    const { device, root } = Compute;
+
+    const segments = flattenSegments(doc);
+    const segmentsData =
+        segments.length > 0 ? segments : [{ ax: 0, az: 0, bx: 0, bz: 0, halfWidth: 0 }];
+    const segRaw = device.createBuffer({
+        label: "roads-raster-segments",
+        size: segmentsData.length * d.sizeOf(GpuSegment),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    const segBuf = root
+        .createBuffer(d.arrayOf(GpuSegment, segmentsData.length), segRaw)
+        .$usage("storage");
+    segBuf.write(
+        segmentsData.map((s) => ({
+            a: d.vec2f(s.ax, s.az),
+            b: d.vec2f(s.bx, s.bz),
+            halfWidth: s.halfWidth,
+        })),
+    );
+
+    const polyVerts: { x: number; y: number }[] = [];
+    const polygonsData = doc.polygons.map((poly) => {
+        const start = polyVerts.length;
+        for (const [x, z] of poly.points) polyVerts.push({ x, y: z });
+        return { start, count: poly.points.length };
+    });
+    const polygonsSafe = polygonsData.length > 0 ? polygonsData : [{ start: 0, count: 0 }];
+    const polyRaw = device.createBuffer({
+        label: "roads-raster-polygons",
+        size: polygonsSafe.length * d.sizeOf(GpuPolygon),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    const polyBuf = root
+        .createBuffer(d.arrayOf(GpuPolygon, polygonsSafe.length), polyRaw)
+        .$usage("storage");
+    polyBuf.write(polygonsSafe);
+
+    const vertsSafe = polyVerts.length > 0 ? polyVerts : [{ x: 0, y: 0 }];
+    const vertsRaw = device.createBuffer({
+        label: "roads-raster-polyverts",
+        size: vertsSafe.length * d.sizeOf(d.vec2f),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    const vertsBuf = root
+        .createBuffer(d.arrayOf(d.vec2f, vertsSafe.length), vertsRaw)
+        .$usage("storage");
+    vertsBuf.write(vertsSafe.map((v) => d.vec2f(v.x, v.y)));
+
+    const [ox, oz] = tileOrigin(tx, tz);
+    const paramsRaw = device.createBuffer({
+        label: "roads-raster-params",
+        size: d.sizeOf(RasterParams),
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    const paramsBuf = root.createBuffer(RasterParams, paramsRaw).$usage("uniform");
+    paramsBuf.write({
+        tileOrigin: d.vec2f(ox, oz),
+        segmentCount: segments.length,
+        polygonCount: doc.polygons.length,
+    });
+
+    const albedoOut = root
+        .createBuffer(d.arrayOf(d.u32, ALBEDO_WORDS), albedoRaw)
+        .$usage("storage");
+    const distOut = root.createBuffer(d.arrayOf(d.u32, DIST_WORDS), distRaw).$usage("storage");
+
+    const bindGroup = root.createBindGroup(rasterLayout, {
+        segments: segBuf,
+        polygons: polyBuf,
+        polyVerts: vertsBuf,
+        params: paramsBuf,
+        albedoOut,
+        distOut,
+    });
+
+    try {
+        const enc = device.createCommandEncoder({ label: "roads-rasterize" });
+        const pass = enc.beginComputePass({ label: "roads-rasterize" });
+        pipeline.with(bindGroup).with(pass).dispatchWorkgroups(DISPATCH.x, DISPATCH.y, 1);
+        pass.end();
+        enc.copyBufferToTexture(
+            { buffer: albedoRaw, bytesPerRow: TILE_RES * 4, rowsPerImage: TILE_RES },
+            { texture: albedoTex, origin: { x: 0, y: 0, z: layer } },
+            { width: TILE_RES, height: TILE_RES, depthOrArrayLayers: 1 },
+        );
+        enc.copyBufferToTexture(
+            { buffer: distRaw, bytesPerRow: TILE_RES, rowsPerImage: TILE_RES },
+            { texture: distTex, origin: { x: 0, y: 0, z: layer } },
+            { width: TILE_RES, height: TILE_RES, depthOrArrayLayers: 1 },
+        );
+        device.queue.submit([enc.finish()]);
+    } finally {
+        segRaw.destroy();
+        polyRaw.destroy();
+        vertsRaw.destroy();
+        paramsRaw.destroy();
+    }
+}

--- a/examples/showcase/roads/src/overlay/rasterize.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.ts
@@ -95,7 +95,7 @@ const segmentsDistanceGpu = tgpu.fn(
 
 /** apply the inside/outside sign convention to a polygon's nearest-edge distance — negative inside,
  *  positive outside, `inside` decided by ray-cast winding. Factored out of `polygonDistanceGpu` as its
- *  own pure fn (`checks.md`'s "factor inward") purely so it's CPU-callable with no bound storage:
+ *  own pure fn (`coding.md`'s "factor inward") purely so it's CPU-callable with no bound storage:
  *  `polygonDistanceGpu`'s enclosing reduction reads the shared `polyVerts` buffer and can only run
  *  inside a real dispatch, but the sign convention itself takes no storage — stage 5's differential
  *  oracle calls this directly to pin the sign, the exact axis a flipped `select` breaks.

--- a/examples/showcase/roads/src/overlay/stroke.ts
+++ b/examples/showcase/roads/src/overlay/stroke.ts
@@ -1,3 +1,4 @@
+import type { StrokeDocument } from "./document";
 import {
     ALBEDO_BYTES_PER_TEXEL,
     DIST_BYTES_PER_TEXEL,
@@ -9,13 +10,12 @@ import {
     tileOrigin,
 } from "./tiles";
 
-// The stage's hand-authored "known pattern": a single straight road-width stroke, standing in for the real
-// stroke document a later stage authors (spec's Approach step 5 — "Road rasterizer" owns polylines/stamps
-// and a compute rasterizer). Stage 4's job is the substrate (atlas + indirection + composite + dirty/
-// redraw), so this is deliberately the simplest shape that exercises every layer of it: a pure
-// distance-to-segment function (the same primitive the real rasterizer will differential-test against,
-// `checks.md`'s two-independent-derivations shape for stage 5) plus a CPU-side packer that stands in for
-// the TGSL compute rasterizer stage 5 builds.
+// The stage's hand-authored "known pattern": a single straight road-width stroke. Stage 4 built this as
+// the substrate's CPU stand-in (atlas + indirection + composite + dirty/redraw); stage 5's `rasterize.ts`
+// is the real GPU rasterizer `strokeDocument()` (below) now feeds in production (`terrain.ts`). This
+// module's own `strokeDistance`/`packStrokeTile` stay live as the CPU analytic reference: `document.test.ts`
+// cross-checks `documentDistance` over `strokeDocument()` against `strokeDistance` directly, and this
+// file's own tests still pin the hand-derived pattern stage 4 built them against.
 //
 // Run along +X through the world origin at Z=0 (grid.ts centres the terrain there, and `heightAt(0, 0)` is
 // the one analytically known height on the seeded surface — an exact perlin-lattice point samples zero
@@ -92,3 +92,22 @@ export const OFF_ROAD_POINT: readonly [x: number, z: number] = [
     0,
     STROKE_Z + STROKE_HALF_WIDTH + 4,
 ];
+
+/** this stage's hand-authored stroke, expressed as a one-polyline {@link StrokeDocument} — the real input
+ *  `terrain.ts` marks dirty and redraws through `rasterize.ts`'s GPU kernel in production. Geometrically
+ *  identical to `strokeDistance`'s pattern (same endpoints, same half-width), so the capture gate's
+ *  on/off-road probes stay valid unchanged. */
+export function strokeDocument(): StrokeDocument {
+    return {
+        polylines: [
+            {
+                points: [
+                    [-STROKE_HALF_LENGTH, STROKE_Z],
+                    [STROKE_HALF_LENGTH, STROKE_Z],
+                ],
+                halfWidth: STROKE_HALF_WIDTH,
+            },
+        ],
+        polygons: [],
+    };
+}

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -17,7 +17,8 @@ import tgpu from "typegpu";
 import * as d from "typegpu/data";
 import * as std from "typegpu/std";
 import * as overlayAtlas from "../overlay/atlas";
-import { packStrokeTile, strokeRect } from "../overlay/stroke";
+import type { StrokeDocument } from "../overlay/document";
+import { strokeDocument } from "../overlay/stroke";
 import { COVERAGE_BAND_PX, DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
 import { bindTerrainKernel, generate, TERRAIN_QUANT } from "./generate";
 import {
@@ -155,6 +156,11 @@ function teardown(): void {
     buffers = null;
 }
 
+// this stage's only producer is the hand-authored stroke (`overlay/stroke.ts`'s `strokeDocument`) —
+// a later stage (6) replaces it with a seeded procedural network. One module-level document, not rebuilt
+// per frame: the stroke's own content is fixed for this stage's lifetime.
+const DOCUMENT: StrokeDocument = strokeDocument();
+
 async function warm(state: State): Promise<void> {
     teardown(); // a rebuild (HMR) re-warms — clear the prior generation's buffers first
     // `Plugin.dispose` only fires on `App.dispose`, never on a direct `state.dispose()` (the path an
@@ -224,24 +230,25 @@ async function warm(state: State): Promise<void> {
     Meshes.register(mesh);
     Draws.register({ name: "terrain", surface: "terrain", mesh: "terrain", args: { indirect } });
 
-    // the stage's hand-authored known pattern (overlay/stroke.ts) — stands in for a real stroke document
-    // (stage 5). Marking it dirty here (not per-frame) means one redraw burst at warm, not a repeated mark.
-    overlayAtlas.markDirty(strokeRect());
+    // the stage's hand-authored known pattern (overlay/stroke.ts), expressed as a StrokeDocument and
+    // rasterized by overlay/rasterize.ts's GPU kernel (stage 5). Marking it dirty here (not per-frame)
+    // means one redraw burst at warm, not a repeated mark.
+    overlayAtlas.markDirty(DOCUMENT);
 
     bindTerrainKernel(vertices, position);
     if (state.signal.aborted) return;
     await generate(SEED);
 }
 
-/** drain the overlay's per-frame dirty-tile throttle (`overlay/atlas.ts`'s `redraw`) — this stage's only
- *  producer is the hand-authored stroke, so `packStrokeTile` stands in for the real stroke-document
- *  rasterizer (stage 5). Exported so the device gate can assert draining actually happened. */
+/** drain the overlay's per-frame dirty-tile throttle (`overlay/atlas.ts`'s `redraw`), rasterizing
+ *  {@link DOCUMENT}'s content into every drained tile via `overlay/rasterize.ts`'s GPU kernel. Exported so
+ *  the device gate can assert draining actually happened. */
 const OverlayRedrawSystem: System = {
     name: "roads-overlay-redraw",
     group: "simulation",
     annotations: { mode: "always" },
     update() {
-        overlayAtlas.redraw(packStrokeTile);
+        overlayAtlas.redraw(DOCUMENT);
     },
 };
 


### PR DESCRIPTION
- **shallot-roads: road rasterizer — GPU compute replaces the CPU TilePacker**
- **shallot-roads: close stage 5 rasterizer review findings**
- **shallot-roads: cite coding.md for factor-inward, not checks.md**
