### PR TITLE
shallot roads/stage 17

### DIFF
--- a/examples/showcase/roads/src/flatness.test.ts
+++ b/examples/showcase/roads/src/flatness.test.ts
@@ -343,7 +343,7 @@ describe("surface flatness — stage 17 arm (a): synthetic non-overlapping netwo
     // a hand-built NON-OVERLAPPING network: five straight roads at 30° heading (not 0°/45°/90°),
     // 200 m apart perpendicular to the heading, 200 m long, plus one 32 m carpark square clear of all
     // roads. Chord endpoint heights are the natural terrain heights (`heightAtCpu`). The 200 m spacing
-    // is well above the ~57 m clearance the chord's own falloff demands (`computeFalloff(cutDepth) +
+    // is well above the ~63 m clearance the chord's own falloff demands (`computeFalloff(cutDepth) +
     // halfWidth + FLAT_CORE_MARGIN`), so no two primitives' falloff bands overlap — the junction zone is
     // empty by construction, and the affine-exactness argument holds at every sampled station.
     const Heading = Math.PI / 6; // 30° — non-axis- and non-45°-aligned
@@ -368,7 +368,7 @@ describe("surface flatness — stage 17 arm (a): synthetic non-overlapping netwo
             halfWidth: RoadHw,
         });
     }
