### PR TITLE
shallot-roads: decouple the straightness window from falloff

### DIFF
--- a/examples/showcase/roads/src/boundaryAnchors.test.ts
+++ b/examples/showcase/roads/src/boundaryAnchors.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { heightMidpointAnchor, worldEdgeAnchors } from "./boundaryAnchors";
+import { heightMidpointAnchor, sideSlopeWindow, worldEdgeAnchors } from "./boundaryAnchors";
 import { detectEdgeOffset } from "./straightness";
-import { flattenHeight } from "./terrain/flatten";
+import { computeFalloff, flattenHeight, SIDE_SLOPE_LIMIT } from "./terrain/flatten";
 
 // Stage 10 repair, blocker 1: `heightSilhouette`'s pre-fix reading anchored the height-axis crossing
 // detector at the road edge itself (`WorldEdgeAnchor.ex`/`ez`, `coreDist = 0`). `detectEdgeOffset`
@@ -90,5 +90,105 @@ describe("worldEdgeAnchors — the analytic road-edge anchors the height-axis in
         for (const a of anchors) {
             expect(Math.hypot(a.nx, a.nz)).toBeCloseTo(1, 5);
         }
+    });
+});
+
+// Stage 11b: stage 10's `heightSilhouette` scanned and anchored on `computeFalloff(cutDepth)` directly —
+// the AASHTO side-slope term maxed with a mesh-sampling floor (`SPACING` today, a differently-derived
+// multiple of it on 11a's still-unshipped branch) — so a wider floor widened the search window into raw
+// terrain *and* moved the threshold anchor, with no change on the ground either was supposed to measure.
+// `sideSlopeWindow` is the AASHTO term alone, upstream of any floor.
+describe("sideSlopeWindow — the decoupled measurement window", () => {
+    test("matches computeFalloff's own AASHTO branch when the shipped SPACING floor doesn't bind", () => {
+        // 2.976 is this network's real measured cut depth (spec Live log, stage 11b) — well past the
+        // point (~0.849 m, where (π/2)·cutDepth/SIDE_SLOPE_LIMIT = SPACING) the shipped 4 m floor binds,
+        // so today computeFalloff and sideSlopeWindow are the *same number*: the fix changes nothing about
+        // today's reading, only what happens when a floor grows past the AASHTO term.
+        const cutDepth = 2.976;
+        expect(sideSlopeWindow(cutDepth)).toBeCloseTo(computeFalloff(cutDepth), 6);
+        expect(sideSlopeWindow(cutDepth)).toBeCloseTo(14.026, 2); // spec's recorded falloffM, rounded to 3dp
+    });
+
+    test("is exactly the AASHTO formula, with no floor term at all", () => {
+        const cutDepth = 5;
+        expect(sideSlopeWindow(cutDepth)).toBeCloseTo(
+            ((Math.PI / 2) * cutDepth) / SIDE_SLOPE_LIMIT,
+            9,
+        );
+    });
+
+    test("zero cut depth gives a zero window — no floor to fall back on", () => {
+        expect(sideSlopeWindow(0)).toBe(0);
+    });
+});
+
+// The flat-across-an-inert-treatment arm the stage owes, run CPU-side against a synthetic straight edge
+// since the concrete floor derivation that would widen `computeFalloff` on a real device (11a's
+// `FALLOFF_SAMPLE_SEGMENTS * SPACING`) lives on a separate, unshipped branch this stage may not port or
+// re-derive (spec Boundaries). What's provable without it: `computeFalloff`'s own shape is
+// `max(floor, AASHTO(cutDepth))` for *some* floor value — stage 10's instrument reads whatever that max
+// produces. `coupled` below reconstructs exactly that shape, generic in `floor`, to model the *class* of
+// defect (any floor derivation), not 11a's specific one. The synthetic edge's true transition is built
+// from the real `flattenHeight` at a *fixed* embedded width (`TRUE_WINDOW`, matching production's
+// `sideSlopeWindow(2.976)`) — the "boundary" here is a fixed array of sampled heights, so a floor value
+// that only feeds `couple`'s own `Math.max` (never the sampler) provably cannot move it. Any reading
+// swing as `floor` varies is the instrument, not the road.
+describe("flat-across-an-inert-treatment: a floor change moves the coupled window, not the boundary", () => {
+    const TrueCutDepth = 2.976;
+    const TrueWindow = sideSlopeWindow(TrueCutDepth); // 14.026 — the synthetic edge's real, fixed width
+    const Natural = 100;
+    const Target = 10;
+    const StepsPerM = 20;
+    const a = worldEdgeAnchors()[0];
+    const sampleAt = (x: number, z: number): number => {
+        const coreDist = (x - a.ex) * a.nx + (z - a.ez) * a.nz;
+        return flattenHeight(Natural, Target, coreDist, TrueWindow);
+    };
+
+    /** stage 10's instrument shape, generalized: `computeFalloff`'s own `max(floor, AASHTO)`, with
+     *  `floor` a free parameter standing in for whatever mesh-sampling derivation produced it — the
+     *  treatment this arm varies. Never reads the sampler or `TRUE_CUT_DEPTH`'s embedding, only
+     *  `sideSlopeWindow`'s own output, exactly mirroring `computeFalloff`'s two-term max. */
+    function coupled(floor: number): number {
+        return Math.max(floor, sideSlopeWindow(TrueCutDepth));
+    }
+
+    function readAt(window: number): number | null {
+        const { mx, mz } = heightMidpointAnchor(a, window);
+        return detectEdgeOffset(sampleAt, mx, mz, a.nx, a.nz, Target, Natural, window, StepsPerM);
+    }
+
+    test("red-first: the coupled (stage-10-shaped) window reads a floor-sized bias on a perfectly straight edge", () => {
+        const inflatedFloor = 20; // > TRUE_WINDOW (14.026) — the treatment: a wider floor, real geometry untouched
+        const window = coupled(inflatedFloor);
+        expect(window).toBeCloseTo(inflatedFloor, 6); // the floor won the max — this is what "coupled" means
+        const offset = readAt(window);
+        expect(offset).not.toBeNull();
+        // biased by -(inflatedFloor - TRUE_WINDOW) / 2: the ease-midpoint anchor moves *outward* with the
+        // window (past the true crossing), so the detector finds it back toward the anchor's own origin —
+        // even though the sampled edge never moved (the same mechanism stage 10's own repair fixed, one
+        // level up: the wrong quantity feeding heightMidpointAnchor, not a wrong constant inside it).
+        expect(offset as number).toBeCloseTo(-(inflatedFloor - TrueWindow) / 2, 1);
+        expect(Math.abs(offset as number)).toBeGreaterThan(1); // not noise — metre-scale, same order as the real defect
+    });
+
+    test("the decoupled window reads flat across the same floor treatment — 0, 20, and 100", () => {
+        const readings = [0, 20, 100].map((floor) => {
+            const window = sideSlopeWindow(TrueCutDepth); // floor never enters this call at all
+            expect(window).toBeCloseTo(TrueWindow, 9); // literally the same number regardless of `floor`
+            return { floor, offset: readAt(window) };
+        });
+        for (const { floor, offset } of readings) {
+            expect(offset, `floor ${floor}`).not.toBeNull();
+            expect(Math.abs(offset as number), `floor ${floor}`).toBeLessThan(0.01);
+        }
+    });
+
+    test("the coupled window, by contrast, moves across the same three floor values — not flat", () => {
+        const offsets = [0, 20, 100].map((floor) => readAt(coupled(floor)));
+        const values = offsets.map((o) => o as number);
+        // 0 and 100 floor: AASHTO term (14.026) wins at floor=0, the floor wins at floor=100 — the spread
+        // across the swept treatment is the coupling, in the same units the real defect was measured in.
+        expect(Math.max(...values) - Math.min(...values)).toBeGreaterThan(1);
     });
 });

