### PR TITLE
shallot-roads: surface-flatness oracle over real vertex data (stage 12)

### DIFF
--- a/examples/showcase/roads/src/capture.ts
+++ b/examples/showcase/roads/src/capture.ts
@@ -3,7 +3,7 @@ import { decodePos } from "@dylanebert/shallot/utils/core";
 import { captureProbePoints } from "./overlay/network";
 import { COVERAGE_BAND_PX } from "./overlay/tiles";
 import { TERRAIN_QUANT } from "./terrain/generate";
-import { gridX, gridZ, HALF, SPACING, VERTS } from "./terrain/grid";
+import { CELLS, gridX, gridZ, SPACING, VERTS } from "./terrain/grid";
 import { readVertices, SEED } from "./terrain/terrain";
 
 // The device gate's world→screen bridge for the pixel-probe capture (the spec's flagged-risk validation —
@@ -90,16 +90,27 @@ export async function withHeight(x: number, z: number): Promise<[x: number, y: n
  *  surface a viewer's eye actually sees at a point that generally doesn't land on a vertex, since the
  *  defect it measures *is* the gap between this reconstruction and the continuous analytic height at the
  *  same point. `raw` is one `readVertices()` readback, reused across every sample in a scan so the GPU is
- *  read back once, not once per probe step. */
-export function meshHeightAt(raw: Uint32Array, x: number, z: number): number {
-    const fx = x / SPACING + HALF;
-    const fz = z / SPACING + HALF;
+ *  read back once, not once per probe step. `spacing`/`cells` default to the live mesh's own
+ *  `grid.ts` constants — `flatness.ts`'s mesh-resolution discrimination arm (stage 12) is the one caller
+ *  that overrides them, reconstructing a *different*-resolution lattice `raw` was built at without a
+ *  second, independently-drifting copy of this same triangle-interpolation formula. */
+export function meshHeightAt(
+    raw: Uint32Array,
+    x: number,
+    z: number,
+    spacing: number = SPACING,
+    cells: number = CELLS,
+): number {
+    const half = cells / 2;
+    const verts = cells + 1;
+    const fx = x / spacing + half;
+    const fz = z / spacing + half;
     const ix0 = Math.floor(fx);
     const iz0 = Math.floor(fz);
     const tx = fx - ix0;
     const tz = fz - iz0;
     const heightOf = (ix: number, iz: number): number => {
-        const idx = iz * VERTS + ix;
+        const idx = iz * verts + ix;
         return decodePos(raw[idx * 4], raw[idx * 4 + 1], TERRAIN_QUANT).y;
     };
     const h00 = heightOf(ix0, iz0);

--- a/examples/showcase/roads/src/flatness.test.ts
+++ b/examples/showcase/roads/src/flatness.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, test } from "bun:test";
+import { meshHeightAt } from "./capture";
+import {
+    buildDeviceFreeVertices,
+    buildLatticeVertices,
+    CROSS_SECTION_TOL,
+    checkSurfaceFlatness,
+    EDGE_EPSILON,
+    gradeBound,
+    RECONSTRUCTION_AGREEMENT_TOL,
+    reconstructionAgreement,
+    SAMPLE_STEP,
+} from "./flatness";
+import type { StrokeDocument } from "./overlay/document";
+import { generateNetwork } from "./overlay/network";
+import { buildNetworkGeometry, computeFalloff } from "./terrain/flatten";
+import { CELLS, SPACING } from "./terrain/grid";
+import { GROUND_LEVEL, makePermutation } from "./terrain/noise";
+import { DEFAULT_SMOOTH_RADIUS, heightAtCpu, MAX_GRADE } from "./terrain/profile";
+import { SEED } from "./terrain/terrain";
+
+// Stage 12's proof procedure (spec Validation, "Surface flatness along the road"): all four arms run
+// device-free against the real seeded network, printed as evidence for the coordinator's report as well as
+// asserted here. Numbers are measured, not predicted — every bound below is read off an actual run
+// (`__explore.test.ts`, deleted before commit) rather than picked in advance, with margin for run-to-run
+// float noise, never fitted so tight a legitimate reading could flip the assertion.
+
+describe("surface flatness — sanity (the oracle can read flat)", () => {
+    test("a manufactured target === natural profile reads flat on both axes", () => {
+        // when the flatten target height exactly equals the natural height everywhere, flattenHeight
+        // returns that one value regardless of coreDist (`terrain/flatten.ts`'s own definition) — so this
+        // is flat by construction, the mutation-style proof the checker isn't just always red
+        // (`coding.md`'s "survives its own mutations").
+        const doc: StrokeDocument = {
+            polylines: [
+                {
+                    points: [
+                        [-50, 0],
+                        [50, 0],
+                    ],
+                    halfWidth: 4,
+                },
+            ],
+            polygons: [],
+        };
+        const segments = [{ ax: -50, az: 0, bx: 50, bz: 0, halfWidth: 4, aHeight: 5, bHeight: 5 }];
+        const raw = buildLatticeVertices(SPACING, CELLS, segments, [], 16, () => 5);
+        const result = checkSurfaceFlatness((x, z) => meshHeightAt(raw, x, z), doc);
+        expect(result.longitudinal.length).toBe(0);
+        expect(result.crossSection.length).toBe(0);
+    });
+
+    test("flat natural terrain with no cut at all reads within tolerance — the RELIEF=0 analogue (arm ii)", () => {
+        // undeformed (GROUND_LEVEL everywhere) natural terrain, no flatten target to blend toward
+        // (empty segments/polygons) — the device-side control is `VITE_ROADS_RELIEF=0` (env-gated, so it
+        // can only be exercised through the real Vite/browser build, `env.ts`'s own module comment); this
+        // is its device-free analogue over the real network's own footprint geometry.
+        const doc = generateNetwork(SEED);
+        const raw = buildLatticeVertices(SPACING, CELLS, [], [], 16, () => GROUND_LEVEL);
+        const result = checkSurfaceFlatness((x, z) => meshHeightAt(raw, x, z), doc);
+        expect(result.longitudinal.length).toBe(0);
+        expect(result.crossSection.length).toBe(0);
+    });
+});
+
+describe("surface flatness — shipped pipeline at SEED=1337 (arm i, the unit's live defect)", () => {
+    const doc = generateNetwork(SEED);
+    const raw = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS);
+    const result = checkSurfaceFlatness((x, z) => meshHeightAt(raw, x, z), doc);
+
+    test("reads red on both axes — cross-section and longitudinal both violate", () => {
+        // measured (2026-08-18, this worktree): 25 longitudinal violations (max delta ~0.335 m against a
+        // ~0.14 m bound) and 1067 cross-section violations (max delta ~0.494 m against a ~0.0024 m bound)
+        // over 1962 total footprint samples across the network's 5 roads. Both axes read red — the
+        // reconstruction-axis defect isn't confined to the longitudinal profile the way stages 6-7's own
+        // (different, vertex-only) flattening oracle stayed green on.
+        console.log(
+            `SURFACE_FLATNESS_SHIPPED longitudinal=${result.longitudinal.length} crossSection=${result.crossSection.length} sampleCount=${result.sampleCount} maxLongitudinalExcess=${result.maxLongitudinalExcess.toFixed(4)} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(4)}`,
+        );
+        expect(result.longitudinal.length).toBeGreaterThan(0);
+        expect(result.crossSection.length).toBeGreaterThan(0);
+    });
+
+    test("violation magnitude sits an order of magnitude over tolerance, not at the noise floor", () => {
+        const maxLongitudinalDelta = result.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
+        const maxCrossSectionDelta = result.crossSection.reduce(
+            (m, v) => Math.max(m, v.deltaFromCentre),
+            0,
+        );
+        // a loose floor (measured ~0.33 m / ~0.49 m) — not fitted tight to today's exact reading, just
+        // ruling out "this is quantization noise wearing a violation's clothes." CROSS_SECTION_TOL is
+        // ~2 mm and the longitudinal step bound ~0.1-0.15 m, so either reading landing here is already
+        // 10-30x its own tolerance.
+        expect(maxLongitudinalDelta).toBeGreaterThan(0.15);
+        expect(maxCrossSectionDelta).toBeGreaterThan(0.15);
+    });
+
+    test("every violation sits inside the road footprint the document itself defines", () => {
+        // the oracle only ever walks centreline/edge lines derived from `doc`'s own halfWidth — a
+        // violation reported outside the document's footprint would mean the sampler drifted off the road
+        // it claims to be checking.
+        for (const v of [...result.longitudinal, ...result.crossSection]) {
+            expect(v.roadIndex).toBeGreaterThanOrEqual(0);
+            expect(v.roadIndex).toBeLessThan(doc.polylines.length);
+        }
+    });
+});
+
+describe("surface flatness — null control: no cut, real relief (arm iii)", () => {
+    test("still finds a real signal — proves the instrument detects steps, not just 'nothing is flat'", () => {
+        // the device-side control is `VITE_ROADS_NO_CUT=1` on real relief (`terrain.ts`'s own `NO_CUT`
+        // env flag) — the flatten kernel is skipped entirely (empty segments/polygons, `flattenHeight`'s
+        // own documented empty-network fallback degrades to plain `heightAt`), but the *document* used to
+        // define the sampled footprint is still the real network — so the sampled lines run through
+        // genuinely undeformed, rolling terrain (RELIEF=40) that was never asked to be flat. This is a
+        // *different* mechanism from the shipped defect (raw noise steepness, not a reconstruction crease)
+        // — it's the null control that still has something to find (`checks.md`'s witness-distinguishable
+        // clause): a broken instrument that always reads "flat" would fail this arm the same way it would
+        // pass arm ii, so the two arms together are what makes either one meaningful.
+        const doc = generateNetwork(SEED);
+        const perm = makePermutation(SEED);
+        const raw = buildLatticeVertices(SPACING, CELLS, [], [], 16, (x, z) =>
+            heightAtCpu(x, z, perm),
+        );
+        const result = checkSurfaceFlatness((x, z) => meshHeightAt(raw, x, z), doc);
+        console.log(
+            `SURFACE_FLATNESS_NO_CUT longitudinal=${result.longitudinal.length} crossSection=${result.crossSection.length} sampleCount=${result.sampleCount}`,
+        );
+        // measured (2026-08-18): 271 longitudinal violations of 1962 samples, well above the shipped
+        // pipeline's own 25 — raw undeformed relief violates the grade bound far more often than the
+        // flattened corridor does, exactly the "real signal" this control is meant to prove exists.
+        expect(result.longitudinal.length).toBeGreaterThan(100);
+    });
+});
+
+describe("surface flatness — discrimination (arm iv)", () => {
+    test("falloff scale (1 vs 3) moves the reading ~not at all — the axis 11c already refuted", () => {
+        const doc = generateNetwork(SEED);
+        const raw1 = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS, 1);
+        const raw3 = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS, 3);
+        const r1 = checkSurfaceFlatness((x, z) => meshHeightAt(raw1, x, z), doc);
+        const r3 = checkSurfaceFlatness((x, z) => meshHeightAt(raw3, x, z), doc);
+        const d1 = r1.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
+        const d3 = r3.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
+        console.log(
+            `SURFACE_FLATNESS_FALLOFF_SCALE scale1_count=${r1.longitudinal.length} scale1_maxDelta=${d1.toFixed(4)} scale3_count=${r3.longitudinal.length} scale3_maxDelta=${d3.toFixed(4)}`,
+        );
+        // measured (2026-08-18): maxDelta moves from ~0.335 m to ~0.331 m (~1.3%) across a 3x falloff
+        // widening — reproduces 11c's live-camera verdict ("it does absolutely nothing for the road
+        // stairstep issue") on this oracle's own reconstruction-axis reading. A 10% relative-change floor
+        // is loose margin against run-to-run drift, not a value fitted to today's ~1.3%.
+        expect(Math.abs(d3 - d1) / d1).toBeLessThan(0.1);
+    });
+
+    test("mesh resolution (SPACING/2) moves the reading — the axis this stage is actually about", () => {
+        const doc = generateNetwork(SEED);
+        const perm = makePermutation(SEED);
+        const { segments, cutDepth } = buildNetworkGeometry(doc, SEED, DEFAULT_SMOOTH_RADIUS);
+        const falloff = computeFalloff(cutDepth, 1);
+        const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
+
+        const rawCoarse = buildLatticeVertices(
+            SPACING,
+            CELLS,
+            segments,
+            doc.polygons,
+            falloff,
+            natural,
+        );
+        const coarse = checkSurfaceFlatness(
+            (x, z) => meshHeightAt(rawCoarse, x, z, SPACING, CELLS),
+            doc,
+        );
+
+        const fineSpacing = SPACING / 2;
+        const fineCells = CELLS * 2;
+        const rawFine = buildLatticeVertices(
+            fineSpacing,
+            fineCells,
+            segments,
+            doc.polygons,
+            falloff,
+            natural,
+        );
+        const fine = checkSurfaceFlatness(
+            (x, z) => meshHeightAt(rawFine, x, z, fineSpacing, fineCells),
+            doc,
+        );
+
+        const dCoarse = coarse.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
+        const dFine = fine.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
+        console.log(
+            `SURFACE_FLATNESS_SPACING coarse_count=${coarse.longitudinal.length} coarse_maxDelta=${dCoarse.toFixed(4)} fine_count=${fine.longitudinal.length} fine_maxDelta=${dFine.toFixed(4)}`,
+        );
+        // measured (2026-08-18): count drops (25 -> 21, fewer *steps* wide enough at Δs=SAMPLE_STEP/2 to
+        // cross the grade bound) while maxDelta *rises* (~0.335 -> ~0.404 m) — the finer lattice resolves
+        // the true crease more sharply rather than smoothing it away over a wider quad. Both readings move
+        // by double digits of a percent (>10%), unlike the falloff-scale arm above (~1.3%) — the
+        // discrimination this arm exists to show: the criterion is sensitive to the mesh-resolution axis
+        // and (per the arm above) insensitive to the falloff-width axis, matching the mechanism's own
+        // predicted asymmetry.
+        const countChange =
+            Math.abs(fine.longitudinal.length - coarse.longitudinal.length) /
+            coarse.longitudinal.length;
+        const deltaChange = Math.abs(dFine - dCoarse) / dCoarse;
+        expect(Math.max(countChange, deltaChange)).toBeGreaterThan(0.1);
+    }, 20_000);
+});
+
+describe("checkSurfaceFlatness — window/threshold derivation, no candidate treatment", () => {
+    test("gradeBound scales with Δs and the road-design grade limit alone", () => {
+        // MAX_GRADE is the only slope-scaling input — no falloff/smoothRadius/falloffScale term appears.
+        expect(gradeBound(SAMPLE_STEP)).toBeGreaterThan(MAX_GRADE * SAMPLE_STEP);
+        expect(gradeBound(2 * SAMPLE_STEP)).toBeGreaterThan(gradeBound(SAMPLE_STEP));
+    });
+
+    test("CROSS_SECTION_TOL and EDGE_EPSILON are small, fixed fractions of the mesh's own scale", () => {
+        expect(CROSS_SECTION_TOL).toBeGreaterThan(0);
+        expect(CROSS_SECTION_TOL).toBeLessThan(0.01); // quantization-scale, not a road-scale slack
+        expect(EDGE_EPSILON).toBeGreaterThan(0);
+        expect(EDGE_EPSILON).toBeLessThan(SPACING / 10);
+    });
+});
+
+describe("reconstructionAgreement — the device arm's own fidelity pin", () => {
+    test("the CPU device-free lattice agrees with an identically-parameterized CPU-built 'device' buffer", () => {
+        // `bun test` has no real device, so this exercises the differential's own logic against a second,
+        // independently-called `buildDeviceFreeVertices` run standing in for `readVertices()` — the real
+        // device arm lives in `gate.ts` (`bun run gate`), which calls this same function against the real
+        // GPU. Same seed/smoothRadius/falloffScale in, so the two builds should be exactly reproducible
+        // (this project's height kernel is itself deterministic-in-seed, `gate.ts`'s own `deterministic`
+        // check) — this pins that {@link reconstructionAgreement}'s own comparison logic reads zero
+        // when there's nothing to disagree about, before it's trusted as the real device's fidelity gate.
+        const doc = generateNetwork(SEED);
+        const deviceStandIn = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS, 1);
+        const agreement = reconstructionAgreement(
+            deviceStandIn,
+            doc,
+            SEED,
+            DEFAULT_SMOOTH_RADIUS,
+            1,
+        );
+        expect(agreement.sampleCount).toBeGreaterThan(0);
+        expect(agreement.maxDiffM).toBeLessThanOrEqual(RECONSTRUCTION_AGREEMENT_TOL);
+    });
+});

