### PR TITLE
shallot-roads: polish + capture

### DIFF
--- a/examples/showcase/roads/playwright.global-setup.ts
+++ b/examples/showcase/roads/playwright.global-setup.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 // Routes this project's gate through `scripts/wsl-bridge.ts` when on WSL, so it drives the Windows host's
-// real GPU instead of falling to the software adapter (`testing.md:145`'s adapter-name skip). The bridge
+// real GPU instead of falling to the software adapter (the driver's own adapter-name skip). The bridge
 // itself only runs under bun (`Bun.spawnSync`/`Bun.spawn` throughout); `playwright test` loads this config
 // under real node (its bin script's node shebang, confirmed empirically — bun's script runner honors
 // shebangs rather than forcing bun), so `scripts/wsl-bridge-connect.ts` is the one bun subprocess this

--- a/examples/showcase/roads/src/capture.ts
+++ b/examples/showcase/roads/src/capture.ts
@@ -1,17 +1,17 @@
 import { computeViewProj, Views } from "@dylanebert/shallot/render/core";
 import { decodePos } from "@dylanebert/shallot/utils/core";
-import { OFF_ROAD_POINT, ON_ROAD_POINT } from "./overlay/stroke";
+import { captureProbePoints } from "./overlay/network";
 import { COVERAGE_BAND_PX } from "./overlay/tiles";
 import { TERRAIN_QUANT } from "./terrain/generate";
 import { gridX, gridZ, VERTS } from "./terrain/grid";
-import { readVertices } from "./terrain/terrain";
+import { readVertices, SEED } from "./terrain/terrain";
 
