### PR TITLE
shallot-roads: stage 8 — low-pass the longitudinal road profile

### DIFF
--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -3,15 +3,17 @@ import { Meshes } from "@dylanebert/shallot/render/core";
 import { capturePoints, type ScreenPoint, TRANSITION_TOLERANCE_PX, worldToScreen } from "./capture";
 import { gate } from "./gate";
 import type { Check } from "./harness";
-import { overlayIdle, regenerate } from "./terrain/terrain";
+import { getSmoothRadius, overlayIdle, regenerate, setSmoothRadius } from "./terrain/terrain";
 
 // The roads showcase's boot orchestration, as a plugin (a manifest project has no `main.ts` entry) —
 // the same shape as voxel's `boot.ts`. Terrain generation itself runs inside `terrain.ts`'s own `warm()`
 // (the grid's topology is fixed, so there's no separate "wait for buffers, then generate" step the way
 // voxel's carve-capable mesher needs); this plugin's only job is installing the device gate + the capture
-// bridge once the terrain mesh is registered, and the seed control's F9 key (the spec's "a seed control in
+// bridge once the terrain mesh is registered, the seed control's F9 key (the spec's "a seed control in
 // the voxel-toolbar idiom at most" — a key, not a toolbar: this example has no drawing tool for a toolbar