--- a/examples/showcase/roads/src/flatness.ts
+++ b/examples/showcase/roads/src/flatness.ts
@@ -1,0 +1,464 @@
+// Stage 12's surface-flatness oracle — the spec's Validation "Surface flatness along the road (the
+// reconstruction axis)", the unit's live defect gate. Stage 9-11 all measured a *boundary* axis (albedo
+// straightness, then height straightness, then a falloff-width knob 11c proved orthogonal to the reported
+// defect); the spec's own diagnosis routes this stage to a different axis entirely — the mesh's
+// piecewise-linear *reconstruction* across the footprint edge, not the boundary's own width or position.
+//
+// A vertex-only check is insufficient by construction: footprint vertices already carry the smoothed,
+// grade-limited profile (`terrain/flatten.ts`'s `networkCore` interpolates `mix(aHeight, bHeight, t)`), so
+// away from junctions they're flat to a few centimetres — a vertex-only oracle would read green over the
+// live defect, the sixth instrument failing the way the first five did (stage 9's screen-space albedo
+// probe, stage 10's un-anchored height probe, stage 11's width-only floor). The predicted defect lives in
+// the *reconstruction*: a triangle straddling the footprint edge has one or more corners *outside* the
+// flattened core, cosine-eased toward off-road terrain that can vary by metres over one 4 m cell — so a
+// point sampled right at the edge, inside a triangle whose other corners sit outside it, reads a height
+// blended toward that off-road variation, not the flat corridor its own analytic position implies. Reading
+// height from `capture.ts`'s `meshHeightAt` (a two-triangle-per-quad reconstruction over a raw vertex
+// buffer) rather than the continuous `flattenHeight` function is what makes this oracle able to see that —
+// the continuous function has no triangles to straddle.
+//
+// Two vertex-buffer sources feed the one oracle below (`checkSurfaceFlatness`), which only ever touches a
+// `Uint32Array` + `meshHeightAt` — never which device produced it:
+//   - {@link buildDeviceFreeVertices} — a CPU-only mirror of `terrain/generate.ts`'s height-kernel loop
+//     (no GPU dispatch), the default-suite arm (`flatness.test.ts`, `bun test ./src -t "surface flatness"`).
+//   - the real `readVertices()` (`terrain/terrain.ts`) — the device arm inside `bun run gate`
+//     (`gate.ts`'s `reconstructionAgreement`, which pins the CPU builder's fidelity against the real GPU
+//     output rather than re-asserting the property device-side).
+//
+// What this oracle cannot see (name the blind axes, `checks.md`'s granularity clause):
+//   - albedo registration — the overlay's own texel/coverage crispness is a separate render-half property
+//     (the spec's "Fs composite" criterion, `terrain.ts`'s fs), untouched by anything read here.
+//   - shading normals — the finite-difference normal `generate.ts`'s kernel emits alongside height is
+//     never read; a normal can look wrong while every height sampled here reads within tolerance.
+//   - everything outside the road footprint — `documentDistance(x, z, doc) > 0` terrain is natural and
+//     unconstrained by design; this oracle only walks centreline + edge lines *inside* a footprint.
+//   - reseed staleness — this always samples the *live* document's own current geometry; a stale
+//     atlas/dirty-tile residue (stage 14's subject) leaves no trace on the heightfield this oracle reads.
+
+import { encodePos } from "@dylanebert/shallot/utils/core";
+import * as d from "typegpu/data";
+import { meshHeightAt } from "./capture";
+import { documentDistance, type PolygonStamp, type StrokeDocument } from "./overlay/document";
+import {
+    buildNetworkGeometry,
+    computeFalloff,
+    flattenHeight,
+    type ProfileSegment,
+} from "./terrain/flatten";
+import { TERRAIN_QUANT } from "./terrain/generate";
+import { CELLS, SPACING } from "./terrain/grid";
+import { makePermutation } from "./terrain/noise";
+import { heightAtCpu, MAX_GRADE, MAX_GRADE_BREAK, PROFILE_STEP } from "./terrain/profile";
+
+// --- derived window + tolerance — no candidate treatment (falloff, smoothRadius, falloffScale) appears
+// in any of these, per the spec's own non-coupling requirement (stage 11's whole lesson: a criterion whose
+// window or threshold is a function of the parameter under test is not a differential over that parameter).
+
+/** the spec's own longitudinal sample spacing bound: no coarser than a quarter of the mesh's own vertex
+ *  spacing, so no triangle edge along a sampled line is ever skipped between two adjacent samples. */
+export const SAMPLE_STEP = SPACING / 4;
+
+/** height-quantization noise on one decoded reconstruction sample — `TERRAIN_QUANT`'s own AABB divided by
+ *  the unorm16 range, the same derivation `capture.test.ts`'s `meshHeightAt` oracle uses. */
+const QUANT_TOL = TERRAIN_QUANT.posScale.y / 65535;
+
+/** the profile's own piecewise-linearity error: half a grade-break step over one arc-length increment
+ *  (`terrain/profile.ts`'s own derivation, ≈ 2 cm at the shipped constants) — the profile control points
+ *  themselves are a grade-*limited*, not grade-*continuous*, sequence, so even a perfect reconstruction of
+ *  them carries this much slack against the idealized continuous grade bound. */
+const PROFILE_LINEARITY_TOL = 0.5 * MAX_GRADE_BREAK * PROFILE_STEP;
+
+/** the longitudinal grade bound over a `ds`-metre step: the road-design grade limit (`MAX_GRADE`) plus the
+ *  profile's own linearity slack plus two independent quantized height reads (one at each end of the
+ *  step). Neither `MAX_GRADE`/`MAX_GRADE_BREAK`/`PROFILE_STEP` (road-design + mesh constants) nor
+ *  `QUANT_TOL` (the codec's own AABB) depends on any candidate treatment. */
+export function gradeBound(ds: number): number {
+    return MAX_GRADE * ds + PROFILE_LINEARITY_TOL + 2 * QUANT_TOL;
+}
+
+/** the cross-section bound: two footprint points at the same longitudinal station should read the same
+ *  height (the flatten target is a pure function of station, `networkCoreCpu`'s own `t`-only interpolation
+ *  below), up to two independent reconstructions' quantization noise. */
+export const CROSS_SECTION_TOL = 2 * QUANT_TOL;
+
+/** how far inside the road edge the two edge lines sit — small relative to `SPACING` so the probe stays
+ *  within the single grid cell the predicted defect straddles (the edge itself), rather than retreating
+ *  into the core's interior where the defect can't reach. Not derived from any falloff/treatment
+ *  quantity — a fixed fraction of the mesh's own cell size. */
+export const EDGE_EPSILON = SPACING / 100;
+
+// --- CPU-only lattice reconstruction — no GPU, no `@dylanebert/shallot/render/core` import, the
+// default-suite arm's own substrate.
+
+/** the nearest-network-primitive core distance + target height at (px, pz) — a plain-JS re-authoring of
+ *  `terrain/flatten.ts`'s GPU `networkCore`, deliberately the *same* formula (not an independent
+ *  derivation the way `overlay/rasterize.ts`'s distance math is): this function's job is to reconstruct
+ *  exactly what the real mesh does, not to provide a second opinion on it — the property under test is the
+ *  mesh's own triangle reconstruction, and the height *per vertex* has to match production's own
+ *  `flattenedHeightAt` or the built lattice isn't the mesh this oracle is meant to read. */
+function networkCoreCpu(
+    px: number,
+    pz: number,
+    segments: readonly ProfileSegment[],
+    polygons: readonly PolygonStamp[],
+    naturalHeightAt: (x: number, z: number) => number,
+): { coreDist: number; targetHeight: number } {
+    let bestCore = Number.POSITIVE_INFINITY;
+    let bestTarget = 0;
+
+    for (const seg of segments) {
+        const abx = seg.bx - seg.ax;
+        const abz = seg.bz - seg.az;
+        const apx = px - seg.ax;
+        const apz = pz - seg.az;
+        const dd = abx * abx + abz * abz;
+        const t = dd > 0 ? Math.min(1, Math.max(0, (apx * abx + apz * abz) / dd)) : 0;
+        const cx = seg.ax + t * abx;
+        const cz = seg.az + t * abz;
+        const core = Math.hypot(px - cx, pz - cz) - seg.halfWidth;
+        if (core < bestCore) {
+            bestCore = core;
+            bestTarget = seg.aHeight + t * (seg.bHeight - seg.aHeight);
+        }
+    }
+
+    for (const poly of polygons) {
+        const pts = poly.points;
+        let inside = false;
+        let nearestEdge = Number.POSITIVE_INFINITY;
+        let cx = 0;
+        let cz = 0;
+        for (const [x, z] of pts) {
+            cx += x;
+            cz += z;
+        }
+        cx /= pts.length;
+        cz /= pts.length;
+        for (let i = 0; i < pts.length; i++) {
+            const [ax, az] = pts[i];
+            const [bx, bz] = pts[(i + 1) % pts.length];
+            if (az > pz !== bz > pz) {
+                const xCross = ax + ((pz - az) / (bz - az)) * (bx - ax);
+                if (px < xCross) inside = !inside;
+            }
+            const abx = bx - ax;
+            const abz = bz - az;
+            const apx = px - ax;
+            const apz = pz - az;
+            const dd = abx * abx + abz * abz;
+            const t = dd > 0 ? Math.min(1, Math.max(0, (apx * abx + apz * abz) / dd)) : 0;
+            const ecx = ax + t * abx;
+            const ecz = az + t * abz;
+            const edgeDist = Math.hypot(px - ecx, pz - ecz);
+            if (edgeDist < nearestEdge) nearestEdge = edgeDist;
+        }
+        const core = inside ? -nearestEdge : nearestEdge;
+        if (core < bestCore) {
+            bestCore = core;
+            bestTarget = naturalHeightAt(cx, cz);
+        }
+    }
+
+    return { coreDist: bestCore, targetHeight: bestTarget };
+}
+
+/** discretize the continuous flatten field (`segments`/`polygons`/`falloff`, `naturalHeightAt`) onto a
+ *  `spacing`-metre, `cells`-quad lattice, encoded the same way `terrain/generate.ts`'s height kernel
+ *  encodes its own vertex stream (`encodePos` against the live `TERRAIN_QUANT`) — the output is a
+ *  `meshHeightAt`-compatible raw buffer regardless of resolution, so the same reconstruction function reads
+ *  both the production-resolution lattice and {@link buildDeviceFreeVertices}'s discrimination arm at a
+ *  different resolution (`flatness.test.ts`'s `SPACING/2` arm). Normal/UV words are left at zero — nothing
+ *  downstream of this buffer reads them (`meshHeightAt` only decodes the position words). */
+export function buildLatticeVertices(
+    spacing: number,
+    cells: number,
+    segments: readonly ProfileSegment[],
+    polygons: readonly PolygonStamp[],
+    falloff: number,
+    naturalHeightAt: (x: number, z: number) => number,
+): Uint32Array {
+    const verts = cells + 1;
+    const half = cells / 2;
+    const raw = new Uint32Array(verts * verts * 4);
+    for (let iz = 0; iz < verts; iz++) {
+        for (let ix = 0; ix < verts; ix++) {
+            const x = (ix - half) * spacing;
+            const z = (iz - half) * spacing;
+            const natural = naturalHeightAt(x, z);
+            const { coreDist, targetHeight } = networkCoreCpu(
+                x,
+                z,
+                segments,
+                polygons,
+                naturalHeightAt,
+            );
+            const y = flattenHeight(natural, targetHeight, coreDist, falloff);
+            const idx = (iz * verts + ix) * 4;
+            const m = encodePos(d.vec3f(x, y, z), 0, TERRAIN_QUANT);
+            raw[idx] = m.x;
+            raw[idx + 1] = m.y;
+        }
+    }
+    return raw;
+}
+
+/** the production-shape reconstruction: `doc`'s own network flattened at `seed`/`smoothRadius`
+ *  (optionally `falloffScale`, stage 11a's still-live multiplier on this branch), at the mesh's real
+ *  `SPACING`/`CELLS` — a drop-in `readVertices()` substitute with no device, `flatness.test.ts`'s and
+ *  `gate.ts`'s shared entry point. `flattenDoc` and `sampleDoc` (the caller's own footprint definition,
+ *  `checkSurfaceFlatness`) are deliberately the same `doc` here; {@link buildLatticeVertices} lets a caller
+ *  split them (stage 12's own null-control arm: an empty `flattenDoc` with the real network's footprint
+ *  still standing, `flatness.test.ts`'s "no-cut" arm). */
+export function buildDeviceFreeVertices(
+    flattenDoc: StrokeDocument,
+    seed: number,
+    smoothRadius: number,
+    falloffScale = 1,
+): Uint32Array {
+    const perm = makePermutation(seed);
+    const { segments, cutDepth } = buildNetworkGeometry(flattenDoc, seed, smoothRadius);
+    const falloff = computeFalloff(cutDepth, falloffScale);
+    return buildLatticeVertices(SPACING, CELLS, segments, flattenDoc.polygons, falloff, (x, z) =>
+        heightAtCpu(x, z, perm),
+    );
+}
+
+// --- the property: cross-section + longitudinal grade over the real reconstruction.
+
+interface RoadFrame {
+    readonly ax: number;
+    readonly az: number;
+    readonly ux: number;
+    readonly uz: number;
+    readonly len: number;
+    readonly nx: number;
+    readonly nz: number;
+    readonly halfWidth: number;
+}
+
+/** every polyline segment in `doc`, resolved into the frame the sampler walks — every consecutive point
+ *  pair, not just `doc.polylines[0]`'s first segment (unlike `boundaryAnchors.ts`'s single-road framing,
+ *  this oracle covers the whole network, since the reconstruction defect is predicted on every road). */
+function segmentFrames(doc: StrokeDocument): RoadFrame[] {
+    const frames: RoadFrame[] = [];
+    for (const line of doc.polylines) {
+        for (let i = 0; i < line.points.length - 1; i++) {
+            const [ax, az] = line.points[i];
+            const [bx, bz] = line.points[i + 1];
+            const dx = bx - ax;
+            const dz = bz - az;
+            const len = Math.hypot(dx, dz) || 1;
+            const ux = dx / len;
+            const uz = dz / len;
+            frames.push({ ax, az, ux, uz, len, nx: -uz, nz: ux, halfWidth: line.halfWidth });
+        }
+    }
+    return frames;
+}
+
+// stay off each segment's own endpoint cap (a distinct geometric case — nearest-point rather than
+// nearest-line — out of this oracle's scope) by sampling only the segment's interior.
+const T_LO = 0.05;
+const T_HI = 0.95;
+
+interface LineSample {
+    readonly t: number;
+    readonly x: number;
+    readonly z: number;
+    readonly h: number;
+}
+
+function sampleLine(
+    frame: RoadFrame,
+    offset: number,
+    sampleAt: (x: number, z: number) => number,
+): LineSample[] {
+    const n = Math.max(1, Math.ceil(((T_HI - T_LO) * frame.len) / SAMPLE_STEP));
+    const out: LineSample[] = [];
+    for (let s = 0; s <= n; s++) {
+        const t = T_LO + ((T_HI - T_LO) * s) / n;
+        const station = t * frame.len;
+        const x = frame.ax + frame.ux * station + frame.nx * offset;
+        const z = frame.az + frame.uz * station + frame.nz * offset;
+        out.push({ t, x, z, h: sampleAt(x, z) });
+    }
+    return out;
+}
+
+export type FlatnessLine = "centre" | "edgePos" | "edgeNeg";
+
+export interface LongitudinalViolation {
+    readonly line: FlatnessLine;
+    readonly roadIndex: number;
+    readonly t: number;
+    readonly x: number;
+    readonly z: number;
+    readonly delta: number;
+    readonly bound: number;
+}
+
+export interface CrossSectionViolation {
+    readonly line: FlatnessLine;
+    readonly roadIndex: number;
+    readonly t: number;
+    readonly x: number;
+    readonly z: number;
+    readonly deltaFromCentre: number;
+    readonly bound: number;
+}
+
+export interface FlatnessResult {
+    readonly longitudinal: readonly LongitudinalViolation[];
+    readonly crossSection: readonly CrossSectionViolation[];
+    /** the worst longitudinal excess over its own step's bound (0 when every step is within tolerance). */
+    readonly maxLongitudinalExcess: number;
+    /** the worst cross-section excess over `CROSS_SECTION_TOL` (0 when every station agrees). */
+    readonly maxCrossSectionExcess: number;
+    readonly sampleCount: number;
+}
+
+/**
+ * the stage 12 property (spec Validation, "Surface flatness along the road"): within the road footprint,
+ * rendered mesh height is a grade-limited function of longitudinal station alone.
+ *
+ * (a) *cross-section* — at each sampled station, the centreline and both edge lines (`±(halfWidth −
+ *     {@link EDGE_EPSILON})`) must read the same height within {@link CROSS_SECTION_TOL}.
+ * (b) *longitudinal* — along each of those three lines independently, adjacent samples (`Δs <=`
+ *     {@link SAMPLE_STEP}) must differ by no more than {@link gradeBound}`(Δs)`.
+ *
+ * `sampleAt` is `meshHeightAt` closed over a vertex buffer — CPU-built ({@link buildDeviceFreeVertices}) or
+ * the real `readVertices()`, this function never knows which. The window (which stations/lines get
+ * sampled) comes only from `doc`'s own geometry (`halfWidth`, segment endpoints); the threshold comes only
+ * from road-design constants and the codec's own quantization — {@link gradeBound}/{@link
+ * CROSS_SECTION_TOL} take no falloff, smoothing radius, or falloff-scale input, so no candidate treatment
+ * can move the window or the threshold (the non-coupling stage 11's whole investigation turned on).
+ */
+export function checkSurfaceFlatness(
+    sampleAt: (x: number, z: number) => number,
+    doc: StrokeDocument,
+): FlatnessResult {
+    const longitudinal: LongitudinalViolation[] = [];
+    const crossSection: CrossSectionViolation[] = [];
+    let sampleCount = 0;
+    let maxLongitudinalExcess = 0;
+    let maxCrossSectionExcess = 0;
+
+    const frames = segmentFrames(doc);
+    for (let roadIndex = 0; roadIndex < frames.length; roadIndex++) {
+        const frame = frames[roadIndex];
+        const inset = frame.halfWidth - EDGE_EPSILON;
+        const centre = sampleLine(frame, 0, sampleAt);
+        const edgePos = sampleLine(frame, inset, sampleAt);
+        const edgeNeg = sampleLine(frame, -inset, sampleAt);
+        sampleCount += centre.length + edgePos.length + edgeNeg.length;
+
+        // cross-section: same station (same t by construction — sampleLine shares T_LO/T_HI/n), every
+        // footprint line should read the centreline's own height.
+        for (let i = 0; i < centre.length; i++) {
+            for (const [line, samples] of [
+                ["edgePos", edgePos],
+                ["edgeNeg", edgeNeg],
+            ] as const) {
+                const delta = Math.abs(samples[i].h - centre[i].h);
+                const excess = delta - CROSS_SECTION_TOL;
+                if (excess > 0) {
+                    maxCrossSectionExcess = Math.max(maxCrossSectionExcess, excess);
+                    crossSection.push({
+                        line,
+                        roadIndex,
+                        t: samples[i].t,
+                        x: samples[i].x,
+                        z: samples[i].z,
+                        deltaFromCentre: delta,
+                        bound: CROSS_SECTION_TOL,
+                    });
+                }
+            }
+        }
+
+        // longitudinal: adjacent-sample grade bound, walked independently along each of the three lines.
+        const ds = ((T_HI - T_LO) * frame.len) / Math.max(1, centre.length - 1);
+        const bound = gradeBound(ds);
+        for (const [line, samples] of [
+            ["centre", centre],
+            ["edgePos", edgePos],
+            ["edgeNeg", edgeNeg],
+        ] as const) {
+            for (let i = 1; i < samples.length; i++) {
+                const delta = Math.abs(samples[i].h - samples[i - 1].h);
+                const excess = delta - bound;
+                if (excess > 0) {
+                    maxLongitudinalExcess = Math.max(maxLongitudinalExcess, excess);
+                    longitudinal.push({
+                        line,
+                        roadIndex,
+                        t: samples[i].t,
+                        x: samples[i].x,
+                        z: samples[i].z,
+                        delta,
+                        bound,
+                    });
+                }
+            }
+        }
+    }
+
+    return {
+        longitudinal,
+        crossSection,
+        maxLongitudinalExcess,
+        maxCrossSectionExcess,
+        sampleCount,
+    };
+}
+
+/** a shared derivation `checkSurfaceFlatness` doesn't otherwise need: whether (x, z) sits in *any*
+ *  footprint at all — exported only for tests that want to sanity-check a sampled point's own membership,
+ *  never consulted by the oracle above (which walks known-on-footprint lines by construction). */
+export function inFootprint(x: number, z: number, doc: StrokeDocument): boolean {
+    return documentDistance(x, z, doc) <= 0;
+}
+
+/**
+ * pins the default-suite CPU reconstruction against the real device: rebuilds the identical lattice
+ * ({@link buildDeviceFreeVertices}) at the live network's own `seed`/`smoothRadius`/`falloffScale` and
+ * compares its footprint-line samples against `deviceRaw` (a real `readVertices()` readback) point for
+ * point. This is the "device arm" the spec asks for — it validates the CPU builder's *fidelity* against
+ * the real GPU output (a reference/differential check), not the surface-flatness property itself (which
+ * `bun test`'s default-suite arm already checks device-free, and is allowed to read red on the shipped
+ * pipeline, `gate.ts` would break every run if it re-asserted "no violations" here). Tolerance is
+ * quantization noise only, doubled for two independent codec round-trips plus float-precision drift
+ * between the CPU (f64) and GPU (f32) paths (`terrain/profile.ts`'s own module header names this same
+ * drift as expected and harmless).
+ */
+export function reconstructionAgreement(
+    deviceRaw: Uint32Array,
+    doc: StrokeDocument,
+    seed: number,
+    smoothRadius: number,
+    falloffScale: number,
+): { maxDiffM: number; sampleCount: number } {
+    const cpuRaw = buildDeviceFreeVertices(doc, seed, smoothRadius, falloffScale);
+    const deviceSample = (x: number, z: number) => meshHeightAt(deviceRaw, x, z);
+    const cpuSample = (x: number, z: number) => meshHeightAt(cpuRaw, x, z);
+
+    let maxDiffM = 0;
+    let sampleCount = 0;
+    for (const frame of segmentFrames(doc)) {
+        const inset = frame.halfWidth - EDGE_EPSILON;
+        for (const offset of [0, inset, -inset]) {
+            for (const s of sampleLine(frame, offset, deviceSample)) {
+                const cpuH = cpuSample(s.x, s.z);
+                maxDiffM = Math.max(maxDiffM, Math.abs(s.h - cpuH));
+                sampleCount++;
+            }
+        }
+    }
+    return { maxDiffM, sampleCount };
+}
+
+/** the tolerance {@link reconstructionAgreement} reads its own `maxDiffM` against — quantization noise on
+ *  two independent decoded reads, ×4 for CPU/GPU float-precision drift (f64 vs f32 accumulation through
+ *  five fbm octaves, a wider margin than the ×2 same-precision case since both encoders round separately
+ *  off slightly different intermediate values, not a value fitted to one observed run). */
+export const RECONSTRUCTION_AGREEMENT_TOL = QUANT_TOL * 4;

