### PR TITLE
shallot-roads: fix endpoint margin to arc-length halfWidth (stage 12)

### DIFF
--- a/examples/showcase/roads/src/flatness.test.ts
+++ b/examples/showcase/roads/src/flatness.test.ts
@@ -69,9 +69,10 @@ describe("surface flatness — shipped pipeline at SEED=1337 (arm i, the unit's 
     const result = checkSurfaceFlatness((x, z) => meshHeightAt(raw, x, z), doc);
 
     test("reads red on both axes — cross-section and longitudinal both violate", () => {
-        // measured (2026-08-18, this worktree): 25 longitudinal violations (max delta ~0.335 m against a
-        // ~0.14 m bound) and 1067 cross-section violations (max delta ~0.494 m against a ~0.0024 m bound)
-        // over 1962 total footprint samples across the network's 5 roads. Both axes read red — the
+        // measured (2026-08-18, this worktree, after the endpoint-margin fix — arc-length halfWidth, not
+        // a fraction of segment length): 34 longitudinal violations (max delta ~0.344 m against a ~0.14 m
+        // bound) and 1117 cross-section violations (max delta ~0.471 m against a ~0.0024 m bound) over
+        // 2052 total footprint samples across the network's 5 roads. Both axes read red — the
         // reconstruction-axis defect isn't confined to the longitudinal profile the way stages 6-7's own
         // (different, vertex-only) flattening oracle stayed green on.
         console.log(
@@ -126,9 +127,10 @@ describe("surface flatness — null control: no cut, real relief (arm iii)", () 
         console.log(
             `SURFACE_FLATNESS_NO_CUT longitudinal=${result.longitudinal.length} crossSection=${result.crossSection.length} sampleCount=${result.sampleCount}`,
         );
-        // measured (2026-08-18): 271 longitudinal violations of 1962 samples, well above the shipped
-        // pipeline's own 25 — raw undeformed relief violates the grade bound far more often than the
-        // flattened corridor does, exactly the "real signal" this control is meant to prove exists.
+        // measured (2026-08-18, after the endpoint-margin fix): 283 longitudinal violations of 2052
+        // samples, well above the shipped pipeline's own 34 — raw undeformed relief violates the grade
+        // bound far more often than the flattened corridor does, exactly the "real signal" this control is
+        // meant to prove exists.
         expect(result.longitudinal.length).toBeGreaterThan(100);
     });
 });
@@ -145,10 +147,11 @@ describe("surface flatness — discrimination (arm iv)", () => {
         console.log(
             `SURFACE_FLATNESS_FALLOFF_SCALE scale1_count=${r1.longitudinal.length} scale1_maxDelta=${d1.toFixed(4)} scale3_count=${r3.longitudinal.length} scale3_maxDelta=${d3.toFixed(4)}`,
         );
-        // measured (2026-08-18): maxDelta moves from ~0.335 m to ~0.331 m (~1.3%) across a 3x falloff
-        // widening — reproduces 11c's live-camera verdict ("it does absolutely nothing for the road
-        // stairstep issue") on this oracle's own reconstruction-axis reading. A 10% relative-change floor
-        // is loose margin against run-to-run drift, not a value fitted to today's ~1.3%.
+        // measured (2026-08-18, after the endpoint-margin fix): maxDelta moves from ~0.344 m to ~0.340 m
+        // (~1.1%) across a 3x falloff widening — reproduces 11c's live-camera verdict ("it does absolutely
+        // nothing for the road stairstep issue") on this oracle's own reconstruction-axis reading. A 10%
+        // relative-change floor is loose margin against run-to-run drift, not a value fitted to today's
+        // ~1.1%.
         expect(Math.abs(d3 - d1) / d1).toBeLessThan(0.1);
     });
 
@@ -192,13 +195,14 @@ describe("surface flatness — discrimination (arm iv)", () => {
         console.log(
             `SURFACE_FLATNESS_SPACING coarse_count=${coarse.longitudinal.length} coarse_maxDelta=${dCoarse.toFixed(4)} fine_count=${fine.longitudinal.length} fine_maxDelta=${dFine.toFixed(4)}`,
         );
-        // measured (2026-08-18): count drops (25 -> 21, fewer *steps* wide enough at Δs=SAMPLE_STEP/2 to
-        // cross the grade bound) while maxDelta *rises* (~0.335 -> ~0.404 m) — the finer lattice resolves
-        // the true crease more sharply rather than smoothing it away over a wider quad. Both readings move
-        // by double digits of a percent (>10%), unlike the falloff-scale arm above (~1.3%) — the
-        // discrimination this arm exists to show: the criterion is sensitive to the mesh-resolution axis
-        // and (per the arm above) insensitive to the falloff-width axis, matching the mechanism's own
-        // predicted asymmetry.
+        // measured (2026-08-18, after the endpoint-margin fix): count drops sharply (34 -> 21, ~38%,
+        // fewer *steps* wide enough at Δs=SAMPLE_STEP/2 to cross the grade bound) while maxDelta rises more
+        // modestly (~0.344 -> ~0.354 m, ~3%) — the finer lattice resolves the true crease more sharply
+        // rather than smoothing it away over a wider quad. The count move alone clears double digits of a
+        // percent (>10%), unlike the falloff-scale arm above (~1.1%) — the discrimination this arm exists
+        // to show survives the margin fix: the criterion is sensitive to the mesh-resolution axis and (per
+        // the arm above) insensitive to the falloff-width axis, matching the mechanism's own predicted
+        // asymmetry.
         const countChange =
             Math.abs(fine.longitudinal.length - coarse.longitudinal.length) /
             coarse.longitudinal.length;

--- a/examples/showcase/roads/src/flatness.ts
+++ b/examples/showcase/roads/src/flatness.ts
@@ -34,6 +34,14 @@
 //     unconstrained by design; this oracle only walks centreline + edge lines *inside* a footprint.
 //   - reseed staleness — this always samples the *live* document's own current geometry; a stale
 //     atlas/dirty-tile residue (stage 14's subject) leaves no trace on the heightfield this oracle reads.
+//   - the segment endpoint cap — every sampled line excises an arc-length margin of exactly `halfWidth`
+//     metres (4 m on this network) at *both* ends of every segment (`sampleWindow`, below): past that
+//     margin, `networkCoreCpu`'s own nearest-*point* clamp is a different geometric case from the
+//     nearest-*line* interior this oracle checks. A green run says nothing about the geometry within one
+//     `halfWidth` of any road endpoint or junction — precisely the band stage 15's own fix (blending
+//     overlapping primitives' falloffs across `networkCore`'s hard nearest-primitive switch) concentrates
+//     its change in, so a green oracle after that fix is evidence about the mid-segment crease only, not
+//     the junction one, unless this margin narrows too.
 
 import { encodePos } from "@dylanebert/shallot/utils/core";
 import * as d from "typegpu/data";
@@ -256,10 +264,34 @@ function segmentFrames(doc: StrokeDocument): RoadFrame[] {
     return frames;
 }
 
-// stay off each segment's own endpoint cap (a distinct geometric case — nearest-point rather than
-// nearest-line — out of this oracle's scope) by sampling only the segment's interior.
-const T_LO = 0.05;
-const T_HI = 0.95;
+// stay off each segment's own endpoint cap (a distinct geometric case — nearest-*point* rather than
+// nearest-*line*, `networkCoreCpu`'s own clamp-to-[0,1] projection: past either endpoint the nearest
+// primitive distance is measured to that endpoint, not perpendicular to the segment). The excluded band
+// is an *arc-length* margin of exactly {@link RoadFrame.halfWidth} metres at each end — the same
+// document-geometry quantity the spec already names for the window, not a fraction of the segment's own
+// length (a fraction silently widens on a longer road and has no geometric referent at all — the bug this
+// replaces sampled a fixed 5% of segment length, 4.6-9.6 m on this network's own five roads, wider than
+// SPACING and comparable to the falloff width, quietly excising the junction/endpoint band stage 15's fix
+// concentrates its own change in). Treatment-free: only `halfWidth`, never `computeFalloff`, a falloff
+// scale, or the smoothing radius.
+function endpointMargin(frame: RoadFrame): number {
+    return frame.halfWidth;
+}
+
+/** the sampled `[tLo, tHi]` interior of `frame` after excising {@link endpointMargin} at each end.
+ *  Degenerates to a single point at the segment's own midpoint (`tLo === tHi === 0.5`) when the two
+ *  margins would cross — a segment shorter than `2 * halfWidth` has no interior left once both endpoint
+ *  caps are removed. Not reachable by this project's own generator (`ROAD_MIN_LENGTH = 80` against
+ *  `halfWidth = 4`), but a reused caller could feed a shorter segment, and the alternative (sampling
+ *  nothing, silently) is exactly the failure mode this stage's own finding was about — so this returns one
+ *  real sample point instead of an empty line. */
+function sampleWindow(frame: RoadFrame): { tLo: number; tHi: number } {
+    const margin = endpointMargin(frame);
+    const tLo = margin / frame.len;
+    const tHi = 1 - tLo;
+    if (tLo >= tHi) return { tLo: 0.5, tHi: 0.5 };
+    return { tLo, tHi };
+}
 
 interface LineSample {
     readonly t: number;
@@ -272,11 +304,14 @@ function sampleLine(
     frame: RoadFrame,
     offset: number,
     sampleAt: (x: number, z: number) => number,
+    tLo: number,
+    tHi: number,
 ): LineSample[] {
-    const n = Math.max(1, Math.ceil(((T_HI - T_LO) * frame.len) / SAMPLE_STEP));
+    const span = tHi - tLo;
+    const n = span <= 0 ? 0 : Math.max(1, Math.ceil((span * frame.len) / SAMPLE_STEP));
     const out: LineSample[] = [];
     for (let s = 0; s <= n; s++) {
-        const t = T_LO + ((T_HI - T_LO) * s) / n;
+        const t = n === 0 ? tLo : tLo + (span * s) / n;
         const station = t * frame.len;
         const x = frame.ax + frame.ux * station + frame.nx * offset;
         const z = frame.az + frame.uz * station + frame.nz * offset;
@@ -347,12 +382,13 @@ export function checkSurfaceFlatness(
     for (let roadIndex = 0; roadIndex < frames.length; roadIndex++) {
         const frame = frames[roadIndex];
         const inset = frame.halfWidth - EDGE_EPSILON;
-        const centre = sampleLine(frame, 0, sampleAt);
-        const edgePos = sampleLine(frame, inset, sampleAt);
-        const edgeNeg = sampleLine(frame, -inset, sampleAt);
+        const { tLo, tHi } = sampleWindow(frame);
+        const centre = sampleLine(frame, 0, sampleAt, tLo, tHi);
+        const edgePos = sampleLine(frame, inset, sampleAt, tLo, tHi);
+        const edgeNeg = sampleLine(frame, -inset, sampleAt, tLo, tHi);
         sampleCount += centre.length + edgePos.length + edgeNeg.length;
 
-        // cross-section: same station (same t by construction — sampleLine shares T_LO/T_HI/n), every
+        // cross-section: same station (same t by construction — sampleLine shares tLo/tHi/n), every
         // footprint line should read the centreline's own height.
         for (let i = 0; i < centre.length; i++) {
             for (const [line, samples] of [
@@ -377,7 +413,7 @@ export function checkSurfaceFlatness(
         }
 
         // longitudinal: adjacent-sample grade bound, walked independently along each of the three lines.
-        const ds = ((T_HI - T_LO) * frame.len) / Math.max(1, centre.length - 1);
+        const ds = ((tHi - tLo) * frame.len) / Math.max(1, centre.length - 1);
         const bound = gradeBound(ds);
         for (const [line, samples] of [
             ["centre", centre],
@@ -446,8 +482,9 @@ export function reconstructionAgreement(
     let sampleCount = 0;
     for (const frame of segmentFrames(doc)) {
         const inset = frame.halfWidth - EDGE_EPSILON;
+        const { tLo, tHi } = sampleWindow(frame);
         for (const offset of [0, inset, -inset]) {
-            for (const s of sampleLine(frame, offset, deviceSample)) {
+            for (const s of sampleLine(frame, offset, deviceSample, tLo, tHi)) {
                 const cpuH = cpuSample(s.x, s.z);
                 maxDiffM = Math.max(maxDiffM, Math.abs(s.h - cpuH));
                 sampleCount++;


### PR DESCRIPTION
## Problem
Adversarial pass over the prior stage-12 diff (PR #71, merged) found `flatness.ts`'s `T_LO`/`T_HI`
excised a fixed 5% of each segment's *length* at both ends, not a document-geometry quantity — 4.6-9.6 m
on this network's own five roads, wider than `SPACING` and comparable to the falloff width, silently
hiding the junction/endpoint band inside the sampled window.

## Cause
The margin was a fraction of segment length rather than an arc-length quantity derived from the
endpoint-cap's own geometric extent (`halfWidth`). It also wasn't disclosed in the header's "cannot see"
list, so a reader of a green run had no way to know the oracle said nothing about roughly a `halfWidth`'s
worth of geometry at every endpoint/junction — exactly the band stage 15's own fix (blending overlapping
primitives' falloffs across `networkCore`'s hard nearest-primitive switch) concentrates its change in.

## Fix
`sampleWindow` derives the excluded band from `halfWidth` alone (treatment-free: no `computeFalloff`, no
falloff scale, no smoothing radius), converted to a `t` fraction per frame from that frame's own `len`.
Degenerates to a single midpoint sample when the two margins would cross, rather than silently sampling
nothing. Header gains a fifth "cannot see" bullet naming the residual cap exclusion, what it's derived
from, and its size.

## Evidence
- `bun test ./src`: 159 pass, 0 fail, 6649 `expect()`, exit 0
- `bun test ./src -t "surface flatness"`: 8 pass, 0 fail, 2316 `expect()`, exit 0
- `bun run gate`: adapter `nvidia lovelace`, 1 passed, 2 skipped, exit 0
- `bun run format` / `bun check`: exit 0
- All four proof arms re-run against the wider sampled population: shipped `SEED=1337` now 34
  longitudinal / 1117 cross-section violations (up from 25/1067 — more footprint now sampled, more of the
  real defect visible); `NO_CUT` null control 283 (still far above shipped, the real-signal proof holds);
  falloff-scale 1-vs-3 moves ~1.1% (still inert, matching 11c); `SPACING`→`SPACING/2` moves the violation
  count ~38% (discrimination survives the margin fix).

Spec: `specs/shallot-roads.md` (kex, private) stage 12.