### PR TITLE
shallot roads/boundary quantization

### DIFF
--- a/examples/showcase/roads/package.json
+++ b/examples/showcase/roads/package.json
@@ -12,6 +12,8 @@
         "typegpu": "~0.12.0"
     },
     "devDependencies": {
-        "@playwright/test": "^1.58.2"
+        "@playwright/test": "^1.58.2",
+        "@types/pngjs": "^6.0.5",
+        "pngjs": "^7.0.0"
     }
 }

--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -2,7 +2,10 @@ import type { Plugin, System } from "@dylanebert/shallot";
 import { Meshes } from "@dylanebert/shallot/render/core";
 import { capturePoints, type ScreenPoint, TRANSITION_TOLERANCE_PX, worldToScreen } from "./capture";
 import { gate } from "./gate";
+import { type GrazingAnchor, grazingCapture } from "./grazingCapture";
 import type { Check } from "./harness";
+import { DIST_RANGE, TILE_RES } from "./overlay/tiles";
+import { SPACING } from "./terrain/grid";
 import { getSmoothRadius, overlayIdle, regenerate, setSmoothRadius } from "./terrain/terrain";
 
 // The roads showcase's boot orchestration, as a plugin (a manifest project has no `main.ts` entry) —
@@ -33,6 +36,15 @@ declare global {
         // it pulls in the published `@dylanebert/shallot` package graph under Playwright's own loader,
         // which chokes on the package's `exports` map — `test/roads.spec.ts` stays bridge-only).
         __roadsTransitionTolerancePx?: number;
+        // stage 9's straightness discriminator (`grazingCapture.ts`) — repositions the camera to a fixed
+        // grazing pose and returns the analytic boundary anchors a straightness probe scans around. The
+        // same bridge-only shape as the rest of this file: `test/straightness.spec.ts` never imports
+        // engine/ECS code directly, only reads this window global.
+        __roadsGrazingCapture?: () => Promise<{ anchors: GrazingAnchor[] }>;
+        // the live mesh/atlas resolution constants under test — read by `test/straightness.spec.ts` so the
+        // two-resolution reading is self-labeling rather than trusting whatever the driver assumed was
+        // edited before the run.
+        __roadsMeshParams?: { spacing: number; tileRes: number; distRange: number };
     }
 }
 
@@ -54,6 +66,8 @@ const BootSystem: System = {
         window.__roadsOverlayIdle = () => overlayIdle();
         window.__roadsTransitionTolerancePx = TRANSITION_TOLERANCE_PX;
         window.__roadsSmoothRadius = () => getSmoothRadius();
+        window.__roadsGrazingCapture = () => grazingCapture();
+        window.__roadsMeshParams = { spacing: SPACING, tileRes: TILE_RES, distRange: DIST_RANGE };
         // F9 reseeds the live procedural network (`terrain.ts`'s `regenerate`) — the same key voxel's own
         // reseed uses. `[`/`]` step the longitudinal smoothing radius (`terrain/profile.ts`'s box-filter
         // radius) down/up by one sample — the strength itself is a human taste call the spec hands back,
@@ -83,6 +97,8 @@ const BootSystem: System = {
         delete window.__roadsOverlayIdle;
         delete window.__roadsTransitionTolerancePx;
         delete window.__roadsSmoothRadius;
+        delete window.__roadsGrazingCapture;
+        delete window.__roadsMeshParams;
     },
 };
 

--- a/examples/showcase/roads/src/capture.ts
+++ b/examples/showcase/roads/src/capture.ts
@@ -67,11 +67,13 @@ export function worldToScreen(
     });
 }
 
