### PR TITLE
shallot-prebuilt-binaries: close fixes

### DIFF
--- a/packages/shallot/AGENTS.md
+++ b/packages/shallot/AGENTS.md
@@ -12,7 +12,7 @@ bunx shallot run [dir]      # build + preview
 bunx shallot verify [dir]   # headless-browser gate, exit 0/nonzero (below)
 ```
 
-The check is `bunx tsc --noEmit` — run it after every change. Native builds (`bunx shallot build --target windows|mac|linux`, `--portable` for bundled Chromium) work from a standard install — the rust window host ships as crate source and compiles on first build, so they need the Rust toolchain plus the target's system dependencies. If you author TGSL, add `eslint-plugin-typegpu` too; the engine runs its recommended rules with zero warnings allowed.
+The check is `bunx tsc --noEmit` — run it after every change. Native builds (`bunx shallot build --target windows|mac|linux`, `--portable` for bundled Chromium) download a prebuilt shell from GitHub Releases when available (no Rust toolchain needed); on a miss, compiles from source, needing the Rust toolchain plus per-target system dependencies. If you author TGSL, add `eslint-plugin-typegpu` too; the engine runs its recommended rules with zero warnings allowed.
 
 A project is pure data: `shallot.json` (the manifest: scene + plugin enablement) + `public/scenes/*.scene` + plugin modules under `src/`. No index.html, no vite config — the CLI supplies the scaffolding.
 

--- a/packages/shallot/README.md
+++ b/packages/shallot/README.md
@@ -15,7 +15,7 @@ bun install
 bunx shallot dev    # run it, with hot reload
 ```
 
-`bunx shallot build` ships it as a web bundle. `bunx shallot verify` boots the project in a headless browser and exits 0 or nonzero; it needs the optional playwright peer (`bun add -d playwright && bunx playwright install chromium`). Native builds (`--target windows|mac|linux`) work from a standard install: the rust window host ships as crate source and compiles on first build, so you need the Rust toolchain plus your target's system dependencies.
+`bunx shallot build` ships it as a web bundle. `bunx shallot verify` boots the project in a headless browser and exits 0 or nonzero; it needs the optional playwright peer (`bun add -d playwright && bunx playwright install chromium`). Native builds (`--target windows|mac|linux`) download a prebuilt release shell from GitHub Releases when available (no Rust toolchain needed); on any miss — 404, offline, checksum mismatch, or a source checkout — they fall back to compiling the Rust window host from source, which needs the Rust toolchain plus per-target system dependencies.
 
 ## add to an existing project
 

--- a/packages/shallot/bin/prebuilt.test.ts
+++ b/packages/shallot/bin/prebuilt.test.ts
@@ -73,14 +73,19 @@ describe("resolvePrebuiltDecision", () => {
         expect(d.decision).toBe("lazy");
     });
 
+    // Exhaustive over PrebuiltFetchResult. The Record<..., true> assignment fails at compile time
+    // if the union gains a member, so the arm's name stays true to its assertion (checks.md).
     test("every fetch result maps to a decision with a non-empty reason", () => {
-        const results: PrebuiltFetchResult[] = [
-            "ok",
-            "not-found",
-            "offline",
-            "checksum-mismatch",
-            "source-checkout",
-        ];
+        const exhaustive: Record<PrebuiltFetchResult, true> = {
+            ok: true,
+            "not-found": true,
+            offline: true,
+            "checksum-mismatch": true,
+            "source-checkout": true,
+            "extract-failed": true,
+            "cache-error": true,
+        };
+        const results = Object.keys(exhaustive) as PrebuiltFetchResult[];
         for (const fr of results) {
             const d = resolvePrebuiltDecision("1.0.0", target, mode, false, fr);
             expect(d.reason.length).toBeGreaterThan(0);
@@ -363,6 +368,128 @@ describe("tryPrebuilt resolver", () => {
             else process.env.XDG_CACHE_HOME = prevXdg;
             globalThis.fetch = prevFetch;
             console.log = prevLog;
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    // F5: a successful extract returns a non-null result with the binary path and a .complete
+    // sentinel. All four existing arms assert toBeNull(); without a success arm, reverting the
+    // success wiring to `return null` leaves the suite green — the exact regression this arm
+    // catches. Reuses the extractTarGz fixture machinery (tar -czf from a src dir).
+    test("successful system extract -> non-null result with binary path + sentinel", async () => {
+        const tmp = mkdtempSync(join(tmpdir(), "shallot-f5-sys-"));
+        const prevXdg = process.env.XDG_CACHE_HOME;
+        const prevFetch = globalThis.fetch;
+        process.env.XDG_CACHE_HOME = tmp;
+        try {
+            const srcDir = join(tmp, "src");
+            mkdirSync(srcDir, { recursive: true });
+            writeFileSync(join(srcDir, "shallot-window"), "#!/bin/sh\necho hi\n");
+            const archivePath = join(tmp, "test.tar.gz");
+            execSync(`tar -czf "${archivePath}" -C "${srcDir}" .`, { stdio: "pipe" });
+            const archiveBuf = readFileSync(archivePath);
+            const archiveHash = sha256Hex(archiveBuf);
+            const archiveName = prebuiltArchiveName(LINUX, "system");
+            const sumsContent = `${archiveHash}  ${archiveName}\n`;
+
+            globalThis.fetch = ((url: string) => {
+                if (url.includes("SHA256SUMS")) {
+                    return Promise.resolve(new Response(sumsContent, { status: 200 }));
+                }
+                return Promise.resolve(new Response(archiveBuf, { status: 200 }));
+            }) as unknown as typeof fetch;
+
+            const result = await tryPrebuilt(LINUX, true, false, "1.0.0");
+            expect(result).not.toBeNull();
+            const cacheDir = prebuiltCacheDir("1.0.0", LINUX, "system");
+            expect(result!.binaryPath).toBe(resolve(cacheDir, "shallot-window"));
+            expect(result!.cefDir).toBeUndefined();
+            expect(existsSync(join(cacheDir, ".complete"))).toBe(true);
+        } finally {
+            if (prevXdg === undefined) delete process.env.XDG_CACHE_HOME;
+            else process.env.XDG_CACHE_HOME = prevXdg;
+            globalThis.fetch = prevFetch;
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    // F5 (linux portable): cefDir points at the cef/ subdir, not the cache root.
+    test("successful linux portable extract -> non-null result with binary/cefDir paths + sentinel", async () => {
+        const tmp = mkdtempSync(join(tmpdir(), "shallot-f5-lx-"));
+        const prevXdg = process.env.XDG_CACHE_HOME;
+        const prevFetch = globalThis.fetch;
+        process.env.XDG_CACHE_HOME = tmp;
+        try {
+            const srcDir = join(tmp, "src");
+            mkdirSync(join(srcDir, "cef"), { recursive: true });
+            writeFileSync(join(srcDir, "shallot-window"), "#!/bin/sh\necho hi\n");
+            writeFileSync(join(srcDir, "cef", "libcef.so"), "fake cef");
+            const archivePath = join(tmp, "test.tar.gz");
+            execSync(`tar -czf "${archivePath}" -C "${srcDir}" .`, { stdio: "pipe" });
+            const archiveBuf = readFileSync(archivePath);
+            const archiveHash = sha256Hex(archiveBuf);
+            const archiveName = prebuiltArchiveName(LINUX, "portable");
+            const sumsContent = `${archiveHash}  ${archiveName}\n`;
+
+            globalThis.fetch = ((url: string) => {
+                if (url.includes("SHA256SUMS")) {
+                    return Promise.resolve(new Response(sumsContent, { status: 200 }));
+                }
+                return Promise.resolve(new Response(archiveBuf, { status: 200 }));
+            }) as unknown as typeof fetch;
+
+            const result = await tryPrebuilt(LINUX, true, true, "1.0.0");
+            expect(result).not.toBeNull();
+            const cacheDir = prebuiltCacheDir("1.0.0", LINUX, "portable");
+            expect(result!.binaryPath).toBe(resolve(cacheDir, "shallot-window"));
+            expect(result!.cefDir).toBe(resolve(cacheDir, "cef"));
+            expect(existsSync(join(cacheDir, ".complete"))).toBe(true);
+        } finally {
+            if (prevXdg === undefined) delete process.env.XDG_CACHE_HOME;
+            else process.env.XDG_CACHE_HOME = prevXdg;
+            globalThis.fetch = prevFetch;
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+
+    // F5 (mac portable): cefDir is the cache root itself (CEF framework at top level), and
+    // helperPath points at shallot-helper — the two path shapes the other arms don't reach.
+    const Mac = "aarch64-apple-darwin";
+    test("successful mac portable extract -> non-null result with binary/cefDir/helper paths + sentinel", async () => {
+        const tmp = mkdtempSync(join(tmpdir(), "shallot-f5-mac-"));
+        const prevXdg = process.env.XDG_CACHE_HOME;
+        const prevFetch = globalThis.fetch;
+        process.env.XDG_CACHE_HOME = tmp;
+        try {
+            const srcDir = join(tmp, "src");
+            mkdirSync(srcDir, { recursive: true });
+            writeFileSync(join(srcDir, "shallot-window"), "#!/bin/sh\necho hi\n");
+            writeFileSync(join(srcDir, "shallot-helper"), "#!/bin/sh\necho helper\n");
+            const archivePath = join(tmp, "test.tar.gz");
+            execSync(`tar -czf "${archivePath}" -C "${srcDir}" .`, { stdio: "pipe" });
+            const archiveBuf = readFileSync(archivePath);
+            const archiveHash = sha256Hex(archiveBuf);
+            const archiveName = prebuiltArchiveName(Mac, "portable");
+            const sumsContent = `${archiveHash}  ${archiveName}\n`;
+
+            globalThis.fetch = ((url: string) => {
+                if (url.includes("SHA256SUMS")) {
+                    return Promise.resolve(new Response(sumsContent, { status: 200 }));
+                }
+                return Promise.resolve(new Response(archiveBuf, { status: 200 }));
+            }) as unknown as typeof fetch;
+
+            const result = await tryPrebuilt(Mac, true, true, "1.0.0");
+            expect(result).not.toBeNull();
+            const cacheDir = prebuiltCacheDir("1.0.0", Mac, "portable");
+            expect(result!.binaryPath).toBe(resolve(cacheDir, "shallot-window"));
+            expect(result!.cefDir).toBe(cacheDir);
+            expect(result!.helperPath).toBe(resolve(cacheDir, "shallot-helper"));
+            expect(existsSync(join(cacheDir, ".complete"))).toBe(true);
+        } finally {
+            if (prevXdg === undefined) delete process.env.XDG_CACHE_HOME;
+            else process.env.XDG_CACHE_HOME = prevXdg;
+            globalThis.fetch = prevFetch;
             rmSync(tmp, { recursive: true, force: true });
         }
     });

--- a/scripts/e2e-prebuilt.ts
+++ b/scripts/e2e-prebuilt.ts
@@ -35,6 +35,8 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
+// GitHub run artifacts expire (~90 days). If this run's artifacts are gone, substitute a fresh
+// workflow_dispatch run id from `gh run list --workflow release.yml`.
 const GREEN_RUN_ID = "32253745114";
 const REPO = "dylanebert/shallot";
 const LINUX_TARGET = "x86_64-unknown-linux-gnu";


### PR DESCRIPTION
Finding 1 [medium]: stale npm-shipped docs (README.md, AGENTS.md) still said
native builds REQUIRE the Rust toolchain — the exact claim this unit falsified.
Rewritten to state prebuilt-first behavior: release builds download a prebuilt
shell from GitHub Releases; any miss falls back to lazy compile, which needs the
Rust toolchain + system deps.

Finding 2 [medium]: no success-path arm for tryPrebuilt — all four existing arms
assert toBeNull(), so reverting the success wiring to return null left all 248
green. Added three arms (system, linux-portable, mac-portable) that drive
tryPrebuilt to a non-null result against local fixture archives with no network,
asserting binary/cefDir/helper paths and the .complete sentinel. Proven red-first
both ways: return null after extract (3 fail), drop sentinel write (3 fail).

Finding 3 [low]: the every-fetch-result arm iterated 5 of 7 fetch results,
omitting extract-failed and cache-error. Made exhaustive over the union type via
a Record<PrebuiltFetchResult, true> assignment (compile-time drift guard).

Also: added a durability comment beside GREEN_RUN_ID in e2e-prebuilt.ts noting
GitHub run artifacts expire (~90 days) and naming the fix.