--- a/examples/showcase/roads/src/gate.ts
+++ b/examples/showcase/roads/src/gate.ts
@@ -1,9 +1,18 @@
 import { decodePos } from "@dylanebert/shallot/utils/core";
+import { RECONSTRUCTION_AGREEMENT_TOL, reconstructionAgreement } from "./flatness";
 import type { Check } from "./harness";
+import { generateNetwork } from "./overlay/network";
 import { TERRAIN_QUANT } from "./terrain/generate";
 import { VERTEX_COUNT } from "./terrain/grid";
 import { RELIEF } from "./terrain/noise";
-import { generate, readVertices, SEED, syncNetworkForSeed } from "./terrain/terrain";
+import {
+    generate,
+    getFalloffScale,
+    getSmoothRadius,
+    readVertices,
+    SEED,
+    syncNetworkForSeed,
+} from "./terrain/terrain";
 
 // The terrain generator's correctness gate — the seed-determinism readback the spec's Validation names
 // ("Overlay correctness"/"Rasterizer fidelity" are later stages; this stage's own arm is the height
@@ -95,5 +104,29 @@ export async function gate(): Promise<Check[]> {
     // restore the boot seed's terrain for the live view.
     syncNetworkForSeed(SEED);
     await generate(SEED);
+
+    // Stage 12's device arm — the spec's "one device arm pinning it against readVertices()". This pins
+    // the *fidelity* of `flatness.ts`'s CPU device-free lattice builder against the real GPU-generated
+    // mesh, not the surface-flatness property itself: the property is expected to read red on the shipped
+    // pipeline right now (the unit's live defect, `bun test ./src -t "surface flatness"`'s own job), and a
+    // gate that re-asserted "no violations" here would break every `bun run gate` run until stage 15 ships
+    // a fix. What this DOES prove is that `bun test`'s device-free arm is reading the same mesh the real
+    // device renders — without it, a CPU/GPU divergence in the height-kernel math could make the
+    // device-free suite pass or fail for the wrong reason entirely.
+    const liveDoc = generateNetwork(SEED);
+    const deviceRaw = await readVertices();
+    const agreement = reconstructionAgreement(
+        deviceRaw,
+        liveDoc,
+        SEED,
+        getSmoothRadius(),
+        getFalloffScale(),
+    );
+    checks.push({
+        name: "surface-flatness-reconstruction-agreement",
+        pass: agreement.maxDiffM <= RECONSTRUCTION_AGREEMENT_TOL,
+        detail: `CPU device-free lattice vs real readVertices(): max |Δh| ${agreement.maxDiffM.toFixed(6)} m over ${agreement.sampleCount} footprint samples (tol ${RECONSTRUCTION_AGREEMENT_TOL.toFixed(6)} m)`,
+    });
+
     return checks;
 }


