### PR TITLE
shallot-roads: remove stage 11a falloff floor + scale knob

### DIFF
--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -11,14 +11,7 @@ import {
 import type { Check } from "./harness";
 import { DIST_RANGE, TILE_RES } from "./overlay/tiles";
 import { SPACING } from "./terrain/grid";
-import {
-    getFalloffScale,
-    getSmoothRadius,
-    overlayIdle,
-    regenerate,
-    setFalloffScale,
-    setSmoothRadius,
-} from "./terrain/terrain";
+import { getSmoothRadius, overlayIdle, regenerate, setSmoothRadius } from "./terrain/terrain";
 
 // The roads showcase's boot orchestration, as a plugin (a manifest project has no `main.ts` entry) —
 // the same shape as voxel's `boot.ts`. Terrain generation itself runs inside `terrain.ts`'s own `warm()`
@@ -26,12 +19,9 @@ import {
 // voxel's carve-capable mesher needs); this plugin's only job is installing the device gate + the capture
 // bridge once the terrain mesh is registered, the seed control's F9 key (the spec's "a seed control in
 // the voxel-toolbar idiom at most" — a key, not a toolbar: this example has no drawing tool for a toolbar
-// to switch between), stage 8's longitudinal smoothing-strength control on the same idiom — `[`/`]`
-// step `terrain/profile.ts`'s box-filter radius down/up by one sample — and stage 11's falloff-width
-// control, `-`/`=`, stepping `terrain/flatten.ts`'s `computeFalloff` scale multiplier. Both live controls
-// land in the same session (spec Approach, stage 11's handover) since the confound that parked the radius
-// (cross-section quantization vs. longitudinal profile on the same edge) is resolved once the falloff
-// lands. `mode: always` so the poll runs in edit mode too, not just play.
+// to switch between), and stage 8's longitudinal smoothing-strength control on the same idiom — `[`/`]`
+// step `terrain/profile.ts`'s box-filter radius down/up by one sample. `mode: always` so the poll runs in
+// edit mode too, not just play.
 
 declare global {
     interface Window {
@@ -46,8 +36,6 @@ declare global {
         // stage 8's smoothing-strength control (`[`/`]`, below) — the live radius, for a driver or test to
         // read without re-deriving it, the same read-bridge shape as the other __roads* globals.
         __roadsSmoothRadius?: () => number;
-        // stage 11's falloff-width control (`-`/`=`, below) — the live scale, the same read-bridge shape.
-        __roadsFalloffScale?: () => number;
         // a plain re-export of capture.ts's derived constant — never imported directly into the Playwright
         // driver (this project's src/ runs in the browser via the dev server; a direct Node-side import of
         // it pulls in the published `@dylanebert/shallot` package graph under Playwright's own loader,
@@ -87,7 +75,6 @@ const BootSystem: System = {
         window.__roadsOverlayIdle = () => overlayIdle();
         window.__roadsTransitionTolerancePx = TRANSITION_TOLERANCE_PX;
         window.__roadsSmoothRadius = () => getSmoothRadius();
-        window.__roadsFalloffScale = () => getFalloffScale();
         window.__roadsGrazingCapture = () => grazingCapture();
         window.__roadsHeightSilhouette = () => heightSilhouette();
         window.__roadsMeshParams = { spacing: SPACING, tileRes: TILE_RES, distRange: DIST_RANGE };
@@ -108,12 +95,6 @@ const BootSystem: System = {
                 } else if (e.key === "]") {
                     e.preventDefault();
                     void setSmoothRadius(getSmoothRadius() + 1);
-                } else if (e.key === "-") {
-                    e.preventDefault();
-                    void setFalloffScale(getFalloffScale() - 0.25);
-                } else if (e.key === "=") {
-                    e.preventDefault();
-                    void setFalloffScale(getFalloffScale() + 0.25);
                 }
             },
             { signal: state.signal },
@@ -126,7 +107,6 @@ const BootSystem: System = {
         delete window.__roadsOverlayIdle;
         delete window.__roadsTransitionTolerancePx;
         delete window.__roadsSmoothRadius;
-        delete window.__roadsFalloffScale;
         delete window.__roadsGrazingCapture;
         delete window.__roadsHeightSilhouette;
         delete window.__roadsMeshParams;

--- a/examples/showcase/roads/src/boundaryAnchors.test.ts
+++ b/examples/showcase/roads/src/boundaryAnchors.test.ts
@@ -94,22 +94,18 @@ describe("worldEdgeAnchors — the analytic road-edge anchors the height-axis in
 });
 
 // Stage 11b: stage 10's `heightSilhouette` scanned and anchored on `computeFalloff(cutDepth)` directly —
-// the AASHTO side-slope term maxed with a mesh-sampling floor (`SPACING` on 11b's own branch;
-// `FALLOFF_SAMPLE_SEGMENTS * SPACING` once 11a's floor rebases in) — so a wider floor widened the search
-// window into raw terrain *and* moved the threshold anchor, with no change on the ground either was
+// the AASHTO side-slope term maxed with a mesh-sampling floor (`SPACING`) — so a wider floor widened the
+// search window into raw terrain *and* moved the threshold anchor, with no change on the ground either was
 // supposed to measure. `sideSlopeWindow` is the AASHTO term alone, upstream of any floor.
 describe("sideSlopeWindow — the decoupled measurement window", () => {
-    test("stays put on today's real network even though 11a's floor now binds computeFalloff", () => {
-        // 2.976 is this network's real measured cut depth (spec Live log, stage 11b), written against
-        // 11b's own branch where the shipped floor was a bare SPACING (4 m) and didn't bind here — this
-        // test predates 11a's floor rebasing in. 11a's floor (FALLOFF_SAMPLE_SEGMENTS * SPACING = 16 m)
-        // exceeds the AASHTO term (14.024 m) at this cut depth, so computeFalloff now binds on the floor
-        // — exactly the case sideSlopeWindow exists to stay clear of. It does: the window is still the
-        // bare AASHTO term, unmoved, strictly narrower than computeFalloff's floored output.
+    test("agrees exactly with computeFalloff on today's real network — the floor is inert here", () => {
+        // 2.976 is this network's real measured cut depth (spec Live log, stage 11b). computeFalloff's
+        // floor is bare SPACING (4 m, stage 13's revert), well below the AASHTO term (14.026 m) at this
+        // cut depth, so the floor never binds and the two functions read the same number.
         const cutDepth = 2.976;
-        expect(computeFalloff(cutDepth)).toBeCloseTo(16, 6);
-        expect(sideSlopeWindow(cutDepth)).toBeCloseTo(14.026, 2); // spec's recorded falloffM/windowM, pre-11a
-        expect(sideSlopeWindow(cutDepth)).toBeLessThan(computeFalloff(cutDepth));
+        expect(computeFalloff(cutDepth)).toBeCloseTo(14.026, 2);
+        expect(sideSlopeWindow(cutDepth)).toBeCloseTo(14.026, 2); // spec's recorded falloffM/windowM
+        expect(sideSlopeWindow(cutDepth)).toBeCloseTo(computeFalloff(cutDepth), 6);
     });
 
     test("is exactly the AASHTO formula, with no floor term at all", () => {
@@ -123,42 +119,17 @@ describe("sideSlopeWindow — the decoupled measurement window", () => {
     test("zero cut depth gives a zero window — no floor to fall back on", () => {
         expect(sideSlopeWindow(0)).toBe(0);
     });
-
-    // Guards the cost of the decoupling, not just its benefit. `heightSilhouette` anchors ground truth at
-    // `heightMidpointAnchor(a, sideSlopeWindow(cutDepth))`, i.e. at half the *window*; the real cosine ease
-    // reaches its midpoint at half `computeFalloff`'s *output*. While no floor binds those are the same
-    // point. Once one binds they separate, reintroducing stage 10's anchor-offset bias at reduced
-    // magnitude — outward, so it inflates the reading and scores a floor against itself. This pins the
-    // magnitude so `sideSlopeWindow`'s docstring cannot drift from the code, and so a future floor
-    // derivation cannot widen the gap silently.
-    test("a bound floor offsets the ground-truth anchor by half the floor's excess", () => {
-        const cutDepth = 2.976; // today's real network
-        const window = sideSlopeWindow(cutDepth);
-        const real = computeFalloff(cutDepth);
-        expect(real).toBeGreaterThan(window); // precondition: the floor actually binds here
-
-        const a = worldEdgeAnchors()[0];
-        const anchored = heightMidpointAnchor(a, window);
-        const truth = heightMidpointAnchor(a, real);
-        const offset = Math.hypot(truth.mx - anchored.mx, truth.mz - anchored.mz);
-
-        expect(offset).toBeCloseTo((real - window) / 2, 9);
-        expect(offset).toBeCloseTo(0.988, 3); // the docstring's number, derived not fitted
-    });
 });
 
-// The flat-across-an-inert-treatment arm, run CPU-side against a synthetic straight edge. Written on 11b's
-// branch when 11a's concrete floor derivation (`FALLOFF_SAMPLE_SEGMENTS * SPACING`) was still unshipped and
-// unportable; 11a has since rebased in, so that floor is live here. The generic form below is kept
-// deliberately: it models the *class* of defect (any floor derivation), which is the durable statement, and
-// the live 16 m case is pinned separately above. What it proves: `computeFalloff`'s own shape is
-// `max(floor, AASHTO(cutDepth))` for *some* floor value — stage 10's instrument reads whatever that max
-// produces. `coupled` below reconstructs exactly that shape, generic in `floor`, to model the *class* of
-// defect (any floor derivation), not 11a's specific one. The synthetic edge's true transition is built
-// from the real `flattenHeight` at a *fixed* embedded width (`TRUE_WINDOW`, matching production's
-// `sideSlopeWindow(2.976)`) — the "boundary" here is a fixed array of sampled heights, so a floor value
-// that only feeds `couple`'s own `Math.max` (never the sampler) provably cannot move it. Any reading
-// swing as `floor` varies is the instrument, not the road.
+// The flat-across-an-inert-treatment arm, run CPU-side against a synthetic straight edge. Predates 11a
+// (written on 11b's branch, when 11a's own floor derivation was still unshipped) and outlives it (11a's
+// concrete floor was removed at stage 13) — kept deliberately generic: it models the *class* of defect
+// (any floor derivation binding against `computeFalloff`'s `max(floor, AASHTO(cutDepth))` shape), which is
+// the durable statement, not any one floor's own number. `coupled` below reconstructs that shape, generic
+// in `floor`. The synthetic edge's true transition is built from the real `flattenHeight` at a *fixed*
+// embedded width (`TRUE_WINDOW`, matching production's `sideSlopeWindow(2.976)`) — the "boundary" here is
+// a fixed array of sampled heights, so a floor value that only feeds `couple`'s own `Math.max` (never the
+// sampler) provably cannot move it. Any reading swing as `floor` varies is the instrument, not the road.
 describe("flat-across-an-inert-treatment: a floor change moves the coupled window, not the boundary", () => {
     const TrueCutDepth = 2.976;
     const TrueWindow = sideSlopeWindow(TrueCutDepth); // 14.026 — the synthetic edge's real, fixed width

--- a/examples/showcase/roads/src/boundaryAnchors.ts
+++ b/examples/showcase/roads/src/boundaryAnchors.ts
@@ -139,27 +139,23 @@ export function heightMidpointAnchor(
 /**
  * stage 11b's decoupled measurement window (metres): the AASHTO side-slope term alone —
  * `(π/2)·cutDepth/SIDE_SLOPE_LIMIT`, the same derivation `terrain/flatten.ts`'s `computeFalloff` uses for
- * its own non-floor branch — deliberately omitting `computeFalloff`'s sampling floor (denominated in
- * `SPACING`, or a differently-derived floor on stage 11a's still-unshipped branch). The floor exists only
- * to keep the *mesh's* piecewise-linear reconstruction resolvable; it carries no side-slope-safety meaning
- * and is exactly the term stage 11 gates (the floor is what widens when 11a's falloff scale grows). This
- * function's only input is `cutDepth` — the network's own measured cut, `buildNetworkGeometry`'s output,
- * upstream of `computeFalloff` entirely — so by construction no floor-widening treatment can reach it: the
- * treatment appears in neither the search window nor (via {@link heightMidpointAnchor}) the threshold
- * anchor built from it. `grazingCapture.ts`'s `heightSilhouette` scans and anchors against this instead of
- * `computeFalloff`'s output, so two networks whose floor differs (today's `SPACING`, 11a's derived
- * multiple of it, any future floor) read on the same window and are comparable. Known limit: whenever a
- * floor actually binds (`computeFalloff`'s output exceeds this), the *real* rendered transition is wider
- * than this window measures against — an accepted scope boundary (`shallot-roads.md` stage 11b). **Live on
- * this branch**, where 11a's sampling floor (`FALLOFF_SAMPLE_SEGMENTS · SPACING` = 16 m) binds against this
- * network's side-slope term of 14.026 m. The consequence is quantified: `heightMidpointAnchor` places the
- * ground-truth anchor at `window / 2`, but the real ease reaches its midpoint at `computeFalloff / 2`, so a
- * bound floor offsets the anchor outward by `(computeFalloff − sideSlopeWindow) / 2` — 0.988 m here. That is
- * stage 10's anchor-offset bias recurring at reduced magnitude, and it inflates the reading rather than
- * deflating it, so a floor measured this way is scored against itself. Readings stay comparable across floor
- * derivations (the point of this window) but are *absolute* only while no floor binds.
+ * its own non-floor branch — deliberately omitting `computeFalloff`'s sampling floor (`SPACING`). The
+ * floor exists only to keep the *mesh's* piecewise-linear reconstruction resolvable; it carries no
+ * side-slope-safety meaning and is exactly the term stage 11 gates. This function's only input is
+ * `cutDepth` — the network's own measured cut, `buildNetworkGeometry`'s output, upstream of
+ * `computeFalloff` entirely — so by construction no floor-widening treatment can reach it: the treatment
+ * appears in neither the search window nor (via {@link heightMidpointAnchor}) the threshold anchor built
+ * from it. `grazingCapture.ts`'s `heightSilhouette` scans and anchors against this instead of
+ * `computeFalloff`'s output, so two networks whose floor differs read on the same window and are
+ * comparable. Known limit: whenever a floor actually binds (`computeFalloff`'s output exceeds this), the
+ * *real* rendered transition is wider than this window measures against — an accepted scope boundary
+ * (`shallot-roads.md` stage 11b). **Inert on today's network** (stage 13 reverted `computeFalloff`'s floor
+ * to bare `SPACING` = 4 m, well below this network's own side-slope term of 14.026 m), so `computeFalloff`
+ * and `sideSlopeWindow` agree exactly here and `heightMidpointAnchor`'s ground-truth anchor carries no
+ * offset — the bound-floor case (`boundaryAnchors.test.ts`'s generic `coupled(floor)` machinery) is still
+ * proven, against a synthetic floor, for whenever a future floor derivation binds again.
  * @example sideSlopeWindow(0) // 0 — no cut, no transition to measure
- * @example sideSlopeWindow(2.976) // 14.026, below computeFalloff(2.976) = 16 — 11a's floor binds here */
+ * @example sideSlopeWindow(2.976) // 14.026, equal to computeFalloff(2.976) on today's network */
 export function sideSlopeWindow(cutDepth: number): number {
     return ((Math.PI / 2) * cutDepth) / SIDE_SLOPE_LIMIT;
 }

--- a/examples/showcase/roads/src/flatness.test.ts
+++ b/examples/showcase/roads/src/flatness.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./flatness";
 import type { StrokeDocument } from "./overlay/document";
 import { generateNetwork } from "./overlay/network";
+import { buildNetworkGeometry, computeFalloff } from "./terrain/flatten";
 import { CELLS, SPACING } from "./terrain/grid";
 import { GROUND_LEVEL, makePermutation } from "./terrain/noise";
 import { DEFAULT_SMOOTH_RADIUS, heightAtCpu, MAX_GRADE } from "./terrain/profile";
@@ -131,6 +132,69 @@ describe("surface flatness — null control: no cut, real relief (arm iii)", () 
         // bound far more often than the flattened corridor does, exactly the "real signal" this control is
         // meant to prove exists.
         expect(result.longitudinal.length).toBeGreaterThan(100);
+    });
+});
+
+describe("surface flatness — mesh-resolution discrimination (independent of the deleted falloff-scale knob)", () => {
+    // Stage 12's arm (iv) originally swept two treatments side by side (falloff-scale and mesh
+    // resolution) to prove the oracle discriminates on a real geometric change while staying ~inert to
+    // the (now-deleted) falloff-scale knob. The falloff-scale leg died with stage 13's removal, but this
+    // leg's own subject — does halving the mesh spacing move the oracle's reported amplitude, the way a
+    // reconstruction-axis defect predicts it should — has nothing to do with that knob and stays live: a
+    // still-real check that the oracle is sensitive to the axis it exists to gate, not a check on 11a.
+    test("halving mesh spacing moves cross-section amplitude by a real, non-trivial margin", () => {
+        const doc = generateNetwork(SEED);
+        const perm = makePermutation(SEED);
+        const { segments, cutDepth } = buildNetworkGeometry(doc, SEED, DEFAULT_SMOOTH_RADIUS);
+        const falloff = computeFalloff(cutDepth);
+        const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
+
+        const rawCoarse = buildLatticeVertices(
+            SPACING,
+            CELLS,
+            segments,
+            doc.polygons,
+            falloff,
+            natural,
+        );
+        const coarse = checkSurfaceFlatness(
+            (x, z) => meshHeightAt(rawCoarse, x, z, SPACING, CELLS),
+            doc,
+        );
+
+        const fineSpacing = SPACING / 2;
+        const fineCells = CELLS * 2;
+        const rawFine = buildLatticeVertices(
+            fineSpacing,
+            fineCells,
+            segments,
+            doc.polygons,
+            falloff,
+            natural,
+        );
+        const fine = checkSurfaceFlatness(
+            (x, z) => meshHeightAt(rawFine, x, z, fineSpacing, fineCells),
+            doc,
+        );
+
+        const crossDeltaCoarse = coarse.crossSection.reduce(
+            (m, v) => Math.max(m, v.deltaFromCentre),
+            0,
+        );
+        const crossDeltaFine = fine.crossSection.reduce(
+            (m, v) => Math.max(m, v.deltaFromCentre),
+            0,
+        );
+        const crossAmpChange = Math.abs(crossDeltaFine - crossDeltaCoarse) / crossDeltaCoarse;
+
+        console.log(
+            `SURFACE_FLATNESS_MESH_RESOLUTION coarse_crossMaxDelta=${crossDeltaCoarse.toFixed(4)} fine_crossMaxDelta=${crossDeltaFine.toFixed(4)} crossAmpChange=${(crossAmpChange * 100).toFixed(1)}%`,
+        );
+
+        // measured (2026-08-18): ~19.2% — a loose floor at 5%, well below the measured reading, just
+        // ruling out "the oracle reads flat to mesh resolution changes" (the property this leg exists to
+        // rule out), not fitted tight to today's exact number.
+        expect(crossAmpChange).toBeGreaterThan(0.05);
     });
 });
 

--- a/examples/showcase/roads/src/flatness.test.ts
+++ b/examples/showcase/roads/src/flatness.test.ts
@@ -13,7 +13,6 @@ import {
 } from "./flatness";
 import type { StrokeDocument } from "./overlay/document";
 import { generateNetwork } from "./overlay/network";
-import { buildNetworkGeometry, computeFalloff } from "./terrain/flatten";
 import { CELLS, SPACING } from "./terrain/grid";
 import { GROUND_LEVEL, makePermutation } from "./terrain/noise";
 import { DEFAULT_SMOOTH_RADIUS, heightAtCpu, MAX_GRADE } from "./terrain/profile";
@@ -135,173 +134,9 @@ describe("surface flatness — null control: no cut, real relief (arm iii)", () 
     });
 });
 
-describe("surface flatness — discrimination (arm iv)", () => {
-    // The spec's own Validation criterion (`shallot-roads.md` stage 12) names *amplitude*, not count: "at
-    // SPACING/2 the violation amplitude moves in the mechanism's predicted direction, and across
-    // falloff-scale 1 vs 3 it moves ≈ not at all." An earlier version of these tests asserted on
-    // violation *count* instead — a population statistic that moves whenever any small geometric
-    // perturbation pushes samples across the bound, so it responds to perturbation-in-general rather than
-    // to the specific mechanism this arm exists to isolate. Measured directly (below): falloff-scale moves
-    // count by 23.5%/34.0% (longitudinal/cross-section) against mesh resolution's 38.2%/38.8% — comparable
-    // orders, no clean separation. Amplitude (maxDelta) is what actually discriminates, and cross-section
-    // is the axis where it does so cleanly; longitudinal amplitude moves the same *direction* but weakly,
-    // so it's corroboration, not a second independent discriminator.
-    //
-    // "≈ not at all" vs "moves" is read here as *at least one order of magnitude apart* — a falloff-scale
-    // effect within 10x of the mesh-resolution effect on the same statistic isn't negligible relative to
-    // it, whatever its absolute size. That threshold is chosen from the spec's own contrastive language,
-    // not fitted to today's readings (which come in at ~90x separation on cross-section amplitude, far
-    // inside the 10x bar).
-
-    test("cross-section amplitude: falloff-scale ~inert, mesh resolution moves — the primary discriminator", () => {
-        const doc = generateNetwork(SEED);
-        const raw1 = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS, 1);
-        const raw3 = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS, 3);
-        const r1 = checkSurfaceFlatness((x, z) => meshHeightAt(raw1, x, z), doc);
-        const r3 = checkSurfaceFlatness((x, z) => meshHeightAt(raw3, x, z), doc);
-
-        const crossDelta1 = r1.crossSection.reduce((m, v) => Math.max(m, v.deltaFromCentre), 0);
-        const crossDelta3 = r3.crossSection.reduce((m, v) => Math.max(m, v.deltaFromCentre), 0);
-        const longDelta1 = r1.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
-        const longDelta3 = r3.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
-
-        console.log(
-            `SURFACE_FLATNESS_FALLOFF_SCALE scale1_longCount=${r1.longitudinal.length} scale1_longMaxDelta=${longDelta1.toFixed(4)} scale1_crossCount=${r1.crossSection.length} scale1_crossMaxDelta=${crossDelta1.toFixed(4)} scale3_longCount=${r3.longitudinal.length} scale3_longMaxDelta=${longDelta3.toFixed(4)} scale3_crossCount=${r3.crossSection.length} scale3_crossMaxDelta=${crossDelta3.toFixed(4)}`,
-        );
-
-        // measured (2026-08-18, after the endpoint-margin fix): cross-section maxDelta moves ~0.2%
-        // (0.4737 -> 0.4730 m), longitudinal maxDelta ~1.1% (0.3436 -> 0.3399 m) across a 3x falloff
-        // widening — this is the arm's primary discriminator; see the paired mesh-resolution test below
-        // for the comparison that makes "~inert" meaningful (a percentage alone means nothing without the
-        // other leg to compare against).
-        expect(Math.abs(crossDelta3 - crossDelta1) / crossDelta1).toBeLessThan(0.1);
-    });
-
-    test("mesh resolution (SPACING/2) moves cross-section amplitude an order of magnitude more than falloff-scale — and violation count does NOT discriminate (negative result, pinned)", () => {
-        const doc = generateNetwork(SEED);
-        const perm = makePermutation(SEED);
-
-        // falloff-scale leg, recomputed here (cheap, same SPACING) so this test stands on its own —
-        // both legs need to sit side by side for the comparison and the count-negative-result pin.
-        const raw1 = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS, 1);
-        const raw3 = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS, 3);
-        const r1 = checkSurfaceFlatness((x, z) => meshHeightAt(raw1, x, z), doc);
-        const r3 = checkSurfaceFlatness((x, z) => meshHeightAt(raw3, x, z), doc);
-        const falloffCrossDelta1 = r1.crossSection.reduce(
-            (m, v) => Math.max(m, v.deltaFromCentre),
-            0,
-        );
-        const falloffCrossDelta3 = r3.crossSection.reduce(
-            (m, v) => Math.max(m, v.deltaFromCentre),
-            0,
-        );
-        const falloffLongDelta1 = r1.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
-        const falloffLongDelta3 = r3.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
-        const falloffCrossCountChange =
-            Math.abs(r3.crossSection.length - r1.crossSection.length) / r1.crossSection.length;
-        const falloffLongCountChange =
-            Math.abs(r3.longitudinal.length - r1.longitudinal.length) / r1.longitudinal.length;
-
-        // mesh-resolution leg: segments/falloff held fixed at production values (falloffScale = 1),
-        // only the reconstruction lattice's own spacing/cells vary — isolates the mesh-resolution axis
-        // from any falloff-width change (the same split the original arm used).
-        const { segments, cutDepth } = buildNetworkGeometry(doc, SEED, DEFAULT_SMOOTH_RADIUS);
-        const falloff = computeFalloff(cutDepth, 1);
-        const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
-
-        const rawCoarse = buildLatticeVertices(
-            SPACING,
-            CELLS,
-            segments,
-            doc.polygons,
-            falloff,
-            natural,
-        );
-        const coarse = checkSurfaceFlatness(
-            (x, z) => meshHeightAt(rawCoarse, x, z, SPACING, CELLS),
-            doc,
-        );
-
-        const fineSpacing = SPACING / 2;
-        const fineCells = CELLS * 2;
-        const rawFine = buildLatticeVertices(
-            fineSpacing,
-            fineCells,
-            segments,
-            doc.polygons,
-            falloff,
-            natural,
-        );
-        const fine = checkSurfaceFlatness(
-            (x, z) => meshHeightAt(rawFine, x, z, fineSpacing, fineCells),
-            doc,
-        );
-
-        const spacingCrossDeltaCoarse = coarse.crossSection.reduce(
-            (m, v) => Math.max(m, v.deltaFromCentre),
-            0,
-        );
-        const spacingCrossDeltaFine = fine.crossSection.reduce(
-            (m, v) => Math.max(m, v.deltaFromCentre),
-            0,
-        );
-        const spacingLongDeltaCoarse = coarse.longitudinal.reduce(
-            (m, v) => Math.max(m, v.delta),
-            0,
-        );
-        const spacingLongDeltaFine = fine.longitudinal.reduce((m, v) => Math.max(m, v.delta), 0);
-        const spacingCrossCountChange =
-            Math.abs(fine.crossSection.length - coarse.crossSection.length) /
-            coarse.crossSection.length;
-        const spacingLongCountChange =
-            Math.abs(fine.longitudinal.length - coarse.longitudinal.length) /
-            coarse.longitudinal.length;
-
-        console.log(
-            `SURFACE_FLATNESS_SPACING coarse_longCount=${coarse.longitudinal.length} coarse_longMaxDelta=${spacingLongDeltaCoarse.toFixed(4)} coarse_crossCount=${coarse.crossSection.length} coarse_crossMaxDelta=${spacingCrossDeltaCoarse.toFixed(4)} fine_longCount=${fine.longitudinal.length} fine_longMaxDelta=${spacingLongDeltaFine.toFixed(4)} fine_crossCount=${fine.crossSection.length} fine_crossMaxDelta=${spacingCrossDeltaFine.toFixed(4)}`,
-        );
-
-        const falloffCrossAmpChange =
-            Math.abs(falloffCrossDelta3 - falloffCrossDelta1) / falloffCrossDelta1;
-        const spacingCrossAmpChange =
-            Math.abs(spacingCrossDeltaFine - spacingCrossDeltaCoarse) / spacingCrossDeltaCoarse;
-        const falloffLongAmpChange =
-            Math.abs(falloffLongDelta3 - falloffLongDelta1) / falloffLongDelta1;
-        const spacingLongAmpChange =
-            Math.abs(spacingLongDeltaFine - spacingLongDeltaCoarse) / spacingLongDeltaCoarse;
-
-        // measured (2026-08-18, after the endpoint-margin fix): cross-section amplitude moves ~19.2%
-        // under SPACING/2 against falloff-scale's own ~0.2% on the same statistic — an order of
-        // magnitude the "≈ not at all" vs "moves" bar (defined above) reads as a real discrimination,
-        // not noise on either side.
-        expect(falloffCrossAmpChange * 10).toBeLessThan(spacingCrossAmpChange);
-
-        // longitudinal amplitude moves the same *direction* (falloff-scale smaller than mesh
-        // resolution) but weakly — ~1.1% vs ~3.1%, roughly 3x apart, not the order-of-magnitude split
-        // cross-section shows. Asserted only as a directional ordering, per the coordinator's own
-        // read: "1.1% vs 3.1% is not a clean split" — this is corroboration that the direction is
-        // right, not a second independent discriminator standing on its own.
-        expect(falloffLongAmpChange).toBeLessThan(spacingLongAmpChange);
-
-        // Negative result, pinned so a later stage (13's removal gate, 15's fix gate) can't cite
-        // violation *count* as a comparable-across-treatments reading the way this arm's own history
-        // briefly did: on both axes, falloff-scale's count change sits within ~15 percentage points of
-        // mesh-resolution's own count change (23.5% vs 38.2% longitudinal, 34.0% vs 38.8%
-        // cross-section) — the same population-noise ballpark as the treatment's own effect, not an
-        // order of magnitude apart the way amplitude is. 20 points is a coarse "same ballpark" bound,
-        // chosen because it is far short of the multiplicative order-of-magnitude gap amplitude shows
-        // above (a 20-point *absolute* gap on a same-order base is nowhere near a 10x *relative* one) —
-        // if this ever tightens to a real order-of-magnitude gap, count would have become a
-        // discriminator after all and this assertion should fail loudly, not be widened to keep it
-        // green.
-        expect(Math.abs(falloffLongCountChange - spacingLongCountChange)).toBeLessThan(0.2);
-        expect(Math.abs(falloffCrossCountChange - spacingCrossCountChange)).toBeLessThan(0.2);
-    }, 20_000);
-});
-
 describe("checkSurfaceFlatness — window/threshold derivation, no candidate treatment", () => {
     test("gradeBound scales with Δs and the road-design grade limit alone", () => {
-        // MAX_GRADE is the only slope-scaling input — no falloff/smoothRadius/falloffScale term appears.
+        // MAX_GRADE is the only slope-scaling input — no falloff/smoothRadius term appears.
         expect(gradeBound(SAMPLE_STEP)).toBeGreaterThan(MAX_GRADE * SAMPLE_STEP);
         expect(gradeBound(2 * SAMPLE_STEP)).toBeGreaterThan(gradeBound(SAMPLE_STEP));
     });
@@ -319,19 +154,13 @@ describe("reconstructionAgreement — the device arm's own fidelity pin", () => 
         // `bun test` has no real device, so this exercises the differential's own logic against a second,
         // independently-called `buildDeviceFreeVertices` run standing in for `readVertices()` — the real
         // device arm lives in `gate.ts` (`bun run gate`), which calls this same function against the real
-        // GPU. Same seed/smoothRadius/falloffScale in, so the two builds should be exactly reproducible
-        // (this project's height kernel is itself deterministic-in-seed, `gate.ts`'s own `deterministic`
-        // check) — this pins that {@link reconstructionAgreement}'s own comparison logic reads zero
-        // when there's nothing to disagree about, before it's trusted as the real device's fidelity gate.
+        // GPU. Same seed/smoothRadius in, so the two builds should be exactly reproducible (this project's
+        // height kernel is itself deterministic-in-seed, `gate.ts`'s own `deterministic` check) — this
+        // pins that {@link reconstructionAgreement}'s own comparison logic reads zero when there's nothing
+        // to disagree about, before it's trusted as the real device's fidelity gate.
         const doc = generateNetwork(SEED);
-        const deviceStandIn = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS, 1);
-        const agreement = reconstructionAgreement(
-            deviceStandIn,
-            doc,
-            SEED,
-            DEFAULT_SMOOTH_RADIUS,
-            1,
-        );
+        const deviceStandIn = buildDeviceFreeVertices(doc, SEED, DEFAULT_SMOOTH_RADIUS);
+        const agreement = reconstructionAgreement(deviceStandIn, doc, SEED, DEFAULT_SMOOTH_RADIUS);
         expect(agreement.sampleCount).toBeGreaterThan(0);
         expect(agreement.maxDiffM).toBeLessThanOrEqual(RECONSTRUCTION_AGREEMENT_TOL);
     });

--- a/examples/showcase/roads/src/flatness.ts
+++ b/examples/showcase/roads/src/flatness.ts
@@ -58,9 +58,9 @@ import { CELLS, SPACING } from "./terrain/grid";
 import { makePermutation } from "./terrain/noise";
 import { heightAtCpu, MAX_GRADE, MAX_GRADE_BREAK, PROFILE_STEP } from "./terrain/profile";
 
-// --- derived window + tolerance — no candidate treatment (falloff, smoothRadius, falloffScale) appears
-// in any of these, per the spec's own non-coupling requirement (stage 11's whole lesson: a criterion whose
-// window or threshold is a function of the parameter under test is not a differential over that parameter).
+// --- derived window + tolerance — no candidate treatment (falloff, smoothRadius) appears in any of these,
+// per the spec's own non-coupling requirement (stage 11's whole lesson: a criterion whose window or
+// threshold is a function of the parameter under test is not a differential over that parameter).
 
 /** the spec's own longitudinal sample spacing bound: no coarser than a quarter of the mesh's own vertex
  *  spacing, so no triangle edge along a sampled line is ever skipped between two adjacent samples. */
@@ -210,10 +210,9 @@ export function buildLatticeVertices(
     return raw;
 }
 
-/** the production-shape reconstruction: `doc`'s own network flattened at `seed`/`smoothRadius`
- *  (optionally `falloffScale`, stage 11a's still-live multiplier on this branch), at the mesh's real
- *  `SPACING`/`CELLS` — a drop-in `readVertices()` substitute with no device, `flatness.test.ts`'s and
- *  `gate.ts`'s shared entry point. `flattenDoc` and `sampleDoc` (the caller's own footprint definition,
+/** the production-shape reconstruction: `doc`'s own network flattened at `seed`/`smoothRadius`, at the
+ *  mesh's real `SPACING`/`CELLS` — a drop-in `readVertices()` substitute with no device, `flatness.test.ts`'s
+ *  and `gate.ts`'s shared entry point. `flattenDoc` and `sampleDoc` (the caller's own footprint definition,
  *  `checkSurfaceFlatness`) are deliberately the same `doc` here; {@link buildLatticeVertices} lets a caller
  *  split them (stage 12's own null-control arm: an empty `flattenDoc` with the real network's footprint
  *  still standing, `flatness.test.ts`'s "no-cut" arm). */
@@ -221,11 +220,10 @@ export function buildDeviceFreeVertices(
     flattenDoc: StrokeDocument,
     seed: number,
     smoothRadius: number,
-    falloffScale = 1,
 ): Uint32Array {
     const perm = makePermutation(seed);
     const { segments, cutDepth } = buildNetworkGeometry(flattenDoc, seed, smoothRadius);
-    const falloff = computeFalloff(cutDepth, falloffScale);
+    const falloff = computeFalloff(cutDepth);
     return buildLatticeVertices(SPACING, CELLS, segments, flattenDoc.polygons, falloff, (x, z) =>
         heightAtCpu(x, z, perm),
     );
@@ -365,8 +363,8 @@ export interface FlatnessResult {
  * the real `readVertices()`, this function never knows which. The window (which stations/lines get
  * sampled) comes only from `doc`'s own geometry (`halfWidth`, segment endpoints); the threshold comes only
  * from road-design constants and the codec's own quantization — {@link gradeBound}/{@link
- * CROSS_SECTION_TOL} take no falloff, smoothing radius, or falloff-scale input, so no candidate treatment
- * can move the window or the threshold (the non-coupling stage 11's whole investigation turned on).
+ * CROSS_SECTION_TOL} take no falloff or smoothing-radius input, so no candidate treatment can move the
+ * window or the threshold (the non-coupling stage 11's whole investigation turned on).
  */
 export function checkSurfaceFlatness(
     sampleAt: (x: number, z: number) => number,
@@ -457,24 +455,23 @@ export function inFootprint(x: number, z: number, doc: StrokeDocument): boolean 
 
 /**
  * pins the default-suite CPU reconstruction against the real device: rebuilds the identical lattice
- * ({@link buildDeviceFreeVertices}) at the live network's own `seed`/`smoothRadius`/`falloffScale` and
- * compares its footprint-line samples against `deviceRaw` (a real `readVertices()` readback) point for
- * point. This is the "device arm" the spec asks for — it validates the CPU builder's *fidelity* against
- * the real GPU output (a reference/differential check), not the surface-flatness property itself (which
- * `bun test`'s default-suite arm already checks device-free, and is allowed to read red on the shipped
- * pipeline, `gate.ts` would break every run if it re-asserted "no violations" here). Tolerance is
- * quantization noise only, doubled for two independent codec round-trips plus float-precision drift
- * between the CPU (f64) and GPU (f32) paths (`terrain/profile.ts`'s own module header names this same
- * drift as expected and harmless).
+ * ({@link buildDeviceFreeVertices}) at the live network's own `seed`/`smoothRadius` and compares its
+ * footprint-line samples against `deviceRaw` (a real `readVertices()` readback) point for point. This is
+ * the "device arm" the spec asks for — it validates the CPU builder's *fidelity* against the real GPU
+ * output (a reference/differential check), not the surface-flatness property itself (which `bun test`'s
+ * default-suite arm already checks device-free, and is allowed to read red on the shipped pipeline,
+ * `gate.ts` would break every run if it re-asserted "no violations" here). Tolerance is quantization noise
+ * only, doubled for two independent codec round-trips plus float-precision drift between the CPU (f64) and
+ * GPU (f32) paths (`terrain/profile.ts`'s own module header names this same drift as expected and
+ * harmless).
  */
 export function reconstructionAgreement(
     deviceRaw: Uint32Array,
     doc: StrokeDocument,
     seed: number,
     smoothRadius: number,
-    falloffScale: number,
 ): { maxDiffM: number; sampleCount: number } {
-    const cpuRaw = buildDeviceFreeVertices(doc, seed, smoothRadius, falloffScale);
+    const cpuRaw = buildDeviceFreeVertices(doc, seed, smoothRadius);
     const deviceSample = (x: number, z: number) => meshHeightAt(deviceRaw, x, z);
     const cpuSample = (x: number, z: number) => meshHeightAt(cpuRaw, x, z);
 

--- a/examples/showcase/roads/src/gate.ts
+++ b/examples/showcase/roads/src/gate.ts
@@ -7,7 +7,6 @@ import { VERTEX_COUNT } from "./terrain/grid";
 import { RELIEF } from "./terrain/noise";
 import {
     generate,
-    getFalloffScale,
     getSmoothRadius,
     readVertices,
     SEED,
@@ -115,13 +114,7 @@ export async function gate(): Promise<Check[]> {
     // device-free suite pass or fail for the wrong reason entirely.
     const liveDoc = generateNetwork(SEED);
     const deviceRaw = await readVertices();
-    const agreement = reconstructionAgreement(
-        deviceRaw,
-        liveDoc,
-        SEED,
-        getSmoothRadius(),
-        getFalloffScale(),
-    );
+    const agreement = reconstructionAgreement(deviceRaw, liveDoc, SEED, getSmoothRadius());
     checks.push({
         name: "surface-flatness-reconstruction-agreement",
         pass: agreement.maxDiffM <= RECONSTRUCTION_AGREEMENT_TOL,

--- a/examples/showcase/roads/src/grazingCapture.ts
+++ b/examples/showcase/roads/src/grazingCapture.ts
@@ -38,12 +38,12 @@ import { getSmoothRadius, readVertices, SEED } from "./terrain/terrain";
 // camera's projection of it — the same reason it needs no camera pose at all.
 //
 // Stage 11b: stage 10's window and threshold scanned `computeFalloff(cutDepth)` directly — the real
-// rendered transition width, floor included — so widening the floor (11a's still-unshipped deliverable)
-// widened the search window and moved the threshold with no real change on the ground, making the reading
-// non-comparable across two floor derivations (spec Approach, stage 11b; `boundaryAnchors.ts`'s
-// `sideSlopeWindow` doc comment has the full argument). `heightSilhouette` below now scans and anchors on
-// `sideSlopeWindow(cutDepth)` instead — a pure function of the network's own measured cut, upstream of any
-// floor — and reports the real `computeFalloff` output separately, as `falloffM`, for evidence only.
+// rendered transition width, floor included — so widening the floor widened the search window and moved
+// the threshold with no real change on the ground, making the reading non-comparable across two floor
+// derivations (spec Approach, stage 11b; `boundaryAnchors.ts`'s `sideSlopeWindow` doc comment has the full
+// argument). `heightSilhouette` below now scans and anchors on `sideSlopeWindow(cutDepth)` instead — a
+// pure function of the network's own measured cut, upstream of any floor — and reports the real
+// `computeFalloff` output separately, as `falloffM`, for evidence only.
 
 const TARGET_T = 0.08; // fraction along the road from its start — near one end, so the far ~90% recedes
 const PITCH = 0.06; // radians (~3.4°) — near-horizontal, the grazing angle itself
@@ -172,9 +172,9 @@ const STEPS_PER_M = 8; // sub-decimetre crossing resolution — cheap at this an
  *  terrain; the deviation from that ground-truth midpoint is the height-silhouette offset, in world
  *  metres. Stage 10's version scanned and anchored on `computeFalloff`'s output directly, which bundles
  *  the AASHTO side-slope term with a mesh-sampling floor denominated in `SPACING` — so widening that floor
- *  (11a's still-unshipped deliverable) widened the search window into raw terrain *and* moved the
- *  threshold, without a real change on the ground the window was supposed to measure (spec Approach, stage
- *  11b). `sideSlopeWindow` is a pure function of `cutDepth` alone, upstream of the floor entirely, so a
+ *  widened the search window into raw terrain *and* moved the threshold, without a real change on the
+ *  ground the window was supposed to measure (spec Approach, stage 11b). `sideSlopeWindow` is a pure
+ *  function of `cutDepth` alone, upstream of the floor entirely, so a
  *  floor change can't reach either the window or the threshold — the property that makes two falloff
  *  floors comparable. `computeFalloff`'s real output still rides along as `falloffM`, informational only.
  *  `raggedness` (`straightness.ts`) aggregates the same way stage 9's screen-space instrument did; what

--- a/examples/showcase/roads/src/terrain/flatten.test.ts
+++ b/examples/showcase/roads/src/terrain/flatten.test.ts
@@ -4,7 +4,6 @@ import { generateNetwork } from "../overlay/network";
 import {
     buildNetworkGeometry,
     computeFalloff,
-    FALLOFF_SAMPLE_SEGMENTS,
     flattenHeight,
     flattenHeightGpu,
     flattenWgsl,
@@ -116,20 +115,16 @@ describe("flattenedHeightAt — degenerate empty network", () => {
     });
 });
 
-describe("computeFalloff — the re-derived FALLOFF (stage 8), sampling floor (stage 11)", () => {
-    test("floors at FALLOFF_SAMPLE_SEGMENTS * SPACING when the cut depth is zero — a transition narrower\n     than the mesh's own reconstruction can't read as a curve", () => {
-        expect(computeFalloff(0)).toBe(FALLOFF_SAMPLE_SEGMENTS * SPACING);
-        expect(computeFalloff(-5)).toBe(FALLOFF_SAMPLE_SEGMENTS * SPACING); // nonsensical input, still floors
-    });
-
-    test("the sampling floor is strictly wider than the old one-quad floor it replaces", () => {
-        expect(FALLOFF_SAMPLE_SEGMENTS * SPACING).toBeGreaterThan(SPACING);
+describe("computeFalloff — the re-derived FALLOFF (stage 8)", () => {
+    test("floors at SPACING when the cut depth is zero — a transition narrower than the mesh can't resolve", () => {
+        expect(computeFalloff(0)).toBe(SPACING);
+        expect(computeFalloff(-5)).toBe(SPACING); // a negative cut depth is nonsensical input, still floors
     });
 
     test("past the floor, the cosine ease's peak slope equals SIDE_SLOPE_LIMIT by construction", () => {
-        for (const cutDepth of [10, 40, 100]) {
+        for (const cutDepth of [1, 4, 10, 40]) {
             const falloff = computeFalloff(cutDepth);
-            expect(falloff).toBeGreaterThan(FALLOFF_SAMPLE_SEGMENTS * SPACING);
+            expect(falloff).toBeGreaterThan(SPACING);
             // flattenHeight's ease derivative peaks at coreDist = falloff / 2 (t = 0.5): d/dCoreDist of
             // targetHeight + (natural - targetHeight) * (0.5 - 0.5 cos(pi t)), t = coreDist / falloff.
             const eps = 1e-4;
@@ -142,48 +137,8 @@ describe("computeFalloff — the re-derived FALLOFF (stage 8), sampling floor (s
     });
 
     test("monotone in cut depth — a deeper cut always widens the transition, never narrows it", () => {
-        expect(computeFalloff(80)).toBeGreaterThan(computeFalloff(40));
-        expect(computeFalloff(40)).toBeGreaterThan(computeFalloff(20));
-    });
-
-    test("scale multiplies the derived result — the live handover's own entry point", () => {
-        expect(computeFalloff(0, 2)).toBe(computeFalloff(0) * 2);
-        expect(computeFalloff(40, 1.5)).toBe(computeFalloff(40) * 1.5);
-        expect(computeFalloff(0)).toBe(computeFalloff(0, 1)); // default scale is a no-op
-    });
-});
-
-describe("FALLOFF_SAMPLE_SEGMENTS — the sampling-derived floor's own justification", () => {
-    // The observable this pins: sampling flattenHeight's own ease at N+1 evenly spaced vertex positions
-    // and reading the sign pattern of the piecewise-linear reconstruction's slopes. This is the property
-    // FALLOFF_SAMPLE_SEGMENTS is chosen to guarantee, not the ease formula's arithmetic restated.
-    function sampledSlopes(segments: number, falloff: number): number[] {
-        const step = falloff / segments;
-        const heights: number[] = [];
-        for (let i = 0; i <= segments; i++) {
-            heights.push(flattenHeight(1, 0, i * step, falloff)); // natural=1, target=0
-        }
-        const slopes: number[] = [];
-        for (let i = 0; i < segments; i++) slopes.push(heights[i + 1] - heights[i]);
-        return slopes;
-    }
-
-    test("at 2 segments the sampled slopes are identical — the ease's own point symmetry collapses the\n     reconstruction to a straight line, indistinguishable from no easing at all", () => {
-        const slopes = sampledSlopes(2, TEST_FALLOFF);
-        expect(slopes.length).toBe(2);
-        expect(slopes[0]).toBeCloseTo(slopes[1], 10);
-    });
-
-    test("at FALLOFF_SAMPLE_SEGMENTS (4) each of the ease's two monotone arcs gets its own interior\n     sample, so both arcs individually show non-constant slope rather than just the whole curve", () => {
-        const slopes = sampledSlopes(FALLOFF_SAMPLE_SEGMENTS, TEST_FALLOFF);
-        expect(slopes.length).toBe(4);
-        // arc 1 (segments 0-1, t in [0, 0.5]) and arc 2 (segments 2-3, t in [0.5, 1]) each split into two
-        // sub-segments with different slopes — the concave arc's own curvature and the convex arc's own
-        // curvature both register, not just an asymmetry between the halves.
-        expect(Math.abs(slopes[1] - slopes[0])).toBeGreaterThan(1e-6); // arc 1 shows curvature on its own
-        expect(Math.abs(slopes[3] - slopes[2])).toBeGreaterThan(1e-6); // arc 2 shows curvature on its own
-        expect(slopes[0]).toBeCloseTo(slopes[3], 10); // point-symmetric about the midpoint, as expected
-        expect(slopes[1]).toBeCloseTo(slopes[2], 10);
+        expect(computeFalloff(20)).toBeGreaterThan(computeFalloff(10));
+        expect(computeFalloff(10)).toBeGreaterThan(computeFalloff(5));
     });
 });
 

--- a/examples/showcase/roads/src/terrain/flatten.ts
+++ b/examples/showcase/roads/src/terrain/flatten.ts
@@ -43,55 +43,13 @@ import { buildPolylineProfile, heightAtCpu } from "./profile";
 // `D·(π/2)/F`. Solving for `F` at the side-slope limit gives the derivation below.
 export const SIDE_SLOPE_LIMIT = 1 / 3; // AASHTO Roadside Design Guide, 1V:3H, rise/run
 
-// Stage 11 (2026-08-18): the previous floor, a bare `SPACING`, was one quad wide — the mesh only carries a
-// height *value* at each vertex and linearly interpolates between them, so a falloff one quad wide has
-// exactly one interior region and reads as a straight-line ramp between two heights, not a cosine. That's
-// the root cause stage 9 traced the metre-scale staircase to.
-//
-// How many vertices does the transition need before its piecewise-linear reconstruction can even *look*
-// like the cosine ease rather than a plain ramp? Any 2-point chord is a straight line by definition, so a
-// single segment across a curved arc can never register that the arc bows away from its own endpoints —
-// revealing an arc's curvature needs an interior sample point splitting it into (at least) two
-// sub-segments. The ease `0.5 - 0.5·cos(π·t)` is exactly two such arcs, concave on `t ∈ [0, 0.5]` and
-// convex on `t ∈ [0.5, 1]`, meeting at the single inflection its own point symmetry locates at `t = 0.5`
-// (`ease(t) + ease(1 - t) = 1` for every `t`, since `cos(π·t)` and `cos(π - π·t) = -cos(π·t)` cancel —
-// which is also *why* a coarser, 2-segment sampling fails outright: its only interior point sits exactly
-// on that symmetric midpoint, where `ease(0.5) = 0.5` lands precisely on the endpoint-to-endpoint chord,
-// so both segments measure the same slope and the reconstruction is indistinguishable from a bare linear
-// ramp — proven directly, not just for this cosine, by the identity above).
-//
-// Applying "an arc needs an interior sample to show it isn't straight" to each of the two monotone arcs
-// separately — not just to the whole curve — takes two sub-segments per arc, four total. `flatten.test.ts`
-// pins this as an observable property of {@link flattenHeight}'s own sampled output (each arc's sampled
-// slopes differ from each other), not the arithmetic restated.
-export const FALLOFF_SAMPLE_SEGMENTS = 4;
-
-// The stage's live handover (spec Approach, stage 11): a wider falloff is a visible look change — roads
-// sit in visibly wider cuttings — and that width is a taste call inside a locked technique
-// (`taste.md` row 2), the same shape as stage 8's smoothing radius. `scale` is the live control's own
-// entry point: it multiplies the *result* of the two derived constraints above, never substitutes for
-// either, so `MIN_FALLOFF_SCALE = 1` (`terrain.ts`'s `setFalloffScale` clamp) can never narrow the
-// transition below what either constraint demands — only widen it further, which is the only direction a
-// taste call over this parameter has room to move without contradicting the derivations.
-export const MIN_FALLOFF_SCALE = 1;
-export const MAX_FALLOFF_SCALE = 3; // an arbitrary live-control ceiling, not a derived bound — 3x the
-// technique's own derived width is well past where a cutting reads as a road rather than a valley
-export const DEFAULT_FALLOFF_SCALE = 1; // ships at the derived width itself, not a verdict
-
 /** the falloff distance (metres) whose cosine-ease transition peaks at exactly {@link SIDE_SLOPE_LIMIT}
- *  for a cut of `cutDepth` metres — floored at the max of two independently justified constraints on the
- *  same quantity: {@link FALLOFF_SAMPLE_SEGMENTS} × {@link SPACING} (a transition narrower than that can't
- *  be resolved by the heightfield's own piecewise-linear reconstruction, regardless of what the AASHTO
- *  slope term asks for) and the AASHTO side-slope term below (the slope a driver survives). AASHTO sets
- *  the width the road demands; sampling sets the width the mesh can represent — whichever is wider wins.
- *  `scale` is the live handover's own multiplier on top of both, defaulting to 1 (untouched).
- * @example computeFalloff(0) // FALLOFF_SAMPLE_SEGMENTS * SPACING — no cut, the sampling floor wins
- * @example computeFalloff(40) // (Math.PI / 2) * 40 / SIDE_SLOPE_LIMIT, well past either floor */
-export function computeFalloff(cutDepth: number, scale = 1): number {
-    return (
-        Math.max(FALLOFF_SAMPLE_SEGMENTS * SPACING, ((Math.PI / 2) * cutDepth) / SIDE_SLOPE_LIMIT) *
-        scale
-    );
+ *  for a cut of `cutDepth` metres — floored at {@link SPACING}, since a transition narrower than the mesh's
+ *  own vertex spacing can't be resolved by the heightfield regardless of what the formula asks for.
+ * @example computeFalloff(0) // SPACING — no cut, the floor wins
+ * @example computeFalloff(4) // (Math.PI / 2) * 4 / SIDE_SLOPE_LIMIT, well past the floor */
+export function computeFalloff(cutDepth: number): number {
+    return Math.max(SPACING, ((Math.PI / 2) * cutDepth) / SIDE_SLOPE_LIMIT);
 }
 
 /** cosine-eased blend from `target` (the flattened plateau, at `coreDist <= 0`) out to `natural`
@@ -347,20 +305,13 @@ export function buildNetworkGeometry(
  *  since a new network or radius produces a different segment list and falloff. Mirrors
  *  `overlay/rasterize.ts`'s per-tile buffer-rebuild shape, but persists across the height kernel's own
  *  dispatches instead of being rebuilt per redraw — the kernel dispatches once per reseed, not once per
- *  throttled tile. `falloffScale` is the live handover's own multiplier ({@link computeFalloff}'s `scale`
- *  argument, `terrain.ts`'s `setFalloffScale`) — defaults to 1 (untouched) for every caller that doesn't
- *  pass one. */
-export function setNetwork(
-    doc: StrokeDocument,
-    seed: number,
-    smoothRadius: number,
-    falloffScale = 1,
-): void {
+ *  throttled tile. */
+export function setNetwork(doc: StrokeDocument, seed: number, smoothRadius: number): void {
     teardownNetworkBuffers();
     const { device, root } = Compute;
 
     const { segments, cutDepth } = buildNetworkGeometry(doc, seed, smoothRadius);
-    const falloff = computeFalloff(cutDepth, falloffScale);
+    const falloff = computeFalloff(cutDepth);
     const segmentsData: readonly ProfileSegment[] =
         segments.length > 0
             ? segments

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -21,13 +21,7 @@ import * as overlayAtlas from "../overlay/atlas";
 import type { StrokeDocument } from "../overlay/document";
 import { generateNetwork } from "../overlay/network";
 import { COVERAGE_BAND_PX, DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
-import {
-    DEFAULT_FALLOFF_SCALE,
-    MAX_FALLOFF_SCALE,
-    MIN_FALLOFF_SCALE,
-    setNetwork,
-    warmNetwork,
-} from "./flatten";
+import { setNetwork, warmNetwork } from "./flatten";
 import { bindTerrainKernel, generate, TERRAIN_QUANT } from "./generate";
 import {
     GridIndices,
@@ -187,10 +181,6 @@ const EMPTY_DOCUMENT: StrokeDocument = { polylines: [], polygons: [] };
 // the spec's taste handover: a live control (`boot.ts`'s bracket-key idiom), not a value baked in and
 // declared good. `setSmoothRadius` below is the control's own entry point.
 let smoothRadius = DEFAULT_SMOOTH_RADIUS;
-// stage 11's live handover, the other half of the same session (`boot.ts`'s bracket-key idiom again):
-// the falloff-width multiplier (`terrain/flatten.ts`'s `computeFalloff` `scale` argument). `setFalloffScale`
-// below is the control's own entry point.
-let falloffScale = DEFAULT_FALLOFF_SCALE;
 
 async function warm(state: State): Promise<void> {
     teardown(); // a rebuild (HMR) re-warms — clear the prior generation's buffers first
@@ -268,7 +258,7 @@ async function warm(state: State): Promise<void> {
 
     bindTerrainKernel(vertices, position);
     warmNetwork(state); // its own onDispose registration, the same pattern
-    setNetwork(NO_CUT ? EMPTY_DOCUMENT : liveDocument, currentSeed, smoothRadius, falloffScale); // the flatten kernel's
+    setNetwork(NO_CUT ? EMPTY_DOCUMENT : liveDocument, currentSeed, smoothRadius); // the flatten kernel's
     // geometry input, kept in sync with the overlay's own document and the height kernel's own
     // permutation seed — except under the no-cut control arm, above
     if (state.signal.aborted) return;
@@ -300,7 +290,7 @@ const OverlayRedrawSystem: System = {
 export async function regenerate(seed: number): Promise<void> {
     currentSeed = seed;
     liveDocument = generateNetwork(seed);
-    setNetwork(liveDocument, seed, smoothRadius, falloffScale);
+    setNetwork(liveDocument, seed, smoothRadius);
     overlayAtlas.markDirty(liveDocument);
     await generate(seed);
 }
@@ -314,7 +304,7 @@ export async function regenerate(seed: number): Promise<void> {
  */
 export async function setSmoothRadius(radius: number): Promise<void> {
     smoothRadius = Math.min(MAX_SMOOTH_RADIUS, Math.max(MIN_SMOOTH_RADIUS, radius));
-    setNetwork(liveDocument, currentSeed, smoothRadius, falloffScale);
+    setNetwork(liveDocument, currentSeed, smoothRadius);
     await generate(currentSeed);
 }
 
@@ -322,26 +312,6 @@ export async function setSmoothRadius(radius: number): Promise<void> {
  *  value, and by tests. */
 export function getSmoothRadius(): number {
     return smoothRadius;
-}
-
-/**
- * the falloff-width live control (`boot.ts`'s `-`/`=` handler, stage 11's own half of this session's two-
- * knob handover): re-derives the network's flatten geometry at the new scale and re-dispatches the height
- * kernel — the same shape as {@link setSmoothRadius}, no overlay `markDirty` needed for the same reason
- * (only target heights move). Clamped to `[MIN_FALLOFF_SCALE, MAX_FALLOFF_SCALE]` (`terrain/flatten.ts`) —
- * the lower bound is 1, never narrowing the transition below either of `computeFalloff`'s two derived
- * constraints.
- */
-export async function setFalloffScale(scale: number): Promise<void> {
-    falloffScale = Math.min(MAX_FALLOFF_SCALE, Math.max(MIN_FALLOFF_SCALE, scale));
-    setNetwork(liveDocument, currentSeed, smoothRadius, falloffScale);
-    await generate(currentSeed);
-}
-
-/** the live falloff-width scale — read by the boot's key handler to step relative to the current value,
- *  and by tests. */
-export function getFalloffScale(): number {
-    return falloffScale;
 }
 
 /**
@@ -364,7 +334,7 @@ export function getFalloffScale(): number {
  * this stage didn't touch).
  */
 export function syncNetworkForSeed(seed: number): void {
-    setNetwork(liveDocument, seed, smoothRadius, falloffScale);
+    setNetwork(liveDocument, seed, smoothRadius);
 }
 
 /** whether every marked overlay tile has drained through the atlas — the device gate polls this before


### PR DESCRIPTION
## Problem

Stage 11c's live human read refuted stage 11a's falloff-width treatment (the sampling-derived floor and the `-`/`=` live scale knob): "it does absolutely nothing for the road stairstep issue. it just seems to perturb the terrain away from the road." The knob perturbs terrain away from the road without touching the reported defect (metre-scale reconstruction stairstep).

## Fix

Removes stage 11a entirely: `FALLOFF_SAMPLE_SEGMENTS` and its derivation comment, the `Math.max(FALLOFF_SAMPLE_SEGMENTS * SPACING, …)` term (`computeFalloff`'s floor reverts to bare `SPACING`), `MIN/MAX/DEFAULT_FALLOFF_SCALE`, `computeFalloff`'s `scale` parameter and every call site (`terrain.ts`'s `falloffScale` state/`set`/`getFalloffScale`, `boot.ts`'s `-`/`=` handler and `__roadsFalloffScale`, `flatness.ts`'s `buildDeviceFreeVertices`/`reconstructionAgreement`, `gate.ts`). Tests pinned to the removed knob come out of `flatten.test.ts` and `flatness.test.ts`; `boundaryAnchors.test.ts` loses the 0.988 m bound-floor-offset pin (the floor is inert again) but keeps the generic `coupled(floor)` machinery test, which predates 11a and pins stage 11b's own decoupling property.

A second commit restores a mesh-resolution discrimination test an adversarial review found had been dropped as collateral: the deleted "arm iv" block conflated a falloff-scale leg (dead, correctly removed) with a mesh-resolution leg (SPACING vs SPACING/2) that has nothing to do with the removed knob and was the suite's only coverage of the oracle's sensitivity to mesh resolution.

## Evidence

Stage 12's surface-flatness oracle amplitude, unchanged within noise across the removal (measured via `checkSurfaceFlatness`, same computation the deleted arm-iv test used):
- `longMaxDelta`: 0.3436 → 0.3446 (+0.3%)
- `crossMaxDelta`: 0.4737 → 0.4749 (+0.3%)

Both well inside the ~10x-separation bar the spec's own arm (iv) used to call a treatment inert.

## Test plan

- [x] `bun test ./examples/showcase/roads/src` — 153 pass, 0 fail, 6690 `expect()`, exit 0 (before: 159 pass/6652 expect; -6 net tests from removing 11a's own pins, +1 restored mesh-resolution test)
- [x] `bun run gate` (real device) — adapter `nvidia lovelace`, 1 passed, 2 skipped (pre-existing opt-in arms), exit 0
- [x] `bun run format` / `bun check` — both exit 0
- [x] Adversarial review (separate executor-tier agent, frozen diff + spec path + recorded floors) — one medium finding (mesh-resolution coverage dropped as collateral) fixed in the second commit; one low finding (stale docblock cross-references) auto-resolved by that fix