-    // carpark at (450, 450) — far from every road (nearest road centre is ~800 m away)
+    // carpark at (450, 450) — far from every road (nearest road centre is ~516 m away)
     const polygons: PolygonStamp[] = [
         {
             points: [
@@ -387,7 +387,7 @@ describe("surface flatness — stage 17 arm (a): synthetic non-overlapping netwo
     const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
 
     test("the junction zone is empty — no two primitives' cores come within JUNCTION_ZONE", () => {
-        // with 200 m spacing and the carpark 800 m from the nearest road, no sampled station falls
+        // with 200 m spacing and the carpark 516 m from the nearest road, no sampled station falls
         // inside a junction zone — `excludedStationCount === 0` is the structural precondition for the
         // exact-zero claim (the carve-out is a deletion primitive, `checks.md`).
         const coarseRaw = buildLatticeVertices(
@@ -421,6 +421,7 @@ describe("surface flatness — stage 17 arm (a): synthetic non-overlapping netwo
             (x, z) => meshHeightAt(coarseRaw, x, z, SPACING, CELLS),
             syntheticDoc,
         );
+        expect(result.sampleCount).toBeGreaterThan(1000);
         expect(result.crossSection.length).toBe(0);
         expect(result.maxCrossSectionExcess).toBe(0);
         expect(result.longitudinal.length).toBe(0);
@@ -443,8 +444,10 @@ describe("surface flatness — stage 17 arm (a): synthetic non-overlapping netwo
             syntheticDoc,
         );
         console.log(
-            `SYNTH_SPACING_HALF crossSection=${result.crossSection.length} longitudinal=${result.longitudinal.length} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(5)} maxLongitudinalExcess=${result.maxLongitudinalExcess.toFixed(5)} excludedStationCount=${result.excludedStationCount}`,
+            `SYNTH_SPACING_HALF crossSection=${result.crossSection.length} longitudinal=${result.longitudinal.length} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(5)} maxLongitudinalExcess=${result.maxLongitudinalExcess.toFixed(5)} excludedStationCount=${result.excludedStationCount} sampleCount=${result.sampleCount}`,
         );
+        expect(result.sampleCount).toBeGreaterThan(1000);
+        expect(result.excludedStationCount).toBe(0);
         expect(result.crossSection.length).toBe(0);
         expect(result.maxCrossSectionExcess).toBe(0);
         expect(result.longitudinal.length).toBe(0);
@@ -475,7 +478,7 @@ describe("surface flatness — stage 17 arm (b): chord over overlapping generate
         console.log(
             `OVERLAP_ARM_SPACING crossSection=${result.crossSection.length} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(5)} longitudinal=${result.longitudinal.length} maxLongitudinalExcess=${result.maxLongitudinalExcess.toFixed(5)}`,
         );
-        // band: well above zero, not fitted to the exact reading (scoping: 96 / 0.23559 m).
+        // band: well above zero, not fitted to the exact reading (scoping: 99 / 0.23559 m).
         // The amplitude is the discriminating statistic — it sat still at 0.2373 → 0.2356 m across the
         // smoothed → chord profile swap, proving the chord removed the non-junction reconstruction error
         // (count fell 362 → 96) without touching the overlap contamination (amplitude stayed).

--- a/examples/showcase/roads/src/flatness.test.ts
+++ b/examples/showcase/roads/src/flatness.test.ts
@@ -14,7 +14,7 @@ import {
     reconstructionAgreement,
     SAMPLE_STEP,
 } from "./flatness";
-import type { StrokeDocument } from "./overlay/document";
+import type { PolygonStamp, Polyline, StrokeDocument } from "./overlay/document";
 import { generateNetwork } from "./overlay/network";
 import { buildNetworkGeometry, computeFalloff, FLAT_CORE_MARGIN } from "./terrain/flatten";
 import { CELLS, SPACING } from "./terrain/grid";
@@ -83,22 +83,23 @@ describe("surface flatness — Leg A: the continuous field, no mesh (arm v)", ()
     const falloff = computeFalloff(cutDepth);
     const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
 
-    test("red-first: band = falloff reads 417 / 0.493 m (the consult's refuted candidate)", () => {
+    test("red-first: band = falloff still reads non-zero — the chord's affine target reduces but does not eliminate the slow-suppression contamination", () => {
         // the suppression band set to the falloff distance is too slow — primitives farther away still
-        // contribute, so the blend contamination leaks outside the junction zone. The consult measured
-        // 417 total cross-section violations / 0.493 m at the analytic limit; this reproduces that red
-        // reading before the green arm, witnessing the instrument discriminates (a pin that reads green on
-        // a broken blend is worth nothing — `coding.md`'s "a check is evidence only if you've seen it
-        // fail").
+        // contribute, so the blend contamination leaks outside the junction zone. Under the smoothed
+        // profile this read 417 / 0.493 m (the consult's refuted candidate); under the chord it reads
+        // 311 / 0.383 m — the amplitude drops (the chord's affine target is less curved than the
+        // smoothed profile's) but is still clearly non-zero, witnessing the instrument discriminates (a
+        // pin that reads green on a broken blend is worth nothing — `coding.md`'s "a check is evidence
+        // only if you've seen it fail"). Pinned with a band, not the old fitted `> 0.4` equality, since
+        // the chord genuinely changed the amplitude.
         const sample = (x: number, z: number) =>
             flattenFieldAt(x, z, segments, doc.polygons, falloff, natural, falloff);
         const result = checkSurfaceFlatness(sample, doc);
-        const total = result.crossSection.length + result.crossSectionInZone.length;
         console.log(
-            `LEG_A_RED_FALLOFF crossSection=${result.crossSection.length} crossSectionInZone=${result.crossSectionInZone.length} total=${total} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(4)}`,
+            `LEG_A_FALLOFF_CHORD crossSection=${result.crossSection.length} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(5)}`,
         );
-        expect(result.crossSection.length).toBeGreaterThan(0);
-        expect(result.maxCrossSectionExcess).toBeGreaterThan(0.4);
+        expect(result.crossSection.length).toBeGreaterThan(100);
+        expect(result.maxCrossSectionExcess).toBeGreaterThan(0.1);
     });
 
     test("the shipped band reads exactly zero outside the junction zone on both axes", () => {
@@ -245,16 +246,19 @@ describe("surface flatness — Leg B: convergence (the real mesh outside the zon
         expect(ratio).toBeLessThanOrEqual(0.75);
     });
 
-    test("both counts strictly decrease from SPACING to SPACING/2", () => {
-        // convergence is monotone: halving the cell halves the violations on both axes. The counts are
-        // pinned as strictly decreasing (not as absolute numbers — a count bound is a non-discriminating
-        // statistic, `checks.md`'s amplitude-never-count clause, and `longitudinal.length < 20` violated
-        // that at 15b).
+    test("cross-section count strictly decreases from SPACING to SPACING/2 (longitudinal is non-discriminating)", () => {
+        // convergence is monotone: halving the cell halves the cross-section violations. The cross-section
+        // count is the discriminating axis (it moves with the blend's non-affine contamination); the
+        // longitudinal count is a non-discriminating statistic (amplitude, never count — `checks.md`'s
+        // clause), and on the chord profile it is small enough (2 at SPACING, 3 at SPACING/2) that a
+        // strict-decrease assertion is noise, not signal. Stage 17: the chord's longitudinal count
+        // actually *increases* 2→3 (both are junction-zone samples, and the finer mesh has more samples
+        // near the zone), so the old both-counts-decrease assertion is retired and only the
+        // cross-section count is pinned.
         console.log(
             `LEG_B_COUNTS coarse_crossSection=${coarse.crossSection.length} fine_crossSection=${fine.crossSection.length} coarse_longitudinal=${coarse.longitudinal.length} fine_longitudinal=${fine.longitudinal.length}`,
         );
         expect(fine.crossSection.length).toBeLessThan(coarse.crossSection.length);
-        expect(fine.longitudinal.length).toBeLessThan(coarse.longitudinal.length);
     });
 });
 
@@ -324,5 +328,182 @@ describe("reconstructionAgreement — the device arm's own fidelity pin", () => 
         const agreement = reconstructionAgreement(deviceStandIn, doc, SEED, DEFAULT_SMOOTH_RADIUS);
         expect(agreement.sampleCount).toBeGreaterThan(0);
         expect(agreement.maxDiffM).toBeLessThanOrEqual(RECONSTRUCTION_AGREEMENT_TOL);
+    });
+});
+
+// Stage 17's two exactness arms — the instrument that decides a round ships with the chord profile
+// (spec Validation, "Surface flatness in the corridor"). The chord's affine target makes the in-corridor
+// reconstruction error vanish identically on a non-overlapping network (barycentric interpolation
+// reproduces an affine field exactly at any cell size and any road angle), and the overlap arm is the
+// discriminating proof that non-overlap is what buys exactness: where two primitives' falloffs overlap,
+// the composite target is a position-weighted combination of two affine fields and is not affine, so
+// exactness dies there and nowhere else.
+
+describe("surface flatness — stage 17 arm (a): synthetic non-overlapping network reads exactly zero", () => {
+    // a hand-built NON-OVERLAPPING network: five straight roads at 30° heading (not 0°/45°/90°),
+    // 200 m apart perpendicular to the heading, 200 m long, plus one 32 m carpark square clear of all
+    // roads. Chord endpoint heights are the natural terrain heights (`heightAtCpu`). The 200 m spacing
+    // is well above the ~57 m clearance the chord's own falloff demands (`computeFalloff(cutDepth) +
+    // halfWidth + FLAT_CORE_MARGIN`), so no two primitives' falloff bands overlap — the junction zone is
+    // empty by construction, and the affine-exactness argument holds at every sampled station.
+    const Heading = Math.PI / 6; // 30° — non-axis- and non-45°-aligned
+    const RoadSpacing = 200; // metres, perpendicular separation between adjacent roads
+    const RoadLen = 200; // metres
+    const RoadHw = 4; // halfWidth, matching the generator's ROAD_HALF_WIDTH
+    const CarparkHalf = 16; // 32 m carpark square, half-extent
+    const ux = Math.cos(Heading);
+    const uz = Math.sin(Heading);
+    const nx = -uz;
+    const nz = ux;
+
+    const polylines: Polyline[] = [];
+    for (let i = -2; i <= 2; i++) {
+        const cx = nx * i * RoadSpacing;
+        const cz = nz * i * RoadSpacing;
+        polylines.push({
+            points: [
+                [cx - ux * (RoadLen / 2), cz - uz * (RoadLen / 2)],
+                [cx + ux * (RoadLen / 2), cz + uz * (RoadLen / 2)],
+            ],
+            halfWidth: RoadHw,
+        });
+    }
+    // carpark at (450, 450) — far from every road (nearest road centre is ~800 m away)
+    const polygons: PolygonStamp[] = [
+        {
+            points: [
+                [450 - CarparkHalf, 450 - CarparkHalf],
+                [450 + CarparkHalf, 450 - CarparkHalf],
+                [450 + CarparkHalf, 450 + CarparkHalf],
+                [450 - CarparkHalf, 450 + CarparkHalf],
+            ],
+        },
+    ];
+    const syntheticDoc: StrokeDocument = { polylines, polygons };
+
+    const perm = makePermutation(SEED);
+    const { segments, cutDepth } = buildNetworkGeometry(syntheticDoc, SEED, DEFAULT_SMOOTH_RADIUS);
+    const falloff = computeFalloff(cutDepth);
+    const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
+
+    test("the junction zone is empty — no two primitives' cores come within JUNCTION_ZONE", () => {
+        // with 200 m spacing and the carpark 800 m from the nearest road, no sampled station falls
+        // inside a junction zone — `excludedStationCount === 0` is the structural precondition for the
+        // exact-zero claim (the carve-out is a deletion primitive, `checks.md`).
+        const coarseRaw = buildLatticeVertices(
+            SPACING,
+            CELLS,
+            segments,
+            polygons,
+            falloff,
+            natural,
+        );
+        const result = checkSurfaceFlatness(
+            (x, z) => meshHeightAt(coarseRaw, x, z, SPACING, CELLS),
+            syntheticDoc,
+        );
+        console.log(
+            `SYNTH_SPACING crossSection=${result.crossSection.length} longitudinal=${result.longitudinal.length} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(5)} maxLongitudinalExcess=${result.maxLongitudinalExcess.toFixed(5)} excludedStationCount=${result.excludedStationCount} sampleCount=${result.sampleCount} cutDepth=${cutDepth.toFixed(4)} falloff=${falloff.toFixed(4)}`,
+        );
+        expect(result.excludedStationCount).toBe(0);
+    });
+
+    test("exactly 0 violations and 0.0000 m on both axes at SPACING", () => {
+        const coarseRaw = buildLatticeVertices(
+            SPACING,
+            CELLS,
+            segments,
+            polygons,
+            falloff,
+            natural,
+        );
+        const result = checkSurfaceFlatness(
+            (x, z) => meshHeightAt(coarseRaw, x, z, SPACING, CELLS),
+            syntheticDoc,
+        );
+        expect(result.crossSection.length).toBe(0);
+        expect(result.maxCrossSectionExcess).toBe(0);
+        expect(result.longitudinal.length).toBe(0);
+        expect(result.maxLongitudinalExcess).toBe(0);
+    });
+
+    test("exactly 0 violations and 0.0000 m on both axes at SPACING/2", () => {
+        const fineSpacing = SPACING / 2;
+        const fineCells = CELLS * 2;
+        const fineRaw = buildLatticeVertices(
+            fineSpacing,
+            fineCells,
+            segments,
+            polygons,
+            falloff,
+            natural,
+        );
+        const result = checkSurfaceFlatness(
+            (x, z) => meshHeightAt(fineRaw, x, z, fineSpacing, fineCells),
+            syntheticDoc,
+        );
+        console.log(
+            `SYNTH_SPACING_HALF crossSection=${result.crossSection.length} longitudinal=${result.longitudinal.length} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(5)} maxLongitudinalExcess=${result.maxLongitudinalExcess.toFixed(5)} excludedStationCount=${result.excludedStationCount}`,
+        );
+        expect(result.crossSection.length).toBe(0);
+        expect(result.maxCrossSectionExcess).toBe(0);
+        expect(result.longitudinal.length).toBe(0);
+        expect(result.maxLongitudinalExcess).toBe(0);
+    });
+});
+
+describe("surface flatness — stage 17 arm (b): chord over overlapping generateNetwork(SEED) stays non-zero", () => {
+    // the red-first overlap arm — the same chord profile over `generateNetwork(SEED)`'s overlapping
+    // roads. This arm is the discriminating proof that non-overlap is what buys exactness: where two
+    // primitives' falloffs overlap, `networkCoreCpu` blends their targets by a position-dependent weight,
+    // so the composite target is a position-weighted combination of two affine fields and is NOT affine.
+    // Barycentric interpolation cannot reproduce a non-affine field, so the reconstruction error is
+    // non-zero exactly there and nowhere else. This arm MUST stay red — it is the evidence that the
+    // synthetic arm's zero is a property of non-overlap, not of the chord profile alone. A zero reading
+    // here would mean the generator no longer produces overlaps, which is stage 18's guarantee, not this
+    // stage's. Pinned with a band (not a fitted equality) because the count is a non-discriminating
+    // statistic (amplitude, never count) and the exact digits are a scoping measurement, not a floor.
+    const doc = generateNetwork(SEED);
+    const perm = makePermutation(SEED);
+    const { segments, cutDepth } = buildNetworkGeometry(doc, SEED, DEFAULT_SMOOTH_RADIUS);
+    const falloff = computeFalloff(cutDepth);
+    const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
+
+    test("non-zero at SPACING — cross-section violations and amplitude both clearly above zero", () => {
+        const raw = buildLatticeVertices(SPACING, CELLS, segments, doc.polygons, falloff, natural);
+        const result = checkSurfaceFlatness((x, z) => meshHeightAt(raw, x, z, SPACING, CELLS), doc);
+        console.log(
+            `OVERLAP_ARM_SPACING crossSection=${result.crossSection.length} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(5)} longitudinal=${result.longitudinal.length} maxLongitudinalExcess=${result.maxLongitudinalExcess.toFixed(5)}`,
+        );
+        // band: well above zero, not fitted to the exact reading (scoping: 96 / 0.23559 m).
+        // The amplitude is the discriminating statistic — it sat still at 0.2373 → 0.2356 m across the
+        // smoothed → chord profile swap, proving the chord removed the non-junction reconstruction error
+        // (count fell 362 → 96) without touching the overlap contamination (amplitude stayed).
+        expect(result.crossSection.length).toBeGreaterThan(50);
+        expect(result.maxCrossSectionExcess).toBeGreaterThan(0.1);
+    });
+
+    test("non-zero at SPACING/2 — amplitude roughly half of SPACING (convergence), still clearly above zero", () => {
+        const fineSpacing = SPACING / 2;
+        const fineCells = CELLS * 2;
+        const raw = buildLatticeVertices(
+            fineSpacing,
+            fineCells,
+            segments,
+            doc.polygons,
+            falloff,
+            natural,
+        );
+        const result = checkSurfaceFlatness(
+            (x, z) => meshHeightAt(raw, x, z, fineSpacing, fineCells),
+            doc,
+        );
+        console.log(
+            `OVERLAP_ARM_SPACING_HALF crossSection=${result.crossSection.length} maxCrossSectionExcess=${result.maxCrossSectionExcess.toFixed(5)} longitudinal=${result.longitudinal.length} maxLongitudinalExcess=${result.maxLongitudinalExcess.toFixed(5)}`,
+        );
+        // band: scoping measurement 50 / 0.11164 m. The amplitude is ~0.47× the SPACING reading,
+        // consistent with first-order convergence — but still clearly non-zero.
+        expect(result.crossSection.length).toBeGreaterThan(20);
+        expect(result.maxCrossSectionExcess).toBeGreaterThan(0.05);
     });
 });

--- a/examples/showcase/roads/src/flatness.test.ts
+++ b/examples/showcase/roads/src/flatness.test.ts
@@ -481,7 +481,7 @@ describe("surface flatness — stage 17 arm (b): chord over overlapping generate
         // band: well above zero, not fitted to the exact reading (scoping: 99 / 0.23559 m).
         // The amplitude is the discriminating statistic — it sat still at 0.2373 → 0.2356 m across the
         // smoothed → chord profile swap, proving the chord removed the non-junction reconstruction error
-        // (count fell 362 → 96) without touching the overlap contamination (amplitude stayed).
+        // (count fell 362 → 99) without touching the overlap contamination (amplitude stayed).
         expect(result.crossSection.length).toBeGreaterThan(50);
         expect(result.maxCrossSectionExcess).toBeGreaterThan(0.1);
     });

--- a/examples/showcase/roads/src/terrain/flatten.test.ts
+++ b/examples/showcase/roads/src/terrain/flatten.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./flatten";
 import { SPACING } from "./grid";
 import { mulberry32 } from "./noise";
-import { MAX_GRADE, PROFILE_STEP } from "./profile";
+import { MAX_GRADE } from "./profile";
 
 // FALLOFF is no longer a fixed module constant (stage 8's re-derivation, `flatten.ts`'s module header) —
 // these pure-math tests exercise `flattenHeight`/`flattenHeightGpu` at an arbitrary representative
@@ -143,62 +143,63 @@ describe("computeFalloff — the re-derived FALLOFF (stage 8)", () => {
 });
 
 describe("buildNetworkGeometry — the CPU profile-to-segment builder", () => {
-    test("every polyline resamples to <= PROFILE_STEP-spaced sub-segments spanning its own endpoints", () => {
+    test("every polyline produces exactly one chord segment spanning its own endpoints (stage 17)", () => {
+        // the chord profile returns exactly two profile points per polyline (the endpoints), so
+        // `buildNetworkGeometry` emits one segment per road — no resampling, no sub-segments.
         const doc = generateNetwork(42);
         const { segments } = buildNetworkGeometry(doc, 1337, 3);
-        expect(segments.length).toBeGreaterThan(doc.polylines.length); // each 2-point road subdivides
-        for (const seg of segments) {
-            const len = Math.hypot(seg.bx - seg.ax, seg.bz - seg.az);
-            expect(len).toBeLessThanOrEqual(PROFILE_STEP + 1e-6);
-        }
-    });
-
-    test("consecutive sub-segments of one road chain endpoint to endpoint, no gap", () => {
-        const doc = generateNetwork(7);
-        const { segments: roadSegs } = buildNetworkGeometry(doc, 1337, 0);
-        // segments are emitted per-polyline in order (buildNetworkGeometry's own loop) — walk that same
-        // order and check each polyline's own run chains endpoint to endpoint.
-        let i = 0;
-        for (const line of doc.polylines) {
+        expect(segments.length).toBe(doc.polylines.length);
+        for (const [i, line] of doc.polylines.entries()) {
+            const seg = segments[i];
             const [[ax, az], [bx, bz]] = line.points;
-            const len = Math.hypot(bx - ax, bz - az);
-            const n = Math.max(1, Math.ceil(len / PROFILE_STEP));
-            for (let s = 0; s < n; s++) {
-                const seg = roadSegs[i++];
-                if (s > 0) {
-                    const prev = roadSegs[i - 2];
-                    expect(seg.ax).toBeCloseTo(prev.bx, 9);
-                    expect(seg.az).toBeCloseTo(prev.bz, 9);
-                    expect(seg.aHeight).toBeCloseTo(prev.bHeight, 9);
-                }
-            }
+            expect(seg.ax).toBeCloseTo(ax, 9);
+            expect(seg.az).toBeCloseTo(az, 9);
+            expect(seg.bx).toBeCloseTo(bx, 9);
+            expect(seg.bz).toBeCloseTo(bz, 9);
         }
     });
 
-    test("segments are emitted road-contiguously — each road's sub-segments form one contiguous run (seed scan)", () => {
+    test("each road's single chord segment spans its own polyline endpoints — no sub-segment chain", () => {
+        // stage 17: the chord is one segment per road, so there's no chain to check — each segment's
+        // endpoints ARE the polyline's endpoints. This pin verifies that directly.
+        const doc = generateNetwork(7);
+        const { segments } = buildNetworkGeometry(doc, 1337, 0);
+        expect(segments.length).toBe(doc.polylines.length);
+        for (const [i, line] of doc.polylines.entries()) {
+            const seg = segments[i];
+            const [[ax, az], [bx, bz]] = line.points;
+            expect(seg.ax).toBeCloseTo(ax, 9);
+            expect(seg.az).toBeCloseTo(az, 9);
+            expect(seg.bx).toBeCloseTo(bx, 9);
+            expect(seg.bz).toBeCloseTo(bz, 9);
+        }
+    });
+
+    test("segments are emitted road-contiguously — one segment per road, road field non-decreasing (seed scan)", () => {
         // The GPU mirror (`networkCore` in `flatten.ts`) groups sub-segments into their owning road
         // by detecting `seg.road` changes in the segment array — it relies on segments being emitted
-        // contiguously per road (all of road 0's sub-segments, then all of road 1's, etc.). The CPU
-        // mirror (`networkCoreCpu` in `flatness.ts`) uses a Map keyed by `road`, so it does not rely
-        // on contiguity — the invariant is load-bearing on one side only. This pin proves the
-        // invariant holds over `buildNetworkGeometry`'s own producing loop (`for (const [road, line]
-        // of doc.polylines.entries())`), widened off a single seed to a scan — stage 6's lesson: a
-        // single hardcoded seed is a fixture, not a corpus, and a regression that only triggers at a
-        // seed the pin never ran reads green. The `road` field must be non-decreasing across the
-        // segment array for every seed in the scan.
+        // contiguously per road. The CPU mirror (`networkCoreCpu` in `flatness.ts`) uses a Map keyed
+        // by `road`, so it does not rely on contiguity — the invariant is load-bearing on one side
+        // only. Stage 17: one segment per road, so the invariant is trivially true — the `road` field
+        // is strictly increasing (0, 1, 2, ..., ROAD_COUNT-1). Widened off a single seed to a scan —
+        // stage 6's lesson: a single hardcoded seed is a fixture, not a corpus.
         const SeedScan = 500;
         for (let seed = 0; seed <= SeedScan; seed++) {
             const doc = generateNetwork(seed);
             const { segments } = buildNetworkGeometry(doc, 1337, 3);
-            expect(segments.length).toBeGreaterThan(doc.polylines.length);
+            expect(segments.length).toBe(doc.polylines.length);
             for (let i = 1; i < segments.length; i++) {
                 expect(segments[i].road).toBeGreaterThanOrEqual(segments[i - 1].road);
             }
         }
     });
 
-    test("grade never exceeds MAX_GRADE along any road's own smoothed profile, at radius 0 (grade-clamp alone)", () => {
-        const doc = generateNetwork(615); // stage 6's pinned regression seed — still a good stress case
+    test("grade stays under MAX_GRADE along any road's chord — by measurement, not by a limiter (stage 17)", () => {
+        // stage 17: the chord has no grade limiter — the grade is the natural chord grade between the
+        // endpoint heights. It stays under MAX_GRADE by measurement (worst chord grade 10.51% on
+        // SEED=1337), not by clampGrade. This pin reads that measurement on seed 615's network against
+        // perm 1337's terrain.
+        const doc = generateNetwork(615);
         const { segments } = buildNetworkGeometry(doc, 1337, 0);
         for (const seg of segments) {
             const len = Math.hypot(seg.bx - seg.ax, seg.bz - seg.az);

--- a/examples/showcase/roads/src/terrain/flatten.ts
+++ b/examples/showcase/roads/src/terrain/flatten.ts
@@ -26,7 +26,7 @@ import * as std from "typegpu/std";
 import type { StrokeDocument } from "../overlay/document";
 import { SPACING } from "./grid";
 import { heightAt, makePermutation } from "./noise";
-import { buildPolylineProfile, heightAtCpu } from "./profile";
+import { buildPolylineProfile, heightAtCpu, PROFILE_STEP } from "./profile";
 
 // FALLOFF is no longer `= SPACING` (stage 6's choice, derived only from a capture probe's own grid
 // alignment, not a road-geometry argument). Once the profile is smoothed the cut depth at a given point
@@ -432,8 +432,23 @@ export function buildNetworkGeometry(
                 road,
             });
         }
-        for (const p of profile) {
-            cutDepth = Math.max(cutDepth, Math.abs(heightAtCpu(p.x, p.z, perm) - p.height));
+        // cutDepth measured along the chord: the chord's target height at the endpoints equals the
+        // natural height there (by construction), so the profile points themselves read zero — the
+        // actual cut lives *between* the endpoints, where natural terrain deviates from the straight
+        // chord. Sample at <= PROFILE_STEP arc-length increments (the same resolution the old resampled
+        // profile used) and measure |natural - chord_target| at each, the same formula as today.
+        const first = line.points[0];
+        const last = line.points[line.points.length - 1];
+        const chordLen = Math.hypot(last[0] - first[0], last[1] - first[1]);
+        const aH = profile[0].height;
+        const bH = profile[profile.length - 1].height;
+        const n = Math.max(1, Math.ceil(chordLen / PROFILE_STEP));
+        for (let s = 0; s <= n; s++) {
+            const t = s / n;
+            const x = first[0] + (last[0] - first[0]) * t;
+            const z = first[1] + (last[1] - first[1]) * t;
+            const chordHeight = aH + (bH - aH) * t;
+            cutDepth = Math.max(cutDepth, Math.abs(heightAtCpu(x, z, perm) - chordHeight));
         }
     }
     return { segments, cutDepth };

--- a/examples/showcase/roads/src/terrain/profile.test.ts
+++ b/examples/showcase/roads/src/terrain/profile.test.ts
@@ -86,60 +86,41 @@ describe("clampGrade", () => {
     });
 });
 
-describe("buildPolylineProfile", () => {
-    test("resamples a straight 2-point line at <= PROFILE_STEP arc-length spacing, endpoints preserved", () => {
+describe("buildPolylineProfile — the straight chord (stage 17)", () => {
+    test("returns exactly the two polyline endpoints, no resampling — one segment per road", () => {
         const perm = makePermutation(1337);
         const points: [number, number][] = [
             [-100, 0],
             [100, 0],
         ];
         const profile = buildPolylineProfile(points, perm, DEFAULT_SMOOTH_RADIUS);
+        expect(profile).toHaveLength(2);
         expect(profile[0].x).toBeCloseTo(-100, 9);
         expect(profile[0].z).toBeCloseTo(0, 9);
-        expect(profile[profile.length - 1].x).toBeCloseTo(100, 9);
-        for (let i = 1; i < profile.length; i++) {
-            const dist = Math.hypot(
-                profile[i].x - profile[i - 1].x,
-                profile[i].z - profile[i - 1].z,
-            );
-            expect(dist).toBeLessThanOrEqual(PROFILE_STEP + 1e-6);
-        }
+        expect(profile[1].x).toBeCloseTo(100, 9);
+        expect(profile[1].z).toBeCloseTo(0, 9);
     });
 
-    test("grade-limits the output even at radius 0 (no box smoothing) — the correctness bound stays active regardless of the taste dial", () => {
-        const perm = makePermutation(9001); // an arbitrary seed likely to hit real terrain variation
+    test("endpoint heights are the natural terrain heights there (heightAtCpu), not smoothed or grade-limited", () => {
+        const perm = makePermutation(9001);
         const points: [number, number][] = [
             [-150, -80],
             [150, 90],
         ];
-        const profile = buildPolylineProfile(points, perm, MIN_SMOOTH_RADIUS);
-        for (let i = 1; i < profile.length; i++) {
-            const dist = Math.hypot(
-                profile[i].x - profile[i - 1].x,
-                profile[i].z - profile[i - 1].z,
-            );
-            if (dist < 1e-9) continue;
-            const grade = Math.abs(profile[i].height - profile[i - 1].height) / dist;
-            expect(grade).toBeLessThanOrEqual(MAX_GRADE + 1e-6);
-        }
+        const profile = buildPolylineProfile(points, perm, DEFAULT_SMOOTH_RADIUS);
+        expect(profile[0].height).toBeCloseTo(heightAtCpu(-150, -80, perm), 9);
+        expect(profile[1].height).toBeCloseTo(heightAtCpu(150, 90, perm), 9);
     });
 
-    test("a higher smoothing radius never increases the profile's own total variation versus a lower one", () => {
+    test("the chord ignores the smoothRadius parameter — same output at any radius (plumbing retained, stage 19)", () => {
         const perm = makePermutation(2024);
         const points: [number, number][] = [
             [-110, 40],
             [110, -40],
         ];
-        const totalVariation = (radius: number) => {
-            const profile = buildPolylineProfile(points, perm, radius);
-            let sum = 0;
-            for (let i = 1; i < profile.length; i++)
-                sum += Math.abs(profile[i].height - profile[i - 1].height);
-            return sum;
-        };
-        expect(totalVariation(MAX_SMOOTH_RADIUS)).toBeLessThanOrEqual(
-            totalVariation(MIN_SMOOTH_RADIUS) + 1e-6,
-        );
+        const atMin = buildPolylineProfile(points, perm, MIN_SMOOTH_RADIUS);
+        const atMax = buildPolylineProfile(points, perm, MAX_SMOOTH_RADIUS);
+        expect(atMin).toEqual(atMax);
     });
 });
 
@@ -193,7 +174,9 @@ describe("longitudinalOracle — the spec's own Validation criterion, proven by 
         expect(check.jitterOk).toBe(false); // but the grade change (2g) exceeds MAX_GRADE_BREAK
     });
 
-    test("stage 8's smoothed profile passes on every road of a real generated network, several seeds", () => {
+    test("the chord profile passes on every road of a real generated network, several seeds", () => {
+        // stage 17: the chord is one straight segment per road — grade is constant along it (so jitter is
+        // zero by construction, one step) and stays under MAX_GRADE by measurement, not by a limiter.
         const perm = makePermutation(1337);
         for (const seed of [1, 42, 615, 9001]) {
             const doc = generateNetwork(seed);

--- a/examples/showcase/roads/src/terrain/profile.ts
+++ b/examples/showcase/roads/src/terrain/profile.ts
@@ -11,7 +11,8 @@
 //
 // The smoothing apparatus (`boxFilter`, `clampGrade`, `limitProfile`, `MAX_GRADE_BREAK`, the
 // `smoothRadius` plumbing) stays in place for stage 19's own deletion PR — `buildPolylineProfile` no
-// longer calls any of it, but the exports and their tests remain green.
+// longer calls any of it. `limitProfile` in particular is exported only to keep biome's
+// `noUnusedVariables` quiet, is unreachable from production, and is deleted at stage 19.
 //
 // Pure CPU module (the device-free split `overlay/document.ts`/`overlay/tiles.ts` use) — `heightAtCpu`
 // below is a from-scratch JS re-authoring of `noise.ts`'s TGSL `perlin2`/`fbm2`/`heightAt` (not a call

--- a/examples/showcase/roads/src/terrain/profile.ts
+++ b/examples/showcase/roads/src/terrain/profile.ts
@@ -1,18 +1,25 @@
-// The longitudinal road profile: a low-pass, grade-limited elevation control-point sequence sampled along
-// each polyline's own centreline — the spec's Locked decision for stage 8 ("low-pass the longitudinal
-// profile, don't linearize it"). `flatten.ts`'s `setNetwork` calls {@link buildPolylineProfile} once per
-// polyline to build the GPU segment list's per-endpoint heights; `networkCore` (flatten.ts) then
-// interpolates between them by the clamped projection parameter `t` it already computes, instead of
-// re-sampling raw `heightAt` at the projected point (stage 6/7's defect: every noise octave at the 4 m
-// vertex scale rode straight into the road's own surface).
+// The longitudinal road profile: a straight chord per polyline — the spec's Locked decision half two
+// (stage 17, the 2026-08-19 rescope). `flatten.ts`'s `setNetwork` calls {@link buildPolylineProfile} once
+// per polyline to build the GPU segment list's per-endpoint heights; `networkCore` (flatten.ts) then
+// interpolates between them by the clamped projection parameter `t` it already computes. On a straight
+// segment the longitudinal station `s` is an affine function of `(x, z)`, so a linear profile in `s`
+// makes the flatten target an affine function of `(x, z)` — barycentric interpolation over a triangle
+// reproduces an affine field exactly, so the in-corridor reconstruction error vanishes identically rather
+// than shrinking with cell size. The resample → box-filter → grade-limit chain this replaces (stage 8's
+// "low-pass, don't linearize") made the target a curved function of station; that curvature was the entire
+// remaining defect.
+//
+// The smoothing apparatus (`boxFilter`, `clampGrade`, `limitProfile`, `MAX_GRADE_BREAK`, the
+// `smoothRadius` plumbing) stays in place for stage 19's own deletion PR — `buildPolylineProfile` no
+// longer calls any of it, but the exports and their tests remain green.
 //
 // Pure CPU module (the device-free split `overlay/document.ts`/`overlay/tiles.ts` use) — `heightAtCpu`
 // below is a from-scratch JS re-authoring of `noise.ts`'s TGSL `perlin2`/`fbm2`/`heightAt` (not a call
 // into them: those are `tgpu.fn`s bound through `noiseLayout`'s storage binding, which has no meaning
 // outside a dispatched kernel). A small CPU/GPU numerical drift (f64 vs f32, ULP-level) is expected and
-// harmless here — the profile's own smoothing changes the height by decimetres to metres by design, which
-// dwarfs it — but the *algorithm* has to match, or the falloff terminus (`flatten.ts`'s cosine ease, which
-// blends back to `heightAt` computed by the real GPU kernel) would show a visible seam.
+// harmless here — the chord's own height changes by decimetres to metres by design, which dwarfs it — but
+// the *algorithm* has to match, or the falloff terminus (`flatten.ts`'s cosine ease, which blends back to
+// `heightAt` computed by the real GPU kernel) would show a visible seam.
 
 const SQRT1_2 = Math.SQRT1_2;
 
@@ -190,7 +197,7 @@ export interface ProfilePoint {
  * heights did, one grade-break apart per adjacent pair), clip to the absolute grade bound, then integrate
  * back to heights anchored at the sequence's first sample.
  */
-function limitProfile(
+export function limitProfile(
     heights: readonly number[],
     steps: readonly number[],
     maxGrade: number,
@@ -211,41 +218,30 @@ function limitProfile(
 }
 
 /**
- * resample `points` (a polyline's own consecutive vertices — 2 for every road this stage's generator
- * produces, `overlay/network.ts`) at <= {@link PROFILE_STEP} arc-length increments, sample natural height
- * at each (`heightAtCpu`), box-filter by `radius` ({@link boxFilter}), then limit on both difference axes
- * ({@link limitProfile}, always active regardless of `radius` — the correctness bound, not the taste
- * dial). Consecutive input segments share their joint vertex (no duplicate sample there), so the whole
- * polyline resamples as one continuous sequence, not per-segment independently — a multi-point future
- * polyline would stay smooth across its own interior joints instead of re-starting the filter at each one.
+ * the straight-chord profile (stage 17, the spec's Locked decision half two): one {@link ProfilePoint} per
+ * polyline endpoint — `points[0]` and `points[points.length - 1]` — with `height` the natural terrain
+ * height there (`heightAtCpu`). `buildNetworkGeometry` (`flatten.ts`) emits exactly one `ProfileSegment`
+ * per polyline spanning these two points, so `networkCore`'s `mix(aHeight, bHeight, t)` is a linear
+ * function of station — affine in `(x, z)` on a straight segment — and barycentric interpolation
+ * reproduces it exactly at any cell size and any road angle. `cutDepth` is measured along the chord as
+ * today (`buildNetworkGeometry`'s own loop over the returned profile points).
+ *
+ * `radius` is retained for the `smoothRadius` plumbing (`boot.ts`'s `[`/`]` control, `terrain.ts`'s
+ * `setSmoothRadius`) but is not consulted — the smoothing apparatus (`boxFilter`, `clampGrade`,
+ * `limitProfile`) stays exported and tested for stage 19's own deletion PR.
  */
 export function buildPolylineProfile(
     points: ReadonlyArray<readonly [number, number]>,
     perm: Uint32Array,
     radius: number,
 ): ProfilePoint[] {
-    const raw: { x: number; z: number }[] = [{ x: points[0][0], z: points[0][1] }];
-    for (let i = 0; i < points.length - 1; i++) {
-        const [ax, az] = points[i];
-        const [bx, bz] = points[i + 1];
-        const len = Math.hypot(bx - ax, bz - az);
-        const n = Math.max(1, Math.ceil(len / PROFILE_STEP));
-        for (let s = 1; s <= n; s++) {
-            const t = s / n;
-            raw.push({ x: ax + (bx - ax) * t, z: az + (bz - az) * t });
-        }
-    }
-
-    const steps: number[] = [];
-    for (let i = 0; i < raw.length - 1; i++) {
-        steps.push(Math.hypot(raw[i + 1].x - raw[i].x, raw[i + 1].z - raw[i].z));
-    }
-
-    const natural = raw.map((p) => heightAtCpu(p.x, p.z, perm));
-    const smoothed = boxFilter(natural, radius);
-    const limited = limitProfile(smoothed, steps, MAX_GRADE);
-
-    return raw.map((p, i) => ({ x: p.x, z: p.z, height: limited[i] }));
+    void radius; // retained for the smoothRadius plumbing; the chord ignores it
+    const first = points[0];
+    const last = points[points.length - 1];
+    return [
+        { x: first[0], z: first[1], height: heightAtCpu(first[0], first[1], perm) },
+        { x: last[0], z: last[1], height: heightAtCpu(last[0], last[1], perm) },
+    ];
 }
 
 /** {@link longitudinalOracle}'s verdict: whether `profile` satisfies the spec's longitudinal Validation


### PR DESCRIPTION
- **shallot-roads: stage 17 — the chord profile plus both exactness arms**
- **shallot-roads: stage 17 — repair four review findings (vacuity guard, excludedStation pin, comment numbers, limitProfile note)**
- **shallot-roads: stage 17 — correct the last stale overlap-arm count (96 → 99)**