-// The device gate's world→screen bridge for the pixel-probe capture (the spec's flagged-risk validation,
-// stage 4's own arm — `checks.md`: the fs composite is observable only in the rendered frame). Rather than
-// hand-deriving the orbit camera's trig in the Playwright driver, this reads the *real* live viewProj the
-// renderer itself uses (`computeViewProj`, `@dylanebert/shallot/render/core`) — so the mapping can't drift
-// from whatever the scene's orbit distance/pitch/fov actually are, and the driver never re-implements
-// camera math it doesn't own.
+// The device gate's world→screen bridge for the pixel-probe capture (the spec's flagged-risk validation —
+// the fs composite is observable only in the rendered frame, never in the compute-write half `bun test`
+// already covers). Rather than hand-deriving the orbit camera's trig in the Playwright driver, this reads
+// the *real* live viewProj the renderer itself uses (`computeViewProj`, `@dylanebert/shallot/render/core`)
+// — so the mapping can't drift from whatever the scene's orbit distance/pitch/fov actually are, and the
+// driver never re-implements camera math it doesn't own.
 
 /** a world point's screen position as a fraction of the canvas (0,0 = top-left, 1,1 = bottom-right) — the
  *  unit `test/roads.spec.ts` multiplies by the captured screenshot's own pixel dimensions, so the mapping
@@ -69,8 +69,8 @@ export function worldToScreen(
 
 /** one grid-aligned world (x, z) → its full 3D world point, height read from the real generated vertex
  *  stream (`readVertices`, `terrain.ts`) rather than re-deriving the noise function in JS — {@link gridX}/
- *  {@link gridZ} require an exact grid column, which `overlay/stroke.ts`'s ON_ROAD_POINT/OFF_ROAD_POINT are
- *  built to be. */
+ *  {@link gridZ} require an exact grid column, which `overlay/network.ts`'s `captureProbePoints` are
+ *  built to return. */
 async function withHeight(x: number, z: number): Promise<[x: number, y: number, z: number]> {
     const raw = await readVertices();
     const ix = gridX(x);
@@ -80,17 +80,19 @@ async function withHeight(x: number, z: number): Promise<[x: number, y: number, 
     return [x, y, z];
 }
 
-/** the capture gate's fixed on-road/off-road world probe points, heights read from the live generated
- *  terrain (`overlay/stroke.ts`'s ON_ROAD_POINT/OFF_ROAD_POINT). */
+/** the capture gate's on-road/off-road world probe points over the full procedural network at the boot's
+ *  pinned {@link SEED} (`overlay/network.ts`'s `captureProbePoints`, `terrain.ts`'s live boot document),
+ *  heights read from the live generated terrain. */
 export async function capturePoints(): Promise<{
     onRoad: [number, number, number];
     offRoad: [number, number, number];
 }> {
-    const [onRoad, offRoad] = await Promise.all([
-        withHeight(...ON_ROAD_POINT),
-        withHeight(...OFF_ROAD_POINT),
+    const { onRoad, offRoad } = captureProbePoints(SEED);
+    const [onRoadPoint, offRoadPoint] = await Promise.all([
+        withHeight(...onRoad),
+        withHeight(...offRoad),
     ]);
-    return { onRoad, offRoad };
+    return { onRoad: onRoadPoint, offRoad: offRoadPoint };
 }
 
 /**

--- a/examples/showcase/roads/src/gate.ts
+++ b/examples/showcase/roads/src/gate.ts
@@ -13,8 +13,8 @@ import { generate, readVertices, SEED } from "./terrain/terrain";
 // (`test/roads.spec.ts`) drives it on a GPU.
 //
 // `bun test ./src` (noise.test.ts, grid.test.ts, generate.test.ts) covers the device-free half: the
-// permutation table's seed determinism, the WGSL structural resolve, and the grid-topology oracle
-// (`testing.md`'s observation ladder — never bind a device in `bun test`). This gate covers the one thing
+// permutation table's seed determinism, the WGSL structural resolve, and the grid-topology oracle —
+// `bun test` never binds a device. This gate covers the one thing
 // only a real device can show: that two GPU dispatches at the same seed actually produce byte-identical
 // vertex content, and two different seeds don't.
 

--- a/examples/showcase/roads/src/overlay/atlas.ts
+++ b/examples/showcase/roads/src/overlay/atlas.ts
@@ -15,6 +15,26 @@ import {
     tileCoordOf,
 } from "./tiles";
 
+// Why a tiled overlay atlas, sampled inside the terrain surface, rather than projected decals:
+//
+// Cost model. A decal is its own geometry (a box or a screen-space quad) rendered over the terrain; its
+// per-frame cost is proportional to how many decal volumes overlap a given pixel — cheap for a handful of
+// bullet holes or footprints, expensive once decals cover most of the visible ground, since a dense
+// overlapping set means every covered pixel re-evaluates every decal that reaches it. This atlas inverts
+// that: the terrain's own fragment shader pays one indirection lookup into {@link Indirection} plus one
+// atlas sample (`terrain/terrain.ts`'s composite) every frame, *regardless* of how many roads or carparks
+// exist — a network of 5 primitives and one of 500 cost the same per-frame sample. The part of the cost
+// that scales with primitive count is the rasterization into dirty tiles below, and that's paid once per
+// edit, throttled ({@link THROTTLE} tiles/frame), never once per frame per pixel.
+//
+// Same-surface sampling. A decal is a second piece of geometry positioned just above the terrain, which
+// needs a depth bias to keep it from z-fighting the surface underneath it — flickering where the two
+// depths are close enough that which one wins a given pixel becomes numerically unstable. That bias is a
+// tuned constant with no value that's simultaneously right at every camera distance and every terrain
+// slope. Reading this atlas from inside the terrain fs, instead of drawing a second surface, has nothing
+// to z-fight: there's exactly one depth value written per pixel, the terrain's own, so the failure mode
+// isn't tuned away, it has no surface to occur on.
+//
 // The overlay atlas's GPU state: two texture-2d-arrays (albedo + boundary distance, `tiles.ts`'s formats)
 // sized to {@link ATLAS_LAYERS} — smaller than {@link TILE_COUNT}, the "small indirection" the spec's
 // Approach names — plus the indirection storage buffer the terrain fs (`terrain/terrain.ts`) looks tile id
@@ -153,7 +173,7 @@ export function redraw(doc: StrokeDocument): number {
 }
 
 /** whether every marked tile has drained through {@link redraw} — the boot path polls this so the
- *  hand-authored stroke is fully resident before the device gate's capture reads the frame. */
+ *  procedural network is fully resident before the device gate's capture reads the frame. */
 export function idle(): boolean {
     return pending.length === 0;
 }

--- a/examples/showcase/roads/src/overlay/document.ts
+++ b/examples/showcase/roads/src/overlay/document.ts
@@ -2,16 +2,16 @@ import { dirtyTiles, type Rect, TEXEL_SIZE } from "./tiles";
 
 // The stroke document: pure data (polylines + width, polygon stamps) plus the CPU analytic distance math
 // stage 5's differential oracle checks the GPU rasterizer (`rasterize.ts`) against. No GPU/engine
-// imports, so `bun test` exercises every formula here without a device (`testing.md`'s logic tier) — the
-// same device-free split `tiles.ts` and `terrain/noise.ts` use.
+// imports, so `bun test` exercises every formula here without a device — the same device-free split
+// `tiles.ts` and `terrain/noise.ts` use.
 //
 // `segmentDistance` below is deliberately a *different* derivation from `rasterize.ts`'s
 // `segmentDistanceGpu`: this one finds the signed perpendicular offset via a 2D cross product once the
 // projection falls strictly between the endpoints, falling back to the nearer endpoint distance outside
 // that range; `rasterize.ts`'s GPU form instead clamps the projection parameter `t` to [0, 1] and always
 // measures straight-line distance to the clamped point. Same geometric quantity, two independently
-// written code paths — `checks.md`'s rule that an agreement check between two things written from one
-// source tests self-consistency, not correctness.
+// written code paths — an agreement check between two things written from one source tests
+// self-consistency, not correctness.
 
 /** one road-width centreline — consecutive points define its segments, `halfWidth` is constant along its
  *  whole length (a real network's per-segment width variation is out of this stage's scope). */

--- a/examples/showcase/roads/src/overlay/network.test.ts
+++ b/examples/showcase/roads/src/overlay/network.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { WORLD_HALF } from "../terrain/grid";
-import { documentDirtyTiles, flattenSegments } from "./document";
-import { generateNetwork, ROAD_COUNT, ROAD_HALF_WIDTH } from "./network";
+import { gridX, gridZ, WORLD_HALF, worldX, worldZ } from "../terrain/grid";
+import { documentDirtyTiles, documentDistance, flattenSegments } from "./document";
+import { captureProbePoints, generateNetwork, ROAD_COUNT, ROAD_HALF_WIDTH } from "./network";
+
+// this module's own copy of `terrain/terrain.ts`'s boot SEED — kept a plain literal rather than an
+// import so this file's tests stay in the pure-data tier (no pull-in of terrain.ts's device-bound module
+// graph); `capture.test.ts` and the device gate exercise the real import.
+const BOOT_SEED = 1337;
 
 // The network generator's determinism gate — the spec's own Validation criterion ("network determinism
 // in its seed"). No device needed: `generateNetwork` is pure XZ placement (module header).
@@ -42,7 +47,7 @@ describe("generateNetwork — shape", () => {
     });
 
     test("every primitive stays within the world footprint over a wide seed scan (no clamped-AABB edge case)", () => {
-        // a single hardcoded seed is a fixture, not a corpus (checks.md) — an earlier version of this
+        // a single hardcoded seed is a fixture, not a corpus — an earlier version of this
         // arm ran only seed 99, which happens not to trigger the escape a WORLD_MARGIN bounding only the
         // segment's *start* point allows: the endpoint is `x0 + cos(heading) * length` with `length` up
         // to ROAD_MAX_LENGTH in either direction, not half of it. Scan a real range, and pin the exact
@@ -91,5 +96,47 @@ describe("generateNetwork — shape", () => {
         const doc = generateNetwork(7);
         expect(() => documentDirtyTiles(doc)).not.toThrow();
         expect(documentDirtyTiles(doc).length).toBeGreaterThan(0);
+    });
+});
+
+describe("captureProbePoints — the device gate's on/off-road pair over the procedural network", () => {
+    test("at the boot seed: both points are grid-aligned, and classify as their names say", () => {
+        const doc = generateNetwork(BOOT_SEED);
+        const { onRoad, offRoad } = captureProbePoints(BOOT_SEED);
+
+        // grid-aligned: worldX(gridX(x)) round-trips exactly for a point already sitting on the grid.
+        expect(worldX(gridX(onRoad[0]))).toBe(onRoad[0]);
+        expect(worldZ(gridZ(onRoad[1]))).toBe(onRoad[1]);
+        expect(worldX(gridX(offRoad[0]))).toBe(offRoad[0]);
+        expect(worldZ(gridZ(offRoad[1]))).toBe(offRoad[1]);
+
+        expect(documentDistance(onRoad[0], onRoad[1], doc)).toBeLessThan(0);
+        expect(documentDistance(offRoad[0], offRoad[1], doc)).toBeGreaterThan(0);
+    });
+
+    test("pinned witness at the boot seed — a regression names itself against these exact coordinates", () => {
+        // computed once against generateNetwork(1337) and checked by hand against documentDistance
+        // (on-road ≈ -3.20 m inside the road's 4 m half-width; off-road ≈ +4.10 m outside it, one grid
+        // step further out — the nearest-to-origin road at this seed, not necessarily road 0).
+        const { onRoad, offRoad } = captureProbePoints(BOOT_SEED);
+        expect(onRoad).toEqual([-8, -24]);
+        expect(offRoad).toEqual([0, -28]);
+    });
+
+    test("is deterministic in the seed, like generateNetwork itself", () => {
+        expect(captureProbePoints(99)).toEqual(captureProbePoints(99));
+    });
+
+    test("classifies correctly over a scan of seeds, not just the boot seed", () => {
+        // ROAD_HALF_WIDTH/ROAD_MIN_LENGTH are fixed across every seed (network.ts), so the derivation's
+        // inside/outside read shouldn't be a boot-seed coincidence — scan a real range rather than trust
+        // one witness, the same lesson the network's own edge-case test above learned at seed 615: a
+        // single hardcoded seed is a fixture, not a corpus.
+        for (let seed = 0; seed < 200; seed++) {
+            const doc = generateNetwork(seed);
+            const { onRoad, offRoad } = captureProbePoints(seed);
+            expect(documentDistance(onRoad[0], onRoad[1], doc)).toBeLessThan(0);
+            expect(documentDistance(offRoad[0], offRoad[1], doc)).toBeGreaterThan(0);
+        }
     });
 });

--- a/examples/showcase/roads/src/overlay/network.ts
+++ b/examples/showcase/roads/src/overlay/network.ts
@@ -1,12 +1,17 @@
-import { WORLD_HALF } from "../terrain/grid";
+import { gridX, gridZ, SPACING, WORLD_HALF, worldX, worldZ } from "../terrain/grid";
 import { mulberry32 } from "../terrain/noise";
-import type { PolygonStamp, Polyline, StrokeDocument } from "./document";
+import {
+    documentDistance,
+    type PolygonStamp,
+    type Polyline,
+    type StrokeDocument,
+} from "./document";
 
 // The seeded procedural network: "a handful" of straight-segment roads plus one carpark polygon, placed
 // by a deterministic RNG (`terrain/noise.ts`'s `mulberry32`, the same seeded-RNG shape the permutation
-// table uses — one source, `coding.md`'s One-source-of-truth). Pure XZ placement, no engine/GPU imports
-// (the same device-free split `overlay/tiles.ts`/`overlay/document.ts` use) — `bun test` exercises the
-// generator's determinism with no device.
+// table uses — one source, not two independently authored copies). Pure XZ placement, no engine/GPU
+// imports (the same device-free split `overlay/tiles.ts`/`overlay/document.ts` use) — `bun test`
+// exercises the generator's determinism with no device.
 //
 // "Terrain-conformed" is the flatten step's job, not this one's (`terrain/flatten.ts`): a road's
 // *longitudinal* profile follows the natural terrain height along its own centreline, so a straight-line
@@ -93,4 +98,72 @@ export function generateNetwork(seed: number): StrokeDocument {
     };
 
     return { polylines, polygons: [polygon] };
+}
+
+/**
+ * deterministic capture-gate probe points for {@link generateNetwork}'s output at `seed` — grid-aligned
+ * so the capture's world→screen bridge can read the real generated terrain height at an exact grid vertex
+ * (`terrain/grid.ts`'s `gridX`/`gridZ`), generalizing `overlay/stroke.ts`'s hand-authored on/off-road pair
+ * (fixed, axis-aligned points valid only for that stroke's own straight-along-+X shape) to a network whose
+ * roads land at arbitrary headings and positions.
+ *
+ * Picks whichever road's midpoint sits nearest the world origin, not always `polylines[0]`: the scene's
+ * fixed orbit camera (`public/scenes/roads.scene`) frames the whole 1024 m grid from its default target,
+ * the world origin, so a road far out near the world's edge projects to only a few screen pixels — its
+ * on/off-road pair would then sit closer than one screen pixel apart, sampling the same rounded pixel
+ * twice (measured: a seed whose nearest road sat 260 m out read identical on/off-road luminance on the
+ * real device). The on-road point is that midpoint's nearest grid vertex; the off-road point steps
+ * outward one grid cell at a time along the segment's own normal, trying both normal directions since
+ * only `polylines[0]` has a carpark anchored to one particular side (`generateNetwork`, above) — whichever
+ * direction clears the road first is a clean single-boundary crossing. Both points are confirmed
+ * inside/outside by {@link documentDistance} at derivation time rather than assumed from the geometry
+ * alone, so a network change that breaks the pairing fails loud instead of silently reading the wrong
+ * pixels.
+ */
+export function captureProbePoints(seed: number): {
+    onRoad: readonly [x: number, z: number];
+    offRoad: readonly [x: number, z: number];
+} {
+    const doc = generateNetwork(seed);
+
+    let nearest = doc.polylines[0];
+    let nearestDist = Number.POSITIVE_INFINITY;
+    for (const line of doc.polylines) {
+        const [[ax, az], [bx, bz]] = line.points;
+        const d = Math.hypot((ax + bx) / 2, (az + bz) / 2);
+        if (d < nearestDist) {
+            nearestDist = d;
+            nearest = line;
+        }
+    }
+
+    const [[ax, az], [bx, bz]] = nearest.points;
+    const mx = (ax + bx) / 2;
+    const mz = (az + bz) / 2;
+    const dx = bx - ax;
+    const dz = bz - az;
+    const len = Math.hypot(dx, dz) || 1;
+    const nx = -dz / len;
+    const nz = dx / len;
+    const halfWidth = nearest.halfWidth;
+
+    const snap = (x: number, z: number): [number, number] => [worldX(gridX(x)), worldZ(gridZ(z))];
+
+    const onRoad = snap(mx, mz);
+    if (documentDistance(onRoad[0], onRoad[1], doc) >= 0) {
+        throw new Error(
+            `captureProbePoints: derived on-road point (${onRoad[0]}, ${onRoad[1]}) is not inside the network at seed ${seed}`,
+        );
+    }
+
+    for (const sign of [1, -1]) {
+        for (let step = 1; step <= 32; step++) {
+            const reach = halfWidth + step * SPACING;
+            const offRoad = snap(mx + sign * nx * reach, mz + sign * nz * reach);
+            if (documentDistance(offRoad[0], offRoad[1], doc) > 0) return { onRoad, offRoad };
+        }
+    }
+    throw new Error(
+        `captureProbePoints: no off-road grid point found within search radius at seed ${seed}`,
+    );
 }

--- a/examples/showcase/roads/src/overlay/queue.ts
+++ b/examples/showcase/roads/src/overlay/queue.ts
@@ -31,8 +31,7 @@ export interface Allocation {
  * resolve tile `id`'s atlas layer against the indirection CPU mirror `cpu` (negative = unallocated):
  * already resident → its existing layer, unchanged counter; otherwise the next free layer, `cpu[id]`
  * written in place. Throws when `nextLayer` would exceed `capacity` rather than silently overwriting a
- * resident layer or wrapping the counter (`coding.md`'s Robust clause — no plausible-fallback substitute
- * for a real capacity limit).
+ * resident layer or wrapping the counter — no plausible-fallback substitute for a real capacity limit.
  *
  * @example allocate(new Int32Array(4).fill(-1), 2, 0, 4) // → { layer: 0, nextLayer: 1 }, cpu[2] === 0
  */

--- a/examples/showcase/roads/src/overlay/rasterize.test.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.test.ts
@@ -18,9 +18,9 @@ import {
 import { DIST_RANGE, decodeDist, encodeDist, TEXEL_SIZE } from "./tiles";
 
 // Stage 5's differential oracle: `segmentDistanceGpu` (rasterize.ts, clamped-projection form, CPU-called
-// through TypeGPU's dual execution — testing.md's logic tier) against `document.ts`'s `segmentDistance`
-// (perpendicular-offset-via-cross-product form) — two independently written derivations of the same
-// geometric quantity (checks.md). The GPU side is additionally quantized through `encodeDistGpu` +
+// through TypeGPU's dual execution) against `document.ts`'s `segmentDistance` (perpendicular-offset-via-
+// cross-product form) — two independently written derivations of the same geometric quantity. The GPU
+// side is additionally quantized through `encodeDistGpu` +
 // `tiles.ts`'s `decodeDist`, the exact byte round-trip the real kernel's output goes through, so the
 // tolerance is the r8unorm quantization step the spec's Approach names, not a raw-float tolerance.
 const QUANT_STEP = (2 * DIST_RANGE) / 255;
@@ -82,9 +82,9 @@ describe("differential oracle — segmentDistanceGpu vs document.ts's segmentDis
 
     test("a multi-primitive (segments + polygons) reduction agrees with documentDistance", () => {
         // documentDistanceGpu itself reads its segments/polygons out of bound storage buffers
-        // (rasterLayout.$.segments / .polygons / .polyVerts), so it can't be CPU-called without a device
-        // (testing.md: "never bind a device in bun test") — the kernel's reduction loop is instead pinned
-        // structurally below ("emitted WGSL"). This exercises the same reduction (min over every segment's
+        // (rasterLayout.$.segments / .polygons / .polyVerts), so it can't be CPU-called without a device —
+        // the kernel's reduction loop is instead pinned structurally below ("emitted WGSL"). This exercises
+        // the same reduction (min over every segment's
         // segmentDistanceGpu AND every polygon's winding+edge reduction) in plain JS, over the same
         // per-primitive kernel math the earlier tests already validated CPU-side — and, unlike the
         // segment-only reduction this replaces, carries a non-empty `polygons` array so
@@ -144,8 +144,8 @@ describe("differential oracle — segmentDistanceGpu vs document.ts's segmentDis
 
 /**
  * plain-JS mirror of `polygonDistanceGpu`'s winding + nearest-edge reduction — over `segmentDistanceGpu`
- * (the same CPU-callable primitive the real reduction calls per edge, `checks.md`'s independent-derivation
- * rule), finishing with the real, exported `polygonSignedDistanceGpu` for the sign. The reduction loop
+ * (the same CPU-callable primitive the real reduction calls per edge, kept as an independent derivation),
+ * finishing with the real, exported `polygonSignedDistanceGpu` for the sign. The reduction loop
  * (winding parity, nearest-edge min) is a JS reimplementation — like `segmentsDistanceGpu`'s reduction
  * above, it reads a bound storage array GPU-side and can't be CPU-called directly — but the sign
  * convention itself, the exact axis a flipped `select` breaks, calls the real kernel code, not a copy.
@@ -346,7 +346,7 @@ describe("emitted WGSL — structural", () => {
             }
         });
 
-        test("the packing expression itself (a cheap structural sentinel, in addition to the eval-based pins above — never the only one, checks.md)", () => {
+        test("the packing expression itself (a cheap structural sentinel, in addition to the eval-based pins above — never the only one)", () => {
             expect(kernel).toContain("let texelX = ((gx * 4u) + k);");
         });
     });

--- a/examples/showcase/roads/src/overlay/rasterize.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.ts
@@ -55,7 +55,7 @@ const rasterLayout = tgpu.bindGroupLayout({
 /**
  * point-segment signed distance (minus half-width), the compute kernel's own derivation: clamp the
  * projection parameter `t` onto [0, 1], measure straight-line distance to the clamped point. CPU-callable
- * (`testing.md`'s logic tier) so `bun test` exercises this exact math with no device — the GPU half of
+ * so `bun test` exercises this exact math with no device — the GPU half of
  * stage 5's differential oracle against `document.ts`'s independently-derived `segmentDistance`.
  * @example segmentDistanceGpu(5, 0, -10, 0, 10, 0, 2) // -2 (on the centreline, inside a 2 m half-width)
  */
@@ -95,7 +95,7 @@ const segmentsDistanceGpu = tgpu.fn(
 
 /** apply the inside/outside sign convention to a polygon's nearest-edge distance — negative inside,
  *  positive outside, `inside` decided by ray-cast winding. Factored out of `polygonDistanceGpu` as its
- *  own pure fn (`coding.md`'s "factor inward") purely so it's CPU-callable with no bound storage:
+ *  own pure fn purely so it's CPU-callable with no bound storage:
  *  `polygonDistanceGpu`'s enclosing reduction reads the shared `polyVerts` buffer and can only run
  *  inside a real dispatch, but the sign convention itself takes no storage — stage 5's differential
  *  oracle calls this directly to pin the sign, the exact axis a flipped `select` breaks.

--- a/examples/showcase/roads/src/overlay/stroke.test.ts
+++ b/examples/showcase/roads/src/overlay/stroke.test.ts
@@ -59,9 +59,9 @@ describe("packStrokeTile — the seeded-tile readback oracle", () => {
 
         // independent re-derivation: recompute the expected texel content at a handful of coordinates by
         // hand-walking the tile's own world origin and texel size, never calling packStrokeTile's internal
-        // texelOffset — an agreement check against the same formula would only prove self-consistency
-        // (checks.md), so this reads the origin from tileOrigin (a different module function) and computes
-        // the byte offset with an inline formula.
+        // texelOffset — an agreement check against the same formula would only prove self-consistency, so
+        // this reads the origin from tileOrigin (a different module function) and computes the byte offset
+        // with an inline formula.
         const [ox, oz] = tileOrigin(tx, tz);
         const probes: Array<[number, number]> = [
             [0, 0],

--- a/examples/showcase/roads/src/overlay/stroke.ts
+++ b/examples/showcase/roads/src/overlay/stroke.ts
@@ -33,8 +33,9 @@ export const ROAD_ALBEDO: readonly [number, number, number] = [0.05, 0.05, 0.06]
 
 /** signed distance in world metres from (x, z) to the stroke's road edge — negative inside the road,
  *  positive outside, zero at the boundary. The primitive stage 5's differential oracle will re-derive
- *  independently against a GPU rasterization of the same shape (`checks.md`'s two-derivations discipline);
- *  here it's the one source both the CPU packer and this stage's unit tests read. */
+ *  independently against a GPU rasterization of the same shape — two derivations written from scratch,
+ *  neither calling the other; here it's the one source both the CPU packer and this stage's unit tests
+ *  read. */
 export function strokeDistance(x: number, z: number): number {
     const clampedX = Math.max(-STROKE_HALF_LENGTH, Math.min(STROKE_HALF_LENGTH, x));
     const dx = x - clampedX;

--- a/examples/showcase/roads/src/overlay/tiles.test.ts
+++ b/examples/showcase/roads/src/overlay/tiles.test.ts
@@ -36,9 +36,9 @@ describe("tile addressing", () => {
 
 describe("dirtyTiles — the dirty-set oracle", () => {
     // an independent hand-derivation of the analytic tile set, walking the full grid by its own formula
-    // rather than calling dirtyTiles' own tileOf/tileId — checks.md's "an agreement check between two
-    // things one author wrote from one document tests the document's self-consistency, never its truth":
-    // this derives the set a different way (world-space overlap of each tile's known footprint) so the two
+    // rather than calling dirtyTiles' own tileOf/tileId — an agreement check between two things one author
+    // wrote from one document tests the document's self-consistency, never its truth: this derives the set
+    // a different way (world-space overlap of each tile's known footprint) so the two
     // can actually disagree if either has a bug.
     function handDerivedDirtySet(minX: number, minZ: number, maxX: number, maxZ: number): number[] {
         const out: number[] = [];

--- a/examples/showcase/roads/src/overlay/tiles.ts
+++ b/examples/showcase/roads/src/overlay/tiles.ts
@@ -2,7 +2,7 @@ import { WORLD_EXTENT, WORLD_HALF } from "../terrain/grid";
 
 // The overlay's fixed world-space tile grid: pure addressing + packing math, no GPU/engine imports (the
 // same device-free split terrain/grid.ts and terrain/noise.ts use) — `bun test` exercises every formula
-// here without a device (testing.md's logic tier). `atlas.ts` is the GPU-resident half that consumes it.
+// here without a device. `atlas.ts` is the GPU-resident half that consumes it.
 //
 // Tile size: 64 m (spec-given, matching Anno's own 512² tile precedent). 1024 m / 64 m = 16 tiles/side
 // exactly (grid.ts's WORLD_EXTENT), so the tile grid tiles the terrain footprint with no partial edge tile

--- a/examples/showcase/roads/src/terrain/flatten.ts
+++ b/examples/showcase/roads/src/terrain/flatten.ts
@@ -7,9 +7,9 @@
 // flattened surface too ("affected-region remesh" — every reseed/regenerate re-dispatches the whole
 // kernel, so there's no separate patch step).
 //
-// Two independently-derived cosine-ease forms (`checks.md`'s two-derivations discipline, the same split
-// `overlay/document.ts`/`overlay/rasterize.ts` use for distance): {@link flattenHeight} is the CPU
-// reference `flatten.test.ts` pins directly; {@link flattenHeightGpu} is TGSL's own re-authoring of the
+// Two independently-derived cosine-ease forms (the same split `overlay/document.ts`/`overlay/rasterize.ts`
+// use for distance): {@link flattenHeight} is the CPU reference `flatten.test.ts` pins directly;
+// {@link flattenHeightGpu} is TGSL's own re-authoring of the
 // same formula (it *can't* call the CPU one — TGSL has no FFI into plain JS), checked against it by a
 // randomized differential test.
 
@@ -51,7 +51,7 @@ export function flattenHeight(
 
 /** the GPU kernel's own cosine-ease derivation — written independently of {@link flattenHeight} (TGSL
  *  can't call a plain JS function anyway), CPU-callable so `flatten.test.ts`'s differential oracle can
- *  compare the two forms with no device (`testing.md`'s logic tier). */
+ *  compare the two forms with no device. */
 export const flattenHeightGpu = tgpu.fn(
     [d.f32, d.f32, d.f32, d.f32],
     d.f32,

--- a/examples/showcase/roads/src/terrain/generate.test.ts
+++ b/examples/showcase/roads/src/terrain/generate.test.ts
@@ -9,8 +9,8 @@ import { heightKernelWgsl } from "./generate";
 import { HALF, SPACING, VERTS } from "./grid";
 
 // The height kernel's structural gate — the device-free seam this stage's `bun test` relies on for the
-// GPU dispatch (`testing.md`'s ladder rung (a)/(b): CPU-callable TGSL + exact resolved WGSL, never a
-// bound device). The kernel's own seed-determinism *readback* runs on the real device instead
+// GPU dispatch (CPU-callable TGSL + exact resolved WGSL, never a bound device). The kernel's own
+// seed-determinism *readback* runs on the real device instead
 // (`gate.ts`, driven by `test/roads.spec.ts`) — the split voxel's `generate.test.ts`/`gate.ts` also make.
 
 describe("height kernel reference", () => {

--- a/examples/showcase/roads/src/terrain/noise.test.ts
+++ b/examples/showcase/roads/src/terrain/noise.test.ts
@@ -5,7 +5,7 @@ import { GROUND_LEVEL, HFREQ, makePermutation, noiseWgsl, RELIEF } from "./noise
 describe("makePermutation", () => {
     // the seed → identical terrain determinism (validated end-to-end on the GPU in the roads gate) rests
     // on the permutation table being deterministic in its seed. These pin that CPU-side foundation —
-    // `testing.md`'s observation ladder never binds a device in `bun test`.
+    // `bun test` never binds a device, so this is the device-free half of that guarantee.
 
     test("is deterministic in the seed", () => {
         expect(makePermutation(1337)).toEqual(makePermutation(1337));

--- a/examples/showcase/roads/src/terrain/noise.ts
+++ b/examples/showcase/roads/src/terrain/noise.ts
@@ -3,8 +3,8 @@
 // (x, z) metres instead of voxel grid cells. No engine/GPU imports, so `bun test` exercises the
 // determinism foundation device-free — the GPU dispatch that consumes this lives in generate.ts.
 //
-// Showcase examples don't import each other's `src/` (examples.md: each is a self-contained project), so
-// this is its own copy of the perlin/fbm/permutation shape, not a shared import from voxel.
+// Showcase examples don't import each other's `src/` — each is a self-contained project — so this is
+// its own copy of the perlin/fbm/permutation shape, not a shared import from voxel.
 
 import tgpu from "typegpu";
 import * as d from "typegpu/data";
@@ -33,8 +33,8 @@ export const noiseLayout = tgpu.bindGroupLayout({
 
 /** the seeded RNG both the permutation table (below) and the procedural network generator
  *  (`overlay/network.ts`) share — one source, not two independently authored copies, since both are
- *  deterministic-in-seed data generators within this one project (`examples.md`'s no-cross-import rule is
- *  about *other* showcase projects, not modules inside this one). */
+ *  deterministic-in-seed data generators within this one project (the no-cross-import rule between
+ *  showcase projects is about *other* projects, not modules inside this one). */
 export function mulberry32(seed: number): () => number {
     let s = seed >>> 0;
     return () => {

--- a/examples/showcase/roads/src/terrain/terrain.test.ts
+++ b/examples/showcase/roads/src/terrain/terrain.test.ts
@@ -4,10 +4,10 @@ import { COVERAGE_BAND_PX, DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../over
 import { terrainFsWgsl } from "./terrain";
 
 // The overlay composite's structural gate — the device-free seam this stage's `bun test` relies on for the
-// fs's atlas-sampling half (`testing.md`'s ladder: CPU-callable/resolved-WGSL first, never a bound
-// device). The composite's actual pixel output is the capture gate's own arm (`gate.ts`/`test/roads.spec.ts`)
-// — checks.md's "layers are a granularity": the compute-write half is proven by the seeded-tile readback
-// oracle (`overlay/stroke.test.ts`), this half by resolution + the capture, neither alone.
+// fs's atlas-sampling half (CPU-callable/resolved-WGSL first, never a bound device). The composite's
+// actual pixel output is the capture gate's own arm (`gate.ts`/`test/roads.spec.ts`) — layers are a
+// granularity: the compute-write half is proven by the seeded-tile readback oracle (`overlay/stroke.test.ts`),
+// this half by resolution + the capture, neither alone.
 
 describe("terrain fs — overlay composite", () => {
     const wgsl = terrainFsWgsl();

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -19,7 +19,6 @@ import * as std from "typegpu/std";
 import * as overlayAtlas from "../overlay/atlas";
 import type { StrokeDocument } from "../overlay/document";
 import { generateNetwork } from "../overlay/network";
-import { strokeDocument } from "../overlay/stroke";
 import { COVERAGE_BAND_PX, DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
 import { setNetwork, warmNetwork } from "./flatten";
 import { bindTerrainKernel, generate, TERRAIN_QUANT } from "./generate";
@@ -158,15 +157,15 @@ function teardown(): void {
     buffers = null;
 }
 
-// The boot document stays the hand-authored known pattern (`overlay/stroke.ts`'s `strokeDocument`) — the
-// exact same one stage 4/5's device gate already validates (fixed on/off-road probe points, an analytic
-// zero-height at the origin) — rather than the freshly-built procedural network (`overlay/network.ts`).
-// Stage 7 is what re-points the capture gate at "the full procedural network" (the spec's own words for
-// its Approach); flipping the *rendered* boot document here would silently invalidate stage 4/5's fixed
-// probe points before that rewiring exists. The generator is real and live from this stage on, though:
-// {@link regenerate} swaps to it on demand (the seed control, `boot.ts`'s F9 handler), exercising the
-// exact same `markDirty`/`redraw`/flatten path production will use once stage 7 makes it the default.
-let liveDocument: StrokeDocument = strokeDocument();
+// The boot document is the seeded procedural network (`overlay/network.ts`'s `generateNetwork`) at this
+// module's own {@link SEED} — the same pinned seed the height kernel boots with, so a fresh load and a
+// capture both see one fixed network. `capture.ts`'s `capturePoints` derives its on/off-road probe points
+// from this exact `generateNetwork(SEED)` call (`overlay/network.ts`'s `captureProbePoints`), so the two
+// can't drift apart. `overlay/stroke.ts`'s hand-authored stroke stays live only as the CPU-vs-GPU
+// differential's known pattern (`document.test.ts`), no longer what boots on screen. {@link regenerate}
+// swaps to a fresh random seed on demand (the seed control, `boot.ts`'s F9 handler), exercising the exact
+// same `markDirty`/`redraw`/flatten path this boot document already takes.
+let liveDocument: StrokeDocument = generateNetwork(SEED);
 
 async function warm(state: State): Promise<void> {
     teardown(); // a rebuild (HMR) re-warms — clear the prior generation's buffers first
@@ -237,9 +236,9 @@ async function warm(state: State): Promise<void> {
     Meshes.register(mesh);
     Draws.register({ name: "terrain", surface: "terrain", mesh: "terrain", args: { indirect } });
 
-    // the boot document (overlay/stroke.ts's known pattern), expressed as a StrokeDocument and rasterized
-    // by overlay/rasterize.ts's GPU kernel (stage 5). Marking it dirty here (not per-frame) means one
-    // redraw burst at warm, not a repeated mark.
+    // the boot document (the procedural network at this module's SEED, above), rasterized by
+    // overlay/rasterize.ts's GPU kernel. Marking it dirty here (not per-frame) means one redraw burst at
+    // warm, not a repeated mark.
     overlayAtlas.markDirty(liveDocument);
 
     bindTerrainKernel(vertices, position);

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -1,4 +1,17 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
+
+// where every run's capture lands — a fixed, git-ignored path (`test-results/`, this project's
+// `.gitignore`) rather than a per-run timestamped name, so "the latest capture" always has one findable
+// location for the spec's human release-look gate to read.
+const CAPTURE_PATH = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "test-results",
+    "roads-capture.png",
+);
 
 // Drive the terrain generator's device gate: load the app, wait for it to warm and expose
 // `window.__roadsGate`, run it on the real GPU, and assert every check passes (and the page raised no
@@ -70,9 +83,10 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
     }
 
     // Phase 2: the overlay substrate's own flagged-risk validation (spec's Locked decision) — a real
-    // captured frame, machine-read, with the hand-authored stroke (overlay/stroke.ts). The compute-write
+    // captured frame, machine-read, over the full procedural network (overlay/network.ts). The compute-write
     // half is proven device-free (overlay/stroke.test.ts's seeded-tile readback oracle); this is the fs
-    // composite's own arm, observable only in the rendered frame (checks.md: layers are a granularity).
+    // composite's own arm, observable only in the rendered frame — the compute-write and the sampled-pixel
+    // output are different granularities, and only this arm sees the second one.
     await page.waitForFunction(
         () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
         null,
@@ -101,6 +115,8 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
     )) as ScreenPoint[];
 
     const screenshot = await page.screenshot();
+    mkdirSync(dirname(CAPTURE_PATH), { recursive: true });
+    writeFileSync(CAPTURE_PATH, screenshot);
     const capture = await page.evaluate(
         async ({ base64, onRoadScreen, offRoadScreen, tolerancePx }) => {
             const binary = atob(base64);


### PR DESCRIPTION
Repoint the device-gate capture at the full procedural network instead of
stage 4/5's hand-authored stroke: terrain.ts boots generateNetwork(SEED),
and overlay/network.ts's captureProbePoints derives grid-aligned on/off-road
probe points from that same network (nearest-to-origin road, both normal
directions tried, verified by documentDistance, throws rather than guessing).
Persist each gate run's screenshot to test-results/roads-capture.png for the
human release-look gate. Land the decal-cost-model-vs-overlay and
same-surface-sampling technique argument as header comments in overlay/atlas.ts.
Drop kex rule-file citations (checks.md, coding.md, testing.md, examples.md)
from ~28 comment sites across the example, keeping the underlying reasoning,
per the spec's residue-on-close item.