-/** one grid-aligned world (x, z) → its full 3D world point, height read from the real generated vertex
- *  stream (`readVertices`, `terrain.ts`) rather than re-deriving the noise function in JS — {@link gridX}/
- *  {@link gridZ} require an exact grid column, which `overlay/network.ts`'s `captureProbePoints` are
- *  built to return. */
-async function withHeight(x: number, z: number): Promise<[x: number, y: number, z: number]> {
+/** one arbitrary world (x, z) → its full 3D world point, height read from the real generated vertex
+ *  stream (`readVertices`, `terrain.ts`) at the *nearest* grid column, rather than re-deriving the noise
+ *  function in JS — exact for a grid-aligned input (`overlay/network.ts`'s `captureProbePoints`), and a
+ *  bounded-error approximation (at most half a grid cell's own height gradient) for an off-grid point such
+ *  as a straightness probe's analytic edge anchor (`grazingCapture.ts`), which only needs a point close
+ *  enough to the real surface to project sensibly, not the exact flattened height. */
+export async function withHeight(x: number, z: number): Promise<[x: number, y: number, z: number]> {
     const raw = await readVertices();
     const ix = gridX(x);
     const iz = gridZ(z);

--- a/examples/showcase/roads/src/grazingCapture.ts
+++ b/examples/showcase/roads/src/grazingCapture.ts
@@ -1,0 +1,135 @@
+import { Orbit } from "@dylanebert/shallot/extras";
+import { Views } from "@dylanebert/shallot/render/core";
+import { withHeight, worldToScreen } from "./capture";
+import { frames } from "./harness";
+import { documentDistance } from "./overlay/document";
+import { generateNetwork } from "./overlay/network";
+import { SEED } from "./terrain/terrain";
+
+// Stage 9's discriminator — the grazing-view half. The release-look screenshot that opened this stage was
+// a hand-orbited shot; this reproduces it as a *fixed, reproducible* camera pose so the two-resolution
+// reading is a real comparison and not two different framings. A near-horizontal grazing angle is the
+// point, not an aesthetic choice: a small world-space deviation projects to a much larger screen-pixel
+// deviation the closer the view direction runs parallel to the surface (the same reason raking light
+// reveals machining marks a top-down look hides) — the straightness signal this stage measures needs that
+// magnification to be visible in a handful of screen pixels at all.
+//
+// Reuses the *same* boot document every run (`generateNetwork(SEED)`, `terrain.ts`'s own boot document) —
+// road index 0's own first segment, deterministic — so a SPACING/TILE_RES/DIST_RANGE edit between runs
+// changes only the mesh/atlas resolution under test, never the network geometry the camera is framed to.
+
+const TARGET_T = 0.08; // fraction along the road from its start — near one end, so the far ~90% recedes
+const PROBE_T_LO = 0.2;
+const PROBE_T_HI = 0.8;
+const PROBE_COUNT = 16; // anchors along the visible run, avoiding both ends' falloff/off-frame risk
+const PITCH = 0.06; // radians (~3.4°) — near-horizontal, the grazing angle itself
+const DISTANCE = 15; // world metres — close to the scene's own min-distance (10), low and near the edge
+const EYE_MARGIN = 0.4; // metres above the read terrain height, clearing z-fighting/embedding
+const ON_BOUNDARY_TOLERANCE = 0.02; // metres — the analytic edge point must sit this close to dist=0
+
+export interface GrazingAnchor {
+    /** the analytic (ground-truth) boundary point's screen position, as a fraction of canvas size. */
+    x: number;
+    y: number;
+    /** unit search direction in screen-fraction space, perpendicular to the projected road boundary at
+     *  this anchor — the axis `straightness.ts`'s `detectEdgeOffset` walks. */
+    dirX: number;
+    dirY: number;
+}
+
+/** the boot document's first road, flattened to its own single segment — the fixed geometry every grazing
+ *  capture (any SPACING/TILE_RES/DIST_RANGE run) frames against. */
+function roadSegment(): { ax: number; az: number; bx: number; bz: number; halfWidth: number } {
+    const doc = generateNetwork(SEED);
+    const [[ax, az], [bx, bz]] = doc.polylines[0].points;
+    return { ax, az, bx, bz, halfWidth: doc.polylines[0].halfWidth };
+}
+
+/** the canvas-presenting camera's eid — the same `Views` disambiguation `capture.ts`'s `cameraEid` uses
+ *  (a shadow-casting light's pooled shadow camera also carries `Camera`, so only a live `canvas` picks the
+ *  display camera out). Re-derived here rather than imported since `capture.ts` keeps it private to its
+ *  own read-only probe bridge; this module's job is to *write* the pose, a different responsibility. */
+function cameraEid(): number {
+    for (const [eid, view] of Views) {
+        if (view.canvas) return eid;
+    }
+    throw new Error("grazingCapture: no canvas-presenting camera in Views");
+}
+
+/**
+ * repositions the scene's orbit camera to a fixed grazing pose looking along the boot document's first
+ * road (near one end, looking toward the other), waits for the pose to settle, and returns the analytic
+ * boundary anchors (screen position + local search direction) the real screenshot's straightness probe
+ * should search around. Exported as `window.__roadsGrazingCapture` (`boot.ts`).
+ */
+export async function grazingCapture(): Promise<{ anchors: GrazingAnchor[] }> {
+    const eid = cameraEid();
+    const { ax, az, bx, bz, halfWidth } = roadSegment();
+    const dx = bx - ax;
+    const dz = bz - az;
+    const len = Math.hypot(dx, dz) || 1;
+    const ux = dx / len;
+    const uz = dz / len;
+    const nx = -uz; // unit normal, network.ts's own convention
+    const nz = ux;
+
+    const targetX = ax + ux * len * TARGET_T;
+    const targetZ = az + uz * len * TARGET_T;
+    const [, targetYRaw] = await withHeight(targetX, targetZ);
+    const targetY = targetYRaw + EYE_MARGIN;
+
+    // forward = (ux, uz); Orbit's own convention (extras/orbit/index.ts) places the camera at
+    // target + distance*(sin(yaw)cos(pitch), sin(pitch), cos(yaw)cos(pitch)) and looks back at target, so
+    // the camera sits *behind* target along -forward when sin(yaw) = -ux, cos(yaw) = -uz.
+    const yaw = Math.atan2(-ux, -uz);
+
+    Orbit.smoothness.set(eid, 1); // snap in one frame instead of easing over several
+    Orbit.pitch.set(eid, PITCH);
+    Orbit.yaw.set(eid, yaw);
+    Orbit.distance.set(eid, DISTANCE);
+    Orbit.pan.set(eid, targetX, targetY, targetZ, 0); // target defaults to world origin (entity 0), so
+    // pan *is* the absolute look-at point (extras/orbit/index.ts's targetX/Y/Z derivation)
+
+    await frames(3); // let OrbitSystem (mode: always) re-derive Transform from the snapped pose
+
+    const anchors: GrazingAnchor[] = [];
+    const doc = generateNetwork(SEED);
+    for (let i = 0; i < PROBE_COUNT; i++) {
+        const t = PROBE_T_LO + ((PROBE_T_HI - PROBE_T_LO) * i) / (PROBE_COUNT - 1);
+        const cx = ax + ux * len * t;
+        const cz = az + uz * len * t;
+        // the far side from the carpark (network.ts anchors it on the +normal side of road 0), so the
+        // probe's search corridor never crosses carpark-rasterized tiles.
+        const ex = cx - nx * halfWidth;
+        const ez = cz - nz * halfWidth;
+        const edgeDist = documentDistance(ex, ez, doc);
+        if (Math.abs(edgeDist) > ON_BOUNDARY_TOLERANCE) {
+            // the analytic edge point should sit within quantization noise of dist=0 by construction; a
+            // gross miss here means the road geometry assumption drifted and the probe would be silently
+            // wrong rather than loudly wrong — fail fast instead of returning a garbage anchor.
+            throw new Error(
+                `grazingCapture: probe ${i} analytic edge point isn't on the boundary (dist ${edgeDist.toFixed(3)})`,
+            );
+        }
+        const [, ey] = await withHeight(ex, ez);
+        const [pt] = worldToScreen([[ex, ey, ez]]);
+
+        // local screen search direction: perpendicular to the projected road boundary at this anchor,
+        // derived from two more projected points along the boundary rather than assumed horizontal — a
+        // near-grazing view can still tilt the boundary's screen-space run away from purely horizontal.
+        const alongEx = ex + ux * 1;
+        const alongEz = ez + uz * 1;
+        const [, alongEy] = await withHeight(alongEx, alongEz);
+        const [alongPt] = worldToScreen([[alongEx, alongEy, alongEz]]);
+        const adx = alongPt.x - pt.x;
+        const ady = alongPt.y - pt.y;
+        const alen = Math.hypot(adx, ady) || 1;
+        // perpendicular to the along-boundary screen direction, in screen-fraction space
+        const dirX = -ady / alen;
+        const dirY = adx / alen;
+
+        anchors.push({ x: pt.x, y: pt.y, dirX, dirY });
+    }
+
+    return { anchors };
+}

--- a/examples/showcase/roads/src/straightness.test.ts
+++ b/examples/showcase/roads/src/straightness.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { detectEdgeOffset, raggedness } from "./straightness";
+
+// The device-free proof that the straightness instrument actually discriminates — the property stage 9's
+// gate gap names: a measurement that can't go red on a deliberately-ragged input is not evidence. Both
+// scenarios below share one synthetic "image": a boundary between a low (lo) and high (hi) plateau,
+// running along the y axis, whose x-position at each row is either exactly the anchor's own x (straight)
+// or offset by an alternating amount (a staircase, the exact shape a grid-quantized silhouette makes).
+
+const LO = 20;
+const HI = 200;
+const RADIUS = 6;
+const ROWS = 24;
+// a hard-step synthetic sampler (no antialiasing) only resolves a crossing to the discrete sample grid's
+// own step size (radius·2/n); this many steps per pixel keeps that quantization bias (half a step) an
+// order of magnitude below the raggedness thresholds below, so the assertions measure the *signal*
+// (straight vs staircase), not the synthetic sampler's own grid.
+const STEPS_PER_PX = 20;
+
+/** a synthetic image sampler: `edgeXAt(y)` gives the true boundary column for row `y`; `sampleAt` reads
+ *  `hi` left of it and `lo` right of it (a hard step, not antialiased — the sub-pixel interpolation in
+ *  {@link detectEdgeOffset} is what recovers a precise crossing from a small number of discrete samples). */
+function stepSampler(edgeXAt: (y: number) => number): (x: number, y: number) => number {
+    return (x, y) => (x < edgeXAt(Math.round(y)) ? HI : LO);
+}
+
+describe("detectEdgeOffset + raggedness discriminate straight from ragged", () => {
+    test("a straight edge reads as ~0 raggedness", () => {
+        const anchorX = 50;
+        const sample = stepSampler(() => anchorX); // edge sits exactly at every anchor
+        const offsets = Array.from({ length: ROWS }, (_, i) =>
+            detectEdgeOffset(sample, anchorX, i, 1, 0, LO, HI, RADIUS, STEPS_PER_PX),
+        );
+        const r = raggedness(offsets);
+        expect(r.n).toBe(ROWS); // every probe found its crossing
+        expect(r.rms).toBeLessThan(0.05); // sub-pixel: exact given a hard step at an integer column
+    });
+
+    test("a staircase edge (grid-quantized silhouette) reads as ragged — the input the instrument must catch", () => {
+        const anchorX = 50;
+        // steps every 4 rows by ±2px, the shape a mesh quantized to a coarse grid casts: flat runs
+        // separated by sudden jumps, not a smooth wobble.
+        const stepAmplitude = 2;
+        const edgeXAt = (y: number) =>
+            anchorX + (Math.floor(y / 4) % 2 === 0 ? stepAmplitude : -stepAmplitude);
+        const sample = stepSampler(edgeXAt);
+        const offsets = Array.from({ length: ROWS }, (_, i) =>
+            detectEdgeOffset(sample, anchorX, i, 1, 0, LO, HI, RADIUS, STEPS_PER_PX),
+        );
+        const r = raggedness(offsets);
+        expect(r.n).toBe(ROWS);
+        // the offsets alternate ±stepAmplitude around the anchor (not all on one side, the way a soft/
+        // misregistered-but-straight edge would read) — rms lands near stepAmplitude itself.
+        expect(r.rms).toBeGreaterThan(1.5);
+        expect(r.max).toBeGreaterThanOrEqual(stepAmplitude - 0.1);
+    });
+
+    test("mutation: zeroing the staircase's amplitude collapses it back to the straight-edge reading — proves the metric tracks the input, not a fixed constant", () => {
+        // this is the input-side mutation the spec's gate-gap calls for: the same code path, the same
+        // probe count and radius, only the deliberately-ragged input's amplitude changed. If raggedness()
+        // reported a fixed number regardless of the sampler, this would still be "ragged" — it isn't.
+        const anchorX = 50;
+        const edgeXAt = (y: number) => anchorX + (Math.floor(y / 4) % 2 === 0 ? 0 : 0); // amplitude zeroed
+        const sample = stepSampler(edgeXAt);
+        const offsets = Array.from({ length: ROWS }, (_, i) =>
+            detectEdgeOffset(sample, anchorX, i, 1, 0, LO, HI, RADIUS, STEPS_PER_PX),
+        );
+        const r = raggedness(offsets);
+        expect(r.rms).toBeLessThan(0.05);
+    });
+
+    test("no crossing in range reports null, not a fabricated offset", () => {
+        const sample = () => LO; // never reaches hi — no edge anywhere in the probe's radius
+        const offset = detectEdgeOffset(sample, 50, 0, 1, 0, LO, HI, RADIUS);
+        expect(offset).toBeNull();
+        expect(raggedness([offset, offset])).toEqual({ rms: 0, max: 0, n: 0 });
+    });
+});

--- a/examples/showcase/roads/src/straightness.ts
+++ b/examples/showcase/roads/src/straightness.ts
@@ -1,0 +1,66 @@
+// Stage 9's straightness instrument — device-free pure math, the pure half of the grazing-view
+// discriminator (`grazingCapture.ts` is the GPU/DOM-bound half that supplies real pixel data and real
+// analytic anchors). The spec's own gate gap: stage 7's capture probe measures transition *width* along
+// one ray perpendicular to the road, so it is structurally blind to boundary *straightness* — the defect
+// axis the release-look screenshot actually showed. This module is the straightness criterion the stage
+// owes: given a luminance sampler and a sequence of analytic (ground-truth) anchor points with their own
+// local search axis, find where the real edge actually sits, and turn the deviations into one number.
+
+/**
+ * walks `sampleAt` along the unit direction (`dirX`, `dirY`) from (`anchorX`, `anchorY`), over
+ * `[-radiusPx, +radiusPx]`, and returns the signed offset (in the same px units as `dirX`/`dirY`) of the
+ * first place the sampled value crosses the midpoint between `lo` and `hi` — linearly interpolated between
+ * the two straddling samples for sub-pixel precision. `null` when no crossing is found in range (the edge
+ * isn't where the anchor expects it, or the probe missed the frame). Deliberately reports only the first
+ * crossing scanning outward from the anchor: a boundary probe expects exactly one transition near its own
+ * anchor, and the *offset itself* — not scanning past it for a second one — is the raggedness measurement.
+ */
+export function detectEdgeOffset(
+    sampleAt: (x: number, y: number) => number,
+    anchorX: number,
+    anchorY: number,
+    dirX: number,
+    dirY: number,
+    lo: number,
+    hi: number,
+    radiusPx: number,
+    stepsPerPx = 4,
+): number | null {
+    const mid = (lo + hi) / 2;
+    const n = Math.max(2, Math.round(radiusPx * 2 * stepsPerPx));
+    let prevT = -radiusPx;
+    let prevV = sampleAt(anchorX + dirX * prevT, anchorY + dirY * prevT);
+    for (let i = 1; i <= n; i++) {
+        const t = -radiusPx + (i / n) * (2 * radiusPx);
+        const v = sampleAt(anchorX + dirX * t, anchorY + dirY * t);
+        const up = prevV < mid && v >= mid;
+        const down = prevV > mid && v <= mid;
+        if (up || down) {
+            const frac = (mid - prevV) / (v - prevV);
+            return prevT + frac * (t - prevT);
+        }
+        prevT = t;
+        prevV = v;
+    }
+    return null;
+}
+
+/** raggedness summary over a sequence of {@link detectEdgeOffset} results (each already a *deviation from
+ *  the analytic anchor*, since the anchor itself is the ground-truth boundary position): RMS and max of
+ *  the non-null offsets, plus how many of the probes actually found an edge. RMS is the metric the
+ *  two-resolution reading compares — a straight rendered edge has every offset near zero; a staircase has
+ *  offsets that swing across the step width. */
+export function raggedness(offsets: ReadonlyArray<number | null>): {
+    rms: number;
+    max: number;
+    n: number;
+} {
+    const valid = offsets.filter((o): o is number => o !== null);
+    if (valid.length === 0) return { rms: 0, max: 0, n: 0 };
+    const meanSq = valid.reduce((sum, o) => sum + o * o, 0) / valid.length;
+    return {
+        rms: Math.sqrt(meanSq),
+        max: Math.max(...valid.map(Math.abs)),
+        n: valid.length,
+    };
+}

--- a/examples/showcase/roads/test/straightness.spec.ts
+++ b/examples/showcase/roads/test/straightness.spec.ts
@@ -15,11 +15,16 @@ import { detectEdgeOffset, raggedness } from "../src/straightness";
 // and reports the raggedness for *that* build — the reading in the spec's Live log is two separate runs
 // of this file, one per source edit, never asserted against each other in-process.
 
+// arm-labeled so re-running under a different source edit (SPACING/TILE_RES/DIST_RANGE) doesn't
+// overwrite the previous arm's capture — needed to diff two arms' frames against each other as a
+// positive witness that a treatment actually reached the rendered image (`ROADS_ARM_LABEL`, default
+// "run", never read by the assertion below — purely a filename for cross-arm comparison).
+const ARM_LABEL = process.env.ROADS_ARM_LABEL ?? "run";
 const CAPTURE_PATH = join(
     dirname(fileURLToPath(import.meta.url)),
     "..",
     "test-results",
-    "straightness-capture.png",
+    `straightness-capture-${ARM_LABEL}.png`,
 );
 
 interface GrazingAnchor {
@@ -108,15 +113,20 @@ test("boundary straightness — grazing-view discriminator (opt-in, not a gate)"
     // analytically on the boundary, so its ±radius endpoints should straddle road and terrain) rather than
     // a shared on/off-road pair from elsewhere on screen — the grazing camera's framing gives no guarantee
     // stage 4/7's own probe points land anywhere near this view.
-    const offsets = anchors.map((a) => {
+    // diagnostic per anchor — kept alongside the offset itself so a null is legible (excluded for low
+    // contrast vs. searched and found nothing) rather than a bare `null` an evidence table can't explain.
+    const diagnostics = anchors.map((a, i) => {
         const ax = a.x * png.width;
         const ay = a.y * png.height;
         const s0 = luminanceAt(ax - a.dirX * SEARCH_RADIUS_PX, ay - a.dirY * SEARCH_RADIUS_PX);
         const s1 = luminanceAt(ax + a.dirX * SEARCH_RADIUS_PX, ay + a.dirY * SEARCH_RADIUS_PX);
         const lo = Math.min(s0, s1);
         const hi = Math.max(s0, s1);
-        if (hi - lo < MIN_CONTRAST) return null; // no real road/terrain contrast straddled — exclude
-        return detectEdgeOffset(
+        const contrast = hi - lo;
+        if (contrast < MIN_CONTRAST) {
+            return { i, offset: null, contrast, reason: "low-contrast" as const };
+        }
+        const offset = detectEdgeOffset(
             (x, y) => luminanceAt(x, y),
             ax,
             ay,
@@ -127,17 +137,26 @@ test("boundary straightness — grazing-view discriminator (opt-in, not a gate)"
             SEARCH_RADIUS_PX,
             STEPS_PER_PX,
         );
+        return {
+            i,
+            offset,
+            contrast,
+            reason: offset === null ? ("no-crossing" as const) : ("found" as const),
+        };
     });
+    const offsets = diagnostics.map((d) => d.offset);
     const r = raggedness(offsets);
 
     console.log(
         `STRAIGHTNESS_READING ${JSON.stringify({
+            armLabel: ARM_LABEL,
             meshParams,
             anchorCount: anchors.length,
             foundCount: r.n,
             rmsPx: r.rms,
             maxPx: r.max,
             offsets,
+            diagnostics,
         })}`,
     );
 

--- a/examples/showcase/roads/test/straightness.spec.ts
+++ b/examples/showcase/roads/test/straightness.spec.ts
@@ -1,0 +1,151 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, type Page, test } from "@playwright/test";
+import { PNG } from "pngjs";
+import { detectEdgeOffset, raggedness } from "../src/straightness";
+
+// Stage 9's discriminator, deliverable 1: does the road boundary's raggedness scale with SPACING (mesh
+// quantization) or with TILE_RES/DIST_RANGE (distance-field resolution)? Not part of the standard device
+// gate (`bun run gate`/`test/roads.spec.ts`) — it's a measurement run, not a pass/fail criterion, since
+// picking a tolerance is the fix stage's job once the mechanism is known (the spec's own "no fix chosen
+// here"). Opt in with `ROADS_STRAIGHTNESS=1 bun run gate` (or `playwright test test/straightness.spec.ts`)
+// so a normal gate run doesn't pay for it. The two-resolution comparison itself is manual: this file reads
+// whatever SPACING/TILE_RES/DIST_RANGE the source currently has (`window.__roadsMeshParams`, `boot.ts`)
+// and reports the raggedness for *that* build — the reading in the spec's Live log is two separate runs
+// of this file, one per source edit, never asserted against each other in-process.
+
+const CAPTURE_PATH = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "test-results",
+    "straightness-capture.png",
+);
+
+interface GrazingAnchor {
+    x: number;
+    y: number;
+    dirX: number;
+    dirY: number;
+}
+
+const SOFTWARE = /swiftshader|llvmpipe|lavapipe|warp|basic render/i;
+
+const adapterName = (page: Page): Promise<string> =>
+    page.evaluate(async () => {
+        const adapter = await navigator.gpu?.requestAdapter();
+        if (!adapter) return "";
+        const { vendor, architecture, device, description } = adapter.info;
+        return [vendor, architecture, device, description].filter(Boolean).join(" ");
+    });
+
+// how far either side of each analytic anchor to search for the real edge.
+const SEARCH_RADIUS_PX = 30;
+const STEPS_PER_PX = 3;
+// an anchor's own ±SEARCH_RADIUS_PX endpoint samples must differ by at least this much to count as a real
+// road/terrain contrast, not two off-road (or two on-road) samples the search radius failed to straddle
+// the boundary with — a low-contrast anchor is excluded rather than fed a near-zero lo/hi that would turn
+// any pixel noise into a spurious "crossing".
+const MIN_CONTRAST = 15;
+
+test("boundary straightness — grazing-view discriminator (opt-in, not a gate)", async ({
+    page,
+}) => {
+    test.skip(
+        !process.env.ROADS_STRAIGHTNESS,
+        "opt-in: set ROADS_STRAIGHTNESS=1 to run stage 9's boundary-raggedness reading",
+    );
+
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    await page.goto("/");
+
+    const adapter = await adapterName(page);
+    console.log(`straightness probe adapter: ${adapter || "none offered"}`);
+    test.skip(
+        adapter === "" || SOFTWARE.test(adapter),
+        `no real-GPU adapter (${adapter || "none offered"})`,
+    );
+
+    await page.waitForFunction(() => typeof window.__roadsGate === "function", null, {
+        timeout: 120_000,
+    });
+    await page.waitForFunction(
+        () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
+        null,
+        { timeout: 10_000 },
+    );
+
+    const meshParams = await page.evaluate(
+        () => (window as unknown as { __roadsMeshParams: unknown }).__roadsMeshParams,
+    );
+
+    // reposition the camera to the fixed grazing pose *before* anything reads screen-space position — the
+    // on-screen anchors and the eventual screenshot must both reflect the moved camera, not the scene's
+    // default orbit pose (`public/scenes/roads.scene`).
+    const { anchors } = (await page.evaluate(() =>
+        (
+            window as unknown as {
+                __roadsGrazingCapture: () => Promise<{ anchors: GrazingAnchor[] }>;
+            }
+        ).__roadsGrazingCapture(),
+    )) as { anchors: GrazingAnchor[] };
+
+    const screenshot = await page.screenshot();
+    mkdirSync(dirname(CAPTURE_PATH), { recursive: true });
+    writeFileSync(CAPTURE_PATH, screenshot);
+
+    const png = PNG.sync.read(screenshot);
+    const luminanceAt = (fracX: number, fracY: number): number => {
+        const x = Math.min(png.width - 1, Math.max(0, Math.round(fracX)));
+        const y = Math.min(png.height - 1, Math.max(0, Math.round(fracY)));
+        const at = (y * png.width + x) * 4;
+        return 0.3 * png.data[at] + 0.59 * png.data[at + 1] + 0.11 * png.data[at + 2];
+    };
+
+    // per-anchor local plateau: sample the two ends of *this anchor's own* search segment (the anchor sits
+    // analytically on the boundary, so its ±radius endpoints should straddle road and terrain) rather than
+    // a shared on/off-road pair from elsewhere on screen — the grazing camera's framing gives no guarantee
+    // stage 4/7's own probe points land anywhere near this view.
+    const offsets = anchors.map((a) => {
+        const ax = a.x * png.width;
+        const ay = a.y * png.height;
+        const s0 = luminanceAt(ax - a.dirX * SEARCH_RADIUS_PX, ay - a.dirY * SEARCH_RADIUS_PX);
+        const s1 = luminanceAt(ax + a.dirX * SEARCH_RADIUS_PX, ay + a.dirY * SEARCH_RADIUS_PX);
+        const lo = Math.min(s0, s1);
+        const hi = Math.max(s0, s1);
+        if (hi - lo < MIN_CONTRAST) return null; // no real road/terrain contrast straddled — exclude
+        return detectEdgeOffset(
+            (x, y) => luminanceAt(x, y),
+            ax,
+            ay,
+            a.dirX,
+            a.dirY,
+            lo,
+            hi,
+            SEARCH_RADIUS_PX,
+            STEPS_PER_PX,
+        );
+    });
+    const r = raggedness(offsets);
+
+    console.log(
+        `STRAIGHTNESS_READING ${JSON.stringify({
+            meshParams,
+            anchorCount: anchors.length,
+            foundCount: r.n,
+            rmsPx: r.rms,
+            maxPx: r.max,
+            offsets,
+        })}`,
+    );
+
+    expect(errors, errors.join("\n")).toEqual([]);
+    // the only assertion this opt-in probe makes: the instrument itself worked (found most of its
+    // anchors) — never a straightness pass/fail, which is the fix stage's own criterion once the
+    // mechanism is known.
+    expect(r.n, `found ${r.n}/${anchors.length} edge crossings`).toBeGreaterThanOrEqual(
+        Math.floor(anchors.length * 0.6),
+    );
+});


### PR DESCRIPTION
- **shallot-roads: stage 9 discriminator — straightness instrument + two-resolution reading**
- **shallot-roads: stage 9 — arm-labeled captures + per-anchor diagnostics**