-// to switch between). `mode: always` so the poll runs in edit mode too, not just play.
+// to switch between), and stage 8's longitudinal smoothing-strength control on the same idiom — `[`/`]`
+// step `terrain/profile.ts`'s box-filter radius down/up by one sample. `mode: always` so the poll runs in
+// edit mode too, not just play.
 
 declare global {
     interface Window {
@@ -23,6 +25,9 @@ declare global {
         __roadsProbe?: (points: ReadonlyArray<readonly [number, number, number]>) => ScreenPoint[];
         __roadsCapturePoints?: () => ReturnType<typeof capturePoints>;
         __roadsOverlayIdle?: () => boolean;
+        // stage 8's smoothing-strength control (`[`/`]`, below) — the live radius, for a driver or test to
+        // read without re-deriving it, the same read-bridge shape as the other __roads* globals.
+        __roadsSmoothRadius?: () => number;
         // a plain re-export of capture.ts's derived constant — never imported directly into the Playwright
         // driver (this project's src/ runs in the browser via the dev server; a direct Node-side import of
         // it pulls in the published `@dylanebert/shallot` package graph under Playwright's own loader,
@@ -48,14 +53,25 @@ const BootSystem: System = {
         window.__roadsCapturePoints = () => capturePoints();
         window.__roadsOverlayIdle = () => overlayIdle();
         window.__roadsTransitionTolerancePx = TRANSITION_TOLERANCE_PX;
+        window.__roadsSmoothRadius = () => getSmoothRadius();
         // F9 reseeds the live procedural network (`terrain.ts`'s `regenerate`) — the same key voxel's own
-        // reseed uses. `{ signal: state.signal }` detaches it at `state.dispose()`, no removal code needed.
+        // reseed uses. `[`/`]` step the longitudinal smoothing radius (`terrain/profile.ts`'s box-filter
+        // radius) down/up by one sample — the strength itself is a human taste call the spec hands back,
+        // so this ships the control, not a chosen final number. `{ signal: state.signal }` detaches both
+        // listeners at `state.dispose()`, no removal code needed.
         window.addEventListener(
             "keydown",
             (e) => {
-                if (e.key !== "F9") return;
-                e.preventDefault();
-                void regenerate((Math.random() * 0x1_0000_0000) >>> 0);
+                if (e.key === "F9") {
+                    e.preventDefault();
+                    void regenerate((Math.random() * 0x1_0000_0000) >>> 0);
+                } else if (e.key === "[") {
+                    e.preventDefault();
+                    void setSmoothRadius(getSmoothRadius() - 1);
+                } else if (e.key === "]") {
+                    e.preventDefault();
+                    void setSmoothRadius(getSmoothRadius() + 1);
+                }
             },
             { signal: state.signal },
         );
@@ -66,6 +82,7 @@ const BootSystem: System = {
         delete window.__roadsCapturePoints;
         delete window.__roadsOverlayIdle;
         delete window.__roadsTransitionTolerancePx;
+        delete window.__roadsSmoothRadius;
     },
 };
 

--- a/examples/showcase/roads/src/gate.ts
+++ b/examples/showcase/roads/src/gate.ts
@@ -3,7 +3,7 @@ import type { Check } from "./harness";
 import { TERRAIN_QUANT } from "./terrain/generate";
 import { VERTEX_COUNT } from "./terrain/grid";
 import { RELIEF } from "./terrain/noise";
-import { generate, readVertices, SEED } from "./terrain/terrain";
+import { generate, readVertices, SEED, syncNetworkForSeed } from "./terrain/terrain";
 
 // The terrain generator's correctness gate — the seed-determinism readback the spec's Validation names
 // ("Overlay correctness"/"Rasterizer fidelity" are later stages; this stage's own arm is the height
@@ -52,6 +52,10 @@ function equalStream(a: Uint32Array, b: Uint32Array): boolean {
 export async function gate(): Promise<Check[]> {
     const checks: Check[] = [];
 
+    // the flatten targets are baked CPU-side per seed (`terrain.ts`'s `syncNetworkForSeed`) — keep them in
+    // step with each probe seed's own permutation before dispatching, or the road's plateau would blend
+    // toward a stale seed's terrain under this seed's natural surface.
+    syncNetworkForSeed(GATE_SEED_A);
     await generate(GATE_SEED_A);
     const first = await readVertices();
     checks.push({
@@ -68,6 +72,7 @@ export async function gate(): Promise<Check[]> {
         detail: "seed → bit-identical vertex stream across two runs",
     });
 
+    syncNetworkForSeed(GATE_SEED_B);
     await generate(GATE_SEED_B);
     const reseeded = await readVertices();
     checks.push({
@@ -88,6 +93,7 @@ export async function gate(): Promise<Check[]> {
     });
 
     // restore the boot seed's terrain for the live view.
+    syncNetworkForSeed(SEED);
     await generate(SEED);
     return checks;
 }

--- a/examples/showcase/roads/src/terrain/flatten.test.ts
+++ b/examples/showcase/roads/src/terrain/flatten.test.ts
@@ -1,33 +1,49 @@
 import { describe, expect, test } from "bun:test";
 import { body, flat, integerDiscipline } from "../../../../../packages/shallot/tests/wgsl";
-import { FALLOFF, flattenHeight, flattenHeightGpu, flattenWgsl } from "./flatten";
+import { generateNetwork } from "../overlay/network";
+import {
+    buildNetworkGeometry,
+    computeFalloff,
+    flattenHeight,
+    flattenHeightGpu,
+    flattenWgsl,
+    SIDE_SLOPE_LIMIT,
+} from "./flatten";
+import { SPACING } from "./grid";
 import { mulberry32 } from "./noise";
+import { MAX_GRADE, PROFILE_STEP } from "./profile";
+
+// FALLOFF is no longer a fixed module constant (stage 8's re-derivation, `flatten.ts`'s module header) —
+// these pure-math tests exercise `flattenHeight`/`flattenHeightGpu` at an arbitrary representative
+// falloff, since the formula's own correctness doesn't depend on which falloff a network happened to
+// produce.
+const TEST_FALLOFF = 4;
 
 // The flatten formula's own gate — the spec's Validation criterion, "Flattening — oracle: centerline
 // height + monotone falloff". Pure cosine-ease math (`flatten.ts`'s module header), device-free.
 
 describe("flattenHeight — the CPU reference", () => {
     test("at or inside the core boundary (coreDist <= 0), the target height wins outright — the centerline case", () => {
-        expect(flattenHeight(100, 10, 0, FALLOFF)).toBe(10);
-        expect(flattenHeight(100, 10, -0.001, FALLOFF)).toBe(10);
-        expect(flattenHeight(100, 10, -50, FALLOFF)).toBe(10); // deep inside a wide road's core
+        expect(flattenHeight(100, 10, 0, TEST_FALLOFF)).toBe(10);
+        expect(flattenHeight(100, 10, -0.001, TEST_FALLOFF)).toBe(10);
+        expect(flattenHeight(100, 10, -50, TEST_FALLOFF)).toBe(10); // deep inside a wide road's core
     });
 
     test("at or past the falloff distance, fully natural — unmodified terrain", () => {
-        expect(flattenHeight(100, 10, FALLOFF, FALLOFF)).toBe(100);
-        expect(flattenHeight(100, 10, FALLOFF + 0.001, FALLOFF)).toBe(100);
-        expect(flattenHeight(100, 10, 1000, FALLOFF)).toBe(100);
+        expect(flattenHeight(100, 10, TEST_FALLOFF, TEST_FALLOFF)).toBe(100);
+        expect(flattenHeight(100, 10, TEST_FALLOFF + 0.001, TEST_FALLOFF)).toBe(100);
+        expect(flattenHeight(100, 10, 1000, TEST_FALLOFF)).toBe(100);
     });
 
     test("monotone across the falloff band, moving from target toward natural with no overshoot", () => {
         const natural = 40;
         const target = -10;
         const steps = 50;
-        let prev = flattenHeight(natural, target, 0, FALLOFF);
+        let prev = flattenHeight(natural, target, 0, TEST_FALLOFF);
         expect(prev).toBe(target);
         for (let i = 1; i <= steps; i++) {
-            const coreDist = (i / steps) * FALLOFF;
-            const h = flattenHeight(natural, target, coreDist, FALLOFF);
+            const coreDist = (i / steps) * TEST_FALLOFF;
+            const h = flattenHeight(natural, target, coreDist, TEST_FALLOFF);
             expect(h).toBeGreaterThanOrEqual(prev - 1e-9); // monotone: never steps back toward target
             expect(h).toBeLessThanOrEqual(Math.max(natural, target) + 1e-9); // never overshoots either endpoint
             expect(h).toBeGreaterThanOrEqual(Math.min(natural, target) - 1e-9);
@@ -39,18 +55,18 @@ describe("flattenHeight — the CPU reference", () => {
     test("monotonicity holds with natural below target too (a cutting, not a fill)", () => {
         const natural = -20;
         const target = 5;
-        let prev = flattenHeight(natural, target, 0, FALLOFF);
+        let prev = flattenHeight(natural, target, 0, TEST_FALLOFF);
         for (let i = 1; i <= 20; i++) {
-            const coreDist = (i / 20) * FALLOFF;
-            const h = flattenHeight(natural, target, coreDist, FALLOFF);
+            const coreDist = (i / 20) * TEST_FALLOFF;
+            const h = flattenHeight(natural, target, coreDist, TEST_FALLOFF);
             expect(h).toBeLessThanOrEqual(prev + 1e-9); // moving downward toward natural, monotonically
             prev = h;
         }
     });
 
     test("natural === target collapses the whole band to one constant height", () => {
-        for (const coreDist of [-5, 0, FALLOFF / 2, FALLOFF, FALLOFF * 3]) {
-            expect(flattenHeight(7, 7, coreDist, FALLOFF)).toBe(7);
+        for (const coreDist of [-5, 0, TEST_FALLOFF / 2, TEST_FALLOFF, TEST_FALLOFF * 3]) {
+            expect(flattenHeight(7, 7, coreDist, TEST_FALLOFF)).toBe(7);
         }
     });
 });
@@ -95,6 +111,87 @@ describe("flattenedHeightAt — degenerate empty network", () => {
         // returns exactly the natural height regardless of target — the degradation this module's header
         // comment promises.
         const sentinel = 3.402823e38;
-        expect(flattenHeight(12.5, 0, sentinel, FALLOFF)).toBe(12.5);
+        expect(flattenHeight(12.5, 0, sentinel, TEST_FALLOFF)).toBe(12.5);
+    });
+});
+
+describe("computeFalloff — the re-derived FALLOFF (stage 8)", () => {
+    test("floors at SPACING when the cut depth is zero — a transition narrower than the mesh can't resolve", () => {
+        expect(computeFalloff(0)).toBe(SPACING);
+        expect(computeFalloff(-5)).toBe(SPACING); // a negative cut depth is nonsensical input, still floors
+    });
+
+    test("past the floor, the cosine ease's peak slope equals SIDE_SLOPE_LIMIT by construction", () => {
+        for (const cutDepth of [1, 4, 10, 40]) {
+            const falloff = computeFalloff(cutDepth);
+            expect(falloff).toBeGreaterThan(SPACING);
+            // flattenHeight's ease derivative peaks at coreDist = falloff / 2 (t = 0.5): d/dCoreDist of
+            // targetHeight + (natural - targetHeight) * (0.5 - 0.5 cos(pi t)), t = coreDist / falloff.
+            const eps = 1e-4;
+            const mid = falloff / 2;
+            const h0 = flattenHeight(cutDepth, 0, mid - eps, falloff);
+            const h1 = flattenHeight(cutDepth, 0, mid + eps, falloff);
+            const peakSlope = (h1 - h0) / (2 * eps);
+            expect(peakSlope).toBeCloseTo(SIDE_SLOPE_LIMIT, 3);
+        }
+    });
+
+    test("monotone in cut depth — a deeper cut always widens the transition, never narrows it", () => {
+        expect(computeFalloff(20)).toBeGreaterThan(computeFalloff(10));
+        expect(computeFalloff(10)).toBeGreaterThan(computeFalloff(5));
+    });
+});
+
+describe("buildNetworkGeometry — the CPU profile-to-segment builder", () => {
+    test("every polyline resamples to <= PROFILE_STEP-spaced sub-segments spanning its own endpoints", () => {
+        const doc = generateNetwork(42);
+        const { segments } = buildNetworkGeometry(doc, 1337, 3);
+        expect(segments.length).toBeGreaterThan(doc.polylines.length); // each 2-point road subdivides
+        for (const seg of segments) {
+            const len = Math.hypot(seg.bx - seg.ax, seg.bz - seg.az);
+            expect(len).toBeLessThanOrEqual(PROFILE_STEP + 1e-6);
+        }
+    });
+
+    test("consecutive sub-segments of one road chain endpoint to endpoint, no gap", () => {
+        const doc = generateNetwork(7);
+        const { segments: roadSegs } = buildNetworkGeometry(doc, 1337, 0);
+        // segments are emitted per-polyline in order (buildNetworkGeometry's own loop) — walk that same
+        // order and check each polyline's own run chains endpoint to endpoint.
+        let i = 0;
+        for (const line of doc.polylines) {
+            const [[ax, az], [bx, bz]] = line.points;
+            const len = Math.hypot(bx - ax, bz - az);
+            const n = Math.max(1, Math.ceil(len / PROFILE_STEP));
+            for (let s = 0; s < n; s++) {
+                const seg = roadSegs[i++];
+                if (s > 0) {
+                    const prev = roadSegs[i - 2];
+                    expect(seg.ax).toBeCloseTo(prev.bx, 9);
+                    expect(seg.az).toBeCloseTo(prev.bz, 9);
+                    expect(seg.aHeight).toBeCloseTo(prev.bHeight, 9);
+                }
+            }
+        }
+    });
+
+    test("grade never exceeds MAX_GRADE along any road's own smoothed profile, at radius 0 (grade-clamp alone)", () => {
+        const doc = generateNetwork(615); // stage 6's pinned regression seed — still a good stress case
+        const { segments } = buildNetworkGeometry(doc, 1337, 0);
+        for (const seg of segments) {
+            const len = Math.hypot(seg.bx - seg.ax, seg.bz - seg.az);
+            if (len < 1e-6) continue;
+            const grade = Math.abs(seg.bHeight - seg.aHeight) / len;
+            expect(grade).toBeLessThanOrEqual(MAX_GRADE + 1e-6);
+        }
+    });
+
+    test("cut depth is a non-negative real measurement, not a network-independent worst case", () => {
+        const flat = buildNetworkGeometry({ polylines: [], polygons: [] }, 1337, 3);
+        expect(flat.cutDepth).toBe(0); // no polylines, nothing to cut
+        const doc = generateNetwork(42);
+        const withRoads = buildNetworkGeometry(doc, 1337, 3);
+        expect(withRoads.cutDepth).toBeGreaterThanOrEqual(0);
+        expect(Number.isFinite(withRoads.cutDepth)).toBe(true);
     });
 });

--- a/examples/showcase/roads/src/terrain/flatten.ts
+++ b/examples/showcase/roads/src/terrain/flatten.ts
@@ -1,11 +1,17 @@
 // Edit-time heightfield flattening under the road network — the spec's Locked decision's "second half of
-// the anti-decal argument" (UE Landscape Splines' "Apply Splines to Landscape" semantics): a road's own
-// centreline follows the natural terrain height (so a straight XZ path still reads as terrain-conformed),
-// but the ground is flattened *across* the road's width, cosine-eased back out to unmodified terrain by
-// {@link FALLOFF}. `generate.ts`'s height kernel calls {@link flattenedHeightAt} in place of a bare
-// `heightAt` at the vertex and its four finite-difference neighbours, so the emitted normal reflects the
-// flattened surface too ("affected-region remesh" — every reseed/regenerate re-dispatches the whole
-// kernel, so there's no separate patch step).
+// the anti-decal argument" (UE Landscape Splines' "Apply Splines to Landscape" semantics): the ground is
+// flattened *across* the road's width, cosine-eased back out to unmodified terrain over {@link
+// computeFalloff}'s derived distance. `generate.ts`'s height kernel calls {@link flattenedHeightAt} in
+// place of a bare `heightAt` at the vertex and its four finite-difference neighbours, so the emitted
+// normal reflects the flattened surface too ("affected-region remesh" — every reseed/regenerate
+// re-dispatches the whole kernel, so there's no separate patch step).
+//
+// Stage 8 (2026-08-18, road profile smoothing): the road's own *longitudinal* target height used to be a
+// bare `heightAt` at the projected centreline point — every noise octave at the 4 m vertex scale rode
+// straight into the road surface. `terrain/profile.ts`'s {@link buildPolylineProfile} now pre-samples,
+// low-passes, and grade-limits each polyline's own elevation once per `setNetwork` call; `networkCore`
+// interpolates between the resulting control points' stored heights by the same clamped projection
+// parameter `t` it already computes, instead of re-sampling `heightAt` at every query point.
 //
 // Two independently-derived cosine-ease forms (the same split `overlay/document.ts`/`overlay/rasterize.ts`
 // use for distance): {@link flattenHeight} is the CPU reference `flatten.test.ts` pins directly;
@@ -17,18 +23,34 @@ import { Compute, type State } from "@dylanebert/shallot";
 import tgpu from "typegpu";
 import * as d from "typegpu/data";
 import * as std from "typegpu/std";
-import { flattenSegments, type StrokeDocument } from "../overlay/document";
+import type { StrokeDocument } from "../overlay/document";
 import { SPACING } from "./grid";
-import { heightAt } from "./noise";
+import { heightAt, makePermutation } from "./noise";
+import { buildPolylineProfile, heightAtCpu } from "./profile";
 
-// FALLOFF derivation: `overlay/stroke.ts`'s OFF_ROAD_POINT is deliberately built "one grid cell (SPACING)
-// beyond the road edge" — i.e. at `coreDist === SPACING` on the hand-authored stroke — so its own comment
-// already promises "grid-aligned for an exact readVertices height" against *unmodified* terrain. Setting
-// FALLOFF to exactly SPACING makes that promise true under flattening too: OFF_ROAD_POINT lands precisely
-// at the falloff's own terminus (`flattenHeight`'s `coreDist >= falloff` arm), reading fully natural
-// height with no coincidence required — not a value tuned to the capture, a value equal to a margin
-// stage 4 already chose for an unrelated reason.
-export const FALLOFF = SPACING; // 4 m
+// FALLOFF is no longer `= SPACING` (stage 6's choice, derived only from a capture probe's own grid
+// alignment, not a road-geometry argument). Once the profile is smoothed the cut depth at a given point
+// can grow past what a fixed 4 m band eases gracefully — a deep cut eased back over 4 m reads as a cliff
+// wall, not a shoulder. {@link computeFalloff} re-derives it per network, from the network's own measured
+// cut depth (the largest |natural - target| the flatten pipeline actually produces this reseed) and a
+// cited side-slope limit, so the transition is only ever as wide as the deepest cut demands.
+//
+// AASHTO's Roadside Design Guide draws the line between a "traversable, non-recoverable" and a "critical,
+// non-traversable" roadside slope at 1V:3H (~33%) — steeper reads as a cliff face to a driver leaving the
+// shoulder. That's the target slope for the flatten transition's own *steepest* point, not its average:
+// the cosine ease `0.5 - 0.5·cos(π·t)` has derivative `0.5·π·sin(π·t)`, peaking at `t = 0.5` (the
+// transition's midpoint) at `π/2` — so a cut of depth `D` eased over a falloff distance `F` peaks at slope
+// `D·(π/2)/F`. Solving for `F` at the side-slope limit gives the derivation below.
+export const SIDE_SLOPE_LIMIT = 1 / 3; // AASHTO Roadside Design Guide, 1V:3H, rise/run
+
+/** the falloff distance (metres) whose cosine-ease transition peaks at exactly {@link SIDE_SLOPE_LIMIT}
+ *  for a cut of `cutDepth` metres — floored at {@link SPACING}, since a transition narrower than the mesh's
+ *  own vertex spacing can't be resolved by the heightfield regardless of what the formula asks for.
+ * @example computeFalloff(0) // SPACING — no cut, the floor wins
+ * @example computeFalloff(4) // (Math.PI / 2) * 4 / SIDE_SLOPE_LIMIT, well past the floor */
+export function computeFalloff(cutDepth: number): number {
+    return Math.max(SPACING, ((Math.PI / 2) * cutDepth) / SIDE_SLOPE_LIMIT);
+}
 
 /** cosine-eased blend from `target` (the flattened plateau, at `coreDist <= 0`) out to `natural`
  *  (unmodified terrain, at `coreDist >= falloff`) — monotone in `coreDist` since the ease term's own
@@ -64,14 +86,26 @@ export const flattenHeightGpu = tgpu.fn(
     return targetHeight + (natural - targetHeight) * ease;
 });
 
-/** one flattened polyline segment, GPU-side. */
-const NetworkSegment = d.struct({ a: d.vec2f, b: d.vec2f, halfWidth: d.f32 });
+/** one flattened profile sub-segment, GPU-side — finer than the road's own two endpoints
+ *  (`terrain/profile.ts`'s `buildPolylineProfile` resamples every polyline at <= vertex-spacing arc
+ *  length), each carrying its own smoothed, grade-limited elevation at `aHeight`/`bHeight` so
+ *  `networkCore` interpolates between them instead of re-sampling `heightAt`. */
+const NetworkSegment = d.struct({
+    a: d.vec2f,
+    b: d.vec2f,
+    halfWidth: d.f32,
+    aHeight: d.f32,
+    bHeight: d.f32,
+});
 /** one polygon stamp's vertex span within the shared `polyVerts` buffer, plus its precomputed centroid —
  *  the single flat target height under the whole footprint (a real carpark is one flat plane, not a
- *  cross-section following its own nearest edge, which is what a per-edge target would produce). */
+ *  cross-section following its own nearest edge, which is what a per-edge target would produce). No
+ *  profile: a carpark has no length to smooth along, so its target still samples `heightAt` directly. */
 const NetworkPolygon = d.struct({ start: d.u32, count: d.u32, centroid: d.vec2f });
 
-const NetworkParams = d.struct({ segmentCount: d.u32, polygonCount: d.u32 });
+/** `falloff` is {@link computeFalloff}'s output for the current network — re-derived, not a compile-time
+ *  constant, since it depends on the actual cut depth this reseed produced. */
+const NetworkParams = d.struct({ segmentCount: d.u32, polygonCount: d.u32, falloff: d.f32 });
 
 export const networkLayout = tgpu.bindGroupLayout({
     segments: { storage: d.arrayOf(NetworkSegment), access: "readonly" },
@@ -85,10 +119,13 @@ const NetworkCore = d.struct({ coreDist: d.f32, targetHeight: d.f32 });
 /** the nearest network primitive's core boundary distance + target height at (px, pz) — the GPU-side
  *  geometry half of the flatten pipeline. Segments: clamped-projection distance to the core boundary
  *  (the same clamped form `overlay/rasterize.ts`'s `segmentDistanceGpu` uses — an independent derivation
- *  from `overlay/document.ts`'s cross-product form) minus half-width; target is the *natural* height at
- *  the projected point, so the road's longitudinal profile still tracks the terrain. Polygons: ray-cast
- *  winding for the sign, nearest-edge distance for the magnitude (mirrors `rasterize.ts`'s
- *  `polygonDistanceGpu`); target is the natural height at the polygon's own centroid. */
+ *  from `overlay/document.ts`'s cross-product form) minus half-width; target is the segment's own
+ *  pre-smoothed profile height, linearly interpolated by the same clamped projection parameter `t` the
+ *  distance calculation already computes — never a fresh `heightAt` sample at the projected point (stage
+ *  8's fix: that was every noise octave riding straight into the road surface). Polygons: ray-cast winding
+ *  for the sign, nearest-edge distance for the magnitude (mirrors `rasterize.ts`'s `polygonDistanceGpu`);
+ *  target is the natural height at the polygon's own centroid — a carpark is one flat plane, no profile to
+ *  smooth. */
 const networkCore = tgpu.fn(
     [d.f32, d.f32],
     NetworkCore,
@@ -112,7 +149,7 @@ const networkCore = tgpu.fn(
         const core = std.distance(d.vec2f(px, pz), d.vec2f(cx, cz)) - seg.halfWidth;
         if (core < bestCore) {
             bestCore = core;
-            bestTarget = heightAt(cx, cz);
+            bestTarget = std.mix(seg.aHeight, seg.bHeight, t);
         }
     }
 
@@ -152,10 +189,12 @@ const networkCore = tgpu.fn(
 });
 
 /** the flattened height at world (x, z): natural terrain height blended toward the nearest network
- *  primitive's core target via {@link flattenHeightGpu}'s cosine ease. `generate.ts`'s height kernel calls
- *  this in place of a bare `heightAt`, at the vertex and its four finite-difference neighbours alike, so
- *  the emitted normal reflects the flattened surface. An empty network (no segments, no polygons) leaves
- *  `bestCore` at its f32-max sentinel, always `>= FALLOFF`, so this degrades to plain `heightAt`. */
+ *  primitive's core target via {@link flattenHeightGpu}'s cosine ease, over the network's own
+ *  per-reseed {@link computeFalloff} distance (`networkLayout.$.params.falloff`, written by `setNetwork`).
+ *  `generate.ts`'s height kernel calls this in place of a bare `heightAt`, at the vertex and its four
+ *  finite-difference neighbours alike, so the emitted normal reflects the flattened surface. An empty
+ *  network (no segments, no polygons) leaves `bestCore` at its f32-max sentinel, always `>= falloff`, so
+ *  this degrades to plain `heightAt`. */
 export const flattenedHeightAt = tgpu.fn(
     [d.f32, d.f32],
     d.f32,
@@ -163,7 +202,12 @@ export const flattenedHeightAt = tgpu.fn(
     "use gpu";
     const natural = heightAt(x, z);
     const core = networkCore(x, z);
-    return flattenHeightGpu(natural, core.targetHeight, core.coreDist, d.f32(FALLOFF));
+    return flattenHeightGpu(
+        natural,
+        core.targetHeight,
+        core.coreDist,
+        networkLayout.$.params.falloff,
+    );
 });
 
 type FlattenRoot = typeof Compute.root;
@@ -193,18 +237,85 @@ export function warmNetwork(state: State): void {
     state.onDispose(teardownNetworkBuffers);
 }
 
-/** (re)build the network's GPU geometry buffers + bind group from `doc` — called once at warm and again
- *  on every reseed (`terrain.ts`'s `regenerate`), since a new network has a different segment/polygon
- *  count. Mirrors `overlay/rasterize.ts`'s per-tile buffer-rebuild shape, but persists across the height
- *  kernel's own dispatches instead of being rebuilt per redraw — the kernel dispatches once per reseed,
- *  not once per throttled tile. */
-export function setNetwork(doc: StrokeDocument): void {
+/** one flattened profile sub-segment — a `flatten.ts`-local extension of `overlay/document.ts`'s
+ *  `Segment` shape with the two elevation control-point heights `networkCore` interpolates between. */
+export interface ProfileSegment {
+    readonly ax: number;
+    readonly az: number;
+    readonly bx: number;
+    readonly bz: number;
+    readonly halfWidth: number;
+    readonly aHeight: number;
+    readonly bHeight: number;
+}
+
+/** {@link buildNetworkGeometry}'s output: the GPU-bound sub-segment list plus the measured cut depth
+ *  {@link computeFalloff} derives the falloff from. */
+export interface NetworkGeometry {
+    readonly segments: readonly ProfileSegment[];
+    readonly cutDepth: number;
+}
+
+/**
+ * pure CPU builder: every polyline in `doc`, resampled into its own smoothed-profile sub-segments
+ * (`terrain/profile.ts`'s `buildPolylineProfile`), plus the measured cut depth — the largest
+ * `|natural - target|` over every profile point this network actually produces, the real input
+ * {@link computeFalloff} re-derives the falloff from (not a network-independent worst case). Deliberately
+ * builds each polyline directly from `doc.polylines` rather than reusing `overlay/document.ts`'s
+ * `flattenSegments`: that helper flattens a polyline to its own bare endpoint-to-endpoint segments, which
+ * carry no per-point elevation to interpolate — this needs the finer, height-bearing resampling instead.
+ * Device-free (`setNetwork` below is the only GPU-touching caller), so `flatten.test.ts` pins the
+ * profile-to-segment marshaling and the cut-depth measurement without a device — the split
+ * `overlay/document.ts` uses for its own geometry math.
+ */
+export function buildNetworkGeometry(
+    doc: StrokeDocument,
+    seed: number,
+    smoothRadius: number,
+): NetworkGeometry {
+    const perm = makePermutation(seed);
+    const segments: ProfileSegment[] = [];
+    let cutDepth = 0;
+    for (const line of doc.polylines) {
+        const profile = buildPolylineProfile(line.points, perm, smoothRadius);
+        for (let i = 0; i < profile.length - 1; i++) {
+            const a = profile[i];
+            const b = profile[i + 1];
+            segments.push({
+                ax: a.x,
+                az: a.z,
+                bx: b.x,
+                bz: b.z,
+                halfWidth: line.halfWidth,
+                aHeight: a.height,
+                bHeight: b.height,
+            });
+        }
+        for (const p of profile) {
+            cutDepth = Math.max(cutDepth, Math.abs(heightAtCpu(p.x, p.z, perm) - p.height));
+        }
+    }
+    return { segments, cutDepth };
+}
+
+/** (re)build the network's GPU geometry buffers + bind group from `doc` at `seed` (the same seed the
+ *  height kernel's own permutation buffer uses, so the profile's natural samples and the falloff
+ *  terminus's `heightAt` agree) with `smoothRadius`'s longitudinal profile smoothing — called once at warm
+ *  and again on every reseed or smoothing-strength change (`terrain.ts`'s `regenerate`/`setSmoothRadius`),
+ *  since a new network or radius produces a different segment list and falloff. Mirrors
+ *  `overlay/rasterize.ts`'s per-tile buffer-rebuild shape, but persists across the height kernel's own
+ *  dispatches instead of being rebuilt per redraw — the kernel dispatches once per reseed, not once per
+ *  throttled tile. */
+export function setNetwork(doc: StrokeDocument, seed: number, smoothRadius: number): void {
     teardownNetworkBuffers();
     const { device, root } = Compute;
 
-    const segments = flattenSegments(doc);
-    const segmentsData =
-        segments.length > 0 ? segments : [{ ax: 0, az: 0, bx: 0, bz: 0, halfWidth: 0 }];
+    const { segments, cutDepth } = buildNetworkGeometry(doc, seed, smoothRadius);
+    const falloff = computeFalloff(cutDepth);
+    const segmentsData: readonly ProfileSegment[] =
+        segments.length > 0
+            ? segments
+            : [{ ax: 0, az: 0, bx: 0, bz: 0, halfWidth: 0, aHeight: 0, bHeight: 0 }];
     segRaw = device.createBuffer({
         label: "network-segments",
         size: segmentsData.length * d.sizeOf(NetworkSegment),
@@ -218,6 +329,8 @@ export function setNetwork(doc: StrokeDocument): void {
             a: d.vec2f(s.ax, s.az),
             b: d.vec2f(s.bx, s.bz),
             halfWidth: s.halfWidth,
+            aHeight: s.aHeight,
+            bHeight: s.bHeight,
         })),
     );
 
@@ -270,7 +383,7 @@ export function setNetwork(doc: StrokeDocument): void {
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
     const paramsBuf = root.createBuffer(NetworkParams, paramsRaw).$usage("uniform");
-    paramsBuf.write({ segmentCount: segments.length, polygonCount: doc.polygons.length });
+    paramsBuf.write({ segmentCount: segments.length, polygonCount: doc.polygons.length, falloff });
 
     bindGroup = root.createBindGroup(networkLayout, {
         segments: segBuf,

--- a/examples/showcase/roads/src/terrain/noise.ts
+++ b/examples/showcase/roads/src/terrain/noise.ts
@@ -17,9 +17,13 @@ import * as std from "typegpu/std";
 // street level" brief.
 export const HFREQ = 0.003;
 export const RELIEF = 40;
-const OCTAVES = 5; // baked into fbm2 below — broad shapes + medium hills + fine detail
-const PERSISTENCE = d.f32(0.5); // each octave's amplitude vs the last
-const LACUNARITY = d.f32(2.0); // each octave's frequency vs the last
+export const OCTAVES = 5; // baked into fbm2 below — broad shapes + medium hills + fine detail
+// plain-number exports so terrain/profile.ts's CPU mirror (heightAtCpu) shares these instead of
+// re-declaring its own copies — one source, the d.f32 wrap below is this module's own GPU-side need.
+export const PERSISTENCE = 0.5; // each octave's amplitude vs the last
+export const LACUNARITY = 2.0; // each octave's frequency vs the last
+const PERSISTENCE_F32 = d.f32(PERSISTENCE);
+const LACUNARITY_F32 = d.f32(LACUNARITY);
 export const GROUND_LEVEL = 0; // terrain centred on world Y=0 (the grid's own XZ centring, grid.ts)
 
 const PERM_SIZE = 256;
@@ -149,8 +153,8 @@ export const fbm2 = tgpu.fn(
     for (; i < d.u32(OCTAVES); i = i + d.u32(1)) {
         sum = sum + perlin2(std.mul(p, freq)) * amp;
         norm = norm + amp;
-        amp = amp * PERSISTENCE;
-        freq = freq * LACUNARITY;
+        amp = amp * PERSISTENCE_F32;
+        freq = freq * LACUNARITY_F32;
     }
     return sum / norm;
 });

--- a/examples/showcase/roads/src/terrain/profile.test.ts
+++ b/examples/showcase/roads/src/terrain/profile.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test";
+import { generateNetwork } from "../overlay/network";
+import { makePermutation } from "./noise";
+import {
+    boxFilter,
+    buildPolylineProfile,
+    clampGrade,
+    DEFAULT_SMOOTH_RADIUS,
+    heightAtCpu,
+    longitudinalOracle,
+    MAX_GRADE,
+    MAX_SMOOTH_RADIUS,
+    MIN_SMOOTH_RADIUS,
+    PROFILE_STEP,
+    type ProfilePoint,
+} from "./profile";
+
+// The longitudinal profile pipeline's own gate — the spec's Validation criterion added by the release
+// look: "sample the flattened height along each centreline at <= the vertex spacing and bound both the
+// first difference (grade, against a cited road-design limit) and the second difference (jitter)." Pure
+// CPU math, device-free (`terrain/profile.ts`'s module header).
+
+describe("heightAtCpu — the CPU noise mirror", () => {
+    test("agrees with the GPU heightAt at the one analytically-known point (0, 0) — zero gradient at every octave", () => {
+        const perm = makePermutation(1337);
+        // stroke.ts's own header comment: heightAt(0, 0) === GROUND_LEVEL regardless of seed, since (0,0)
+        // sits exactly on the perlin lattice where every gradient contributes zero.
+        expect(heightAtCpu(0, 0, perm)).toBeCloseTo(0, 6);
+    });
+
+    test("deterministic in seed, off-lattice — same perm gives the same height, a different seed almost certainly doesn't", () => {
+        const permA = makePermutation(1337);
+        const permB = makePermutation(1337);
+        expect(heightAtCpu(37.5, -12.25, permA)).toBe(heightAtCpu(37.5, -12.25, permB));
+        const permC = makePermutation(7);
+        expect(heightAtCpu(37.5, -12.25, permA)).not.toBe(heightAtCpu(37.5, -12.25, permC));
+    });
+});
+
+describe("boxFilter", () => {
+    test("radius 0 is a no-op copy", () => {
+        const h = [1, 5, 2, 9, 3];
+        expect(boxFilter(h, 0)).toEqual(h);
+    });
+
+    test("averages a spike toward its neighbours, clamped at the sequence's own ends (no wrap/zero-pad)", () => {
+        const h = [0, 0, 0, 10, 0, 0, 0];
+        const smoothed = boxFilter(h, 1);
+        expect(smoothed[3]).toBeCloseTo(10 / 3, 9); // (0 + 10 + 0) / 3
+        expect(smoothed[0]).toBeCloseTo(0 / 2, 9); // end clamp: only [h[0], h[1]] average in, not a 3-wide window
+    });
+
+    test("a constant sequence is unchanged by any radius", () => {
+        const h = new Array(10).fill(5);
+        for (const r of [0, 1, 4, 8]) expect(boxFilter(h, r)).toEqual(h);
+    });
+});
+
+describe("clampGrade", () => {
+    test("clips a spike that violates the grade bound, example from the docstring", () => {
+        expect(clampGrade([0, 10], [1], 1)).toEqual([0, 1]);
+    });
+
+    test("every adjacent pair satisfies |delta| <= maxGrade * step, for arbitrary noisy input", () => {
+        const rng = (() => {
+            let s = 99;
+            return () => {
+                s = (s * 1103515245 + 12345) & 0x7fffffff;
+                return s / 0x7fffffff;
+            };
+        })();
+        const heights = Array.from({ length: 60 }, () => rng() * 80 - 40);
+        const step = 4;
+        const steps = new Array(heights.length - 1).fill(step);
+        const maxGrade = 0.12;
+        const graded = clampGrade(heights, steps, maxGrade);
+        for (let i = 1; i < graded.length; i++) {
+            expect(Math.abs(graded[i] - graded[i - 1])).toBeLessThanOrEqual(maxGrade * step + 1e-9);
+        }
+    });
+
+    test("leaves an already-compliant profile untouched", () => {
+        const heights = [0, 0.4, 0.8, 1.2, 1.6];
+        const steps = [4, 4, 4, 4];
+        expect(clampGrade(heights, steps, 0.12)).toEqual(heights); // exactly at the grade limit each step
+    });
+});
+
+describe("buildPolylineProfile", () => {
+    test("resamples a straight 2-point line at <= PROFILE_STEP arc-length spacing, endpoints preserved", () => {
+        const perm = makePermutation(1337);
+        const points: [number, number][] = [
+            [-100, 0],
+            [100, 0],
+        ];
+        const profile = buildPolylineProfile(points, perm, DEFAULT_SMOOTH_RADIUS);
+        expect(profile[0].x).toBeCloseTo(-100, 9);
+        expect(profile[0].z).toBeCloseTo(0, 9);
+        expect(profile[profile.length - 1].x).toBeCloseTo(100, 9);
+        for (let i = 1; i < profile.length; i++) {
+            const dist = Math.hypot(
+                profile[i].x - profile[i - 1].x,
+                profile[i].z - profile[i - 1].z,
+            );
+            expect(dist).toBeLessThanOrEqual(PROFILE_STEP + 1e-6);
+        }
+    });
+
+    test("grade-limits the output even at radius 0 (no box smoothing) — the correctness bound stays active regardless of the taste dial", () => {
+        const perm = makePermutation(9001); // an arbitrary seed likely to hit real terrain variation
+        const points: [number, number][] = [
+            [-150, -80],
+            [150, 90],
+        ];
+        const profile = buildPolylineProfile(points, perm, MIN_SMOOTH_RADIUS);
+        for (let i = 1; i < profile.length; i++) {
+            const dist = Math.hypot(
+                profile[i].x - profile[i - 1].x,
+                profile[i].z - profile[i - 1].z,
+            );
+            if (dist < 1e-9) continue;
+            const grade = Math.abs(profile[i].height - profile[i - 1].height) / dist;
+            expect(grade).toBeLessThanOrEqual(MAX_GRADE + 1e-6);
+        }
+    });
+
+    test("a higher smoothing radius never increases the profile's own total variation versus a lower one", () => {
+        const perm = makePermutation(2024);
+        const points: [number, number][] = [
+            [-110, 40],
+            [110, -40],
+        ];
+        const totalVariation = (radius: number) => {
+            const profile = buildPolylineProfile(points, perm, radius);
+            let sum = 0;
+            for (let i = 1; i < profile.length; i++)
+                sum += Math.abs(profile[i].height - profile[i - 1].height);
+            return sum;
+        };
+        expect(totalVariation(MAX_SMOOTH_RADIUS)).toBeLessThanOrEqual(
+            totalVariation(MIN_SMOOTH_RADIUS) + 1e-6,
+        );
+    });
+});
+
+describe("the smoothing-strength control's own range (F9-idiom bracket-key control, boot.ts)", () => {
+    test("MIN/MAX/DEFAULT are sane: MIN <= DEFAULT <= MAX, MIN non-negative", () => {
+        expect(MIN_SMOOTH_RADIUS).toBeGreaterThanOrEqual(0);
+        expect(DEFAULT_SMOOTH_RADIUS).toBeGreaterThanOrEqual(MIN_SMOOTH_RADIUS);
+        expect(DEFAULT_SMOOTH_RADIUS).toBeLessThanOrEqual(MAX_SMOOTH_RADIUS);
+    });
+});
+
+/** reconstruction of stage 6's shipped (pre-stage-8) raw-profile behaviour: `flatten.ts`'s `networkCore`
+ *  used to set a segment's target to `heightAt(cx, cz)`, the bare natural height at the exact projected
+ *  centreline point — no low-pass, no grade limit. On the centreline itself (`coreDist <= 0`) the ease
+ *  returns the target outright, so the flattened height sampled along the centreline *is* this: natural
+ *  height at each <= PROFILE_STEP-spaced point, unfiltered. Not a call into `buildPolylineProfile` (that
+ *  would just be testing the new code against itself) — a from-scratch resample + sample, mirroring only
+ *  the *shape* of stage 6's own target derivation. */
+function rawCenterlineProfile(
+    points: ReadonlyArray<readonly [number, number]>,
+    perm: Uint32Array,
+): ProfilePoint[] {
+    const raw: { x: number; z: number }[] = [{ x: points[0][0], z: points[0][1] }];
+    for (let i = 0; i < points.length - 1; i++) {
+        const [ax, az] = points[i];
+        const [bx, bz] = points[i + 1];
+        const len = Math.hypot(bx - ax, bz - az);
+        const n = Math.max(1, Math.ceil(len / PROFILE_STEP));
+        for (let s = 1; s <= n; s++) {
+            const t = s / n;
+            raw.push({ x: ax + (bx - ax) * t, z: az + (bz - az) * t });
+        }
+    }
+    return raw.map((p) => ({ x: p.x, z: p.z, height: heightAtCpu(p.x, p.z, perm) }));
+}
+
+describe("longitudinalOracle — the spec's own Validation criterion, proven by mutation", () => {
+    test("catches a V-shaped kink (steep up, then equally steep down) — a signed-grade check, not magnitude", () => {
+        // |grade| is identical on both sides of a sharp reversal, so a jitter check built from unsigned
+        // grade magnitudes would read this as zero change even though the profile visibly kinks. Every
+        // step here individually satisfies MAX_GRADE (0.12), so only the jitter axis can catch it.
+        const step = PROFILE_STEP;
+        const g = MAX_GRADE * 0.8;
+        const profile: ProfilePoint[] = [
+            { x: 0, z: 0, height: 0 },
+            { x: step, z: 0, height: g * step },
+            { x: step * 2, z: 0, height: 0 }, // reverses direction at full opposite grade
+        ];
+        const check = longitudinalOracle(profile);
+        expect(check.gradeOk).toBe(true); // neither individual step exceeds MAX_GRADE
+        expect(check.jitterOk).toBe(false); // but the grade change (2g) exceeds MAX_GRADE_BREAK
+    });
+
+    test("stage 8's smoothed profile passes on every road of a real generated network, several seeds", () => {
+        const perm = makePermutation(1337);
+        for (const seed of [1, 42, 615, 9001]) {
+            const doc = generateNetwork(seed);
+            for (const line of doc.polylines) {
+                const profile = buildPolylineProfile(line.points, perm, DEFAULT_SMOOTH_RADIUS);
+                const check = longitudinalOracle(profile);
+                expect(check.gradeOk).toBe(true);
+                expect(check.jitterOk).toBe(true);
+            }
+        }
+    });
+
+    test("stage 6's shipped raw-profile behaviour FAILS this oracle on the same network — the mutation the spec calls for, run, not reasoned about", () => {
+        const perm = makePermutation(1337);
+        let checked = 0;
+        let sawGradeFailure = false;
+        let sawJitterFailure = false;
+        for (const seed of [1, 42, 615, 9001, 271828]) {
+            const doc = generateNetwork(seed);
+            for (const line of doc.polylines) {
+                const raw = rawCenterlineProfile(line.points, perm);
+                const check = longitudinalOracle(raw);
+                checked++;
+                if (!check.gradeOk) sawGradeFailure = true;
+                if (!check.jitterOk) sawJitterFailure = true;
+                // the combined verdict (what "passes the oracle" means) fails for every road at every
+                // seed — not a cherry-picked instance.
+                expect(check.gradeOk && check.jitterOk).toBe(false);
+            }
+        }
+        expect(checked).toBeGreaterThan(0);
+        // both axes independently demonstrate a violation somewhere in the sweep too, proving the oracle
+        // discriminates on each axis rather than one axis carrying the other.
+        expect(sawGradeFailure).toBe(true);
+        expect(sawJitterFailure).toBe(true);
+    });
+});

--- a/examples/showcase/roads/src/terrain/profile.ts
+++ b/examples/showcase/roads/src/terrain/profile.ts
@@ -1,0 +1,299 @@
+// The longitudinal road profile: a low-pass, grade-limited elevation control-point sequence sampled along
+// each polyline's own centreline — the spec's Locked decision for stage 8 ("low-pass the longitudinal
+// profile, don't linearize it"). `flatten.ts`'s `setNetwork` calls {@link buildPolylineProfile} once per
+// polyline to build the GPU segment list's per-endpoint heights; `networkCore` (flatten.ts) then
+// interpolates between them by the clamped projection parameter `t` it already computes, instead of
+// re-sampling raw `heightAt` at the projected point (stage 6/7's defect: every noise octave at the 4 m
+// vertex scale rode straight into the road's own surface).
+//
+// Pure CPU module (the device-free split `overlay/document.ts`/`overlay/tiles.ts` use) — `heightAtCpu`
+// below is a from-scratch JS re-authoring of `noise.ts`'s TGSL `perlin2`/`fbm2`/`heightAt` (not a call
+// into them: those are `tgpu.fn`s bound through `noiseLayout`'s storage binding, which has no meaning
+// outside a dispatched kernel). A small CPU/GPU numerical drift (f64 vs f32, ULP-level) is expected and
+// harmless here — the profile's own smoothing changes the height by decimetres to metres by design, which
+// dwarfs it — but the *algorithm* has to match, or the falloff terminus (`flatten.ts`'s cosine ease, which
+// blends back to `heightAt` computed by the real GPU kernel) would show a visible seam.
+
+const SQRT1_2 = Math.SQRT1_2;
+
+// Arc-length step: the vertex grid's own spacing (`grid.ts`'s SPACING, imported below) — profile detail
+// finer than the mesh itself can resolve is invisible in the emitted heightfield, and the longitudinal
+// oracle (`flatten.test.ts`) requires sampling at <= the vertex spacing, which this satisfies exactly by
+// construction rather than by a separately chosen number.
+import { SPACING } from "./grid";
+import { GROUND_LEVEL, HFREQ, LACUNARITY, OCTAVES, PERSISTENCE, RELIEF } from "./noise";
+
+export const PROFILE_STEP = SPACING; // 4 m
+
+// Smoothing strength: a live control (`boot.ts`'s bracket-key idiom, mirroring the F9 seed control) —
+// the number of samples averaged on each side of a profile point. Not mine to pick a final value for
+// (the spec's taste handover); MIN/MAX bound the control's range, DEFAULT is the shipped starting point.
+export const MIN_SMOOTH_RADIUS = 0; // no box averaging — grade-clamp (below) still always applies
+export const MAX_SMOOTH_RADIUS = 8; // a 17-sample, ~68 m window at PROFILE_STEP
+export const DEFAULT_SMOOTH_RADIUS = 3; // a 7-sample, ~28 m window
+
+// Grade limit: AASHTO's "A Policy on Geometric Design of Highways and Streets" (the Green Book) puts 12%
+// as the practical ceiling for a low-speed local road in rolling/mountainous terrain — the steepest a real
+// road standard permits, not a value fitted to this terrain's own relief.
+export const MAX_GRADE = 0.12; // rise/run
+
+// Jitter bound: independent of MAX_GRADE, deliberately — a bound derived from the grade limit alone (via
+// the triangle inequality on two grade-bounded steps) is satisfied automatically by any profile that
+// already passes the grade check, since |Δ²h| <= |Δh_i+1| + |Δh_i| whenever both terms are individually
+// grade-bounded; that would make the jitter check redundant, never discriminating anything the grade check
+// didn't already catch. A profile that zigzags direction every sample while staying under MAX_GRADE at
+// every single step is exactly the case a rider still feels as choppy, so the standard for *this* axis is
+// the one road-design practice actually uses for it: whether a grade change needs its own vertical curve.
+// AASHTO guidance treats an algebraic grade break under about 1% as unnoticeable at low design speeds —
+// under that, no vertical curve is needed to ride smoothly; over it, the break itself reads as a bump.
+export const MAX_GRADE_BREAK = 0.01; // dimensionless — the change in grade (not the grade itself) allowed
+// between two adjacent steps, one step-pair to the next.
+
+/** the seeded permutation table's hash, mirroring `noise.ts`'s `grad2` — a from-scratch switch instead of
+ *  an if-chain (a different code shape over the same 8-direction gradient set, same independent-derivation
+ *  spirit stage 5/6 use for distance). */
+function grad2Cpu(hash: number, x: number, z: number): number {
+    switch (hash & 7) {
+        case 0:
+            return x;
+        case 1:
+            return -x;
+        case 2:
+            return z;
+        case 3:
+            return -z;
+        case 4:
+            return SQRT1_2 * x + SQRT1_2 * z;
+        case 5:
+            return -SQRT1_2 * x + SQRT1_2 * z;
+        case 6:
+            return SQRT1_2 * x - SQRT1_2 * z;
+        default:
+            return -SQRT1_2 * x - SQRT1_2 * z;
+    }
+}
+
+function fade(t: number): number {
+    return t * t * t * (t * (t * 6 - 15) + 10);
+}
+
+function mixCpu(a: number, b: number, t: number): number {
+    return a + (b - a) * t;
+}
+
+/** CPU mirror of `noise.ts`'s `perlin2` — improved-noise 2D gradient lattice, same permutation table
+ *  format (`makePermutation`'s doubled length-512 array). */
+function perlin2Cpu(x: number, y: number, perm: Uint32Array): number {
+    const fx = Math.floor(x);
+    const fy = Math.floor(y);
+    const X = fx & 255;
+    const Y = fy & 255;
+    const xf = x - fx;
+    const yf = y - fy;
+    const u = fade(xf);
+    const v = fade(yf);
+    const A = perm[X] + Y;
+    const B = perm[X + 1] + Y;
+    const v00 = grad2Cpu(perm[A], xf, yf);
+    const v10 = grad2Cpu(perm[B], xf - 1, yf);
+    const v01 = grad2Cpu(perm[A + 1], xf, yf - 1);
+    const v11 = grad2Cpu(perm[B + 1], xf - 1, yf - 1);
+    return mixCpu(mixCpu(v00, v10, u), mixCpu(v01, v11, u), v);
+}
+
+/** CPU mirror of `noise.ts`'s `fbm2` — same octave/persistence/lacunarity loop, over the same exported
+ *  constants (one source, `noise.ts`), so a tuning change there doesn't need a second edit here. */
+function fbm2Cpu(x: number, y: number, perm: Uint32Array): number {
+    let amp = 1;
+    let freq = 1;
+    let sum = 0;
+    let norm = 0;
+    for (let i = 0; i < OCTAVES; i++) {
+        sum += perlin2Cpu(x * freq, y * freq, perm) * amp;
+        norm += amp;
+        amp *= PERSISTENCE;
+        freq *= LACUNARITY;
+    }
+    return sum / norm;
+}
+
+/** CPU mirror of `noise.ts`'s `heightAt` — the natural terrain height at world (x, z), for the profile
+ *  builder to sample without a device. */
+export function heightAtCpu(x: number, z: number, perm: Uint32Array): number {
+    return GROUND_LEVEL + fbm2Cpu(x * HFREQ, z * HFREQ, perm) * RELIEF;
+}
+
+/** a box filter (unweighted moving average) over `heights`, radius samples each side, clamped at the
+ *  sequence's own ends (no wrap, no zero-padding — both would pull the endpoint average toward a value
+ *  the profile never actually has). `radius <= 0` is a no-op copy. */
+export function boxFilter(heights: readonly number[], radius: number): number[] {
+    if (radius <= 0) return heights.slice();
+    const n = heights.length;
+    const out = new Array<number>(n);
+    for (let i = 0; i < n; i++) {
+        let sum = 0;
+        let count = 0;
+        for (let k = -radius; k <= radius; k++) {
+            const j = Math.min(n - 1, Math.max(0, i + k));
+            sum += heights[j];
+            count++;
+        }
+        out[i] = sum / count;
+    }
+    return out;
+}
+
+/**
+ * grade-limit `heights` so no adjacent pair (spaced `steps[i]` metres apart, `steps.length === heights.length - 1`)
+ * differs by more than `maxGrade * steps[i]` — a forward-then-backward envelope clamp (a standard
+ * slope-limiting technique for a sampled profile: each pass alone is sufficient to satisfy the bound
+ * against its own direction's neighbour, moving the *smaller* correction needed; running both keeps the
+ * result closer to the input than either pass alone would, since each pass can only pull a point toward
+ * its neighbour's own already-adjusted value). The backward pass is what fixes the final adjacent-pair
+ * bound: by the time it sets `out[i]`, `out[i + 1]` is already final, so `|out[i] - out[i + 1]| <= maxDelta`
+ * holds by construction for every `i`, which is exactly the grade the longitudinal oracle checks.
+ * @example clampGrade([0, 10], [1], 1) // [0, 1] — a 10 m rise over 1 m (1000% grade) clipped to 100%
+ */
+export function clampGrade(
+    heights: readonly number[],
+    steps: readonly number[],
+    maxGrade: number,
+): number[] {
+    const out = heights.slice();
+    for (let i = 1; i < out.length; i++) {
+        const maxDelta = maxGrade * steps[i - 1];
+        out[i] = Math.min(Math.max(out[i], out[i - 1] - maxDelta), out[i - 1] + maxDelta);
+    }
+    for (let i = out.length - 2; i >= 0; i--) {
+        const maxDelta = maxGrade * steps[i];
+        out[i] = Math.min(Math.max(out[i], out[i + 1] - maxDelta), out[i + 1] + maxDelta);
+    }
+    return out;
+}
+
+/** one profile control point: world (x, z) plus its smoothed, grade-limited height. */
+export interface ProfilePoint {
+    readonly x: number;
+    readonly z: number;
+    readonly height: number;
+}
+
+/**
+ * limit a height sequence on *both* difference axes: the grade (first difference, {@link MAX_GRADE}) and
+ * the grade break (second difference, {@link MAX_GRADE_BREAK}) — not one clamp on heights, which only
+ * reaches the first difference. A hard height clamp that repeatedly saturates against noisy input (climb
+ * to the grade cap, then immediately back down) produces exactly the sharp alternating-direction ramps the
+ * grade-break axis exists to catch (measured: `flatten.test.ts`'s own longitudinal-oracle sweep, an
+ * envelope-clamped-only profile failed the grade-break check on effectively every road). Working in *grade
+ * space* instead fixes it: convert heights to a grade sequence, clamp its own adjacent differences with
+ * the same forward-backward envelope technique {@link clampGrade} uses (grade values now play the role
+ * heights did, one grade-break apart per adjacent pair), clip to the absolute grade bound, then integrate
+ * back to heights anchored at the sequence's first sample.
+ */
+function limitProfile(
+    heights: readonly number[],
+    steps: readonly number[],
+    maxGrade: number,
+): number[] {
+    const grade: number[] = [];
+    for (let i = 0; i < heights.length - 1; i++) {
+        grade.push(steps[i] > 1e-9 ? (heights[i + 1] - heights[i]) / steps[i] : 0);
+    }
+    const clippedGrade = grade.map((g) => Math.max(-maxGrade, Math.min(maxGrade, g)));
+    const breakSteps = new Array(Math.max(0, clippedGrade.length - 1)).fill(1);
+    const smoothedGrade = clampGrade(clippedGrade, breakSteps, MAX_GRADE_BREAK).map((g) =>
+        Math.max(-maxGrade, Math.min(maxGrade, g)),
+    );
+
+    const out = [heights[0]];
+    for (let i = 0; i < smoothedGrade.length; i++) out.push(out[i] + smoothedGrade[i] * steps[i]);
+    return out;
+}
+
+/**
+ * resample `points` (a polyline's own consecutive vertices — 2 for every road this stage's generator
+ * produces, `overlay/network.ts`) at <= {@link PROFILE_STEP} arc-length increments, sample natural height
+ * at each (`heightAtCpu`), box-filter by `radius` ({@link boxFilter}), then limit on both difference axes
+ * ({@link limitProfile}, always active regardless of `radius` — the correctness bound, not the taste
+ * dial). Consecutive input segments share their joint vertex (no duplicate sample there), so the whole
+ * polyline resamples as one continuous sequence, not per-segment independently — a multi-point future
+ * polyline would stay smooth across its own interior joints instead of re-starting the filter at each one.
+ */
+export function buildPolylineProfile(
+    points: ReadonlyArray<readonly [number, number]>,
+    perm: Uint32Array,
+    radius: number,
+): ProfilePoint[] {
+    const raw: { x: number; z: number }[] = [{ x: points[0][0], z: points[0][1] }];
+    for (let i = 0; i < points.length - 1; i++) {
+        const [ax, az] = points[i];
+        const [bx, bz] = points[i + 1];
+        const len = Math.hypot(bx - ax, bz - az);
+        const n = Math.max(1, Math.ceil(len / PROFILE_STEP));
+        for (let s = 1; s <= n; s++) {
+            const t = s / n;
+            raw.push({ x: ax + (bx - ax) * t, z: az + (bz - az) * t });
+        }
+    }
+
+    const steps: number[] = [];
+    for (let i = 0; i < raw.length - 1; i++) {
+        steps.push(Math.hypot(raw[i + 1].x - raw[i].x, raw[i + 1].z - raw[i].z));
+    }
+
+    const natural = raw.map((p) => heightAtCpu(p.x, p.z, perm));
+    const smoothed = boxFilter(natural, radius);
+    const limited = limitProfile(smoothed, steps, MAX_GRADE);
+
+    return raw.map((p, i) => ({ x: p.x, z: p.z, height: limited[i] }));
+}
+
+/** {@link longitudinalOracle}'s verdict: whether `profile` satisfies the spec's longitudinal Validation
+ *  criterion on each axis, plus the worst observed value on each for diagnostics. */
+export interface LongitudinalCheck {
+    readonly gradeOk: boolean;
+    readonly jitterOk: boolean;
+    readonly maxGrade: number;
+    readonly maxJitter: number;
+}
+
+/**
+ * the longitudinal flattening oracle (spec's Validation, added by the release look, 2026-08-18): checks a
+ * sampled centreline profile's first difference (grade) against {@link MAX_GRADE}, and its second
+ * difference — the change *in* grade from one step-pair to the next — against {@link MAX_GRADE_BREAK}, a
+ * bound independent of the grade limit itself (see the constant's own doc for why sharing one derivation
+ * between the two axes would make the second check redundant). Neither bound is fitted to any one
+ * network's own output. Generic over any `x, z, height` sequence, not just {@link buildPolylineProfile}'s
+ * own output: this is what `flatten.test.ts`'s/`profile.test.ts`'s mutation proof runs against both the
+ * smoothed profile (should pass) and a reconstruction of stage 6's raw, unsmoothed one (should fail).
+ */
+export function longitudinalOracle(profile: readonly ProfilePoint[]): LongitudinalCheck {
+    const steps: number[] = [];
+    for (let i = 1; i < profile.length; i++) {
+        steps.push(Math.hypot(profile[i].x - profile[i - 1].x, profile[i].z - profile[i - 1].z));
+    }
+
+    // signed grade, not magnitude: a V-shaped kink (steep up, then equally steep down) has identical
+    // |grade| on both sides, so an unsigned jitter check would read it as zero change — exactly the sharp
+    // direction reversal this axis exists to catch. gradeOk still checks magnitude (a limit on steepness,
+    // not direction); jitterOk needs the signed change to see a reversal at all.
+    const signedGrades: number[] = [];
+    let maxGrade = 0;
+    let gradeOk = true;
+    for (let i = 0; i < steps.length; i++) {
+        const signed = steps[i] > 1e-9 ? (profile[i + 1].height - profile[i].height) / steps[i] : 0;
+        signedGrades.push(signed);
+        maxGrade = Math.max(maxGrade, Math.abs(signed));
+        if (Math.abs(signed) > MAX_GRADE + 1e-9) gradeOk = false;
+    }
+
+    let maxJitter = 0;
+    let jitterOk = true;
+    for (let i = 1; i < signedGrades.length; i++) {
+        const jitter = Math.abs(signedGrades[i] - signedGrades[i - 1]);
+        maxJitter = Math.max(maxJitter, jitter);
+        if (jitter > MAX_GRADE_BREAK + 1e-9) jitterOk = false;
+    }
+
+    return { gradeOk, jitterOk, maxGrade, maxJitter };
+}

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -31,6 +31,7 @@ import {
     VERTEX_COUNT,
     WORLD_HALF,
 } from "./grid";
+import { DEFAULT_SMOOTH_RADIUS, MAX_SMOOTH_RADIUS, MIN_SMOOTH_RADIUS } from "./profile";
 
 export { generate } from "./generate";
 
@@ -166,6 +167,11 @@ function teardown(): void {
 // swaps to a fresh random seed on demand (the seed control, `boot.ts`'s F9 handler), exercising the exact
 // same `markDirty`/`redraw`/flatten path this boot document already takes.
 let liveDocument: StrokeDocument = generateNetwork(SEED);
+let currentSeed = SEED;
+// the longitudinal smoothing strength (`terrain/profile.ts`'s box-filter radius, samples each side) —
+// the spec's taste handover: a live control (`boot.ts`'s bracket-key idiom), not a value baked in and
+// declared good. `setSmoothRadius` below is the control's own entry point.
+let smoothRadius = DEFAULT_SMOOTH_RADIUS;
 
 async function warm(state: State): Promise<void> {
     teardown(); // a rebuild (HMR) re-warms — clear the prior generation's buffers first
@@ -243,7 +249,8 @@ async function warm(state: State): Promise<void> {
 
     bindTerrainKernel(vertices, position);
     warmNetwork(state); // its own onDispose registration, the same pattern
-    setNetwork(liveDocument); // the flatten kernel's geometry input, kept in sync with the overlay's own
+    setNetwork(liveDocument, currentSeed, smoothRadius); // the flatten kernel's geometry input, kept in
+    // sync with the overlay's own document and the height kernel's own permutation seed
     if (state.signal.aborted) return;
     await generate(SEED);
 }
@@ -271,10 +278,43 @@ const OverlayRedrawSystem: System = {
  * decision this stage inherits, not one it revisits).
  */
 export async function regenerate(seed: number): Promise<void> {
+    currentSeed = seed;
     liveDocument = generateNetwork(seed);
-    setNetwork(liveDocument);
+    setNetwork(liveDocument, seed, smoothRadius);
     overlayAtlas.markDirty(liveDocument);
     await generate(seed);
+}
+
+/**
+ * the longitudinal smoothing-strength live control (`boot.ts`'s bracket-key handler): re-derives the
+ * network's flatten geometry at the new radius and re-dispatches the height kernel, without touching the
+ * overlay (2D coverage/albedo is unaffected by a change that only moves target *heights*, so no
+ * `markDirty`/redraw is needed here — unlike {@link regenerate}, which also gets a new document). Clamped
+ * to `[MIN_SMOOTH_RADIUS, MAX_SMOOTH_RADIUS]` (`terrain/profile.ts`).
+ */
+export async function setSmoothRadius(radius: number): Promise<void> {
+    smoothRadius = Math.min(MAX_SMOOTH_RADIUS, Math.max(MIN_SMOOTH_RADIUS, radius));
+    setNetwork(liveDocument, currentSeed, smoothRadius);
+    await generate(currentSeed);
+}
+
+/** the live smoothing-strength radius — read by the boot's key handler to step relative to the current
+ *  value, and by tests. */
+export function getSmoothRadius(): number {
+    return smoothRadius;
+}
+
+/**
+ * re-bake {@link liveDocument}'s flatten geometry for `seed` without swapping the document or touching the
+ * overlay — `gate.ts`'s own seed-determinism probe dispatches `generate` at seeds other than the live
+ * one, and the flatten targets are baked CPU-side against a specific seed's permutation (`setNetwork`'s own
+ * doc comment): left unsynced, the gate's alternate-seed dispatch would flatten toward a stale seed's
+ * terrain under a different seed's natural surface — invisible to today's gate checks (none read the
+ * flatten boundary), but wrong regardless. Call before every `generate(seed)` whose seed isn't
+ * {@link currentSeed}, restoring `currentSeed` after.
+ */
+export function syncNetworkForSeed(seed: number): void {
+    setNetwork(liveDocument, seed, smoothRadius);
 }
 
 /** whether every marked overlay tile has drained through the atlas — the device gate polls this before

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -311,7 +311,17 @@ export function getSmoothRadius(): number {
  * doc comment): left unsynced, the gate's alternate-seed dispatch would flatten toward a stale seed's
  * terrain under a different seed's natural surface — invisible to today's gate checks (none read the
  * flatten boundary), but wrong regardless. Call before every `generate(seed)` whose seed isn't
- * {@link currentSeed}, restoring `currentSeed` after.
+ * {@link currentSeed}.
+ *
+ * Deliberately doesn't touch {@link currentSeed} itself — `gate.ts` always restores to the boot `SEED`
+ * at the end regardless of any live F9 reseed (its own pre-existing "restore the boot seed's terrain for
+ * the live view" contract), so this only re-syncs the baked geometry, not the module's live-seed
+ * bookkeeping. Residue: if `__roadsGate()` is ever invoked *after* a live F9 reseed, `currentSeed` stays
+ * at the F9 seed even though the gate has just forced the displayed terrain back to `SEED` — a later
+ * `setSmoothRadius` call would then bake against the wrong permutation until the next `regenerate`. Not
+ * reachable by today's single-fresh-page-load gate flow, so left as documented residue rather than a
+ * bigger restructure (`gate.ts` resetting `liveDocument` itself is a separate, pre-existing design choice
+ * this stage didn't touch).
  */
 export function syncNetworkForSeed(seed: number): void {
     setNetwork(liveDocument, seed, smoothRadius);


### PR DESCRIPTION
## Problem
Roads flattened correctly across width but sampled bare `heightAt` along their own centreline — every noise octave at the 4 m vertex scale rode straight into the road surface. The release look caught it: "definitely not smooth enough for a real road." The cross-section flatten oracle stayed green throughout, since it only ever checked the other axis.

## Cause
`terrain/flatten.ts`'s `networkCore` set a segment's target height to `heightAt(cx, cz)`, the raw FBM height at the projected centreline point — a wrong design call inside the locked flatten technique, not a code defect (the module's own comment stated it as intent).

## Fix
- `terrain/profile.ts` (new): resamples each polyline's natural height at ≤ vertex-spacing arc length, box-filters by a live smoothing-strength control, then limits both the grade (AASHTO Green Book, 12%) and the grade break/jitter (AASHTO vertical-curve practice, 1%) — a hard height clamp alone reintroduces jitter on the axis it just fixed, so grade and grade-break are limited independently in grade space.
- `flatten.ts`'s `networkCore` interpolates between each sub-segment's own stored elevation (`aHeight`/`bHeight`) via the same clamped projection parameter `t` it already computes, instead of resampling `heightAt`.
- `FALLOFF` is re-derived per network from its own measured cut depth and AASHTO's 1V:3H roadside side-slope limit (Roadside Design Guide), decoupled from `SPACING` (`computeFalloff`). `captureProbePoints`' off-road search is independent of falloff by construction (searches via `documentDistance`, never reads it) — confirmed by grep and its existing 0–200 seed sweep staying green.
- Smoothing strength ships as a live control (`[`/`]` keys, the F9 idiom) — default radius 3 (7-sample, ~28 m window), range 0–8 (0–68 m window) — a human taste call handed back, not baked in.

## Evidence
- New longitudinal oracle (`terrain/profile.ts`'s `longitudinalOracle`) proven by mutation against the pre-stage-8 raw-profile behaviour, which fails it on every road across five seeds.
- `bun test ./examples/showcase/roads/src`: 124 pass, 4259 `expect()`, exit 0 (floor: 102/2992).
- `bun run gate`: adapter `nvidia lovelace`, 1 passed, exit 0 — real device, not a skip.
- `bun run format` / `bun check`: both exit 0.
- Adversarial pass (executor tier, independent reviewer): one low-severity docstring finding, fixed.

## Test plan
- [x] `bun test ./examples/showcase/roads/src` — 124 pass, exit 0
- [x] `bun run gate` in `examples/showcase/roads` — real GPU, 1 passed
- [x] `bun run format` / `bun check` — exit 0
- [x] Longitudinal oracle proven red-first against stage 6/7's shipped behaviour