### PR TITLE
shallot-roads: height-axis straightness criterion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -273,6 +273,8 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
+        "@types/pngjs": "^6.0.5",
+        "pngjs": "^7.0.0",
       },
     },
     "examples/showcase/sandbox": {

--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -2,7 +2,12 @@ import type { Plugin, System } from "@dylanebert/shallot";
 import { Meshes } from "@dylanebert/shallot/render/core";
 import { capturePoints, type ScreenPoint, TRANSITION_TOLERANCE_PX, worldToScreen } from "./capture";
 import { gate } from "./gate";
-import { type GrazingAnchor, grazingCapture } from "./grazingCapture";
+import {
+    type GrazingAnchor,
+    grazingCapture,
+    type HeightSilhouetteResult,
+    heightSilhouette,
+} from "./grazingCapture";
 import type { Check } from "./harness";
 import { DIST_RANGE, TILE_RES } from "./overlay/tiles";
 import { SPACING } from "./terrain/grid";
@@ -41,6 +46,10 @@ declare global {
         // same bridge-only shape as the rest of this file: `test/straightness.spec.ts` never imports
         // engine/ECS code directly, only reads this window global.
         __roadsGrazingCapture?: () => Promise<{ anchors: GrazingAnchor[] }>;
+        // stage 10's corrected straightness criterion (`grazingCapture.ts`'s `heightSilhouette`) — the
+        // same anchors, but the world-space height axis instead of the screen-space albedo edge. No camera
+        // pose to set up first, unlike `__roadsGrazingCapture` above.
+        __roadsHeightSilhouette?: () => Promise<HeightSilhouetteResult>;
         // the live mesh/atlas resolution constants under test — read by `test/straightness.spec.ts` so the
         // two-resolution reading is self-labeling rather than trusting whatever the driver assumed was
         // edited before the run.
@@ -67,6 +76,7 @@ const BootSystem: System = {
         window.__roadsTransitionTolerancePx = TRANSITION_TOLERANCE_PX;
         window.__roadsSmoothRadius = () => getSmoothRadius();
         window.__roadsGrazingCapture = () => grazingCapture();
+        window.__roadsHeightSilhouette = () => heightSilhouette();
         window.__roadsMeshParams = { spacing: SPACING, tileRes: TILE_RES, distRange: DIST_RANGE };
         // F9 reseeds the live procedural network (`terrain.ts`'s `regenerate`) — the same key voxel's own
         // reseed uses. `[`/`]` step the longitudinal smoothing radius (`terrain/profile.ts`'s box-filter
@@ -98,6 +108,7 @@ const BootSystem: System = {
         delete window.__roadsTransitionTolerancePx;
         delete window.__roadsSmoothRadius;
         delete window.__roadsGrazingCapture;
+        delete window.__roadsHeightSilhouette;
         delete window.__roadsMeshParams;
     },
 };

--- a/examples/showcase/roads/src/boundaryAnchors.test.ts
+++ b/examples/showcase/roads/src/boundaryAnchors.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test";
+import { heightMidpointAnchor, worldEdgeAnchors } from "./boundaryAnchors";
+import { detectEdgeOffset } from "./straightness";
+import { flattenHeight } from "./terrain/flatten";
+
+// Stage 10 repair, blocker 1: `heightSilhouette`'s pre-fix reading anchored the height-axis crossing
+// detector at the road edge itself (`WorldEdgeAnchor.ex`/`ez`, `coreDist = 0`). `detectEdgeOffset`
+// (`straightness.ts`) reports where the sampled signal crosses the *midpoint* between its `lo`/`hi`
+// brackets, and `terrain/flatten.ts`'s `flattenHeight` cosine ease (`0.5 - 0.5·cos(π·t)`) reaches that
+// midpoint at `t = 0.5`, i.e. `coreDist = falloff / 2` — not at the road edge. So a perfectly straight
+// edge, anchored at the edge, reads a constant `falloff / 2` bias, mistaken for raggedness.
+// `heightMidpointAnchor` moves the anchor to that ease midpoint instead — this file proves both halves on
+// a synthetic straight edge built from the real `flattenHeight` formula, pure math, no device.
+const FALLOFF = 14.026; // an arbitrary representative falloff, same order as computeFalloff's own range
+const NATURAL = 100;
+const TARGET = 10;
+const STEPS_PER_M = 20;
+
+describe("heightMidpointAnchor — the height-axis instrument's own ground-truth zero point", () => {
+    // a real production anchor (`worldEdgeAnchors`'s road-frame derivation), fed a synthetic sampler that
+    // is exactly `flattenHeight` evaluated at the signed distance from that anchor along its own outward
+    // normal — the same geometry `heightSilhouette` samples, minus the device mesh readback.
+    const a = worldEdgeAnchors()[0];
+    const sampleAt = (x: number, z: number): number => {
+        const coreDist = (x - a.ex) * a.nx + (z - a.ez) * a.nz;
+        return flattenHeight(NATURAL, TARGET, coreDist, FALLOFF);
+    };
+
+    test("anchoring at the road edge (coreDist = 0) reads a falloff/2 bias on a perfectly straight edge — the pre-fix defect", () => {
+        const offset = detectEdgeOffset(
+            sampleAt,
+            a.ex,
+            a.ez,
+            a.nx,
+            a.nz,
+            TARGET,
+            NATURAL,
+            FALLOFF,
+            STEPS_PER_M,
+        );
+        expect(offset).not.toBeNull();
+        expect(offset as number).toBeCloseTo(FALLOFF / 2, 1);
+    });
+
+    test("anchoring at heightMidpointAnchor reads ~0 on the same straight edge — the fix", () => {
+        const { mx, mz } = heightMidpointAnchor(a, FALLOFF);
+        const offset = detectEdgeOffset(
+            sampleAt,
+            mx,
+            mz,
+            a.nx,
+            a.nz,
+            TARGET,
+            NATURAL,
+            FALLOFF,
+            STEPS_PER_M,
+        );
+        expect(offset).not.toBeNull();
+        expect(offset as number).toBeCloseTo(0, 1);
+    });
+
+    test("mutation: a genuinely ragged edge still reads ragged through heightMidpointAnchor — the fix corrects the anchor, not the raggedness signal", () => {
+        const raggedSampleAt = (x: number, z: number): number => {
+            const coreDist = (x - a.ex) * a.nx + (z - a.ez) * a.nz;
+            // the real crossing sits FALLOFF/4 past the ease midpoint — a genuine deviation, not the
+            // constant bias the two tests above isolate.
+            return flattenHeight(NATURAL, TARGET, coreDist - FALLOFF / 4, FALLOFF);
+        };
+        const { mx, mz } = heightMidpointAnchor(a, FALLOFF);
+        const offset = detectEdgeOffset(
+            raggedSampleAt,
+            mx,
+            mz,
+            a.nx,
+            a.nz,
+            TARGET,
+            NATURAL,
+            FALLOFF,
+            STEPS_PER_M,
+        );
+        expect(offset).not.toBeNull();
+        expect(offset as number).toBeCloseTo(FALLOFF / 4, 1);
+    });
+});
+
+describe("worldEdgeAnchors — the analytic road-edge anchors the height-axis instrument walks", () => {
+    test("returns 16 anchors, each with a unit outward search normal", () => {
+        const anchors = worldEdgeAnchors();
+        expect(anchors.length).toBe(16);
+        for (const a of anchors) {
+            expect(Math.hypot(a.nx, a.nz)).toBeCloseTo(1, 5);
+        }
+    });
+});

--- a/examples/showcase/roads/src/boundaryAnchors.ts
+++ b/examples/showcase/roads/src/boundaryAnchors.ts
@@ -1,0 +1,134 @@
+import { documentDistance, type StrokeDocument } from "./overlay/document";
+import { generateNetwork } from "./overlay/network";
+import { SEED } from "./terrain/terrain";
+
+// The analytic (ground-truth) boundary anchor derivation `grazingCapture.ts`'s two straightness
+// instruments both need — `grazingCapture()` (screen-space, needs a live camera/Orbit) projects these to
+// screen pixels, `heightSilhouette()` (world-space, device-free apart from the mesh readback) walks them
+// directly. Pulled into its own module, with zero `@dylanebert/shallot/extras`/`render/core` imports, so
+// it stays importable under plain `bun test` — `grazingCapture.ts` imports `Orbit` at module scope, which
+// throws under bun (`GPUTextureUsage is not defined`, `@dylanebert/shallot/extras`'s own eager surface
+// registration), so this module is the only path to a device-free unit test over the shared anchor math
+// (`boundaryAnchors.test.ts`).
+//
+// Reuses the *same* boot document every run (`generateNetwork(SEED)`, `terrain.ts`'s own boot document) —
+// road index 0's own first segment, deterministic — so a SPACING/TILE_RES/DIST_RANGE edit between runs
+// changes only the mesh/atlas resolution under test, never the network geometry the probes are framed to.
+
+const PROBE_T_LO = 0.2;
+const PROBE_T_HI = 0.8;
+const PROBE_COUNT = 16; // anchors along the visible run, avoiding both ends' falloff/off-frame risk
+const ON_BOUNDARY_TOLERANCE = 0.02; // metres — the analytic edge point must sit this close to dist=0
+
+/** the boot document's first road, flattened to its own single segment — the fixed geometry every probe
+ *  (any SPACING/TILE_RES/DIST_RANGE run) frames against. */
+function roadSegment(): { ax: number; az: number; bx: number; bz: number; halfWidth: number } {
+    const doc = generateNetwork(SEED);
+    const [[ax, az], [bx, bz]] = doc.polylines[0].points;
+    return { ax, az, bx, bz, halfWidth: doc.polylines[0].halfWidth };
+}
+
+export interface RoadFrame {
+    ax: number;
+    az: number;
+    ux: number;
+    uz: number;
+    len: number;
+    nx: number;
+    nz: number;
+    halfWidth: number;
+}
+
+/** {@link roadSegment}'s endpoints resolved into the frame every boundary probe anchors to: unit tangent
+ *  (`ux`/`uz`), unit outward-from-carpark normal (`nx`/`nz`, `network.ts`'s own convention), and the
+ *  segment length. */
+export function roadFrame(): RoadFrame {
+    const { ax, az, bx, bz, halfWidth } = roadSegment();
+    const dx = bx - ax;
+    const dz = bz - az;
+    const len = Math.hypot(dx, dz) || 1;
+    const ux = dx / len;
+    const uz = dz / len;
+    const nx = -uz; // unit normal, network.ts's own convention
+    const nz = ux;
+    return { ax, az, ux, uz, len, nx, nz, halfWidth };
+}
+
+export interface EdgeAnchorPoint {
+    ex: number;
+    ez: number;
+}
+
+/** probe `i`'s analytic boundary point along `frame` — `PROBE_T_LO..PROBE_T_HI` fraction along the
+ *  centreline, offset by `halfWidth` toward the far side from the carpark (network.ts anchors it on the
+ *  +normal side of road 0, so the probe's search corridor never crosses carpark-rasterized tiles). */
+function edgeAnchorPoint(i: number, frame: RoadFrame): EdgeAnchorPoint {
+    const t = PROBE_T_LO + ((PROBE_T_HI - PROBE_T_LO) * i) / (PROBE_COUNT - 1);
+    const cx = frame.ax + frame.ux * frame.len * t;
+    const cz = frame.az + frame.uz * frame.len * t;
+    const ex = cx - frame.nx * frame.halfWidth;
+    const ez = cz - frame.nz * frame.halfWidth;
+    return { ex, ez };
+}
+
+/** all {@link PROBE_COUNT} analytic boundary points along `frame`, each verified within
+ *  {@link ON_BOUNDARY_TOLERANCE} of the analytic boundary (`documentDistance`) — the analytic edge point
+ *  should sit within quantization noise of `dist = 0` by construction; a gross miss means the road
+ *  geometry assumption drifted, so this fails loud rather than returning a garbage anchor. Shared by
+ *  `grazingCapture.ts`'s `grazingCapture()` (needs the screen projection too) and {@link worldEdgeAnchors}
+ *  (needs only the raw point) — one derivation, so a fix here lands in both instruments at once. */
+export function edgeAnchorPoints(frame: RoadFrame, doc: StrokeDocument): EdgeAnchorPoint[] {
+    return Array.from({ length: PROBE_COUNT }, (_, i) => {
+        const p = edgeAnchorPoint(i, frame);
+        const edgeDist = documentDistance(p.ex, p.ez, doc);
+        if (Math.abs(edgeDist) > ON_BOUNDARY_TOLERANCE) {
+            throw new Error(
+                `edgeAnchorPoints: probe ${i} analytic edge point isn't on the boundary (dist ${edgeDist.toFixed(3)})`,
+            );
+        }
+        return p;
+    });
+}
+
+/** one boundary anchor for the height-axis criterion: the analytic edge point plus a world-space unit
+ *  search direction (perpendicular to the road centreline, metres, pointing outward toward natural
+ *  terrain) instead of a screen one. */
+export interface WorldEdgeAnchor {
+    ex: number;
+    ez: number;
+    nx: number;
+    nz: number;
+}
+
+/** the {@link PROBE_COUNT} boundary anchors in raw world coordinates rather than a screen projection —
+ *  the height-axis criterion needs the point and a world-space search axis, never a camera. */
+export function worldEdgeAnchors(): WorldEdgeAnchor[] {
+    const frame = roadFrame();
+    const doc = generateNetwork(SEED);
+    // the outward search axis: away from the corridor's own centreline, toward natural terrain — the sign
+    // only labels which side of the anchor is "positive", detection works either way (`detectEdgeOffset`
+    // scans symmetrically), but a consistent outward convention keeps the sign of a returned offset legible.
+    return edgeAnchorPoints(frame, doc).map(({ ex, ez }) => ({
+        ex,
+        ez,
+        nx: -frame.nx,
+        nz: -frame.nz,
+    }));
+}
+
+/** the height-axis instrument's own ground-truth zero point: not the road edge itself
+ *  ({@link WorldEdgeAnchor.ex}/`ez`, `coreDist = 0`) but `terrain/flatten.ts`'s `flattenHeight` cosine
+ *  ease's own midpoint (`coreDist = falloff / 2`). `straightness.ts`'s `detectEdgeOffset` reports where
+ *  the sampled signal crosses the *midpoint* between its `lo`/`hi` brackets; the ease
+ *  `0.5 - 0.5·cos(π·t)` reaches exactly `0.5` at `t = 0.5`, i.e. `coreDist = falloff / 2` — so that is
+ *  where a perfectly straight edge's detected crossing sits by construction, not at the road edge.
+ *  Anchoring the reading at `coreDist = 0` instead reports a constant `falloff / 2` bias on every
+ *  straight edge, indistinguishable from boundary raggedness (`boundaryAnchors.test.ts` proves the bias
+ *  and the fix against a synthetic straight edge). */
+export function heightMidpointAnchor(
+    a: WorldEdgeAnchor,
+    falloff: number,
+): { mx: number; mz: number } {
+    const half = falloff / 2;
+    return { mx: a.ex + a.nx * half, mz: a.ez + a.nz * half };
+}

--- a/examples/showcase/roads/src/capture.test.ts
+++ b/examples/showcase/roads/src/capture.test.ts
@@ -80,7 +80,7 @@ describe("meshHeightAt — the real rendered surface, not nearest-vertex", () =>
         expect(h).toBeCloseTo(9, 1);
     });
 
-    test("mutation: swapping the triangle split (as if grid.ts's winding flipped) changes the reading — the\n     test discriminates the split, not just the corner values", () => {
+    test("mutation: swapping the triangle split (as if grid.ts's winding flipped) changes the reading — the test discriminates the split, not just the corner values", () => {
         const raw = rawWithQuad(ix0, iz0, 0, 0, 0, 10); // only h11 is non-zero
         const inLowerLeft = meshHeightAt(raw, x0 + SPACING * 0.2, z0 + SPACING * 0.2);
         const inUpperRight = meshHeightAt(raw, x0 + SPACING * 0.8, z0 + SPACING * 0.8);

--- a/examples/showcase/roads/src/capture.test.ts
+++ b/examples/showcase/roads/src/capture.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { TRANSITION_TOLERANCE_PX } from "./capture";
+import { encodePos } from "@dylanebert/shallot/utils/core";
+import * as d from "typegpu/data";
+import { meshHeightAt, TRANSITION_TOLERANCE_PX } from "./capture";
+import { TERRAIN_QUANT } from "./terrain/generate";
+import { HALF, SPACING, VERTEX_COUNT, vertexIndex, worldX, worldZ } from "./terrain/grid";
 
 describe("TRANSITION_TOLERANCE_PX", () => {
     test("is a small positive pixel bound, not a fraction or a huge slack", () => {
@@ -9,5 +13,78 @@ describe("TRANSITION_TOLERANCE_PX", () => {
         // genuinely soft/misregistered edge — the exact defect this gate exists to find).
         expect(TRANSITION_TOLERANCE_PX).toBeGreaterThan(0);
         expect(TRANSITION_TOLERANCE_PX).toBeLessThanOrEqual(4);
+    });
+});
+
+// meshHeightAt's own oracle: a synthetic raw vertex stream (one grid.ts quad's worth of real values,
+// everything else left at the quantizer's zero point) — device-free, since encodePos/decodePos are plain
+// callable functions outside a dispatched kernel (the same pattern flatten.test.ts's flattenHeightGpu
+// differential relies on).
+function rawWithQuad(
+    ix0: number,
+    iz0: number,
+    h00: number,
+    h10: number,
+    h01: number,
+    h11: number,
+): Uint32Array {
+    const raw = new Uint32Array(VERTEX_COUNT * 4);
+    const set = (ix: number, iz: number, y: number) => {
+        const w = encodePos(d.vec3f(worldX(ix), y, worldZ(iz)), 0, TERRAIN_QUANT);
+        const idx = vertexIndex(ix, iz);
+        raw[idx * 4] = w.x;
+        raw[idx * 4 + 1] = w.y;
+    };
+    set(ix0, iz0, h00);
+    set(ix0 + 1, iz0, h10);
+    set(ix0, iz0 + 1, h01);
+    set(ix0 + 1, iz0 + 1, h11);
+    return raw;
+}
+
+// quantization step (posScale.y / 65535, TERRAIN_QUANT's own AABB) — the tolerance every assertion below
+// is derived against, not a value picked to make the test pass.
+const QUANT_TOL = TERRAIN_QUANT.posScale.y / 65535;
+
+describe("meshHeightAt — the real rendered surface, not nearest-vertex", () => {
+    const ix0 = HALF; // an arbitrary interior column, away from the grid's own edges
+    const iz0 = HALF;
+    const x0 = worldX(ix0);
+    const z0 = worldZ(iz0);
+
+    test("at a vertex itself, reads that vertex's own height exactly (within quantization)", () => {
+        const raw = rawWithQuad(ix0, iz0, 5, 8, 2, 11);
+        expect(meshHeightAt(raw, x0, z0)).toBeCloseTo(5, 2);
+    });
+
+    test("a flat quad reads flat everywhere inside it, both triangles", () => {
+        const raw = rawWithQuad(ix0, iz0, 3, 3, 3, 3);
+        expect(meshHeightAt(raw, x0 + SPACING * 0.2, z0 + SPACING * 0.2)).toBeCloseTo(3, 2); // lower-left tri
+        expect(meshHeightAt(raw, x0 + SPACING * 0.8, z0 + SPACING * 0.8)).toBeCloseTo(3, 2); // upper-right tri
+    });
+
+    test("interpolates linearly within the lower-left triangle (i0, i2, i1)", () => {
+        const raw = rawWithQuad(ix0, iz0, 0, 10, 0, 10);
+        // (tx, tz) = (0.3, 0.3): inside the i0/i2/i1 triangle (tx+tz <= 1). h00=0, h10=10, h01=0, so this
+        // quad's height only varies along x — the plane through those three points gives 0.3 * 10 = 3.
+        const h = meshHeightAt(raw, x0 + SPACING * 0.3, z0 + SPACING * 0.3);
+        expect(h).toBeCloseTo(3, 1);
+    });
+
+    test("interpolates linearly within the upper-right triangle (i1, i2, i3)", () => {
+        const raw = rawWithQuad(ix0, iz0, 0, 10, 0, 10);
+        // (tx, tz) = (0.9, 0.9): tx+tz > 1, the i1/i2/i3 triangle, defined by h10=10, h01=0, h11=10 — that
+        // plane is h = 10*tx regardless of tz (h10 and h11 agree at tx=1; h01 is 0 at tx=0), so (0.9, 0.9)
+        // reads 9, not the h00/h10/h01 plane's own reading at the same (tx, tz) — a different triangle.
+        const h = meshHeightAt(raw, x0 + SPACING * 0.9, z0 + SPACING * 0.9);
+        expect(h).toBeCloseTo(9, 1);
+    });
+
+    test("mutation: swapping the triangle split (as if grid.ts's winding flipped) changes the reading — the\n     test discriminates the split, not just the corner values", () => {
+        const raw = rawWithQuad(ix0, iz0, 0, 0, 0, 10); // only h11 is non-zero
+        const inLowerLeft = meshHeightAt(raw, x0 + SPACING * 0.2, z0 + SPACING * 0.2);
+        const inUpperRight = meshHeightAt(raw, x0 + SPACING * 0.8, z0 + SPACING * 0.8);
+        expect(inLowerLeft).toBeCloseTo(0, 1); // h11 doesn't reach the lower-left triangle at all
+        expect(inUpperRight).toBeGreaterThan(QUANT_TOL * 10); // h11 does reach the upper-right triangle
     });
 });

--- a/examples/showcase/roads/src/capture.ts
+++ b/examples/showcase/roads/src/capture.ts
@@ -3,7 +3,7 @@ import { decodePos } from "@dylanebert/shallot/utils/core";
 import { captureProbePoints } from "./overlay/network";
 import { COVERAGE_BAND_PX } from "./overlay/tiles";
 import { TERRAIN_QUANT } from "./terrain/generate";
-import { gridX, gridZ, VERTS } from "./terrain/grid";
+import { gridX, gridZ, HALF, SPACING, VERTS } from "./terrain/grid";
 import { readVertices, SEED } from "./terrain/terrain";
 
 // The device gate's world→screen bridge for the pixel-probe capture (the spec's flagged-risk validation —
@@ -80,6 +80,38 @@ export async function withHeight(x: number, z: number): Promise<[x: number, y: n
     const idx = iz * VERTS + ix;
     const y = decodePos(raw[idx * 4], raw[idx * 4 + 1], TERRAIN_QUANT).y;
     return [x, y, z];
+}
+
+/** the real rendered surface height at an arbitrary off-grid world (x, z) — a two-triangle-per-quad linear
+ *  reconstruction from the four surrounding vertices (`grid.ts`'s own split: `(i0,i2,i1)` and `(i1,i2,i3)`),
+ *  the same plane the rasterizer actually draws. Unlike {@link withHeight}'s nearest-vertex read (a
+ *  bounded approximation, fine for projecting a point sensibly), this is exact everywhere inside the
+ *  mesh's footprint — `straightness.ts`'s height-silhouette criterion (`grazingCapture.ts`) needs the
+ *  surface a viewer's eye actually sees at a point that generally doesn't land on a vertex, since the
+ *  defect it measures *is* the gap between this reconstruction and the continuous analytic height at the
+ *  same point. `raw` is one `readVertices()` readback, reused across every sample in a scan so the GPU is
+ *  read back once, not once per probe step. */
+export function meshHeightAt(raw: Uint32Array, x: number, z: number): number {
+    const fx = x / SPACING + HALF;
+    const fz = z / SPACING + HALF;
+    const ix0 = Math.floor(fx);
+    const iz0 = Math.floor(fz);
+    const tx = fx - ix0;
+    const tz = fz - iz0;
+    const heightOf = (ix: number, iz: number): number => {
+        const idx = iz * VERTS + ix;
+        return decodePos(raw[idx * 4], raw[idx * 4 + 1], TERRAIN_QUANT).y;
+    };
+    const h00 = heightOf(ix0, iz0);
+    const h10 = heightOf(ix0 + 1, iz0);
+    const h01 = heightOf(ix0, iz0 + 1);
+    const h11 = heightOf(ix0 + 1, iz0 + 1);
+    // lower-left triangle (i0, i2, i1) covers tx + tz <= 1; upper-right (i1, i2, i3) the complement —
+    // grid.ts's own winding, so this interpolates over exactly the triangle the renderer draws there.
+    if (tx + tz <= 1) return h00 + tx * (h10 - h00) + tz * (h01 - h00);
+    const utx = 1 - tx;
+    const utz = 1 - tz;
+    return h11 + utx * (h01 - h11) + utz * (h10 - h11);
 }
 
 /** the capture gate's on-road/off-road world probe points over the full procedural network at the boot's

--- a/examples/showcase/roads/src/env.ts
+++ b/examples/showcase/roads/src/env.ts
@@ -1,0 +1,34 @@
+// Env-driven override arms for a device reading that needs a different build-time constant without a
+// source edit — the idiom `test/straightness.spec.ts`'s `ROADS_ARM_LABEL`/`ROADS_STRAIGHTNESS` set on the
+// Node/Playwright side; these read the browser side, where only Vite-exposed `import.meta.env` reaches
+// (Vite merges `VITE_`-prefixed shell env vars into it automatically, no config needed — the same env the
+// `bunx shallot dev` child process, spawned by `playwright.config.ts`'s `webServer`, inherits). Optional
+// chained + try/caught the same way shallot's own `devEnabled`
+// (`@dylanebert/shallot/render/core`) reads `import.meta.env.DEV`, so `bun test` (no Vite, no
+// `import.meta.env`) falls back cleanly instead of throwing.
+
+function readEnv(key: string): string | undefined {
+    try {
+        const env = import.meta.env as Record<string, unknown> | undefined;
+        const v = env?.[key];
+        return typeof v === "string" ? v : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/** `envNumber("VITE_ROADS_RELIEF", 40)` — `fallback` when unset, not a real number, or `import.meta.env`
+ *  is absent (bun test). */
+export function envNumber(key: string, fallback: number): number {
+    const raw = readEnv(key);
+    if (raw === undefined) return fallback;
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : fallback;
+}
+
+/** `envFlag("VITE_ROADS_NO_CUT")` — true only for `"1"`/`"true"`, false otherwise (unset, absent
+ *  `import.meta.env`, or any other value). */
+export function envFlag(key: string): boolean {
+    const raw = readEnv(key);
+    return raw === "1" || raw === "true";
+}

--- a/examples/showcase/roads/src/grazingCapture.ts
+++ b/examples/showcase/roads/src/grazingCapture.ts
@@ -1,8 +1,13 @@
 import { Orbit } from "@dylanebert/shallot/extras";
 import { Views } from "@dylanebert/shallot/render/core";
+import {
+    edgeAnchorPoints,
+    heightMidpointAnchor,
+    roadFrame,
+    worldEdgeAnchors,
+} from "./boundaryAnchors";
 import { meshHeightAt, withHeight, worldToScreen } from "./capture";
 import { frames } from "./harness";
-import { documentDistance } from "./overlay/document";
 import { generateNetwork } from "./overlay/network";
 import { detectEdgeOffset, raggedness } from "./straightness";
 import { buildNetworkGeometry, computeFalloff } from "./terrain/flatten";
@@ -19,9 +24,9 @@ import { getSmoothRadius, readVertices, SEED } from "./terrain/terrain";
 // `test/straightness.spec.ts` still saves; the actual reading (`heightSilhouette`, below) is now
 // camera-independent — it lives entirely in the heightfield, not in what a camera happens to project.
 //
-// Reuses the *same* boot document every run (`generateNetwork(SEED)`, `terrain.ts`'s own boot document) —
-// road index 0's own first segment, deterministic — so a SPACING/TILE_RES/DIST_RANGE edit between runs
-// changes only the mesh/atlas resolution under test, never the network geometry the camera is framed to.
+// The analytic anchor derivation (road frame, per-probe boundary point, world-space anchor) lives in
+// `boundaryAnchors.ts` — this module only adds the camera-dependent half (`grazingCapture`, needs
+// `Orbit`/`Views`) and the height-axis reading (`heightSilhouette`, needs the mesh readback).
 //
 // Stage 10: stage 9's `detectEdgeOffset`/`raggedness` (`straightness.ts`) are dimension-agnostic — a 1D
 // sampler walked over a search axis, looking for a crossing — so the height-axis criterion below reuses
@@ -32,13 +37,9 @@ import { getSmoothRadius, readVertices, SEED } from "./terrain/terrain";
 // camera's projection of it — the same reason it needs no camera pose at all.
 
 const TARGET_T = 0.08; // fraction along the road from its start — near one end, so the far ~90% recedes
-const PROBE_T_LO = 0.2;
-const PROBE_T_HI = 0.8;
-const PROBE_COUNT = 16; // anchors along the visible run, avoiding both ends' falloff/off-frame risk
 const PITCH = 0.06; // radians (~3.4°) — near-horizontal, the grazing angle itself
 const DISTANCE = 15; // world metres — close to the scene's own min-distance (10), low and near the edge
 const EYE_MARGIN = 0.4; // metres above the read terrain height, clearing z-fighting/embedding
-const ON_BOUNDARY_TOLERANCE = 0.02; // metres — the analytic edge point must sit this close to dist=0
 
 export interface GrazingAnchor {
     /** the analytic (ground-truth) boundary point's screen position, as a fraction of canvas size. */
@@ -48,14 +49,6 @@ export interface GrazingAnchor {
      *  this anchor — the axis `straightness.ts`'s `detectEdgeOffset` walks. */
     dirX: number;
     dirY: number;
-}
-
-/** the boot document's first road, flattened to its own single segment — the fixed geometry every grazing
- *  capture (any SPACING/TILE_RES/DIST_RANGE run) frames against. */
-function roadSegment(): { ax: number; az: number; bx: number; bz: number; halfWidth: number } {
-    const doc = generateNetwork(SEED);
-    const [[ax, az], [bx, bz]] = doc.polylines[0].points;
-    return { ax, az, bx, bz, halfWidth: doc.polylines[0].halfWidth };
 }
 
 /** the canvas-presenting camera's eid — the same `Views` disambiguation `capture.ts`'s `cameraEid` uses
@@ -77,14 +70,8 @@ function cameraEid(): number {
  */
 export async function grazingCapture(): Promise<{ anchors: GrazingAnchor[] }> {
     const eid = cameraEid();
-    const { ax, az, bx, bz, halfWidth } = roadSegment();
-    const dx = bx - ax;
-    const dz = bz - az;
-    const len = Math.hypot(dx, dz) || 1;
-    const ux = dx / len;
-    const uz = dz / len;
-    const nx = -uz; // unit normal, network.ts's own convention
-    const nz = ux;
+    const frame = roadFrame();
+    const { ax, az, ux, uz, len } = frame;
 
     const targetX = ax + ux * len * TARGET_T;
     const targetZ = az + uz * len * TARGET_T;
@@ -107,23 +94,7 @@ export async function grazingCapture(): Promise<{ anchors: GrazingAnchor[] }> {
 
     const anchors: GrazingAnchor[] = [];
     const doc = generateNetwork(SEED);
-    for (let i = 0; i < PROBE_COUNT; i++) {
-        const t = PROBE_T_LO + ((PROBE_T_HI - PROBE_T_LO) * i) / (PROBE_COUNT - 1);
-        const cx = ax + ux * len * t;
-        const cz = az + uz * len * t;
-        // the far side from the carpark (network.ts anchors it on the +normal side of road 0), so the
-        // probe's search corridor never crosses carpark-rasterized tiles.
-        const ex = cx - nx * halfWidth;
-        const ez = cz - nz * halfWidth;
-        const edgeDist = documentDistance(ex, ez, doc);
-        if (Math.abs(edgeDist) > ON_BOUNDARY_TOLERANCE) {
-            // the analytic edge point should sit within quantization noise of dist=0 by construction; a
-            // gross miss here means the road geometry assumption drifted and the probe would be silently
-            // wrong rather than loudly wrong — fail fast instead of returning a garbage anchor.
-            throw new Error(
-                `grazingCapture: probe ${i} analytic edge point isn't on the boundary (dist ${edgeDist.toFixed(3)})`,
-            );
-        }
+    for (const { ex, ez } of edgeAnchorPoints(frame, doc)) {
         const [, ey] = await withHeight(ex, ez);
         const [pt] = worldToScreen([[ex, ey, ez]]);
 
@@ -147,56 +118,11 @@ export async function grazingCapture(): Promise<{ anchors: GrazingAnchor[] }> {
     return { anchors };
 }
 
-/** one boundary anchor for the height-axis criterion: the same analytic edge point
- *  {@link grazingCapture}'s anchors project to screen space, plus a world-space unit search direction
- *  (perpendicular to the road centreline, metres) instead of a screen one. */
-export interface WorldEdgeAnchor {
-    ex: number;
-    ez: number;
-    nx: number;
-    nz: number;
-}
-
-/** the same {@link PROBE_COUNT} boundary anchors {@link grazingCapture} derives, in raw world coordinates
- *  rather than a screen projection — stage 10's height-axis criterion needs the point and a world-space
- *  search axis, never a camera. Exported separately since a camera pose plays no role in this reading. */
-export function worldEdgeAnchors(): WorldEdgeAnchor[] {
-    const { ax, az, bx, bz, halfWidth } = roadSegment();
-    const dx = bx - ax;
-    const dz = bz - az;
-    const len = Math.hypot(dx, dz) || 1;
-    const ux = dx / len;
-    const uz = dz / len;
-    const nx = -uz;
-    const nz = ux;
-    const doc = generateNetwork(SEED);
-
-    const anchors: WorldEdgeAnchor[] = [];
-    for (let i = 0; i < PROBE_COUNT; i++) {
-        const t = PROBE_T_LO + ((PROBE_T_HI - PROBE_T_LO) * i) / (PROBE_COUNT - 1);
-        const cx = ax + ux * len * t;
-        const cz = az + uz * len * t;
-        const ex = cx - nx * halfWidth;
-        const ez = cz - nz * halfWidth;
-        const edgeDist = documentDistance(ex, ez, doc);
-        if (Math.abs(edgeDist) > ON_BOUNDARY_TOLERANCE) {
-            throw new Error(
-                `worldEdgeAnchors: probe ${i} analytic edge point isn't on the boundary (dist ${edgeDist.toFixed(3)})`,
-            );
-        }
-        // the outward search axis: away from the corridor's own centreline, toward natural terrain — the
-        // sign only labels which side of the anchor is "positive", detection works either way (`detectEdgeOffset`
-        // scans symmetrically), but a consistent outward convention keeps the sign of a returned offset legible.
-        anchors.push({ ex, ez, nx: -nx, nz: -nz });
-    }
-    return anchors;
-}
-
-/** one anchor's height-axis reading: the world-metre offset (along {@link WorldEdgeAnchor.nx}/`nz`) between
- *  the analytic boundary point and where the *real* mesh height actually crosses from the flattened
- *  corridor to natural terrain — `null` when no crossing was found (the search radius missed it) or the
- *  endpoints didn't differ enough to trust as a real transition (`reason: "low-contrast"`, the flat-ground
- *  control case: no cut, no differential, nothing to find). */
+/** one anchor's height-axis reading: the world-metre offset (along the anchor's own outward normal)
+ *  between the analytic boundary's {@link heightMidpointAnchor} and where the *real* mesh height actually
+ *  crosses from the flattened corridor to natural terrain — `null` when no crossing was found (the search
+ *  radius missed it) or the endpoints didn't differ enough to trust as a real transition (`reason:
+ *  "low-contrast"`, the flat-ground control case: no cut, no differential, nothing to find). */
 export interface HeightReading {
     i: number;
     offset: number | null;
@@ -223,13 +149,13 @@ const MIN_CONTRAST_M = 100 * (TERRAIN_QUANT.posScale.y / 65535);
 const STEPS_PER_M = 8; // sub-decimetre crossing resolution — cheap at this anchor/radius count
 
 /** stage 10's height-axis straightness criterion: walks the *real* rendered mesh height
- *  (`capture.ts`'s `meshHeightAt`) outward from each analytic boundary anchor over the network's own
- *  derived falloff distance, and finds where it actually crosses from the flattened plateau to natural
- *  terrain — the deviation from the anchor (which sits exactly on the analytic boundary by construction)
- *  is the height-silhouette offset, in world metres. `raggedness` (`straightness.ts`) aggregates the same
- *  way stage 9's screen-space instrument did; what changed is only the sampled quantity and its axis
- *  (world height, not screen luminance) — the corrected criterion `boot.ts` exposes as
- *  `window.__roadsHeightSilhouette`. */
+ *  (`capture.ts`'s `meshHeightAt`) outward from each analytic boundary anchor's
+ *  `boundaryAnchors.ts`'s {@link heightMidpointAnchor} over the network's own derived falloff distance,
+ *  and finds where it actually crosses from the flattened plateau to natural terrain — the deviation from
+ *  that ground-truth midpoint is the height-silhouette offset, in world metres. `raggedness`
+ *  (`straightness.ts`) aggregates the same way stage 9's screen-space instrument did; what changed is only
+ *  the sampled quantity and its axis (world height, not screen luminance) — the corrected criterion
+ *  `boot.ts` exposes as `window.__roadsHeightSilhouette`. */
 export async function heightSilhouette(): Promise<HeightSilhouetteResult> {
     const anchors = worldEdgeAnchors();
     const raw = await readVertices();
@@ -248,17 +174,8 @@ export async function heightSilhouette(): Promise<HeightSilhouetteResult> {
         if (contrastM < MIN_CONTRAST_M) {
             return { i, offset: null, contrastM, reason: "low-contrast" as const };
         }
-        const offset = detectEdgeOffset(
-            sampleAt,
-            a.ex,
-            a.ez,
-            a.nx,
-            a.nz,
-            lo,
-            hi,
-            falloff,
-            STEPS_PER_M,
-        );
+        const { mx, mz } = heightMidpointAnchor(a, falloff);
+        const offset = detectEdgeOffset(sampleAt, mx, mz, a.nx, a.nz, lo, hi, falloff, STEPS_PER_M);
         return {
             i,
             offset,

--- a/examples/showcase/roads/src/grazingCapture.ts
+++ b/examples/showcase/roads/src/grazingCapture.ts
@@ -1,10 +1,13 @@
 import { Orbit } from "@dylanebert/shallot/extras";
 import { Views } from "@dylanebert/shallot/render/core";
-import { withHeight, worldToScreen } from "./capture";
+import { meshHeightAt, withHeight, worldToScreen } from "./capture";
 import { frames } from "./harness";
 import { documentDistance } from "./overlay/document";
 import { generateNetwork } from "./overlay/network";
-import { SEED } from "./terrain/terrain";
+import { detectEdgeOffset, raggedness } from "./straightness";
+import { buildNetworkGeometry, computeFalloff } from "./terrain/flatten";
+import { TERRAIN_QUANT } from "./terrain/generate";
+import { getSmoothRadius, readVertices, SEED } from "./terrain/terrain";
 
 // Stage 9's discriminator — the grazing-view half. The release-look screenshot that opened this stage was
 // a hand-orbited shot; this reproduces it as a *fixed, reproducible* camera pose so the two-resolution
@@ -12,11 +15,21 @@ import { SEED } from "./terrain/terrain";
 // point, not an aesthetic choice: a small world-space deviation projects to a much larger screen-pixel
 // deviation the closer the view direction runs parallel to the surface (the same reason raking light
 // reveals machining marks a top-down look hides) — the straightness signal this stage measures needs that
-// magnification to be visible in a handful of screen pixels at all.
+// magnification to be visible in a handful of screen pixels at all. Kept for the evidence screenshot
+// `test/straightness.spec.ts` still saves; the actual reading (`heightSilhouette`, below) is now
+// camera-independent — it lives entirely in the heightfield, not in what a camera happens to project.
 //
 // Reuses the *same* boot document every run (`generateNetwork(SEED)`, `terrain.ts`'s own boot document) —
 // road index 0's own first segment, deterministic — so a SPACING/TILE_RES/DIST_RANGE edit between runs
 // changes only the mesh/atlas resolution under test, never the network geometry the camera is framed to.
+//
+// Stage 10: stage 9's `detectEdgeOffset`/`raggedness` (`straightness.ts`) are dimension-agnostic — a 1D
+// sampler walked over a search axis, looking for a crossing — so the height-axis criterion below reuses
+// them unchanged, only swapping what's sampled (real mesh height, `capture.ts`'s `meshHeightAt`, in place
+// of screen-pixel luminance) and the axis it's sampled along (the world-space normal to the road
+// centreline, in metres, in place of a screen-space search direction). The defect stage 9 found lives in
+// the heightfield itself, so the corrected instrument measures the heightfield directly rather than a
+// camera's projection of it — the same reason it needs no camera pose at all.
 
 const TARGET_T = 0.08; // fraction along the road from its start — near one end, so the far ~90% recedes
 const PROBE_T_LO = 0.2;
@@ -132,4 +145,136 @@ export async function grazingCapture(): Promise<{ anchors: GrazingAnchor[] }> {
     }
 
     return { anchors };
+}
+
+/** one boundary anchor for the height-axis criterion: the same analytic edge point
+ *  {@link grazingCapture}'s anchors project to screen space, plus a world-space unit search direction
+ *  (perpendicular to the road centreline, metres) instead of a screen one. */
+export interface WorldEdgeAnchor {
+    ex: number;
+    ez: number;
+    nx: number;
+    nz: number;
+}
+
+/** the same {@link PROBE_COUNT} boundary anchors {@link grazingCapture} derives, in raw world coordinates
+ *  rather than a screen projection — stage 10's height-axis criterion needs the point and a world-space
+ *  search axis, never a camera. Exported separately since a camera pose plays no role in this reading. */
+export function worldEdgeAnchors(): WorldEdgeAnchor[] {
+    const { ax, az, bx, bz, halfWidth } = roadSegment();
+    const dx = bx - ax;
+    const dz = bz - az;
+    const len = Math.hypot(dx, dz) || 1;
+    const ux = dx / len;
+    const uz = dz / len;
+    const nx = -uz;
+    const nz = ux;
+    const doc = generateNetwork(SEED);
+
+    const anchors: WorldEdgeAnchor[] = [];
+    for (let i = 0; i < PROBE_COUNT; i++) {
+        const t = PROBE_T_LO + ((PROBE_T_HI - PROBE_T_LO) * i) / (PROBE_COUNT - 1);
+        const cx = ax + ux * len * t;
+        const cz = az + uz * len * t;
+        const ex = cx - nx * halfWidth;
+        const ez = cz - nz * halfWidth;
+        const edgeDist = documentDistance(ex, ez, doc);
+        if (Math.abs(edgeDist) > ON_BOUNDARY_TOLERANCE) {
+            throw new Error(
+                `worldEdgeAnchors: probe ${i} analytic edge point isn't on the boundary (dist ${edgeDist.toFixed(3)})`,
+            );
+        }
+        // the outward search axis: away from the corridor's own centreline, toward natural terrain — the
+        // sign only labels which side of the anchor is "positive", detection works either way (`detectEdgeOffset`
+        // scans symmetrically), but a consistent outward convention keeps the sign of a returned offset legible.
+        anchors.push({ ex, ez, nx: -nx, nz: -nz });
+    }
+    return anchors;
+}
+
+/** one anchor's height-axis reading: the world-metre offset (along {@link WorldEdgeAnchor.nx}/`nz`) between
+ *  the analytic boundary point and where the *real* mesh height actually crosses from the flattened
+ *  corridor to natural terrain — `null` when no crossing was found (the search radius missed it) or the
+ *  endpoints didn't differ enough to trust as a real transition (`reason: "low-contrast"`, the flat-ground
+ *  control case: no cut, no differential, nothing to find). */
+export interface HeightReading {
+    i: number;
+    offset: number | null;
+    contrastM: number;
+    reason: "found" | "no-crossing" | "low-contrast";
+}
+
+export interface HeightSilhouetteResult {
+    falloffM: number;
+    cutDepthM: number;
+    anchorCount: number;
+    readings: HeightReading[];
+    rmsM: number;
+    maxM: number;
+    foundCount: number;
+}
+
+// noise floor for a real road/terrain height differential: 100x the Y-axis quantization step
+// (`TERRAIN_QUANT.posScale.y / 65535`, ~1.2 mm at RELIEF=40) puts the floor around 12 cm — comfortably
+// above quantization/interpolation noise, comfortably below the metre-scale defect this criterion exists
+// to catch, so a genuine transition is never mistaken for noise and a flat/no-cut control (no differential
+// at all) reads as "nothing to find" rather than a spurious crossing on numerical noise.
+const MIN_CONTRAST_M = 100 * (TERRAIN_QUANT.posScale.y / 65535);
+const STEPS_PER_M = 8; // sub-decimetre crossing resolution — cheap at this anchor/radius count
+
+/** stage 10's height-axis straightness criterion: walks the *real* rendered mesh height
+ *  (`capture.ts`'s `meshHeightAt`) outward from each analytic boundary anchor over the network's own
+ *  derived falloff distance, and finds where it actually crosses from the flattened plateau to natural
+ *  terrain — the deviation from the anchor (which sits exactly on the analytic boundary by construction)
+ *  is the height-silhouette offset, in world metres. `raggedness` (`straightness.ts`) aggregates the same
+ *  way stage 9's screen-space instrument did; what changed is only the sampled quantity and its axis
+ *  (world height, not screen luminance) — the corrected criterion `boot.ts` exposes as
+ *  `window.__roadsHeightSilhouette`. */
+export async function heightSilhouette(): Promise<HeightSilhouetteResult> {
+    const anchors = worldEdgeAnchors();
+    const raw = await readVertices();
+    const doc = generateNetwork(SEED);
+    const { cutDepth } = buildNetworkGeometry(doc, SEED, getSmoothRadius());
+    const falloff = computeFalloff(cutDepth);
+
+    const sampleAt = (x: number, z: number): number => meshHeightAt(raw, x, z);
+
+    const readings: HeightReading[] = anchors.map((a, i) => {
+        const s0 = sampleAt(a.ex - a.nx * falloff, a.ez - a.nz * falloff);
+        const s1 = sampleAt(a.ex + a.nx * falloff, a.ez + a.nz * falloff);
+        const lo = Math.min(s0, s1);
+        const hi = Math.max(s0, s1);
+        const contrastM = hi - lo;
+        if (contrastM < MIN_CONTRAST_M) {
+            return { i, offset: null, contrastM, reason: "low-contrast" as const };
+        }
+        const offset = detectEdgeOffset(
+            sampleAt,
+            a.ex,
+            a.ez,
+            a.nx,
+            a.nz,
+            lo,
+            hi,
+            falloff,
+            STEPS_PER_M,
+        );
+        return {
+            i,
+            offset,
+            contrastM,
+            reason: offset === null ? ("no-crossing" as const) : ("found" as const),
+        };
+    });
+
+    const r = raggedness(readings.map((d) => d.offset));
+    return {
+        falloffM: falloff,
+        cutDepthM: cutDepth,
+        anchorCount: anchors.length,
+        readings,
+        rmsM: r.rms,
+        maxM: r.max,
+        foundCount: r.n,
+    };
 }

--- a/examples/showcase/roads/src/straightness.ts
+++ b/examples/showcase/roads/src/straightness.ts
@@ -1,19 +1,28 @@
 // Stage 9's straightness instrument — device-free pure math, the pure half of the grazing-view
-// discriminator (`grazingCapture.ts` is the GPU/DOM-bound half that supplies real pixel data and real
-// analytic anchors). The spec's own gate gap: stage 7's capture probe measures transition *width* along
-// one ray perpendicular to the road, so it is structurally blind to boundary *straightness* — the defect
-// axis the release-look screenshot actually showed. This module is the straightness criterion the stage
-// owes: given a luminance sampler and a sequence of analytic (ground-truth) anchor points with their own
+// discriminator (`grazingCapture.ts` is the GPU/DOM-bound half that supplies the real sampled data and
+// the analytic anchors). The spec's own gate gap: stage 7's capture probe measures transition *width*
+// along one ray perpendicular to the road, so it is structurally blind to boundary *straightness* — the
+// defect axis the release-look screenshot actually showed. This module is the straightness criterion the
+// stage owes: given a 1D sampler and a sequence of analytic (ground-truth) anchor points with their own
 // local search axis, find where the real edge actually sits, and turn the deviations into one number.
+//
+// Deliberately dimension-agnostic: `detectEdgeOffset` doesn't know whether it's walking screen pixels or
+// world metres, or whether it's sampling luminance or height — only that it's a 1D signal crossing a
+// midpoint. Stage 9 fed it screen-space albedo luminance; stage 10 (`grazingCapture.ts`'s
+// `heightSilhouette`) feeds it world-space mesh height instead, at the axis the defect actually lives on
+// (screen-space albedo was blind to a height silhouette whose texture boundary stayed sharp). Same code,
+// different sampler.
 
 /**
  * walks `sampleAt` along the unit direction (`dirX`, `dirY`) from (`anchorX`, `anchorY`), over
- * `[-radiusPx, +radiusPx]`, and returns the signed offset (in the same px units as `dirX`/`dirY`) of the
- * first place the sampled value crosses the midpoint between `lo` and `hi` — linearly interpolated between
- * the two straddling samples for sub-pixel precision. `null` when no crossing is found in range (the edge
- * isn't where the anchor expects it, or the probe missed the frame). Deliberately reports only the first
- * crossing scanning outward from the anchor: a boundary probe expects exactly one transition near its own
- * anchor, and the *offset itself* — not scanning past it for a second one — is the raggedness measurement.
+ * `[-radiusPx, +radiusPx]`, and returns the signed offset (in whatever unit `dirX`/`dirY`/`radiusPx` are
+ * expressed in — screen pixels for stage 9's albedo probe, world metres for stage 10's height probe) of
+ * the first place the sampled value crosses the midpoint between `lo` and `hi` — linearly interpolated
+ * between the two straddling samples for sub-step precision. `null` when no crossing is found in range
+ * (the edge isn't where the anchor expects it, or the probe missed the frame/heightfield). Deliberately
+ * reports only the first crossing scanning outward from the anchor: a boundary probe expects exactly one
+ * transition near its own anchor, and the *offset itself* — not scanning past it for a second one — is the
+ * raggedness measurement.
  */
 export function detectEdgeOffset(
     sampleAt: (x: number, y: number) => number,

--- a/examples/showcase/roads/src/terrain/noise.ts
+++ b/examples/showcase/roads/src/terrain/noise.ts
@@ -9,14 +9,16 @@
 import tgpu from "typegpu";
 import * as d from "typegpu/data";
 import * as std from "typegpu/std";
+import { envNumber } from "../env";
 
 // heightmap knobs, in world units (metres), since the terrain kernel samples world position directly —
 // unlike voxel, which samples grid-cell coordinates. HFREQ's period (1/HFREQ ≈ 330 m) puts about three
 // broad hills across the 1024 m field (grid.ts); RELIEF is the vertical amplitude in metres (|fbm2| ≤ 1
 // ⇒ height ∈ GROUND_LEVEL ± RELIEF) — gentle rolling hills, not mountains, the showcase's "readable at
-// street level" brief.
+// street level" brief. RELIEF is `VITE_ROADS_RELIEF`-overridable: the straightness instrument's flat-
+// ground control needs undeformed terrain, not just a disabled flatten step (`env.ts`).
 export const HFREQ = 0.003;
-export const RELIEF = 40;
+export const RELIEF = envNumber("VITE_ROADS_RELIEF", 40);
 export const OCTAVES = 5; // baked into fbm2 below — broad shapes + medium hills + fine detail
 // plain-number exports so terrain/profile.ts's CPU mirror (heightAtCpu) shares these instead of
 // re-declaring its own copies — one source, the d.f32 wrap below is this module's own GPU-side need.

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -16,6 +16,7 @@ import { MeshQuant } from "@dylanebert/shallot/utils/core";
 import tgpu from "typegpu";
 import * as d from "typegpu/data";
 import * as std from "typegpu/std";
+import { envFlag } from "../env";
 import * as overlayAtlas from "../overlay/atlas";
 import type { StrokeDocument } from "../overlay/document";
 import { generateNetwork } from "../overlay/network";
@@ -168,6 +169,14 @@ function teardown(): void {
 // same `markDirty`/`redraw`/flatten path this boot document already takes.
 let liveDocument: StrokeDocument = generateNetwork(SEED);
 let currentSeed = SEED;
+// the straightness instrument's no-cut control: `liveDocument` still drives the overlay and the height-
+// axis anchors (the analytic road edge stays a real, checkable position), only the *flatten* kernel gets
+// an empty network — `flatten.ts`'s own documented fallback ("empty network... degrades to plain
+// heightAt") — so the rendered mesh is genuinely undeformed terrain rather than a cut against zeroed
+// RELIEF. `VITE_ROADS_NO_CUT`-gated (`env.ts`); paired with `VITE_ROADS_RELIEF=0` (`noise.ts`) for the
+// spec's "zeroed-RELIEF, no-cut control" arm.
+const NO_CUT = envFlag("VITE_ROADS_NO_CUT");
+const EMPTY_DOCUMENT: StrokeDocument = { polylines: [], polygons: [] };
 // the longitudinal smoothing strength (`terrain/profile.ts`'s box-filter radius, samples each side) —
 // the spec's taste handover: a live control (`boot.ts`'s bracket-key idiom), not a value baked in and
 // declared good. `setSmoothRadius` below is the control's own entry point.
@@ -249,8 +258,9 @@ async function warm(state: State): Promise<void> {
 
     bindTerrainKernel(vertices, position);
     warmNetwork(state); // its own onDispose registration, the same pattern
-    setNetwork(liveDocument, currentSeed, smoothRadius); // the flatten kernel's geometry input, kept in
-    // sync with the overlay's own document and the height kernel's own permutation seed
+    setNetwork(NO_CUT ? EMPTY_DOCUMENT : liveDocument, currentSeed, smoothRadius); // the flatten kernel's
+    // geometry input, kept in sync with the overlay's own document and the height kernel's own
+    // permutation seed — except under the no-cut control arm, above
     if (state.signal.aborted) return;
     await generate(SEED);
 }

--- a/examples/showcase/roads/test/straightness.spec.ts
+++ b/examples/showcase/roads/test/straightness.spec.ts
@@ -168,3 +168,114 @@ test("boundary straightness — grazing-view discriminator (opt-in, not a gate)"
         Math.floor(anchors.length * 0.6),
     );
 });
+
+// Stage 10: stage 9's mechanism finding (`shallot-roads.md`'s Approach) — the road boundary staircase a
+// person reads as metre-scale lives in the flattened corridor's *height*, not its albedo edge, so a
+// screen-space luminance probe (above) is structurally blind to it (0.74 px rms genuine spread against a
+// complaint a person reads as metres). This probe re-points the same anchor machinery at the world-space
+// heightfield directly (`window.__roadsHeightSilhouette`, `grazingCapture.ts`) — no screen projection, no
+// luminance, no camera dependence for the reading itself. `window.__roadsGrazingCapture` is still called
+// first, purely to move the camera and save an evidence screenshot a person can look at alongside the
+// number; the PNG is decoded only for a non-blank sanity check, never fed into the height reading.
+// a network whose deepest cut is below this reads as "no meaningful cut" (the flat-ground/zeroed-RELIEF
+// control) — derived from the same MIN_CONTRAST_M floor `grazingCapture.ts` uses per-anchor (100x the
+// height quantization step), so the same noise floor gates both the per-anchor and the whole-run read.
+const MIN_MEANINGFUL_CUT_M = 0.12;
+
+test("boundary straightness — height-axis world-space discriminator (opt-in, not a gate)", async ({
+    page,
+}) => {
+    test.skip(
+        !process.env.ROADS_STRAIGHTNESS,
+        "opt-in: set ROADS_STRAIGHTNESS=1 to run the height-axis straightness reading",
+    );
+
+    const errors: string[] = [];
+    page.on("pageerror", (e) => errors.push(String(e)));
+
+    await page.goto("/");
+
+    const adapter = await adapterName(page);
+    console.log(`height-silhouette probe adapter: ${adapter || "none offered"}`);
+    test.skip(
+        adapter === "" || SOFTWARE.test(adapter),
+        `no real-GPU adapter (${adapter || "none offered"})`,
+    );
+
+    await page.waitForFunction(() => typeof window.__roadsGate === "function", null, {
+        timeout: 120_000,
+    });
+    await page.waitForFunction(
+        () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
+        null,
+        { timeout: 10_000 },
+    );
+
+    const meshParams = await page.evaluate(
+        () => (window as unknown as { __roadsMeshParams: unknown }).__roadsMeshParams,
+    );
+
+    // evidence only — the height reading below needs no camera pose at all.
+    await page.evaluate(() =>
+        (
+            window as unknown as {
+                __roadsGrazingCapture: () => Promise<unknown>;
+            }
+        ).__roadsGrazingCapture(),
+    );
+    const evidenceScreenshot = await page.screenshot();
+    const evidencePath = join(
+        dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "test-results",
+        `height-silhouette-capture-${ARM_LABEL}.png`,
+    );
+    mkdirSync(dirname(evidencePath), { recursive: true });
+    writeFileSync(evidencePath, evidenceScreenshot);
+    const png = PNG.sync.read(evidenceScreenshot);
+    const nonBlack = png.data.some((v, i) => i % 4 !== 3 && v > 0);
+    expect(nonBlack, "evidence screenshot is entirely black — camera pose likely wrong").toBe(true);
+
+    const result = (await page.evaluate(() =>
+        (
+            window as unknown as {
+                __roadsHeightSilhouette: () => Promise<{
+                    falloffM: number;
+                    cutDepthM: number;
+                    anchorCount: number;
+                    readings: unknown[];
+                    rmsM: number;
+                    maxM: number;
+                    foundCount: number;
+                }>;
+            }
+        ).__roadsHeightSilhouette(),
+    )) as {
+        falloffM: number;
+        cutDepthM: number;
+        anchorCount: number;
+        readings: unknown[];
+        rmsM: number;
+        maxM: number;
+        foundCount: number;
+    };
+
+    console.log(
+        `HEIGHT_SILHOUETTE_READING ${JSON.stringify({
+            armLabel: ARM_LABEL,
+            meshParams,
+            ...result,
+        })}`,
+    );
+
+    expect(errors, errors.join("\n")).toEqual([]);
+    // same validity bar as the screen-space probe: the instrument itself has to work (find most of its
+    // anchors, when there's a real cut to find) before its reading means anything — never a straightness
+    // pass/fail, which stays stage 11's job.
+    if (result.cutDepthM > MIN_MEANINGFUL_CUT_M) {
+        expect(
+            result.foundCount,
+            `found ${result.foundCount}/${result.anchorCount} height crossings`,
+        ).toBeGreaterThanOrEqual(Math.floor(result.anchorCount * 0.6));
+    }
+});

--- a/examples/showcase/roads/test/straightness.spec.ts
+++ b/examples/showcase/roads/test/straightness.spec.ts
@@ -169,7 +169,7 @@ test("boundary straightness — grazing-view discriminator (opt-in, not a gate)"
     );
 });
 
-// Stage 10: stage 9's mechanism finding (`shallot-roads.md`'s Approach) — the road boundary staircase a
+// Stage 10: stage 9's mechanism finding (the spec's Approach) — the road boundary staircase a
 // person reads as metre-scale lives in the flattened corridor's *height*, not its albedo edge, so a
 // screen-space luminance probe (above) is structurally blind to it (0.74 px rms genuine spread against a
 // complaint a person reads as metres). This probe re-points the same anchor machinery at the world-space
@@ -277,5 +277,24 @@ test("boundary straightness — height-axis world-space discriminator (opt-in, n
             result.foundCount,
             `found ${result.foundCount}/${result.anchorCount} height crossings`,
         ).toBeGreaterThanOrEqual(Math.floor(result.anchorCount * 0.6));
+        // a magnitude validity bound, not a straightness tolerance (stage 11's own job): rmsM must sit
+        // comfortably above sub-instrument-resolution noise and can never structurally exceed falloffM,
+        // the search radius `heightSilhouette` walks each anchor over (`grazingCapture.ts`) — a reading
+        // outside either bound means the instrument itself regressed, not that the road did.
+        // RMS_FLOOR_M: two orders of magnitude below the mesh's own vertex spacing (SPACING) — the same
+        // "100x the physical noise floor" margin `grazingCapture.ts`'s own MIN_CONTRAST_M uses against
+        // height quantization, applied here to the mesh's spatial resolution. A reading this much smaller
+        // than the grid itself is sub-millimetre axis-blindness (stage 9's own screen-space defect, 0.74
+        // px rms against a metre-scale complaint), not a real quantized boundary.
+        const spacingM = (meshParams as { spacing: number }).spacing;
+        const rmsFloorM = spacingM / 100;
+        expect(
+            result.rmsM,
+            `rmsM ${result.rmsM} is sub-instrument-resolution against SPACING ${spacingM}`,
+        ).toBeGreaterThan(rmsFloorM);
+        expect(
+            result.rmsM,
+            `rmsM ${result.rmsM} exceeds falloffM ${result.falloffM}, the instrument's own search radius`,
+        ).toBeLessThanOrEqual(result.falloffM);
     }
 });

--- a/examples/showcase/roads/test/straightness.spec.ts
+++ b/examples/showcase/roads/test/straightness.spec.ts
@@ -296,5 +296,22 @@ test("boundary straightness — height-axis world-space discriminator (opt-in, n
             result.rmsM,
             `rmsM ${result.rmsM} exceeds falloffM ${result.falloffM}, the instrument's own search radius`,
         ).toBeLessThanOrEqual(result.falloffM);
+    } else {
+        // the control arm (zeroed RELIEF, no cut): with no meaningful cut there is no height silhouette
+        // to find, so a "found" reading here can only be MIN_CONTRAST_M's per-anchor gate tripping on
+        // something other than a real transition — a regression in the instrument, not a road. The bound
+        // is derived, not fit to today's 0: MIN_CONTRAST_M (`grazingCapture.ts`) is built with a 100x
+        // margin over raw quantization noise specifically so that margin can't be crossed by noise alone;
+        // treating that same 1-in-100 margin as a per-anchor false-positive tolerance and scaling it by
+        // the anchor count (rounded up to a whole anchor) gives the largest count consistent with "still
+        // just noise" rather than a real crossing. At 16 anchors this is 1 — today's control reads 0,
+        // comfortably inside it, but the bound doesn't move if the anchor set does.
+        const controlFoundBound = Math.ceil(result.anchorCount * (1 / 100));
+        expect(
+            result.foundCount,
+            `found ${result.foundCount}/${result.anchorCount} height crossings on the zeroed-RELIEF, ` +
+                `no-cut control — expected at most ${controlFoundBound} (noise floor), since there is no ` +
+                "cut for a genuine height silhouette to cross",
+        ).toBeLessThanOrEqual(controlFoundBound);
     }
 });


### PR DESCRIPTION
## Problem

The boundary-straightness instrument measured the wrong axis. It read screen-space perpendicular deviation of the *albedo* edge, so it was blind to a corridor whose height silhouette steps in world space while its texture boundary stays sharp — reporting 0.74 px rms against a defect a person reads as a metre-scale staircase.

## Cause

Two layers, found one after the other.

The instrument's sampler was luminance in screen space, not height in world space. Re-pointing it at the mesh height exposed a second defect underneath: `detectEdgeOffset` returns where the signal crosses the midpoint between its `lo`/`hi` samples, but the anchor sat at the road half-width edge (`coreDist = 0`). `flattenHeight`'s cosine ease reaches 0.5 at `coreDist = falloff/2`, so a *perfectly straight* edge read 7.013 m of "deviation" — a constant bias, the same order of magnitude as the human report the criterion was supposed to be validated against.

## Fix

- `grazingCapture.ts` gains `heightSilhouette`, walking the real rendered mesh height (`capture.ts`'s `meshHeightAt`, a two-triangle-per-quad reconstruction over a GPU→CPU vertex readback) along the world-space normal to the road edge. `straightness.ts`'s `detectEdgeOffset`/`raggedness` are dimension-agnostic and are reused unchanged.
- `boundaryAnchors.ts` (new) holds the anchor derivation both probes share, and `heightMidpointAnchor` places the ground-truth anchor at the ease midpoint the detector actually finds — derived from `flattenHeight`'s own formula, not a subtracted constant.
- `env.ts` + `VITE_ROADS_RELIEF` / `VITE_ROADS_NO_CUT` make the zeroed-RELIEF, no-cut control arm runnable without a source edit. Defaults are unchanged when the vars are unset, so the shipped example and the standard gate are untouched.
- The device test now bounds `rmsM` on the shipped arm and `foundCount` on the control arm; previously the control arm ran zero assertions.

No change to `SPACING`, `ROAD_HALF_WIDTH`, `computeFalloff`, or topology — the falloff fix is the next stage.

## Evidence

- `bun test ./examples/showcase/roads/src` → 137 pass, 0 fail, 4297 `expect()`, exit 0, 1049 ms (floor 133/4274/~1080 ms — four tests added, elapsed unchanged).
- `bun run gate` → adapter `nvidia lovelace`, 1 passed, 2 skipped, exit 0. Not a software-adapter skip.
- `ROADS_STRAIGHTNESS=1 bun run gate test/straightness.spec.ts`, both arms on the real device: shipped `rmsM 5.7646 / maxM 11.363 / found 15/16`; control (`VITE_ROADS_RELIEF=0 VITE_ROADS_NO_CUT=1`) `rmsM 0 / found 0/16`. The shipped reading is metre-scale, matching the human report the criterion owes.
- `bun run format` and `bun check` at the repo root both exit 0.
- Red-first on both new checks: the bias check was watched returning 7.013 against an expected ~0 before the anchor fix; the control-arm assertion was watched failing (`found 5/16 … expected at most 1`) under a deliberate perturbation, then reverted.
- Three adversarial review passes (instrument validity, spec-conformance/blast-radius, and a separate pass over the repair) — the first two also discharge the adversarial pass the previous stage shipped owing.

Known limit, recorded rather than papered over: the control arm proves no false positives on flat ground, not that the corrected anchor is unbiased on a real edge — with no cut there is no silhouette to find. The unbiasedness proof is the CPU synthetic-straight-edge test in `boundaryAnchors.test.ts`.
