### PR TITLE
shallot-roads: 24a corridor-pose capture and px/m budget arm

### DIFF
--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -7,6 +7,7 @@ import {
     withHeight,
     worldToScreen,
 } from "./capture";
+import { corridorCapture } from "./corridorCapture";
 import { gate } from "./gate";
 import {
     type GrazingAnchor,
@@ -55,6 +56,10 @@ declare global {
         // two-resolution reading is self-labeling rather than trusting whatever the driver assumed was
         // edited before the run.
         __roadsMeshParams?: { spacing: number; tileRes: number; distRange: number };
+        // stage 24a's corridor-pose capture (`corridorCapture.ts`) — repositions the orbit to the
+        // derived corridor pose for 24b's release-look screenshot. The Playwright driver calls this,
+        // waits, and saves the screenshot to a second file alongside the gate's own.
+        __roadsCorridorCapture?: () => Promise<void>;
         // stage 14's reseed-integrity device arm (`test/roads.spec.ts`) — a deterministic bridge onto the
         // real F9 handler's own `regenerate` call, so the check can drive two reseeds by fixed seed
         // instead of `Math.random()`'s live keypress (which could coincidentally re-touch the probed
@@ -84,6 +89,7 @@ const BootSystem: System = {
         window.__roadsCapturePoints = () => capturePoints();
         window.__roadsOverlayIdle = () => overlayIdle();
         window.__roadsTransitionTolerancePx = TRANSITION_TOLERANCE_PX;
+        window.__roadsCorridorCapture = () => corridorCapture();
         window.__roadsGrazingCapture = () => grazingCapture();
         window.__roadsHeightSilhouette = () => heightSilhouette();
         window.__roadsMeshParams = { spacing: SPACING, tileRes: TILE_RES, distRange: DIST_RANGE };
@@ -109,6 +115,7 @@ const BootSystem: System = {
         delete window.__roadsCapturePoints;
         delete window.__roadsOverlayIdle;
         delete window.__roadsTransitionTolerancePx;
+        delete window.__roadsCorridorCapture;
         delete window.__roadsGrazingCapture;
         delete window.__roadsHeightSilhouette;
         delete window.__roadsMeshParams;

--- a/examples/showcase/roads/src/corridorCapture.ts
+++ b/examples/showcase/roads/src/corridorCapture.ts
@@ -1,0 +1,63 @@
+// Stage 24a's corridor-pose capture — repositions the scene's orbit camera to the derived corridor
+// pose (corridorPose.ts) so a screenshot can be taken for 24b's release look. Reuses the same
+// `Orbit.*` write mechanism `grazingCapture.ts` uses (Orbit.pitch/yaw/distance/pan/smoothness),
+// not a second pose-override mechanism — only the constants differ, and they are re-derived from
+// the px/m budget rather than borrowed from the grazing pose (which frames a boundary at pitch
+// 0.06 / distance 15, not a corridor in terrain).
+//
+// Exposed as `window.__roadsCorridorCapture` (`boot.ts`); the Playwright driver
+// (`test/roads.spec.ts`) calls it, waits, and saves the screenshot to a second file alongside the
+// gate's own `test-results/roads-capture.png` (which stays unchanged in pose — it feeds the
+// fs-composite pixel probes and must not move).
+
+import { Orbit } from "@dylanebert/shallot/extras";
+import { Views } from "@dylanebert/shallot/render/core";
+import { roadFrame } from "./boundaryAnchors";
+import { withHeight } from "./capture";
+import { CORRIDOR_DISTANCE, CORRIDOR_PITCH } from "./corridorPose";
+import { frames } from "./harness";
+
+// Target at the road's midpoint (t = 0.5) — the corridor is visible in both directions with
+// terrain flanking on both sides, unlike grazingCapture's t = 0.08 (near one end, for a boundary).
+const TARGET_T = 0.5;
+const EYE_MARGIN = 0.4; // metres above the read terrain height, clearing z-fighting/embedding
+
+/** the canvas-presenting camera's eid — the same `Views` disambiguation `capture.ts`'s
+ *  `cameraEid` and `grazingCapture.ts`'s `cameraEid` use (a shadow-casting light's pooled shadow
+ *  camera also carries `Camera`, so only a live `canvas` picks the display camera out). */
+function cameraEid(): number {
+    for (const [eid, view] of Views) {
+        if (view.canvas) return eid;
+    }
+    throw new Error("corridorCapture: no canvas-presenting camera in Views");
+}
+
+/**
+ * repositions the scene's orbit camera to the derived corridor pose (looking along the boot
+ * document's first road at the derived pitch and distance), waits for the pose to settle, and
+ * returns. The caller (`test/roads.spec.ts` via `window.__roadsCorridorCapture`) takes the
+ * screenshot after this resolves.
+ */
+export async function corridorCapture(): Promise<void> {
+    const eid = cameraEid();
+    const frame = roadFrame();
+    const { ax, az, ux, uz, len } = frame;
+
+    const targetX = ax + ux * len * TARGET_T;
+    const targetZ = az + uz * len * TARGET_T;
+    const [, targetYRaw] = await withHeight(targetX, targetZ);
+    const targetY = targetYRaw + EYE_MARGIN;
+
+    // forward = (ux, uz); Orbit's convention places the camera at
+    // target + distance*(sin(yaw)cos(pitch), sin(pitch), cos(yaw)cos(pitch)) looking back at target,
+    // so the camera sits behind target along -forward when sin(yaw) = -ux, cos(yaw) = -uz.
+    const yaw = Math.atan2(-ux, -uz);
+
+    Orbit.smoothness.set(eid, 1); // snap in one frame instead of easing
+    Orbit.pitch.set(eid, CORRIDOR_PITCH);
+    Orbit.yaw.set(eid, yaw);
+    Orbit.distance.set(eid, CORRIDOR_DISTANCE);
+    Orbit.pan.set(eid, targetX, targetY, targetZ, 0);
+
+    await frames(3); // let OrbitSystem (mode: always) re-derive Transform from the snapped pose
+}

--- a/examples/showcase/roads/src/corridorPose.test.ts
+++ b/examples/showcase/roads/src/corridorPose.test.ts
@@ -1,0 +1,92 @@
+// Stage 24a's px/m budget arm — asserts the corridor-pose capture's admissibility from scene and
+// document constants, never measured off the image. Both halves of the budget:
+//   1. cutDepth ≥ 5 px of vertical extent (the resolution threshold, anchored on the road's own
+//      resolved on-screen width at the default pose: 8 m × f_px / 900 ≈ 5.5 px)
+//   2. ≥30 m of unflattened terrain flanking the corridor in frame (the corridor must read *set
+//      into* terrain, or the look loses its comparison)
+//
+// Every constant is justified by a derivation or a document/scene quantity — none by "the arm
+// passes here" (per checks.md and this unit's residue on fitted floors). See `corridorPose.ts`'s
+// header comment for the full derivation.
+
+import { describe, expect, test } from "bun:test";
+import {
+    CAMERA_FOV_DEG,
+    CORRIDOR_DISTANCE,
+    CORRIDOR_PITCH,
+    CUT_DEPTH,
+    cutDepthPx,
+    FALLOFF,
+    flankingTerrainM,
+    fovHRad,
+    fPx,
+    HALF_WIDTH,
+    VIEWPORT_HEIGHT,
+    VIEWPORT_WIDTH,
+} from "./corridorPose";
+
+describe("corridor-pose px/m budget (stage 24a)", () => {
+    test("f_px is derived from the viewport height and the camera's default FOV", () => {
+        // f_px = (h/2) / tan(fov/2) — the perspective focal length in pixels.
+        // h = 720 (Playwright default viewport height, playwright.config.ts sets no viewport).
+        // fov = 60° (roads.scene sets no fov; render/index.ts Camera trait defaults fov: 60).
+        const expected = 720 / 2 / Math.tan((60 * Math.PI) / 180 / 2);
+        expect(fPx()).toBeCloseTo(expected, 1);
+        expect(fPx()).toBeCloseTo(623.5, 0);
+    });
+
+    test("cutDepth projects to ≥5 px of vertical extent at the derived pose", () => {
+        // The 5 px anchor: the road's own on-screen width at the default pose (900 m).
+        // 8 m (2 × ROAD_HALF_WIDTH) × f_px / 900 = 5.54 px — the smallest extent this
+        // artifact demonstrably resolves, so the threshold is a resolved quantity, not a
+        // number picked to make something pass.
+        const roadWidthPxAtDefault = (2 * HALF_WIDTH * fPx()) / 900;
+        expect(roadWidthPxAtDefault).toBeGreaterThanOrEqual(5);
+        expect(roadWidthPxAtDefault).toBeLessThanOrEqual(6);
+
+        // The corridor pose must make cutDepth at least as resolvable as the road width.
+        expect(cutDepthPx()).toBeGreaterThanOrEqual(5);
+
+        // Re-derive independently from the constants (not via cutDepthPx's shortcut):
+        // screen_px = cutDepth × cos(pitch) × f_px / distance
+        const independent = (CUT_DEPTH * Math.cos(CORRIDOR_PITCH) * fPx()) / CORRIDOR_DISTANCE;
+        expect(independent).toBeGreaterThanOrEqual(5);
+        expect(independent).toBeCloseTo(cutDepthPx(), 5);
+    });
+
+    test("≥30 m of unflattened terrain flanks the corridor in frame at the derived pose", () => {
+        // The corridor half-width is halfWidth + falloff (the road plus its eased transition).
+        // The visible lateral half-extent at the target distance is D × tan(fov_h/2).
+        // Flanking = lateral half-extent − corridor half-width.
+        expect(flankingTerrainM()).toBeGreaterThanOrEqual(30);
+
+        // Re-derive independently:
+        const corridorHalfWidth = HALF_WIDTH + FALLOFF;
+        const lateralHalfExtent = CORRIDOR_DISTANCE * Math.tan(fovHRad() / 2);
+        expect(lateralHalfExtent - corridorHalfWidth).toBeGreaterThanOrEqual(30);
+        expect(lateralHalfExtent - corridorHalfWidth).toBeCloseTo(flankingTerrainM(), 5);
+    });
+
+    test("the derived distance is the maximum satisfying cutDepth = 5 px at the derived pitch", () => {
+        // D = cutDepth × cos(pitch) × f_px / 5 — by construction, so cutDepth reads exactly 5 px.
+        const maxDistance = (CUT_DEPTH * Math.cos(CORRIDOR_PITCH) * fPx()) / 5;
+        expect(CORRIDOR_DISTANCE).toBeCloseTo(maxDistance, 5);
+    });
+
+    test("the pitch is half the corridor's average side-slope angle", () => {
+        // atan(cutDepth / falloff) / 2 — below the side-slope angle so the camera sees the
+        // transition as a surface, with enough elevation for terrain context.
+        const sideSlopeAngle = Math.atan(CUT_DEPTH / FALLOFF);
+        expect(CORRIDOR_PITCH).toBeCloseTo(sideSlopeAngle / 2, 5);
+    });
+
+    test("scene constants are what the derivation cites (not fitted)", () => {
+        // Each constant is named and sourced — none justified by "the arm passes here."
+        expect(VIEWPORT_HEIGHT).toBe(720); // Playwright default
+        expect(VIEWPORT_WIDTH).toBe(1280); // Playwright default
+        expect(CAMERA_FOV_DEG).toBe(60); // camera default (roads.scene sets no fov)
+        expect(HALF_WIDTH).toBe(4); // ROAD_HALF_WIDTH (overlay/network.ts)
+        expect(CUT_DEPTH).toBeCloseTo(1.4404, 3); // buildNetworkGeometry at seed 1337
+        expect(FALLOFF).toBeCloseTo(6.7876, 3); // computeFalloff(cutDepth)
+    });
+});

--- a/examples/showcase/roads/src/corridorPose.ts
+++ b/examples/showcase/roads/src/corridorPose.ts
@@ -1,0 +1,133 @@
+// Stage 24a's corridor-pose derivation — the admissible artifact for the release look (24b).
+//
+// The gate's default-orbit capture (`test-results/roads-capture.png`) is the scene's own orbit
+// (`public/scenes/roads.scene`: distance 900, pitch 0.5), where the post-selection earthwork's
+// 1.4404 m vertical excursion projects to ≈0.9 px — under the frame's FBM mottling and an order of
+// magnitude below the ~8–10 px of natural-relief silhouette waviness. 24b's hostile read against
+// "the earthwork reads as an artificial trench/embankment rather than terrain" is unreadable at that
+// pose whether or not the failure is present. This module derives a second pose that makes the
+// earthwork's vertical excursion resolvable (≥5 px) while keeping ≥30 m of unflattened terrain
+// flanking the corridor in frame (the corridor must read *set into* terrain, or the look loses its
+// comparison).
+//
+// This module is pure (no `@dylanebert/shallot` imports) so the CPU arm (`corridorPose.test.ts`)
+// can import it under `bun test` and the browser-side `corridorCapture.ts` can import it alongside
+// its `Orbit.*` writes — the same separation as `flatten-math.ts` / `flatten.ts`.
+
+import { generateNetwork, ROAD_HALF_WIDTH } from "./overlay/network";
+import { buildNetworkGeometry } from "./terrain/flatten";
+import { computeFalloff } from "./terrain/flatten-math";
+
+// ─── Scene constants (from the scene file and the camera defaults) ────────────────────────────
+//
+// The viewport is Playwright's default: 1280 × 720 (`playwright.config.ts` sets no `viewport`).
+// The camera's FOV is 60° (`roads.scene` sets no `fov`; `render/index.ts`'s Camera trait defaults
+// `fov: 60`). These are the scene's own quantities, not fitted to this arm.
+
+/** Playwright's default viewport height in pixels (`playwright.config.ts` sets no `viewport`). */
+export const VIEWPORT_HEIGHT = 720;
+
+/** Playwright's default viewport width in pixels. */
+export const VIEWPORT_WIDTH = 1280;
+
+/** The camera's vertical field of view in degrees (`roads.scene` sets no `fov`; default 60). */
+export const CAMERA_FOV_DEG = 60;
+
+// ─── Document constants (from the network geometry and the flatten math) ──────────────────────
+//
+// cutDepth and falloff are the network's own measured quantities at the pinned seed 1337
+// (`buildNetworkGeometry(generateNetwork(1337), 1337)`), the same figures the spec's Live log
+// records (1.4404 m → 6.7876 m). halfWidth is `ROAD_HALF_WIDTH` from `overlay/network.ts`.
+
+const doc = generateNetwork(1337);
+const { cutDepth } = buildNetworkGeometry(doc, 1337);
+const falloff = computeFalloff(cutDepth);
+const halfWidth = ROAD_HALF_WIDTH;
+
+/** The network's measured cut depth at seed 1337, in metres. */
+export const CUT_DEPTH = cutDepth;
+
+/** The network's falloff distance at seed 1337, in metres. */
+export const FALLOFF = falloff;
+
+/** The road's half-width in metres (`ROAD_HALF_WIDTH` from `overlay/network.ts`). */
+export const HALF_WIDTH = halfWidth;
+
+// ─── The derived pose ─────────────────────────────────────────────────────────────────────────
+//
+// f_px (focal length in pixels) = (h/2) / tan(fov/2):
+//   f_px = (720/2) / tan(30°) = 360 / 0.57735 = 623.54 px
+//
+// A vertical world displacement Δh at orbit distance D, pitch θ projects to
+//   screen_px = Δh × cos(θ) × f_px / D
+// (the component of the vertical displacement perpendicular to the view direction at pitch θ).
+//
+// Constraint 1 — cutDepth ≥ 5 px vertical:
+//   cutDepth × cos(θ) × f_px / D ≥ 5
+//   D ≤ cutDepth × cos(θ) × f_px / 5 = 1.4404 × cos(θ) × 623.54 / 5 = 179.6 × cos(θ)
+//
+// The 5 px anchor is the road's own already-resolved on-screen width at the current pose:
+// 8 m (2 × halfWidth) × f_px / 900 = 5.54 px — the smallest extent this artifact demonstrably
+// resolves, so the threshold is anchored on a resolved quantity in the same frame rather than
+// picked to make something pass.
+//
+// Constraint 2 — ≥30 m of unflattened terrain flanking the corridor in frame:
+//   D × tan(fov_h/2) − (halfWidth + falloff) ≥ 30
+//   D ≥ (halfWidth + falloff + 30) / tan(fov_h/2)
+// where fov_h = 2 × atan(tan(fov/2) × aspect) = 2 × atan(tan(30°) × 1280/720) = 91.48°
+//   → tan(fov_h/2) = tan(30°) × 1280/720 = 1.0264
+//   D ≥ (4 + 6.7876 + 30) / 1.0264 = 39.74 m
+//
+// Pitch derivation: the corridor's average side-slope angle is atan(cutDepth / falloff) =
+// atan(1.4404 / 6.7876) = 0.2094 rad (12.0°). The pitch is set to half this angle — below the
+// side-slope angle so the camera sees the transition as a surface (not edge-on), with enough
+// elevation to read terrain on both sides while keeping the vertical excursion maximally
+// projected (cos(0.1047) = 0.9945, losing <1% of the vertical signal).
+//
+// Distance: set to the maximum satisfying cutDepth = 5 px at the derived pitch
+// (maximum terrain context at the resolution threshold):
+//   D = 179.6 × cos(0.1047) = 178.6 m
+//
+// Verification:
+//   cutDepth px = 1.4404 × cos(0.1047) × 623.54 / 178.6 = 5.00 px ≥ 5  ✓
+//   flanking    = 178.6 × 1.0264 − (4 + 6.7876) = 172.6 m ≥ 30        ✓
+//
+// A reviewer at stage 24's split prescribed distance ~120, pitch ~0.12 — taken as measurement,
+// not remedy. This derivation's pitch (0.1047) lands near that band; the distance (178.6) lands
+// ~50% beyond it. The difference: this derivation sets cutDepth to exactly 5 px (the resolution
+// threshold), so D is the maximum distance that still resolves the excursion. D = 120 would give
+// cutDepth ≈7.4 px — more margin, but the threshold is 5, not 7, and no derivation selects 7.
+
+/** Half the corridor's average side-slope angle: atan(cutDepth / falloff) / 2.
+ *  Below the side-slope angle so the camera sees the transition as a surface; enough elevation
+ *  to read terrain on both sides while keeping cos(θ) ≈ 1. */
+export const CORRIDOR_PITCH = Math.atan(CUT_DEPTH / FALLOFF) / 2;
+
+/** Maximum orbit distance at which cutDepth projects to ≥5 px at {@link CORRIDOR_PITCH}.
+ *  Derived: cutDepth × cos(pitch) × f_px / 5. */
+export const CORRIDOR_DISTANCE = (CUT_DEPTH * Math.cos(CORRIDOR_PITCH) * fPx()) / 5;
+
+// ─── Budget computation (used by the CPU arm and re-used by the capture) ───────────────────────
+
+/** Focal length in pixels: (viewport_height / 2) / tan(fov / 2). */
+export function fPx(): number {
+    return VIEWPORT_HEIGHT / 2 / Math.tan((CAMERA_FOV_DEG * Math.PI) / 180 / 2);
+}
+
+/** Horizontal field of view in radians: 2 × atan(tan(fov_v/2) × aspect). */
+export function fovHRad(): number {
+    const fovVRad = (CAMERA_FOV_DEG * Math.PI) / 180;
+    const aspect = VIEWPORT_WIDTH / VIEWPORT_HEIGHT;
+    return 2 * Math.atan(Math.tan(fovVRad / 2) * aspect);
+}
+
+/** The vertical screen-pixel extent of {@link CUT_DEPTH} at the derived pose. */
+export function cutDepthPx(): number {
+    return (CUT_DEPTH * Math.cos(CORRIDOR_PITCH) * fPx()) / CORRIDOR_DISTANCE;
+}
+
+/** The metres of unflattened terrain flanking the corridor at the derived pose.
+ *  Lateral half-extent at the target distance minus the corridor half-width. */
+export function flankingTerrainM(): number {
+    return CORRIDOR_DISTANCE * Math.tan(fovHRad() / 2) - (HALF_WIDTH + FALLOFF);
+}

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -14,6 +14,16 @@ const CAPTURE_PATH = join(
     "roads-capture.png",
 );
 
+// Stage 24a's corridor-pose capture — a second file alongside the gate's own, written at the derived
+// corridor pose (corridorPose.ts). The default-orbit capture above stays unchanged in pose; this one
+// is the admissible artifact for 24b's release look.
+const CORRIDOR_CAPTURE_PATH = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "test-results",
+    "roads-corridor-capture.png",
+);
+
 // Drive the terrain generator's device gate: load the app, wait for it to warm and expose
 // `window.__roadsGate`, run it on the real GPU, and assert every check passes (and the page raised no
 // error). The checks themselves live in `src/gate.ts` against the published surface — this driver is the
@@ -317,6 +327,25 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
         reseedCapture.newRoadLum,
         `final-network on-road point ${reseedCapture.newRoadLum.toFixed(1)} vs off-road ${reseedCapture.offRoadLum.toFixed(1)} — doesn't read as road after the reseed that should have drawn it`,
     ).toBeLessThan(reseedCapture.offRoadLum * 0.75);
+
+    expect(errors, errors.join("\n")).toEqual([]);
+
+    // Phase 4: stage 24a's corridor-pose capture. Reposition the orbit to the derived corridor pose
+    // (corridorCapture.ts via window.__roadsCorridorCapture), wait for it to settle, and save the
+    // screenshot to a second file. The default-orbit capture (Phase 2) is already saved and must not
+    // move — it feeds the fs-composite pixel probes. This capture is the admissible artifact for 24b's
+    // human release look: the earthwork's 1.4404 m vertical excursion projects to ≥5 px at this pose
+    // (asserted device-free by corridorPose.test.ts), while ≥30 m of unflattened terrain flanks the
+    // corridor in frame.
+    await page.evaluate(() =>
+        (
+            window as unknown as { __roadsCorridorCapture: () => Promise<void> }
+        ).__roadsCorridorCapture(),
+    );
+    await page.waitForTimeout(500); // let the render loop paint the re-posed frame
+    const corridorScreenshot = await page.screenshot();
+    mkdirSync(dirname(CORRIDOR_CAPTURE_PATH), { recursive: true });
+    writeFileSync(CORRIDOR_CAPTURE_PATH, corridorScreenshot);
 
     expect(errors, errors.join("\n")).toEqual([]);
 });


### PR DESCRIPTION
A second capture alongside the gate's own default-orbit screenshot, at a derived corridor pose where the earthwork's 1.4404 m cutDepth projects to >=5 px vertical (the road's own resolved on-screen width) while >=30 m of unflattened terrain flanks the corridor in frame. The pose is derived from f_px = (h/2)/tan(fov/2) and the orbit depth against a two-sided budget, not borrowed from the grazingCapture's boundary framing. A CPU arm asserts both halves of the budget from scene and document constants, never measured off the image.
