### PR TITLE
shallot-roads: stage 25 — scene frustum bound + subject-anchored default frame

### DIFF
--- a/examples/showcase/roads/public/scenes/roads.scene
+++ b/examples/showcase/roads/public/scenes/roads.scene
@@ -5,16 +5,38 @@
     <a ambient-light />
     <a directional-light shadow="distance: 1200" />
 
-    <!-- orbit camera framing the ~1 km² grid (terrain/grid.ts: 1024 m × 1024 m, centred on the world
-         origin — the grid's own centring). distance/max-distance are sized to the terrain's footprint
-         the same way voxel sizes its orbit to the voxel grid: the orbit defaults (distance 10 / max 30)
-         would frame a speck of a 1024 m field and clamp on first zoom. min-distance drops low enough to
-         read ground-level detail near the camera. clear-color is a daytime sky (sRGB hex). The sun shadow
-         distance (above) covers the grid so terrain self-shadows across its relief. -->
+    <!-- orbit camera framing the road, not the grid (terrain/grid.ts: 1024 m × 1024 m, centred on the
+         world origin — the grid's own centring). The subject is an 8 m road inside a ~36 m earthwork
+         corridor (cutDepth 1.44 m → falloff 6.79 m per side, per corridorPose.ts's measured figures at
+         seed 1337), not the 1 km² grid that contains it.
+
+         distance: derived from the subject the way corridorPose.ts derives its corridor-pose distance —
+         the earthwork corridor (~36 m wide) must be resolvable in frame. corridorPose.ts derives an
+         admissible interval [39.74 m, 178.6 m] from the constraints (≥5 px vertical for cutDepth, ≥30 m
+         flanking terrain) and operates at 120 m (49% margin over the 5 px floor). That interval was
+         derived at the *corridor* pose's grazing pitch (0.10470); at this scene's pitch 0.5 the upper
+         end tightens to ~157 m, and 120 m sits inside both — so borrowing the number is sound, but it
+         is a presentation choice (deliberately ungated, per the 24b read) and not a derived bound. The
+         scene default uses the same 120 m so the demo opens on the subject rather than a speck — the prior 900 m was
+         derived to frame the 1024 m grid footprint (900·tan(30°)·2 ≈ 1040 m ≈ the grid), which made
+         the 8 m road sub-pixel. max-distance stays at 2500 so the user can still zoom out to survey
+         the full grid. min-distance drops low enough to read ground-level detail near the camera.
+
+         far: derived from the reachable orbit — the farthest point the camera can see is max-distance
+         (2500) plus the grid's half-diagonal (WORLD_HALF·√2 = 512·1.4142 ≈ 724 m), so far = 2500 + 724
+         = 3224, rounded up to 3225. The bound is deliberately the 2D (xz) one: adding terrain relief
+         (RELIEF = 40 m) moves the worst case to √(3224² + 40²) = 3224.25, which the rounding already
+         covers. The engine default (far: 1000, render/index.ts:369) clips the far grid corner at every
+         orbit past ~276 m of distance — that was every default view before this stage (900 + 724 =
+         1624 > 1000) and is still every zoom-out toward max-distance (3224 > 1000); at this stage's
+         120 m default the far corner sits at 844 m and does not clip, so the clip is a zoom-out bug
+         rather than an opening-frame one, and the derived bound is what covers both. clear-color is a daytime sky
+         (sRGB hex). The sun shadow distance (above) covers the grid so terrain self-shadows across
+         its relief. -->
     <a
-        camera="clear-color: 0x78a7ff"
+        camera="clear-color: 0x78a7ff; far: 3225"
         sear
-        orbit="distance: 900; max-distance: 2500; min-distance: 10; pitch: 0.5"
+        orbit="distance: 120; max-distance: 2500; min-distance: 10; pitch: 0.5"
         transform
     />
 </scene>

--- a/examples/showcase/roads/src/corridorPose.test.ts
+++ b/examples/showcase/roads/src/corridorPose.test.ts
@@ -1,7 +1,10 @@
 // Stage 24a's px/m budget arm — asserts the corridor-pose capture's admissibility from scene and
 // document constants, never measured off the image. Three assertions:
 //   1. cutDepth ≥ 5 px of vertical extent (the resolution threshold, anchored on the road's own
-//      resolved on-screen width at the default pose: 8 m × f_px / 900 ≈ 5.5 px)
+//      resolved on-screen width at the *measurement point* — the pre-stage-25 scene default,
+//      900 m: 8 m × f_px / 900 ≈ 5.5 px. Every 900 in this file is that historical measurement
+//      point, never the scene's current default, which stage 25 moved to 120 m; the literals are
+//      fixed on purpose and re-fitting them to the scene would track a presentation choice)
 //   2. ≥30 m of unflattened terrain flanking the corridor in frame (the corridor must read *set
 //      into* terrain, or the look loses its comparison)
 //   3. earthwork px vs confounder px in the same frame — the failure mode's magnitude compared
@@ -40,7 +43,8 @@ import { computeFalloff } from "./terrain/flatten-math";
 // from the default pose to the corridor pose.
 const DEFAULT_PITCH = 0.5;
 
-// The confounder's measured pixel extent at the default pose (900 m, pitch 0.5): the spec records
+// The confounder's measured pixel extent at the measurement point (900 m, pitch 0.5 — the
+// pre-stage-25 scene default, not the current one): the spec records
 // ~8–10 px of natural-relief silhouette waviness in the same frame (Live log, stage 24's split).
 // Midpoint of the recorded range.
 const CONFUNDER_PX_AT_DEFAULT = 9;
@@ -68,7 +72,8 @@ describe("corridor-pose px/m budget (stage 24a)", () => {
     });
 
     test("cutDepth projects to ≥5 px of vertical extent at the fixed-literal pose", () => {
-        // The 5 px anchor: the road's own on-screen width at the default pose (900 m).
+        // The 5 px anchor: the road's own on-screen width at the measurement point (900 m, the
+        // pre-stage-25 scene default). The literal is provenance, not the live scene value.
         const roadWidthPxAtDefault = (2 * HALF_WIDTH * fPx()) / 900;
         expect(roadWidthPxAtDefault).toBeGreaterThanOrEqual(5);
         expect(roadWidthPxAtDefault).toBeLessThanOrEqual(6);
@@ -95,7 +100,7 @@ describe("corridor-pose px/m budget (stage 24a)", () => {
     });
 
     test("earthwork px vs confounder px in the same frame (Validation's comparison)", () => {
-        // Scale the confounder from the default pose (900 m, pitch 0.5) to the corridor pose.
+        // Scale the confounder from the measurement point (900 m, pitch 0.5) to the corridor pose.
         // Both earthwork and confounder are vertical displacements projected through f_px/D/cos(θ),
         // so the ratio is independent of D and θ — it is cutDepth / effective_confounder_magnitude,
         // a property of the subject, not the pose. Pinning it makes a cutDepth change visible.

--- a/examples/showcase/roads/src/corridorPose.ts
+++ b/examples/showcase/roads/src/corridorPose.ts
@@ -1,11 +1,17 @@
 // Stage 24a's corridor-pose derivation — the admissible artifact for the release look (24b).
 //
 // The gate's default-orbit capture (`test-results/roads-capture.png`) is the scene's own orbit
-// (`public/scenes/roads.scene`: distance 900, pitch 0.5), where the post-selection earthwork's
-// 1.4404 m vertical excursion projects to ≈0.9 px — under the frame's FBM mottling and an order of
-// magnitude below the ~8–10 px of natural-relief silhouette waviness. 24b's hostile read against
-// "the earthwork reads as an artificial trench/embankment rather than terrain" is unreadable at that
-// pose whether or not the failure is present. This module derives a second pose that makes the
+// (`public/scenes/roads.scene`). **At the pose this module was derived against — the pre-stage-25
+// default, distance 900, pitch 0.5 — the post-selection earthwork's 1.4404 m vertical excursion
+// projects to ≈0.9 px**, under the frame's FBM mottling and an order of magnitude below the ~8–10 px
+// of natural-relief silhouette waviness, so 24b's hostile read against "the earthwork reads as an
+// artificial trench/embankment rather than terrain" was unreadable at that pose whether or not the
+// failure was present. **Every 900 m figure in this module and its arm is that historical
+// measurement point, not the scene's current default** — stage 25 moved the scene default to 120 m
+// (where the same excursion projects to ≈6.6 px) for presentation reasons, and deliberately did not
+// re-anchor this module on it: the pose and its anchors are fixed literals precisely so they cannot
+// drift with an unrelated stage (24a's whole finding). A future reader must not "update" the 900s to
+// track the scene — that would re-fit the anchors to the treatment. This module derives a second pose that makes the
 // earthwork's vertical excursion resolvable (≥5 px) while keeping ≥30 m of unflattened terrain
 // flanking the corridor in frame (the corridor must read *set into* terrain, or the look loses its
 // comparison).
@@ -65,10 +71,13 @@ export const HALF_WIDTH = 4;
 //   cutDepth × cos(θ) × f_px / D ≥ 5
 //   D ≤ cutDepth × cos(θ) × f_px / 5 = 1.4404 × cos(θ) × 623.54 / 5 = 179.6 × cos(θ)
 //
-// The 5 px anchor is the road's own already-resolved on-screen width at the default pose:
-// 8 m (2 × halfWidth) × f_px / 900 = 5.54 px — the smallest extent this artifact demonstrably
-// resolves, so the threshold is anchored on a resolved quantity in the same frame rather than
-// picked to make something pass.
+// The 5 px anchor is the road's own already-resolved on-screen width at the *measurement point*
+// (the pre-stage-25 scene default, 900 m): 8 m (2 × halfWidth) × f_px / 900 = 5.54 px — the smallest
+// extent this artifact was demonstrated to resolve, so the threshold is anchored on a resolved
+// quantity in that frame rather than picked to make something pass. The anchor stays at 900 m by
+// design: it is the frame the ≈0.9 px inadmissibility reading came from, and re-deriving it at stage
+// 25's 120 m default (where the road is ~41.6 px) would raise the floor to track a presentation
+// choice rather than a resolved quantity.
 //
 // Constraint 2 — ≥30 m of unflattened terrain flanking the corridor in frame:
 //   D × tan(fov_h/2) − (halfWidth + falloff) ≥ 30

--- a/examples/showcase/roads/src/frustum.test.ts
+++ b/examples/showcase/roads/src/frustum.test.ts
@@ -1,0 +1,82 @@
+// Stage 25's frustum-coverage arm — Validation's "Camera frustum covers the world it can reach".
+//
+// The engine's Camera trait defaults `far: 1000` (`packages/shallot/src/standard/render/index.ts:369`).
+// The scene's orbit can reach `max-distance` from the target, and the grid's far corner sits
+// `WORLD_HALF·√2` beyond the world origin — so the farthest reachable point is `max-distance + WORLD_HALF·√2`
+// from the camera. If `far` is below that, the far grid corner clips behind the far plane at some
+// orbit position the user can actually reach.
+//
+// This arm parses the scene file's own `camera` and `orbit` attributes and asserts
+// `far ≥ max-distance + WORLD_HALF·√2`. The orbit numbers are read from the scene file, never
+// duplicated into the arm, and the treatment (`far`'s value) appears on neither side of the
+// derivation — so it is a claim about the mechanism (nothing the camera can orbit to may sit behind
+// the far plane), not a restatement of the value it polices. If `far` is absent from the scene's
+// camera attribute, the engine default (1000) applies and the arm reds — which is the bug this
+// stage fixes.
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { WORLD_HALF } from "./terrain/grid";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const SCENE_PATH = join(__dirname, "..", "public", "scenes", "roads.scene");
+
+/** The engine's Camera trait default for `far` (`render/index.ts:369`). */
+const ENGINE_FAR_DEFAULT = 1000;
+
+/** Parse a semicolon-separated `key: value` attribute string into a Map. */
+function parseAttributePairs(attr: string): Map<string, string> {
+    const map = new Map<string, string>();
+    for (const pair of attr.split(";")) {
+        const colon = pair.indexOf(":");
+        if (colon === -1) continue;
+        const key = pair.slice(0, colon).trim();
+        const value = pair.slice(colon + 1).trim();
+        if (key) map.set(key, value);
+    }
+    return map;
+}
+
+/** Extract the value of a quoted attribute (`name="value"`) from the scene file text. */
+function extractAttribute(sceneText: string, attrName: string): string | null {
+    const match = sceneText.match(new RegExp(`${attrName}="([^"]*)"`));
+    return match ? match[1] : null;
+}
+
+describe("camera frustum covers the world it can reach (stage 25)", () => {
+    const sceneText = readFileSync(SCENE_PATH, "utf-8");
+
+    const cameraAttr = extractAttribute(sceneText, "camera");
+    const orbitAttr = extractAttribute(sceneText, "orbit");
+
+    test("the scene defines both camera and orbit attributes", () => {
+        expect(cameraAttr).not.toBeNull();
+        expect(orbitAttr).not.toBeNull();
+    });
+
+    test("far ≥ max-distance + WORLD_HALF·√2 (nothing the camera can reach clips behind the far plane)", () => {
+        const camera = parseAttributePairs(cameraAttr!);
+        const orbit = parseAttributePairs(orbitAttr!);
+
+        // far: read from the scene's camera attribute, or fall back to the engine default.
+        const far = camera.has("far")
+            ? Number.parseInt(camera.get("far")!, 10)
+            : ENGINE_FAR_DEFAULT;
+
+        // max-distance: read from the scene's orbit attribute — never duplicated into the arm.
+        expect(orbit.has("max-distance")).toBe(true);
+        const maxDistance = Number.parseInt(orbit.get("max-distance")!, 10);
+
+        // The derived bound: the farthest reachable point from the camera is the orbit's
+        // max-distance plus the grid's half-diagonal (WORLD_HALF·√2).
+        const bound = maxDistance + WORLD_HALF * Math.sqrt(2);
+
+        expect(
+            far,
+            `far ${far} must be ≥ max-distance ${maxDistance} + WORLD_HALF·√2 ${WORLD_HALF}·${Math.sqrt(2).toFixed(4)} = ${bound.toFixed(1)}`,
+        ).toBeGreaterThanOrEqual(bound);
+    });
+});

--- a/examples/showcase/roads/src/overlay/network.ts
+++ b/examples/showcase/roads/src/overlay/network.ts
@@ -363,8 +363,10 @@ export function generateNetwork(seed: number, options?: GenerateNetworkOptions):
  * roads land at arbitrary headings and positions.
  *
  * Picks whichever road's midpoint sits nearest the world origin, not always `polylines[0]`: the scene's
- * fixed orbit camera (`public/scenes/roads.scene`) frames the whole 1024 m grid from its default target,
- * the world origin, so a road far out near the world's edge projects to only a few screen pixels — its
+ * fixed orbit camera (`public/scenes/roads.scene`) targets the world origin, so a road far out near the
+ * world's edge is either off-frame entirely (at stage 25's 120 m default, which frames ~250 m across) or
+ * projects to only a few screen pixels (at the pre-stage-25 900 m default, which framed the whole grid,
+ * and at any zoomed-out orbit the user can reach) — its
  * on/off-road pair would then sit closer than one screen pixel apart, sampling the same rounded pixel
  * twice (measured: a seed whose nearest road sat 260 m out read identical on/off-road luminance on the
  * real device). The on-road point is that midpoint's nearest grid vertex; the off-road point steps


### PR DESCRIPTION
## Problem

Stage 25 of `specs/shallot-roads.md` landed as PR #90, but that PR's base was the stale remote branch `shallot-roads/24a-repair` rather than `main` — so the work merged onto a side branch and `main` never received it. This is the third instance of the unit's recorded gitlink family: kex's recorded pointer would name a sha reachable from no remote trunk ref, unresolvable from a fresh clone or the other device, with every gate green.

## Cause

`shallot-roads/24a-repair` was left published after 24a shipped (its content is already on `main` as the squash `f053a06`), and the ship wrapper's PR creation picked it up as the base.

## Fix

Squash `shallot-roads/24a-repair` onto `main`. The 3-dot content diff against `main` is exactly stage 25's five files — the `a84b3bf` commit riding along is 24a, whose tree is byte-identical to `f053a06`, so nothing but stage 25 lands. The stale branch is deleted with this merge, and kex's gitlink is then bumped to this merge commit and verified an ancestor of `origin/main`.

## Stage 25 itself

Two coupled one-line defects in `examples/showcase/roads/public/scenes/roads.scene`, both surfaced by the 24b human look (*"starts a bit too zoomed out, or could use a farther far clip plane"*):

- **`far`**: the engine `Camera` default is `far: 1000` while the orbit reaches `max-distance: 2500` over a grid with a 724 m half-diagonal, so the far grid corner clipped at every orbit past ~276 m of distance. Now `far: 3225`, derived as `max-distance + WORLD_HALF·√2` = 3224, rounded up (the round-up also covers the 3D relief term, worst case 3224.25).
- **default `distance`**: 900 was derived to frame the 1024 m *grid*, making the 8 m road and its ~36 m earthwork corridor sub-pixel. Now 120, re-anchored on the subject the way `corridorPose.ts` does. Deliberately ungated — a presentation choice, with its derivation in a comment beside it.

New arm `src/frustum.test.ts` implements Validation's "Camera frustum covers the world it can reach": it parses the scene file's own `camera`/`orbit` attributes, imports `WORLD_HALF` from `terrain/grid.ts`, and asserts `far ≥ max-distance + WORLD_HALF·√2` — the treatment appears on neither side of the derivation, so the arm reds when the camera's reach moves rather than restating the value it polices.

A review round then relabelled every `900 m` in `corridorPose.ts`, `corridorPose.test.ts` and `overlay/network.ts` as the historical measurement point rather than "the default pose", and repaired a self-contradiction in the scene's own new comment. All four were prose in files the first diff never opened — the unit's stage-23 pattern, where a diff-scoped reviewer finds nothing.

## Evidence

- `bun test ./examples/showcase/roads/src` — **167 pass / 0 fail** (floor 165 before the stage; the +2 are the new arm)
- `bun run gate` in `examples/showcase/roads` — exit 0 on `apple metal-3` (1 passed / 2 skipped; the skips are the retired opt-in straightness arms). Not a software-adapter skip.
- `bun run format` 0 errors, `bun check` exit 0
- Red-first demonstrated before the fix landed: `far 1000 must be ≥ max-distance 2500 + WORLD_HALF·√2 512·1.4142 = 3224.1 — Expected: >= 3224.0773439350246, Received: 1000`, exit 1
- fs-composite probes re-checked rather than re-fitted: both probe points project inside the frame at the new 120 m default (onRoad 0.905, 0.464; offRoad 0.929, 0.492), so the gate's pass is real and not `luminanceAt`'s edge clamp