### PR DESCRIPTION
## Problem
Stage 12 owes the unit's live defect gate: an instrument reading the road surface's actual reconstructed
mesh height (not the vertex stream, not the continuous flatten function) along the road footprint, since
the predicted crease lives in triangles straddling the footprint edge — a vertex-only or continuous-function
check reads green over it by construction.

## Cause
No instrument existed that read height from the piecewise-linear reconstruction over real vertex data.
Five prior instruments (screen-space albedo straightness, height straightness, boundary width) all measured
a different axis; the mesh's own triangle interpolation across the footprint edge was never checked.

## Fix
`flatness.ts`: a device-free CPU lattice builder (`buildDeviceFreeVertices`, mirrors `generate.ts`'s height
kernel with no GPU) plus `checkSurfaceFlatness`, which walks centreline + both edge lines at
`±(halfWidth − ε)` and checks (a) cross-section agreement at each station and (b) longitudinal grade,
window/threshold derived only from document geometry and road-design constants (no candidate treatment).
`gate.ts`'s device arm pins the CPU lattice's fidelity against a real `readVertices()` readback (not the
property itself, which is expected red on the shipped pipeline right now). `capture.ts`'s `meshHeightAt`
gained optional spacing/cells params so a mesh-resolution discrimination arm reuses one reconstruction
formula instead of a second copy.

## Evidence
- `bun test ./src` (from `examples/showcase/roads`): 159 pass, 0 fail, 6531 `expect()`, exit 0
- `bun test ./src -t "surface flatness"`: 8 pass, 0 fail, 2198 `expect()`, exit 0
- `bun run gate`: adapter `nvidia lovelace`, 1 passed, 2 skipped, exit 0
- `bun run format` / `bun check` at the shallot root: exit 0
- Four proof arms (all device-free, pinned against a real `readVertices()` readback via
  `reconstructionAgreement`): shipped `SEED=1337` reads red on both axes (25 longitudinal / 1067
  cross-section violations, max delta ~0.335 m / ~0.494 m against ~0.14 m / ~0.0024 m tolerances); a
  flat/no-cut synthetic reads clean; a no-flatten null control on real relief reads red with *more*
  violations (271), proving the instrument finds real steps rather than defaulting to "flat"; falloff-scale
  1 vs 3 moves the reading ~1.3% (reproducing 11c's live finding that the width knob is inert) while mesh
  resolution SPACING/2 moves it >10%, the discrimination that would have caught stage 11a.

Spec: `specs/shallot-roads.md` (kex, private) stage 12.