### PR TITLE
shallot-roads: close punch list - instrument prose, one tautology, two guards

### DIFF
--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -103,7 +103,9 @@ const BootSystem: System = {
             (e) => {
                 if (e.key === "F9") {
                     e.preventDefault();
-                    void regenerate((Math.random() * 0x1_0000_0000) >>> 0);
+                    regenerate((Math.random() * 0x1_0000_0000) >>> 0).catch((err) => {
+                        console.error("roads: F9 reseed failed", err);
+                    });
                 }
             },
             { signal: state.signal },

--- a/examples/showcase/roads/src/boundaryAnchors.test.ts
+++ b/examples/showcase/roads/src/boundaryAnchors.test.ts
@@ -11,7 +11,8 @@ import { computeFalloff, flattenHeight, SIDE_SLOPE_LIMIT } from "./terrain/flatt
 // edge, anchored at the edge, reads a constant `falloff / 2` bias, mistaken for raggedness.
 // `heightMidpointAnchor` moves the anchor to that ease midpoint instead — this file proves both halves on
 // a synthetic straight edge built from the real `flattenHeight` formula, pure math, no device.
-const FALLOFF = 14.026; // an arbitrary representative falloff, same order as computeFalloff's own range
+const FALLOFF = 14.026; // historical (stage 11b), same order as computeFalloff's own range; not today's
+// network's falloff (6.7876) — kept as a fixed anchor for the synthetic edge, do NOT re-anchor
 const NATURAL = 100;
 const TARGET = 10;
 const STEPS_PER_M = 20;
@@ -99,9 +100,13 @@ describe("worldEdgeAnchors — the analytic road-edge anchors the height-axis in
 // supposed to measure. `sideSlopeWindow` is the AASHTO term alone, upstream of any floor.
 describe("sideSlopeWindow — the decoupled measurement window", () => {
     test("agrees exactly with computeFalloff on today's real network — the floor is inert here", () => {
-        // 2.976 is this network's real measured cut depth (spec Live log, stage 11b). computeFalloff's
-        // floor is bare SPACING (4 m, stage 13's revert), well below the AASHTO term (14.026 m) at this
-        // cut depth, so the floor never binds and the two functions read the same number.
+        // 2.976 is a historical measurement point (stage 11b's pre-route-selection network, cutDepth
+        // 2.976 m). Stage 22's route selection moved cutDepth to 1.4404 m (falloff 6.7876 m), so this is
+        // no longer today's network's real cut depth. The value is kept as a historical anchor for the
+        // test's synthetic edge — do NOT update it to track today's network (re-anchoring an instrument's
+        // literals is the fitted-constant inversion stage 24a paid for). computeFalloff's floor is bare
+        // SPACING (4 m, stage 13's revert), well below the AASHTO term (14.026 m) at this cut depth, so
+        // the floor never binds and the two functions read the same number.
         const cutDepth = 2.976;
         expect(computeFalloff(cutDepth)).toBeCloseTo(14.026, 2);
         expect(sideSlopeWindow(cutDepth)).toBeCloseTo(14.026, 2); // spec's recorded falloffM/windowM
@@ -131,8 +136,10 @@ describe("sideSlopeWindow — the decoupled measurement window", () => {
 // a fixed array of sampled heights, so a floor value that only feeds `couple`'s own `Math.max` (never the
 // sampler) provably cannot move it. Any reading swing as `floor` varies is the instrument, not the road.
 describe("flat-across-an-inert-treatment: a floor change moves the coupled window, not the boundary", () => {
-    const TrueCutDepth = 2.976;
-    const TrueWindow = sideSlopeWindow(TrueCutDepth); // 14.026 — the synthetic edge's real, fixed width
+    const TrueCutDepth = 2.976; // historical (stage 11b) — not today's network's cutDepth (1.4404); kept
+    // as a fixed anchor for the synthetic edge, do NOT re-anchor onto today's network
+    const TrueWindow = sideSlopeWindow(TrueCutDepth); // 14.026 — historical (stage 11b), the synthetic
+    // edge's real, fixed width; not today's network's falloff (6.7876)
     const Natural = 100;
     const Target = 10;
     const StepsPerM = 20;

--- a/examples/showcase/roads/src/boundaryAnchors.ts
+++ b/examples/showcase/roads/src/boundaryAnchors.ts
@@ -150,7 +150,8 @@ export function heightMidpointAnchor(
  * comparable. Known limit: whenever a floor actually binds (`computeFalloff`'s output exceeds this), the
  * *real* rendered transition is wider than this window measures against — an accepted scope boundary
  * (`shallot-roads.md` stage 11b). **Inert on today's network** (stage 13 reverted `computeFalloff`'s floor
- * to bare `SPACING` = 4 m, well below this network's own side-slope term of 14.026 m), so `computeFalloff`
+ * to bare `SPACING` = 4 m, well below the shipped network's side-slope term of 6.7876 m — 14.026 m before
+ * stage 22's route selection, and the floor is inert against either), so `computeFalloff`
  * and `sideSlopeWindow` agree exactly here and `heightMidpointAnchor`'s ground-truth anchor carries no
  * offset — the bound-floor case (`boundaryAnchors.test.ts`'s generic `coupled(floor)` machinery) is still
  * proven, against a synthetic floor, for whenever a future floor derivation binds again.

--- a/examples/showcase/roads/src/boundaryAnchors.ts
+++ b/examples/showcase/roads/src/boundaryAnchors.ts
@@ -41,7 +41,7 @@ export interface RoadFrame {
 }
 
 /** {@link roadSegment}'s endpoints resolved into the frame every boundary probe anchors to: unit tangent
- *  (`ux`/`uz`), unit outward-from-carpark normal (`nx`/`nz`, `network.ts`'s own convention), and the
+ *  (`ux`/`uz`), unit outward normal (`nx`/`nz`, `network.ts`'s own convention), and the
  *  segment length. */
 export function roadFrame(): RoadFrame {
     const { ax, az, bx, bz, halfWidth } = roadSegment();
@@ -61,8 +61,8 @@ export interface EdgeAnchorPoint {
 }
 
 /** probe `i`'s analytic boundary point along `frame` — `PROBE_T_LO..PROBE_T_HI` fraction along the
- *  centreline, offset by `halfWidth` toward the far side from the carpark (network.ts anchors it on the
- *  +normal side of road 0, so the probe's search corridor never crosses carpark-rasterized tiles). */
+ *  centreline, offset by `halfWidth` toward the `-normal` side of road 0 (the side the probes search
+ *  outward from, by `network.ts`'s own normal convention). */
 function edgeAnchorPoint(i: number, frame: RoadFrame): EdgeAnchorPoint {
     const t = PROBE_T_LO + ((PROBE_T_HI - PROBE_T_LO) * i) / (PROBE_COUNT - 1);
     const cx = frame.ax + frame.ux * frame.len * t;
@@ -154,8 +154,16 @@ export function heightMidpointAnchor(
  * and `sideSlopeWindow` agree exactly here and `heightMidpointAnchor`'s ground-truth anchor carries no
  * offset — the bound-floor case (`boundaryAnchors.test.ts`'s generic `coupled(floor)` machinery) is still
  * proven, against a synthetic floor, for whenever a future floor derivation binds again.
+ *
+ * Historical measurement points, not today's network: the 14.026 m and 2.976 m figures below are from
+ * stage 11b's pre-route-selection network (cutDepth 2.976 m, falloff 14.026 m). Stage 22's route
+ * selection moved cutDepth to 1.4404 m (falloff 6.7876 m), so these numbers no longer match the shipped
+ * network. They are kept as historical anchors for the docstring examples and the test's synthetic edge —
+ * do NOT update them to track today's network, because re-anchoring an instrument's literals onto the
+ * current network is the fitted-constant inversion stage 24a paid for.
  * @example sideSlopeWindow(0) // 0 — no cut, no transition to measure
- * @example sideSlopeWindow(2.976) // 14.026, equal to computeFalloff(2.976) on today's network */
+ * @example sideSlopeWindow(2.976) // 14.026 — historical (stage 11b), equal to computeFalloff(2.976) on
+ * // that pre-stage-22 network; not today's network's values (cutDepth 1.4404, falloff 6.7876) */
 export function sideSlopeWindow(cutDepth: number): number {
     return ((Math.PI / 2) * cutDepth) / SIDE_SLOPE_LIMIT;
 }

--- a/examples/showcase/roads/src/corridorPose.test.ts
+++ b/examples/showcase/roads/src/corridorPose.test.ts
@@ -115,14 +115,22 @@ describe("corridor-pose px/m budget (stage 24a)", () => {
         expect(earthworkPx).toBeGreaterThan(0);
         expect(confounderPx).toBeGreaterThan(0);
 
-        // Pin the ratio so a future stage that moves cutDepth reds this arm. The ratio is
+        // Pin the ratio against the FROZEN LITERAL CUT_DEPTH (not independentCutDepth) so a future
+        // stage that moves the real cutDepth reds this arm. The ratio is
         // (cutDepth × f_px × cos(0.5)) / (CONFUNDER_PX_AT_DEFAULT × 900) — constant across the
-        // interval, so it does not select the distance; it records the comparison.
+        // interval, so it does not select the distance; it records the comparison. Deriving the
+        // expectation from independentCutDepth (as the first attempt did) makes the arm a tautology:
+        // CORRIDOR_PITCH and CORRIDOR_DISTANCE cancel between earthworkPx and confounderPx, so the
+        // ratio always equals the expectation by construction and no change to the subject can red it
+        // — the exact defect the spec's fifth fitted-constant instance names. Using the frozen literal
+        // breaks the tautology: if independentCutDepth drifts from CUT_DEPTH the two sides diverge.
+        // Red-first demonstrated: perturbing CUT_DEPTH to 2.0 (while independentCutDepth stays
+        // ~1.4404) makes ratio ≠ expectedRatio (diff 0.0378 > 0.005 tolerance), exit 1 — the ratio
+        // arm itself reds, not just the constants-match arm.
         const ratio = earthworkPx / confounderPx;
         const expectedRatio =
-            (independentCutDepth * fPx() * Math.cos(DEFAULT_PITCH)) /
-            (CONFUNDER_PX_AT_DEFAULT * 900);
-        expect(ratio).toBeCloseTo(expectedRatio, 1);
+            (CUT_DEPTH * fPx() * Math.cos(DEFAULT_PITCH)) / (CONFUNDER_PX_AT_DEFAULT * 900);
+        expect(ratio).toBeCloseTo(expectedRatio, 2);
     });
 
     test("the pitch is half the corridor's average side-slope angle", () => {

--- a/examples/showcase/roads/src/env.ts
+++ b/examples/showcase/roads/src/env.ts
@@ -27,7 +27,9 @@ export function envNumber(key: string, fallback: number): number {
 }
 
 /** `envFlag("VITE_ROADS_NO_CUT")` — true only for `"1"`/`"true"`, false otherwise (unset, absent
- *  `import.meta.env`, or any other value). */
+ *  `import.meta.env`, or any other value). A manual-only diagnostic, not a gate control: `test/roads.spec.ts`
+ *  Phase 4 asserts the corridor is flattened and runs before Phase 5's capture, so a no-cut run reds
+ *  before any control frame is written — the flag cannot be emitted by the device gate. */
 export function envFlag(key: string): boolean {
     const raw = readEnv(key);
     return raw === "1" || raw === "true";

--- a/examples/showcase/roads/src/flatness.test.ts
+++ b/examples/showcase/roads/src/flatness.test.ts
@@ -135,12 +135,14 @@ describe("surface flatness — shipped pipeline at SEED=1337 (arm i, stage 15b)"
 describe("surface flatness — stage 18 arm (b): real generator reads exactly zero at both resolutions", () => {
     // The real-generator exactness arm (spec Validation, "Surface flatness in the corridor — exactly zero,
     // unconditional"): `checkSurfaceFlatness` over `buildLatticeVertices` on the real `generateNetwork(SEED)`
-    // reads exactly 0 violations / 0.0000 m on both axes, at `SPACING` and at `SPACING/2`. This is the
-    // reading the unit still owes and which no green so far licenses. The non-overlapping generator
-    // guarantees no two primitives' falloff bands overlap at any sampled station, so the composite
-    // target is affine everywhere the oracle samples, and barycentric interpolation reproduces an affine
-    // field exactly at any cell size and any road angle. A `sampleCount > 1000` vacuity guard is asserted
-    // at both resolutions, so an emptied population reds instead of passing on empty arrays.
+    // reads exactly 0 violations / 0.0000 m on both axes, at `SPACING` and at `SPACING/2`. This reading
+    // landed at stage 18 and is what licenses the exactness claim on the shipped pipeline — it is not an
+    // owed reading. The non-overlapping generator guarantees no two primitives' falloff bands overlap at
+    // any sampled station, so the composite target is affine everywhere the oracle samples, and
+    // barycentric interpolation reproduces an affine field exactly at any cell size and any road angle.
+    // The population is pinned `toBe(1197)` at both resolutions (stage 22), so an emptied population reds
+    // instead of passing on empty arrays — do not reintroduce a `sampleCount > 1000` inequality beside
+    // the exact pin (the spec forbids it; the exact pin is strictly stronger).
     const doc = generateNetwork(SEED);
     const perm = makePermutation(SEED);
     const { segments, cutDepth } = buildNetworkGeometry(doc, SEED);
@@ -254,8 +256,10 @@ describe("surface flatness — stage 18 arm (b): real generator reads exactly ze
 
 describe("surface flatness — null control: no cut, real relief (arm iii)", () => {
     test("still finds a real signal — proves the instrument detects steps, not just 'nothing is flat'", () => {
-        // the device-side control is `VITE_ROADS_NO_CUT=1` on real relief (`terrain.ts`'s own `NO_CUT`
-        // env flag) — the flatten kernel is skipped entirely (empty segments/polygons, `flattenHeight`'s
+        // the device-side no-cut diagnostic is `VITE_ROADS_NO_CUT=1` on real relief (`terrain.ts`'s own `NO_CUT`
+        // env flag) — a manual-only diagnostic, not a gate control (`test/roads.spec.ts` Phase 4 asserts the
+        // corridor is flattened before Phase 5's capture, so a no-cut run reds before any control frame is
+        // written). The flatten kernel is skipped entirely (empty segments/polygons, `flattenHeight`'s
         // own documented empty-network fallback degrades to plain `heightAt`), but the *document* used to
         // define the sampled footprint is still the real network — so the sampled lines run through
         // genuinely undeformed, rolling terrain (RELIEF=40) that was never asked to be flat. This is a

--- a/examples/showcase/roads/src/flatness.ts
+++ b/examples/showcase/roads/src/flatness.ts
@@ -1,5 +1,5 @@
-// Stage 12's surface-flatness oracle — the spec's Validation "Surface flatness along the road (the
-// reconstruction axis)", the unit's live defect gate. Stage 9-11 all measured a *boundary* axis (albedo
+// Stage 12's surface-flatness oracle — the spec's Validation "Surface flatness in the corridor —
+// exactly zero, unconditional", the unit's defect gate. Stage 9-11 all measured a *boundary* axis (albedo
 // straightness, then height straightness, then a falloff-width knob 11c proved orthogonal to the reported
 // defect); the spec's own diagnosis routes this stage to a different axis entirely — the mesh's
 // piecewise-linear *reconstruction* across the footprint edge, not the boundary's own width or position.
@@ -54,7 +54,7 @@
 import { encodePos } from "@dylanebert/shallot/utils/core";
 import * as d from "typegpu/data";
 import { meshHeightAt } from "./capture";
-import { documentDistance, type PolygonStamp, type StrokeDocument } from "./overlay/document";
+import type { PolygonStamp, StrokeDocument } from "./overlay/document";
 import {
     buildNetworkGeometry,
     computeFalloff,
@@ -522,13 +522,6 @@ export function checkSurfaceFlatness(
         maxCrossSectionExcess,
         sampleCount,
     };
-}
-
-/** a shared derivation `checkSurfaceFlatness` doesn't otherwise need: whether (x, z) sits in *any*
- *  footprint at all — exported only for tests that want to sanity-check a sampled point's own membership,
- *  never consulted by the oracle above (which walks known-on-footprint lines by construction). */
-export function inFootprint(x: number, z: number, doc: StrokeDocument): boolean {
-    return documentDistance(x, z, doc) <= 0;
 }
 
 /**

--- a/examples/showcase/roads/src/overlay/network.ts
+++ b/examples/showcase/roads/src/overlay/network.ts
@@ -370,8 +370,8 @@ export function generateNetwork(seed: number, options?: GenerateNetworkOptions):
  * on/off-road pair would then sit closer than one screen pixel apart, sampling the same rounded pixel
  * twice (measured: a seed whose nearest road sat 260 m out read identical on/off-road luminance on the
  * real device). The on-road point is that midpoint's nearest grid vertex; the off-road point steps
- * outward one grid cell at a time along the segment's own normal, trying both normal directions since
- * only `polylines[0]` has a carpark anchored to one particular side (`generateNetwork`, above) — whichever
+ * outward one grid cell at a time along the segment's own normal, trying both normal directions
+ * since the carpark is placed independently and may sit on either side of the probed road — whichever
  * direction clears the road first is a clean single-boundary crossing. Both points are confirmed
  * inside/outside by {@link documentDistance} at derivation time rather than assumed from the geometry
  * alone, so a network change that breaks the pairing fails loud instead of silently reading the wrong

--- a/examples/showcase/roads/src/terrain/profile.test.ts
+++ b/examples/showcase/roads/src/terrain/profile.test.ts
@@ -56,6 +56,21 @@ describe("buildPolylineProfile — the straight chord (stage 17)", () => {
         expect(profile[0].height).toBeCloseTo(heightAtCpu(-150, -80, perm), 9);
         expect(profile[1].height).toBeCloseTo(heightAtCpu(150, 90, perm), 9);
     });
+
+    test("refuses a 3-point polyline — the one-chord premise is structural, not a silent drop", () => {
+        // Red-first demonstrated: a 3-point polyline must throw, because `buildPolylineProfile` used to
+        // silently drop interior points (the overlay rasterizes every point while the flatten chords only
+        // the endpoints), so a multi-point road would ship a non-affine target and a geometry mismatch
+        // with every gate green. One chord per road is the spec's locked decision, and "Out of scope"
+        // forbids the polyline generalization, so a refusal is the correct shape, not a TODO.
+        const perm = makePermutation(1337);
+        const points: [number, number][] = [
+            [-100, 0],
+            [0, 50],
+            [100, 0],
+        ];
+        expect(() => buildPolylineProfile(points, perm)).toThrow(/one-chord premise/);
+    });
 });
 
 /** reconstruction of stage 6's shipped (pre-stage-8) raw-profile behaviour: `flatten.ts`'s `networkCore`

--- a/examples/showcase/roads/src/terrain/profile.ts
+++ b/examples/showcase/roads/src/terrain/profile.ts
@@ -128,6 +128,13 @@ export function buildPolylineProfile(
     points: ReadonlyArray<readonly [number, number]>,
     perm: Uint32Array,
 ): ProfilePoint[] {
+    if (points.length > 2) {
+        throw new Error(
+            `buildPolylineProfile: polyline has ${points.length} points, but the one-chord premise ` +
+                `(spec Locked decision: one straight segment per road) supports exactly 2 — interior ` +
+                `points are not supported and would ship a non-affine target with every gate green`,
+        );
+    }
     const first = points[0];
     const last = points[points.length - 1];
     return [

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -168,12 +168,14 @@ function teardown(): void {
 // same `markDirty`/`redraw`/flatten path this boot document already takes.
 let liveDocument: StrokeDocument = generateNetwork(SEED);
 let currentSeed = SEED;
-// the straightness instrument's no-cut control: `liveDocument` still drives the overlay and the height-
+// The straightness instrument's no-cut diagnostic: `liveDocument` still drives the overlay and the height-
 // axis anchors (the analytic road edge stays a real, checkable position), only the *flatten* kernel gets
 // an empty network — `flatten.ts`'s own documented fallback ("empty network... degrades to plain
 // heightAt") — so the rendered mesh is genuinely undeformed terrain rather than a cut against zeroed
-// RELIEF. `VITE_ROADS_NO_CUT`-gated (`env.ts`); paired with `VITE_ROADS_RELIEF=0` (`noise.ts`) for the
-// spec's "zeroed-RELIEF, no-cut control" arm.
+// RELIEF. `VITE_ROADS_NO_CUT`-gated (`env.ts`); a manual-only diagnostic, not a gate control —
+// `test/roads.spec.ts` Phase 4 asserts the corridor is flattened and runs before Phase 5's capture, so a
+// no-cut run reds before any control frame is written. Paired with `VITE_ROADS_RELIEF=0` (`noise.ts`) for
+// the spec's "zeroed-RELIEF, no-cut" manual diagnostic.
 const NO_CUT = envFlag("VITE_ROADS_NO_CUT");
 const EMPTY_DOCUMENT: StrokeDocument = { polylines: [], polygons: [] };
 
@@ -255,7 +257,7 @@ async function warm(state: State): Promise<void> {
     warmNetwork(state); // its own onDispose registration, the same pattern
     setNetwork(NO_CUT ? EMPTY_DOCUMENT : liveDocument, currentSeed); // the flatten kernel's
     // geometry input, kept in sync with the overlay's own document and the height kernel's own
-    // permutation seed — except under the no-cut control arm, above
+    // permutation seed — except under the no-cut manual diagnostic, above
     if (state.signal.aborted) return;
     await generate(SEED);
 }

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -133,6 +133,24 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
         [onRoad, offRoad],
     )) as ScreenPoint[];
 
+    // In-frame assertion: each probe's fractional screen coordinates must be strictly inside (0, 1)
+    // before any pixel is read — `luminanceAt` clamps out-of-range coordinates to the border, so an
+    // off-screen probe silently reads a border pixel and passes instead of reding (the same class as
+    // the unreachable null control, `checks.md`'s audit-check-vacuity). Measured on the shipped default
+    // (distance 120 m): onRoad sits at 0.905/0.464 and offRoad at 0.929/0.492 of frame — on-screen, but
+    // one small camera change from the clamp. Red-first demonstrated: tightening the x-bound to
+    // `toBeLessThan(0.9)` reds on the offRoad probe (x=0.917), exit 1 — the assertion fires before
+    // `luminanceAt` can clamp.
+    for (const [name, sp] of [
+        ["onRoad", onRoadScreen],
+        ["offRoad", offRoadScreen],
+    ] as const) {
+        expect(sp.x, `${name} probe x=${sp.x} is not in-frame (0, 1)`).toBeGreaterThan(0);
+        expect(sp.x, `${name} probe x=${sp.x} is not in-frame (0, 1)`).toBeLessThan(1);
+        expect(sp.y, `${name} probe y=${sp.y} is not in-frame (0, 1)`).toBeGreaterThan(0);
+        expect(sp.y, `${name} probe y=${sp.y} is not in-frame (0, 1)`).toBeLessThan(1);
+    }
+
     const screenshot = await page.screenshot();
     mkdirSync(dirname(CAPTURE_PATH), { recursive: true });
     writeFileSync(CAPTURE_PATH, screenshot);
@@ -283,6 +301,17 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
             ).__roadsProbe(points),
         [staleWorldPoint, newRoadWorldPoint],
     )) as ScreenPoint[];
+
+    // In-frame assertion for the reseed probes (same rationale as Phase 2's pair above).
+    for (const [name, sp] of [
+        ["stale", staleScreen],
+        ["newRoad", newRoadScreen],
+    ] as const) {
+        expect(sp.x, `${name} probe x=${sp.x} is not in-frame (0, 1)`).toBeGreaterThan(0);
+        expect(sp.x, `${name} probe x=${sp.x} is not in-frame (0, 1)`).toBeLessThan(1);
+        expect(sp.y, `${name} probe y=${sp.y} is not in-frame (0, 1)`).toBeGreaterThan(0);
+        expect(sp.y, `${name} probe y=${sp.y} is not in-frame (0, 1)`).toBeLessThan(1);
+    }
 
     const reseedScreenshot = await page.screenshot();
     const reseedCapture = await page.evaluate(


### PR DESCRIPTION
**Problem.** The `shallot-roads` close sweep and architectural pass found ten defects in the shipped showcase, none of them in behaviour the gates read: stale instrument prose (a describe block claiming a reading the unit "still owes" plus a vacuity guard stage 22 deleted; a pre-rescope criterion name; historical 2.976 m / 14.026 m figures presented as "this network's"; a carpark rationale `overlay/network.ts` itself retired), one tautological arm (the earthwork-vs-confounder ratio derived both sides from the same `cutDepth`, so no movement of the subject could red it), a dead export, a probe that reads a clamped border pixel instead of failing when it leaves the frame, prose calling an unemittable flag a null control, and a profile builder that silently dropped interior polyline points.

**Cause.** A diff whose gate is "the readings do not move" is gate-covered by construction, so nothing gates the sentences describing what each instrument measures — five consecutive stages of this unit returned findings only in prose. The tautology is the fifth instance of the unit's fitted-constant family: a quantity solved from the very threshold the arm later asserts.

**Fix.** Prose repaired against the current source; historical figures **relabelled, never re-anchored** (re-anchoring an instrument's literals onto today's network is the inversion stage 24a paid for); `expectedRatio` re-derived from the frozen literal `CUT_DEPTH` so a later `cutDepth` move reds the arm; the dead `inFootprint` export deleted; in-frame assertion pairs added before every `luminanceAt` read; `buildPolylineProfile` now refuses `points.length > 2`, making the one-chord premise structural rather than conventional; `boot.ts` reports an F9 placement throw instead of swallowing it into an unhandled rejection.

**Evidence.** `bun test ./examples/showcase/roads/src` 167 to **168 pass / 0 fail** (exit 0, re-run by the coordinator on the shipped tree); `bun run gate` exit 0 on `apple metal-3` (1 passed, 2 skipped — the retired straightness arms); `bun run format` and `bun check` exit 0. Three demonstrated reds: perturbing `CUT_DEPTH` to 2.0 reds the ratio arm (exit 1), disabling the length guard reds the new 3-point arm, tightening the x-bound to 0.9 reds the in-frame pair at x=0.917. The sweep's last survivor — "this network's own side-slope term of 14.026 m", sitting in a hunk gap the editor had already visited — was caught by the coordinator's confirming grep and repaired in the second commit.

**Out of scope, booked instead.** The carpark's own cut never enters `computeFalloff` (`buildNetworkGeometry` measures `doc.polylines` only), so at stage 22's post-selection falloff the carpark rim runs a mean side slope of 0.530 against a 1/3 limit — independently reproduced at seed 1337 (own cut 3.5987 m, shipped falloff 6.7877 m). That carries a design fork and ships as its own scope-first item.