--- a/examples/showcase/roads/src/boundaryAnchors.ts
+++ b/examples/showcase/roads/src/boundaryAnchors.ts
@@ -1,5 +1,6 @@
 import { documentDistance, type StrokeDocument } from "./overlay/document";
 import { generateNetwork } from "./overlay/network";
+import { SIDE_SLOPE_LIMIT } from "./terrain/flatten";
 import { SEED } from "./terrain/terrain";
 
 // The analytic (ground-truth) boundary anchor derivation `grazingCapture.ts`'s two straightness
@@ -117,18 +118,43 @@ export function worldEdgeAnchors(): WorldEdgeAnchor[] {
 }
 
 /** the height-axis instrument's own ground-truth zero point: not the road edge itself
- *  ({@link WorldEdgeAnchor.ex}/`ez`, `coreDist = 0`) but `terrain/flatten.ts`'s `flattenHeight` cosine
- *  ease's own midpoint (`coreDist = falloff / 2`). `straightness.ts`'s `detectEdgeOffset` reports where
- *  the sampled signal crosses the *midpoint* between its `lo`/`hi` brackets; the ease
- *  `0.5 - 0.5·cos(π·t)` reaches exactly `0.5` at `t = 0.5`, i.e. `coreDist = falloff / 2` — so that is
- *  where a perfectly straight edge's detected crossing sits by construction, not at the road edge.
- *  Anchoring the reading at `coreDist = 0` instead reports a constant `falloff / 2` bias on every
- *  straight edge, indistinguishable from boundary raggedness (`boundaryAnchors.test.ts` proves the bias
- *  and the fix against a synthetic straight edge). */
+ *  ({@link WorldEdgeAnchor.ex}/`ez`, `coreDist = 0`) but the cosine ease's own midpoint
+ *  (`coreDist = window / 2`, `window` being whatever transition width the caller is measuring against —
+ *  `terrain/flatten.ts`'s `flattenHeight` reaches `0.5 - 0.5·cos(π·t) = 0.5` at `t = 0.5`).
+ *  `straightness.ts`'s `detectEdgeOffset` reports where the sampled signal crosses the *midpoint* between
+ *  its `lo`/`hi` brackets, so that ease-midpoint, not the road edge, is where a perfectly straight edge's
+ *  detected crossing sits by construction. Anchoring the reading at `coreDist = 0` instead reports a
+ *  constant `window / 2` bias on every straight edge, indistinguishable from boundary raggedness
+ *  (`boundaryAnchors.test.ts` proves the bias and the fix against a synthetic straight edge). Generic in
+ *  `window` rather than hard-coded to {@link sideSlopeWindow}'s output: the caller decides which
+ *  transition width it's measuring against. */
 export function heightMidpointAnchor(
     a: WorldEdgeAnchor,
-    falloff: number,
+    window: number,
 ): { mx: number; mz: number } {
-    const half = falloff / 2;
+    const half = window / 2;
     return { mx: a.ex + a.nx * half, mz: a.ez + a.nz * half };
+}
+
+/**
+ * stage 11b's decoupled measurement window (metres): the AASHTO side-slope term alone —
+ * `(π/2)·cutDepth/SIDE_SLOPE_LIMIT`, the same derivation `terrain/flatten.ts`'s `computeFalloff` uses for
+ * its own non-floor branch — deliberately omitting `computeFalloff`'s sampling floor (denominated in
+ * `SPACING`, or a differently-derived floor on stage 11a's still-unshipped branch). The floor exists only
+ * to keep the *mesh's* piecewise-linear reconstruction resolvable; it carries no side-slope-safety meaning
+ * and is exactly the term stage 11 gates (the floor is what widens when 11a's falloff scale grows). This
+ * function's only input is `cutDepth` — the network's own measured cut, `buildNetworkGeometry`'s output,
+ * upstream of `computeFalloff` entirely — so by construction no floor-widening treatment can reach it: the
+ * treatment appears in neither the search window nor (via {@link heightMidpointAnchor}) the threshold
+ * anchor built from it. `grazingCapture.ts`'s `heightSilhouette` scans and anchors against this instead of
+ * `computeFalloff`'s output, so two networks whose floor differs (today's `SPACING`, 11a's derived
+ * multiple of it, any future floor) read on the same window and are comparable. Known limit: whenever a
+ * floor actually binds (`computeFalloff`'s output exceeds this), the *real* rendered transition is wider
+ * than this window measures against — an accepted scope boundary (`shallot-roads.md` stage 11b), inert on
+ * this branch since the shipped `SPACING` floor (4 m) never binds for any network with a meaningful cut
+ * (binds only below `cutDepth ≈ 0.849 m`, per this same formula) — the risk is a future floor, not today's.
+ * @example sideSlopeWindow(0) // 0 — no cut, no transition to measure
+ * @example sideSlopeWindow(2.976) // 14.026, matching computeFalloff(2.976) — this network's floor doesn't bind */
+export function sideSlopeWindow(cutDepth: number): number {
+    return ((Math.PI / 2) * cutDepth) / SIDE_SLOPE_LIMIT;
 }

--- a/examples/showcase/roads/src/grazingCapture.ts
+++ b/examples/showcase/roads/src/grazingCapture.ts
@@ -4,6 +4,7 @@ import {
     edgeAnchorPoints,
     heightMidpointAnchor,
     roadFrame,
+    sideSlopeWindow,
     worldEdgeAnchors,
 } from "./boundaryAnchors";
 import { meshHeightAt, withHeight, worldToScreen } from "./capture";
@@ -35,6 +36,14 @@ import { getSmoothRadius, readVertices, SEED } from "./terrain/terrain";
 // centreline, in metres, in place of a screen-space search direction). The defect stage 9 found lives in
 // the heightfield itself, so the corrected instrument measures the heightfield directly rather than a
 // camera's projection of it — the same reason it needs no camera pose at all.
+//
+// Stage 11b: stage 10's window and threshold scanned `computeFalloff(cutDepth)` directly — the real
+// rendered transition width, floor included — so widening the floor (11a's still-unshipped deliverable)
+// widened the search window and moved the threshold with no real change on the ground, making the reading
+// non-comparable across two floor derivations (spec Approach, stage 11b; `boundaryAnchors.ts`'s
+// `sideSlopeWindow` doc comment has the full argument). `heightSilhouette` below now scans and anchors on
+// `sideSlopeWindow(cutDepth)` instead — a pure function of the network's own measured cut, upstream of any
+// floor — and reports the real `computeFalloff` output separately, as `falloffM`, for evidence only.
 
 const TARGET_T = 0.08; // fraction along the road from its start — near one end, so the far ~90% recedes
 const PITCH = 0.06; // radians (~3.4°) — near-horizontal, the grazing angle itself
@@ -131,7 +140,15 @@ export interface HeightReading {
 }
 
 export interface HeightSilhouetteResult {
+    /** `computeFalloff`'s output for this network — the *real* rendered transition width, floor included.
+     *  Informational only as of stage 11b: neither the search window nor the threshold anchor below reads
+     *  this value (they read {@link HeightSilhouetteResult.windowM} instead), so it no longer bounds
+     *  `rmsM`/`maxM`. */
     falloffM: number;
+    /** stage 11b's decoupled measurement window (`boundaryAnchors.ts`'s `sideSlopeWindow(cutDepthM)`) —
+     *  what the search radius and the threshold anchor actually read, comparable across two networks whose
+     *  `computeFalloff` floor differs even when `falloffM` isn't. */
+    windowM: number;
     cutDepthM: number;
     anchorCount: number;
     readings: HeightReading[];
@@ -148,34 +165,42 @@ export interface HeightSilhouetteResult {
 const MIN_CONTRAST_M = 100 * (TERRAIN_QUANT.posScale.y / 65535);
 const STEPS_PER_M = 8; // sub-decimetre crossing resolution — cheap at this anchor/radius count
 
-/** stage 10's height-axis straightness criterion: walks the *real* rendered mesh height
- *  (`capture.ts`'s `meshHeightAt`) outward from each analytic boundary anchor's
- *  `boundaryAnchors.ts`'s {@link heightMidpointAnchor} over the network's own derived falloff distance,
- *  and finds where it actually crosses from the flattened plateau to natural terrain — the deviation from
- *  that ground-truth midpoint is the height-silhouette offset, in world metres. `raggedness`
- *  (`straightness.ts`) aggregates the same way stage 9's screen-space instrument did; what changed is only
- *  the sampled quantity and its axis (world height, not screen luminance) — the corrected criterion
- *  `boot.ts` exposes as `window.__roadsHeightSilhouette`. */
+/** stage 10's height-axis straightness criterion, stage 11b's window: walks the *real* rendered mesh
+ *  height (`capture.ts`'s `meshHeightAt`) outward from each analytic boundary anchor's
+ *  `boundaryAnchors.ts`'s {@link heightMidpointAnchor} over `sideSlopeWindow(cutDepth)` — not
+ *  `computeFalloff(cutDepth)` — and finds where it actually crosses from the flattened plateau to natural
+ *  terrain; the deviation from that ground-truth midpoint is the height-silhouette offset, in world
+ *  metres. Stage 10's version scanned and anchored on `computeFalloff`'s output directly, which bundles
+ *  the AASHTO side-slope term with a mesh-sampling floor denominated in `SPACING` — so widening that floor
+ *  (11a's still-unshipped deliverable) widened the search window into raw terrain *and* moved the
+ *  threshold, without a real change on the ground the window was supposed to measure (spec Approach, stage
+ *  11b). `sideSlopeWindow` is a pure function of `cutDepth` alone, upstream of the floor entirely, so a
+ *  floor change can't reach either the window or the threshold — the property that makes two falloff
+ *  floors comparable. `computeFalloff`'s real output still rides along as `falloffM`, informational only.
+ *  `raggedness` (`straightness.ts`) aggregates the same way stage 9's screen-space instrument did; what
+ *  changed since then is only the sampled quantity and its axis (world height, not screen luminance) — the
+ *  corrected criterion `boot.ts` exposes as `window.__roadsHeightSilhouette`. */
 export async function heightSilhouette(): Promise<HeightSilhouetteResult> {
     const anchors = worldEdgeAnchors();
     const raw = await readVertices();
     const doc = generateNetwork(SEED);
     const { cutDepth } = buildNetworkGeometry(doc, SEED, getSmoothRadius());
-    const falloff = computeFalloff(cutDepth);
+    const falloff = computeFalloff(cutDepth); // informational only — see HeightSilhouetteResult.falloffM
+    const win = sideSlopeWindow(cutDepth); // what the search + threshold below actually read
 
     const sampleAt = (x: number, z: number): number => meshHeightAt(raw, x, z);
 
     const readings: HeightReading[] = anchors.map((a, i) => {
-        const s0 = sampleAt(a.ex - a.nx * falloff, a.ez - a.nz * falloff);
-        const s1 = sampleAt(a.ex + a.nx * falloff, a.ez + a.nz * falloff);
+        const s0 = sampleAt(a.ex - a.nx * win, a.ez - a.nz * win);
+        const s1 = sampleAt(a.ex + a.nx * win, a.ez + a.nz * win);
         const lo = Math.min(s0, s1);
         const hi = Math.max(s0, s1);
         const contrastM = hi - lo;
         if (contrastM < MIN_CONTRAST_M) {
             return { i, offset: null, contrastM, reason: "low-contrast" as const };
         }
-        const { mx, mz } = heightMidpointAnchor(a, falloff);
-        const offset = detectEdgeOffset(sampleAt, mx, mz, a.nx, a.nz, lo, hi, falloff, STEPS_PER_M);
+        const { mx, mz } = heightMidpointAnchor(a, win);
+        const offset = detectEdgeOffset(sampleAt, mx, mz, a.nx, a.nz, lo, hi, win, STEPS_PER_M);
         return {
             i,
             offset,
@@ -187,6 +212,7 @@ export async function heightSilhouette(): Promise<HeightSilhouetteResult> {
     const r = raggedness(readings.map((d) => d.offset));
     return {
         falloffM: falloff,
+        windowM: win,
         cutDepthM: cutDepth,
         anchorCount: anchors.length,
         readings,

--- a/examples/showcase/roads/test/straightness.spec.ts
+++ b/examples/showcase/roads/test/straightness.spec.ts
@@ -241,6 +241,7 @@ test("boundary straightness — height-axis world-space discriminator (opt-in, n
             window as unknown as {
                 __roadsHeightSilhouette: () => Promise<{
                     falloffM: number;
+                    windowM: number;
                     cutDepthM: number;
                     anchorCount: number;
                     readings: unknown[];
@@ -252,6 +253,7 @@ test("boundary straightness — height-axis world-space discriminator (opt-in, n
         ).__roadsHeightSilhouette(),
     )) as {
         falloffM: number;
+        windowM: number;
         cutDepthM: number;
         anchorCount: number;
         readings: unknown[];
@@ -278,9 +280,11 @@ test("boundary straightness — height-axis world-space discriminator (opt-in, n
             `found ${result.foundCount}/${result.anchorCount} height crossings`,
         ).toBeGreaterThanOrEqual(Math.floor(result.anchorCount * 0.6));
         // a magnitude validity bound, not a straightness tolerance (stage 11's own job): rmsM must sit
-        // comfortably above sub-instrument-resolution noise and can never structurally exceed falloffM,
-        // the search radius `heightSilhouette` walks each anchor over (`grazingCapture.ts`) — a reading
-        // outside either bound means the instrument itself regressed, not that the road did.
+        // comfortably above sub-instrument-resolution noise and can never structurally exceed windowM,
+        // the search radius `heightSilhouette` actually walks each anchor over as of stage 11b
+        // (`grazingCapture.ts`, `boundaryAnchors.ts`'s `sideSlopeWindow`) — a reading outside either bound
+        // means the instrument itself regressed, not that the road did. `falloffM` (the real, floor-
+        // inclusive `computeFalloff` output) rides along for evidence only and is no longer the bound.
         // RMS_FLOOR_M: two orders of magnitude below the mesh's own vertex spacing (SPACING) — the same
         // "100x the physical noise floor" margin `grazingCapture.ts`'s own MIN_CONTRAST_M uses against
         // height quantization, applied here to the mesh's spatial resolution. A reading this much smaller
@@ -294,8 +298,8 @@ test("boundary straightness — height-axis world-space discriminator (opt-in, n
         ).toBeGreaterThan(rmsFloorM);
         expect(
             result.rmsM,
-            `rmsM ${result.rmsM} exceeds falloffM ${result.falloffM}, the instrument's own search radius`,
-        ).toBeLessThanOrEqual(result.falloffM);
+            `rmsM ${result.rmsM} exceeds windowM ${result.windowM}, the instrument's own search radius`,
+        ).toBeLessThanOrEqual(result.windowM);
     } else {
         // the control arm (zeroed RELIEF, no cut): with no meaningful cut there is no height silhouette
         // to find, so a "found" reading here can only be MIN_CONTRAST_M's per-anchor gate tripping on


### PR DESCRIPTION
heightSilhouette scanned and anchored on computeFalloff(cutDepth) directly, so
widening that output's mesh-sampling floor (11a's still-unshipped deliverable)
widened the search window into raw terrain and moved the threshold anchor with
no real change on the ground, making the reading non-comparable across two
floor derivations. boundaryAnchors.ts's new sideSlopeWindow(cutDepth) is the
AASHTO side-slope term alone, upstream of any floor; heightSilhouette now
scans and anchors on that instead, reporting the real computeFalloff output
separately as falloffM (informational only).

Validity: reproduces stage 10's shipped reading exactly at the shipped
falloff (windowM == falloffM when the floor doesn't bind, which it does not
today), and a CPU-side red-first mutation proves the old computeFalloff-shaped
coupling biases a perfectly straight synthetic edge as its floor term grows
while sideSlopeWindow does not, since the floor never reaches it.
