### PR TITLE
roads interactive/3

### DIFF
--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -2,6 +2,7 @@ import type { Plugin, System } from "@dylanebert/shallot";
 import { Meshes } from "@dylanebert/shallot/render/core";
 import {
     capturePoints,
+    markingProbePoints,
     type ScreenPoint,
     TRANSITION_TOLERANCE_PX,
     withHeight,
@@ -48,6 +49,15 @@ declare global {
         // network's flatten target is gone.
         __roadsRegenerate?: (seed: number) => Promise<void>;
         __roadsHeightAt?: (x: number, z: number) => Promise<[number, number, number]>;
+        // stage 3's marking device probes — four world points derived from the document, each on a
+        // distinct marking class (edge line, asphalt, dash gap, dash). The device gate asserts the
+        // luminance bands at these points are disjoint.
+        __roadsMarkingProbePoints?: () => Promise<{
+            edgeLine: [number, number, number];
+            asphalt: [number, number, number];
+            dashGap: [number, number, number];
+            dash: [number, number, number];
+        }>;
     }
 }
 
@@ -71,6 +81,7 @@ const BootSystem: System = {
         window.__roadsCorridorCapture = () => corridorCapture();
         window.__roadsRegenerate = (seed) => regenerate(seed);
         window.__roadsHeightAt = (x, z) => withHeight(x, z);
+        window.__roadsMarkingProbePoints = () => markingProbePoints();
         // F9 reseeds the live procedural network (`terrain.ts`'s `regenerate`) — the same key voxel's own
         // reseed uses. `{ signal: state.signal }` detaches the listener at `state.dispose()`, no removal
         // code needed.
@@ -96,6 +107,7 @@ const BootSystem: System = {
         delete window.__roadsCorridorCapture;
         delete window.__roadsRegenerate;
         delete window.__roadsHeightAt;
+        delete window.__roadsMarkingProbePoints;
     },
 };
 

--- a/examples/showcase/roads/src/capture.ts
+++ b/examples/showcase/roads/src/capture.ts
@@ -1,7 +1,8 @@
 import { computeViewProj, Views } from "@dylanebert/shallot/render/core";
 import { decodePos } from "@dylanebert/shallot/utils/core";
-import { captureProbePoints } from "./overlay/network";
-import { COVERAGE_BAND_PX } from "./overlay/tiles";
+import { markingDistance } from "./overlay/document";
+import { captureProbePoints, generateNetwork } from "./overlay/network";
+import { COVERAGE_BAND_PX, DASH_DUTY, DASH_OFFSET, DASH_PERIOD, EDGE_INSET } from "./overlay/tiles";
 import { TERRAIN_QUANT } from "./terrain/generate";
 import { CELLS, gridX, gridZ, SPACING, VERTS } from "./terrain/grid";
 import { readVertices } from "./terrain/terrain";
@@ -138,6 +139,103 @@ export async function capturePoints(): Promise<{
         withHeight(...offRoad),
     ]);
     return { onRoad: onRoadPoint, offRoad: offRoadPoint };
+}
+
+/**
+ * the capture gate's marking probe points — four world points derived from the document (never
+ * hand-placed), each sitting on a distinct marking class the fs composites: one on an edge line
+ * (solid white), one on the asphalt between the edge line and the centreline, one in a dash gap
+ * (centreline absent → reads road), and one on a dash (broken yellow centreline). The device gate
+ * asserts the luminance bands at these four points are DISJOINT — a probe that cannot discriminate
+ * the classes it gates is not evidence (roads-interactive.md stage 3, Marking fidelity).
+ *
+ * Derivation: the standard chord's midpoint, offset along the road's normal by (halfWidth −
+ * EDGE_INSET) for the edge line, by halfWidth/2 for the asphalt between, and along the centreline
+ * at stations chosen by the dash phase (fract(s / DASH_PERIOD) < DASH_DUTY for a dash, >= DASH_DUTY
+ * for a gap). Heights read from the live generated terrain.
+ */
+export async function markingProbePoints(): Promise<{
+    edgeLine: [number, number, number];
+    asphalt: [number, number, number];
+    dashGap: [number, number, number];
+    dash: [number, number, number];
+}> {
+    const doc = generateNetwork();
+    const line = doc.polylines[0];
+    const [[ax, az], [bx, bz]] = line.points;
+    const mx = (ax + bx) / 2;
+    const mz = (az + bz) / 2;
+    const dx = bx - ax;
+    const dz = bz - az;
+    const len = Math.hypot(dx, dz) || 1;
+    const nx = -dz / len; // unit normal (network.ts's convention)
+    const nz = dx / len;
+    const halfWidth = line.halfWidth;
+
+    // edge line: midpoint, offset laterally by (halfWidth - EDGE_INSET) toward one edge
+    const edgeOffset = halfWidth - EDGE_INSET;
+    const edgeLineX = mx + nx * edgeOffset;
+    const edgeLineZ = mz + nz * edgeOffset;
+
+    // asphalt between: midpoint, offset laterally by halfWidth/2 (between centreline and edge line)
+    const asphaltOffset = halfWidth / 2;
+    const asphaltX = mx + nx * asphaltOffset;
+    const asphaltZ = mz + nz * asphaltOffset;
+
+    // dash / dash gap: scan along the centreline for the first station in a dash and the first in a gap.
+    // Start at the midpoint (station = len/2) and step in both directions to find each class.
+    const midStation = len / 2;
+    let dashStation = -1;
+    let gapStation = -1;
+    const step = 0.5; // half-metre steps — finer than LINE_WIDTH, coarse enough to be fast
+    for (let s = midStation; s < len && (dashStation < 0 || gapStation < 0); s += step) {
+        const phase = ((s + DASH_OFFSET) / DASH_PERIOD) % 1;
+        if (dashStation < 0 && phase < DASH_DUTY) dashStation = s;
+        if (gapStation < 0 && phase >= DASH_DUTY) gapStation = s;
+    }
+    // fall back to scanning backward if forward didn't find both
+    for (let s = midStation - step; s >= 0 && (dashStation < 0 || gapStation < 0); s -= step) {
+        const phase = ((s + DASH_OFFSET) / DASH_PERIOD) % 1;
+        if (dashStation < 0 && phase < DASH_DUTY) dashStation = s;
+        if (gapStation < 0 && phase >= DASH_DUTY) gapStation = s;
+    }
+    if (dashStation < 0 || gapStation < 0) {
+        throw new Error("markingProbePoints: could not find both a dash and a gap station");
+    }
+
+    const ux = dx / len;
+    const uz = dz / len;
+    const dashX = ax + ux * dashStation;
+    const dashZ = az + uz * dashStation;
+    const gapX = ax + ux * gapStation;
+    const gapZ = az + uz * gapStation;
+
+    // verify the probe points classify correctly against the document
+    if (markingDistance(edgeLineX, edgeLineZ, doc) >= 0) {
+        throw new Error("markingProbePoints: edge line probe is not inside a marking");
+    }
+    if (markingDistance(asphaltX, asphaltZ, doc) <= 0) {
+        throw new Error("markingProbePoints: asphalt probe is inside a marking");
+    }
+    if (markingDistance(dashX, dashZ, doc) >= 0) {
+        throw new Error("markingProbePoints: dash probe is not inside a marking");
+    }
+    if (markingDistance(gapX, gapZ, doc) <= 0) {
+        throw new Error("markingProbePoints: dash gap probe is inside a marking");
+    }
+
+    const [edgeLinePt, asphaltPt, dashPt, gapPt] = await Promise.all([
+        withHeight(edgeLineX, edgeLineZ),
+        withHeight(asphaltX, asphaltZ),
+        withHeight(dashX, dashZ),
+        withHeight(gapX, gapZ),
+    ]);
+    return {
+        edgeLine: edgeLinePt,
+        asphalt: asphaltPt,
+        dashGap: gapPt,
+        dash: dashPt,
+    };
 }
 
 /**

--- a/examples/showcase/roads/src/overlay/document.test.ts
+++ b/examples/showcase/roads/src/overlay/document.test.ts
@@ -10,7 +10,6 @@ import {
     type StrokeDocument,
     segmentDistance,
 } from "./document";
-import { ROAD_HALF_WIDTH } from "./network";
 import { strokeDistance, strokeDocument } from "./stroke";
 import { EDGE_INSET, LINE_HALF_WIDTH } from "./tiles";
 
@@ -204,14 +203,16 @@ describe("markingDistanceForSegment", () => {
     const seg: Segment = { ax: -100, az: 0, bx: 100, bz: 0, halfWidth: 4 };
 
     test("negative inside an edge line (centred at d = -EDGE_INSET, width LINE_WIDTH)", () => {
-        // the edge line is at |z| = halfWidth - EDGE_INSET = 3.7 m from the centreline
-        const edgeLineZ = ROAD_HALF_WIDTH - EDGE_INSET; // 3.7
+        // the edge line is at |z| = halfWidth - EDGE_INSET = 3.7 m from the centreline.
+        // Derived from the segment's own halfWidth, not ROAD_HALF_WIDTH, so the probe stays on the
+        // edge line whatever the road width is — one fixture, one source of truth.
+        const edgeLineZ = seg.halfWidth - EDGE_INSET; // 3.7
         const result = markingDistanceForSegment(0, edgeLineZ, seg);
         expect(result).toBeLessThan(0); // inside the edge line
     });
 
     test("zero at the edge line boundary (LINE_HALF_WIDTH from the centre)", () => {
-        const edgeLineZ = ROAD_HALF_WIDTH - EDGE_INSET; // 3.7
+        const edgeLineZ = seg.halfWidth - EDGE_INSET; // 3.7
         const boundary = edgeLineZ + LINE_HALF_WIDTH; // 3.75
         expect(markingDistanceForSegment(0, boundary, seg)).toBeCloseTo(0, 6);
     });
@@ -254,7 +255,7 @@ describe("markingDistance", () => {
         expect(markingDistance(20, 0, doc)).toBeLessThan(0);
         // on the centreline, in a gap (station 100/midpoint with offset) → positive
         expect(markingDistance(0, 0, doc)).toBeGreaterThan(0);
-        // on the edge line → negative
-        expect(markingDistance(0, ROAD_HALF_WIDTH - EDGE_INSET, doc)).toBeLessThan(0);
+        // on the edge line → negative. Derived from the doc's own halfWidth, not ROAD_HALF_WIDTH.
+        expect(markingDistance(0, doc.polylines[0].halfWidth - EDGE_INSET, doc)).toBeLessThan(0);
     });
 });

--- a/examples/showcase/roads/src/overlay/document.test.ts
+++ b/examples/showcase/roads/src/overlay/document.test.ts
@@ -4,10 +4,15 @@ import {
     documentDistance,
     drivable,
     flattenSegments,
+    markingDistance,
+    markingDistanceForSegment,
+    type Segment,
     type StrokeDocument,
     segmentDistance,
 } from "./document";
+import { ROAD_HALF_WIDTH } from "./network";
 import { strokeDistance, strokeDocument } from "./stroke";
+import { EDGE_INSET, LINE_HALF_WIDTH } from "./tiles";
 
 describe("flattenSegments", () => {
     test("one polyline with N points yields N-1 segments, in order", () => {
@@ -191,5 +196,65 @@ describe("drivable", () => {
         ] as const) {
             expect(drivable(x, z, doc)).toBe(documentDistance(x, z, doc) <= 0);
         }
+    });
+});
+
+describe("markingDistanceForSegment", () => {
+    // the standard chord's shape: a horizontal road from (-100, 0) to (100, 0), halfWidth 4
+    const seg: Segment = { ax: -100, az: 0, bx: 100, bz: 0, halfWidth: 4 };
+
+    test("negative inside an edge line (centred at d = -EDGE_INSET, width LINE_WIDTH)", () => {
+        // the edge line is at |z| = halfWidth - EDGE_INSET = 3.7 m from the centreline
+        const edgeLineZ = ROAD_HALF_WIDTH - EDGE_INSET; // 3.7
+        const result = markingDistanceForSegment(0, edgeLineZ, seg);
+        expect(result).toBeLessThan(0); // inside the edge line
+    });
+
+    test("zero at the edge line boundary (LINE_HALF_WIDTH from the centre)", () => {
+        const edgeLineZ = ROAD_HALF_WIDTH - EDGE_INSET; // 3.7
+        const boundary = edgeLineZ + LINE_HALF_WIDTH; // 3.75
+        expect(markingDistanceForSegment(0, boundary, seg)).toBeCloseTo(0, 6);
+    });
+
+    test("negative on the centreline inside a dash (station 120, phase < DASH_DUTY with offset)", () => {
+        // with DASH_OFFSET, station 120: phase = fract((120 + DASH_OFFSET) / DASH_PERIOD) ≈ 0.09 < 0.25 → in a dash
+        // world point at station 120 from A=(-100,0) along +X is (20, 0)
+        const result = markingDistanceForSegment(20, 0, seg);
+        expect(result).toBeLessThan(0); // inside the centreline dash
+    });
+
+    test("positive on the centreline in a gap (station 100/midpoint, phase >= DASH_DUTY with offset)", () => {
+        // with DASH_OFFSET, station 100 (midpoint): phase = fract((100 + DASH_OFFSET) / DASH_PERIOD) ≈ 0.45 >= 0.25 → in a gap
+        // world point at station 100 from A=(-100,0) along +X is (0, 0) — the on-road probe point
+        const result = markingDistanceForSegment(0, 0, seg);
+        expect(result).toBeGreaterThan(0); // in a gap, outside the marking
+    });
+
+    test("positive on the asphalt between the edge line and the centreline", () => {
+        // |z| = 2.0 m: between the edge line (3.7 m) and the centreline (0 m)
+        const result = markingDistanceForSegment(0, 2, seg);
+        expect(result).toBeGreaterThan(0); // on the asphalt, no marking here
+    });
+});
+
+describe("markingDistance", () => {
+    test("is the minimum over every segment, same as documentDistance's shape", () => {
+        const doc: StrokeDocument = {
+            polylines: [
+                {
+                    points: [
+                        [-100, 0],
+                        [100, 0],
+                    ],
+                    halfWidth: 4,
+                },
+            ],
+        };
+        // on the centreline, in a dash (station 120 with offset) → negative
+        expect(markingDistance(20, 0, doc)).toBeLessThan(0);
+        // on the centreline, in a gap (station 100/midpoint with offset) → positive
+        expect(markingDistance(0, 0, doc)).toBeGreaterThan(0);
+        // on the edge line → negative
+        expect(markingDistance(0, ROAD_HALF_WIDTH - EDGE_INSET, doc)).toBeLessThan(0);
     });
 });

--- a/examples/showcase/roads/src/overlay/document.ts
+++ b/examples/showcase/roads/src/overlay/document.ts
@@ -1,4 +1,13 @@
-import { dirtyTiles, type Rect, TEXEL_SIZE } from "./tiles";
+import {
+    DASH_DUTY,
+    DASH_OFFSET,
+    DASH_PERIOD,
+    dirtyTiles,
+    EDGE_INSET,
+    LINE_HALF_WIDTH,
+    type Rect,
+    TEXEL_SIZE,
+} from "./tiles";
 
 // The stroke document: pure data (one road's polyline + width) plus the CPU analytic distance math
 // stage 5's differential oracle checks the GPU rasterizer (`rasterize.ts`) against. No GPU/engine
@@ -77,6 +86,64 @@ export function documentDistance(px: number, pz: number, doc: StrokeDocument): n
     let best = Number.POSITIVE_INFINITY;
     for (const seg of flattenSegments(doc)) {
         const d = segmentDistance(px, pz, seg);
+        if (d < best) best = d;
+    }
+    return best;
+}
+
+/** the signed distance to the nearest road marking at (px, pz) for one segment — negative inside a
+ *  marking, zero at its boundary, positive outside. Two solid edge lines inset from the road edge
+ *  (centred at d = −EDGE_INSET on the existing edge distance) and a broken centreline (perpendicular
+ *  distance to the centreline via d + halfWidth, station along the chord via fract(s / DASH_PERIOD) <
+ *  DASH_DUTY). Cross-product derivation, like {@link segmentDistance} — the CPU twin the GPU's
+ *  `markingDistanceGpu` (rasterize.ts, clamped-projection form) is checked against, independently.
+ *
+ *  Geometry per the Locked decision: one chord, so the dash phase has no joint to break at.
+ *  Two-lane two-way: broken yellow centreline, solid white edges. */
+export function markingDistanceForSegment(px: number, pz: number, seg: Segment): number {
+    const { ax, az, bx, bz } = seg;
+    const abx = bx - ax;
+    const abz = bz - az;
+    const len = Math.hypot(abx, abz);
+    if (len === 0) return Number.POSITIVE_INFINITY;
+    const ux = abx / len;
+    const uz = abz / len;
+    const along = (px - ax) * ux + (pz - az) * uz; // signed station along the chord from A
+    const cross = (px - ax) * uz - (pz - az) * ux; // signed perpendicular offset (2D cross product)
+    const edgeDist = segmentDistance(px, pz, seg); // the existing edge distance (handles endpoints)
+
+    // edge line: solid, centred at d = −EDGE_INSET, width LINE_WIDTH
+    const edgeLineDist = Math.abs(edgeDist + EDGE_INSET) - LINE_HALF_WIDTH;
+
+    // centreline: broken, lateral distance from the perpendicular offset, longitudinal from the dash phase
+    const lateral = Math.abs(cross) - LINE_HALF_WIDTH;
+    let longitudinal: number;
+    if (along < 0) {
+        longitudinal = -along; // before A — centreline does not extend past the endpoint
+    } else if (along > len) {
+        longitudinal = along - len; // after B
+    } else {
+        const phase =
+            (along + DASH_OFFSET) / DASH_PERIOD - Math.floor((along + DASH_OFFSET) / DASH_PERIOD); // fract((s + DASH_OFFSET) / DASH_PERIOD)
+        if (phase < DASH_DUTY) {
+            // inside a dash — distance to the nearer dash boundary (negative = inside)
+            longitudinal = -Math.min(phase, DASH_DUTY - phase) * DASH_PERIOD;
+        } else {
+            // inside a gap — distance to the nearer dash (positive = outside)
+            longitudinal = Math.min(phase - DASH_DUTY, 1 - phase) * DASH_PERIOD;
+        }
+    }
+    const centreDist = Math.max(lateral, longitudinal);
+
+    return Math.min(edgeLineDist, centreDist);
+}
+
+/** the document's analytic marking distance at (px, pz) — the minimum (nearest) signed distance to any
+ *  road marking over every segment. The CPU half of stage 3's marking differential oracle. */
+export function markingDistance(px: number, pz: number, doc: StrokeDocument): number {
+    let best = Number.POSITIVE_INFINITY;
+    for (const seg of flattenSegments(doc)) {
+        const d = markingDistanceForSegment(px, pz, seg);
         if (d < best) best = d;
     }
     return best;

--- a/examples/showcase/roads/src/overlay/rasterize.test.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { body, flat, integerDiscipline } from "../../../../../packages/shallot/tests/wgsl";
-import { type Segment, segmentDistance } from "./document";
-import { encodeDistGpu, rasterizeWgsl, segmentDistanceGpu } from "./rasterize";
+import { markingDistanceForSegment, type Segment, segmentDistance } from "./document";
+import { encodeDistGpu, markingDistanceGpu, rasterizeWgsl, segmentDistanceGpu } from "./rasterize";
 import { DIST_RANGE, decodeDist, encodeDist, TEXEL_SIZE } from "./tiles";
 
 // Stage 5's differential oracle: `segmentDistanceGpu` (rasterize.ts, clamped-projection form, CPU-called
@@ -110,10 +110,10 @@ describe("emitted WGSL — structural", () => {
         expect(kernel).toContain("word = (word | (byte << (k * 8u)))");
     });
 
-    test("albedo is written once per texel with the precomputed constant word, not recomputed per-thread", () => {
-        expect(flat(wgsl)).toContain("const roadAlbedoWord: u32 =");
+    test("albedo rgb is a precomputed constant; the per-texel alpha carries the encoded marking distance", () => {
+        expect(flat(wgsl)).toContain("const roadAlbedoRgb: u32 =");
         const kernel = flat(body(wgsl, "@compute @workgroup_size(8, 8, 1) fn roadsrasterize"));
-        expect(kernel).toContain("albedoOut[albedoIdx] = roadAlbedoWord");
+        expect(kernel).toContain("albedoOut[albedoIdx] = (roadAlbedoRgb | (markingByte << 24u))");
     });
 
     describe("texel-group column ↔ world-x ↔ byte-column correspondence", () => {
@@ -200,5 +200,103 @@ describe("emitted WGSL — structural", () => {
         test("the packing expression itself (a cheap structural sentinel, in addition to the eval-based pins above — never the only one)", () => {
             expect(kernel).toContain("let texelX = ((gx * 4u) + k);");
         });
+    });
+});
+
+// Stage 3's marking differential oracle: `markingDistanceGpu` (rasterize.ts, clamped-projection form,
+// CPU-called through TypeGPU's dual execution) against `document.ts`'s `markingDistanceForSegment`
+// (cross-product form) — two independently written derivations of the same geometric quantity, the
+// signed distance to the nearest road marking (edge lines + broken centreline). The GPU side is
+// quantized through `encodeDistGpu` + `tiles.ts`'s `decodeDist`, the exact byte round-trip the real
+// kernel's output goes through, so the tolerance is the same r8unorm quantization step as the coverage
+// differential above. `rasterize.ts` never imports `markingDistance` — the two derivations are
+// independent by contract, because the differential arm is worthless if one side calls the other.
+//
+// RED-FIRST CONTROL: mutating one side's dash duty (DASH_DUTY) was witnessed red — changing the CPU
+// side's DASH_DUTY to DASH_DUTY * 0.5 (halving the dash fraction) while leaving the GPU side unchanged
+// produces disagreement at points inside a dash whose phase falls in the second half of the original
+// duty cycle: the CPU side now reads those points as in a gap (marking distance positive) while the GPU
+// side still reads them as in a dash (marking distance negative), exceeding the tolerance. This was
+// confirmed by running the mutated comparison and observing the failure before restoring the real duty.
+describe("marking differential oracle — markingDistanceGpu vs document.ts's markingDistanceForSegment", () => {
+    test("agree within one quantization step over random segments and sample points", () => {
+        const rng = mulberry32(42);
+        const rand = (lo: number, hi: number) => lo + rng() * (hi - lo);
+        for (let i = 0; i < 200; i++) {
+            const seg: Segment = {
+                ax: rand(-100, 100),
+                az: rand(-100, 100),
+                bx: rand(-100, 100),
+                bz: rand(-100, 100),
+                halfWidth: rand(1, 8),
+            };
+            const px = rand(-120, 120);
+            const pz = rand(-120, 120);
+
+            const cpu = markingDistanceForSegment(px, pz, seg);
+            const gpuRaw = markingDistanceGpu(
+                px,
+                pz,
+                seg.ax,
+                seg.az,
+                seg.bx,
+                seg.bz,
+                seg.halfWidth,
+            );
+            const gpuQuantized = decodeDist(encodeDistGpu(gpuRaw));
+            const cpuQuantized = quantizeCpu(cpu);
+            expect(Math.abs(gpuQuantized - cpuQuantized)).toBeLessThanOrEqual(TOLERANCE);
+            // and the raw (unquantized) forms agree far tighter — same geometric quantity, f32 roundoff only
+            expect(Math.abs(gpuRaw - cpu)).toBeLessThan(1e-4);
+        }
+    });
+
+    test("agree on the centreline (where the dash phase is the nearest marking), inside a dash and in a gap", () => {
+        // a horizontal road from (-100, 0) to (100, 0), halfWidth 4 — the standard chord's shape.
+        // Points on the centreline (z=0) are where the centreline marking is nearest, so the dash
+        // duty actually determines the distance — this is the axis the red-first control mutates.
+        const seg: Segment = { ax: -100, az: 0, bx: 100, bz: 0, halfWidth: 4 };
+        // station 100: phase = fract((100 + DASH_OFFSET) / DASH_PERIOD) ≈ 0.45 >= DASH_DUTY (0.25) → in a gap (offset shifts midpoint into gap)
+        // station 120: phase = fract((120 + DASH_OFFSET) / DASH_PERIOD) ≈ 0.09 < DASH_DUTY → in a dash
+        const inDash: Array<[number, number]> = [
+            [20, 0], // station 120, on the centreline, in a dash
+            [70, 0.01], // station 170, near the centreline, in a dash
+        ];
+        // station 100 (midpoint): phase ≈ 0.45 >= DASH_DUTY → in a gap (the offset's purpose)
+        // station 50: phase = fract((50 + DASH_OFFSET) / DASH_PERIOD) ≈ 0.35 >= DASH_DUTY → in a gap
+        const inGap: Array<[number, number]> = [
+            [0, 0], // station 100, on the centreline, in a gap
+            [-50, 0.01], // station 50, near the centreline, in a gap
+        ];
+        for (const [px, pz] of inDash) {
+            const cpu = markingDistanceForSegment(px, pz, seg);
+            const gpuRaw = markingDistanceGpu(
+                px,
+                pz,
+                seg.ax,
+                seg.az,
+                seg.bx,
+                seg.bz,
+                seg.halfWidth,
+            );
+            expect(Math.abs(gpuRaw - cpu)).toBeLessThan(1e-4);
+            // inside a dash → marking distance should be negative (inside the marking)
+            expect(cpu).toBeLessThan(0);
+        }
+        for (const [px, pz] of inGap) {
+            const cpu = markingDistanceForSegment(px, pz, seg);
+            const gpuRaw = markingDistanceGpu(
+                px,
+                pz,
+                seg.ax,
+                seg.az,
+                seg.bx,
+                seg.bz,
+                seg.halfWidth,
+            );
+            expect(Math.abs(gpuRaw - cpu)).toBeLessThan(1e-4);
+            // in a gap → marking distance should be positive (outside the marking)
+            expect(cpu).toBeGreaterThan(0);
+        }
     });
 });

--- a/examples/showcase/roads/src/overlay/rasterize.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.ts
@@ -23,7 +23,17 @@ import * as d from "typegpu/data";
 import * as std from "typegpu/std";
 import { flattenSegments, type StrokeDocument } from "./document";
 import { ROAD_ALBEDO } from "./stroke";
-import { DIST_RANGE, TEXEL_SIZE, TILE_RES, tileOrigin } from "./tiles";
+import {
+    DASH_DUTY,
+    DASH_OFFSET,
+    DASH_PERIOD,
+    DIST_RANGE,
+    EDGE_INSET,
+    LINE_HALF_WIDTH,
+    TEXEL_SIZE,
+    TILE_RES,
+    tileOrigin,
+} from "./tiles";
 
 const GROUP_TEXELS = 4; // texels packed per output distance/index word (4 × r8 = one u32, little-endian)
 const GROUPS_PER_SIDE = TILE_RES / GROUP_TEXELS; // 128 — TILE_RES is a multiple of 4 by construction
@@ -112,17 +122,72 @@ export const encodeDistGpu = tgpu.fn(
     return d.u32(std.round(unit * d.f32(255)));
 });
 
-/** pack ROAD_ALBEDO's rgb + full alpha into rgba8unorm's little-endian byte order — every texel gets the
- *  same word (stage 4's `packStrokeTile` wrote albedo everywhere too: cheap, and the fs never reads it
- *  past the coverage the distance channel derives). Computed once at module load, not per-thread. */
-function packAlbedoWord(rgb: readonly [number, number, number]): number {
+/** pack ROAD_ALBEDO's rgb into rgba8unorm's little-endian byte order — the alpha byte is now per-texel
+ *  (the encoded marking distance, not the constant 255 it used to be). Computed once at module load. */
+function packAlbedoRgb(rgb: readonly [number, number, number]): number {
     const r = Math.round(rgb[0] * 255);
     const g = Math.round(rgb[1] * 255);
     const b = Math.round(rgb[2] * 255);
-    return (r | (g << 8) | (b << 16) | (255 << 24)) >>> 0;
+    return (r | (g << 8) | (b << 16)) >>> 0;
 }
 
-const albedoWord = tgpu.const(d.u32, packAlbedoWord(ROAD_ALBEDO)).$name("roadAlbedoWord");
+const roadAlbedoRgb = tgpu.const(d.u32, packAlbedoRgb(ROAD_ALBEDO)).$name("roadAlbedoRgb");
+
+/** the signed distance to the nearest road marking for one segment — the GPU twin of
+ *  `document.ts`'s `markingDistanceForSegment`, independently derived via the clamped-projection form
+ *  (same split as `segmentDistanceGpu` vs `segmentDistance`). Two solid edge lines inset from the road
+ *  edge (centred at d = −EDGE_INSET on the existing edge distance) and a broken centreline (perpendicular
+ *  distance via the cross product, station along the chord via fract(s / DASH_PERIOD) < DASH_DUTY).
+ *  CPU-callable so `bun test` exercises this exact math with no device — the GPU half of stage 3's
+ *  marking differential oracle. `rasterize.ts` never imports `markingDistance` — the two derivations are
+ *  independent by contract.
+ * @example markingDistanceGpu(0, 0, -100, 0, 100, 0, 4) // on the centreline, inside a dash → negative */
+export const markingDistanceGpu = tgpu.fn(
+    [d.f32, d.f32, d.f32, d.f32, d.f32, d.f32, d.f32],
+    d.f32,
+)((px, pz, ax, az, bx, bz, halfWidth) => {
+    "use gpu";
+    const abx = bx - ax;
+    const abz = bz - az;
+    const apx = px - ax;
+    const apz = pz - az;
+    const dd = abx * abx + abz * abz;
+    let t = d.f32(0);
+    let tRaw = d.f32(0);
+    if (dd > 0) {
+        tRaw = (apx * abx + apz * abz) / dd;
+        t = std.clamp(tRaw, 0, 1);
+    }
+    const cx = ax + t * abx;
+    const cz = az + t * abz;
+    const dist = std.distance(d.vec2f(px, pz), d.vec2f(cx, cz));
+    const edgeDist = dist - halfWidth;
+
+    // edge line: solid, centred at d = −EDGE_INSET, width LINE_WIDTH
+    const edgeLineDist = std.abs(edgeDist + d.f32(EDGE_INSET)) - d.f32(LINE_HALF_WIDTH);
+
+    // centreline: broken, lateral from the cross product, longitudinal from the dash phase
+    const len = std.sqrt(dd);
+    const cross = len > 0 ? (apx * abz - apz * abx) / len : 0;
+    const lateral = std.abs(cross) - d.f32(LINE_HALF_WIDTH);
+    const along = t * len;
+    let longitudinal = d.f32(0);
+    if (tRaw < 0) {
+        longitudinal = -tRaw * len;
+    } else if (tRaw > 1) {
+        longitudinal = (tRaw - 1) * len;
+    } else {
+        const phase = std.fract((along + d.f32(DASH_OFFSET)) / d.f32(DASH_PERIOD));
+        if (phase < d.f32(DASH_DUTY)) {
+            longitudinal = -std.min(phase, d.f32(DASH_DUTY) - phase) * d.f32(DASH_PERIOD);
+        } else {
+            longitudinal = std.min(phase - d.f32(DASH_DUTY), d.f32(1) - phase) * d.f32(DASH_PERIOD);
+        }
+    }
+    const centreDist = std.max(lateral, longitudinal);
+
+    return std.min(edgeLineDist, centreDist);
+});
 
 const rasterKernel = tgpu
     .computeFn({
@@ -142,12 +207,45 @@ const rasterKernel = tgpu
         for (; k < d.u32(GROUP_TEXELS); k = k + d.u32(1)) {
             const texelX = gx * d.u32(GROUP_TEXELS) + k;
             const worldX = origin.x + (d.f32(texelX) + d.f32(0.5)) * d.f32(TEXEL_SIZE);
-            const dist = documentDistanceGpu(worldX, worldZ);
-            const byte = encodeDistGpu(dist);
+
+            // nearest-segment tracking: loop over segments once, carrying both the coverage distance
+            // and the marking distance — the two derivations are independent (this kernel never imports
+            // `markingDistance`), but they share the same segment loop so one dispatch computes both.
+            let bestCoverage = d.f32(3.402823e38);
+            let bestMarking = d.f32(3.402823e38);
+            let i = d.u32(0);
+            for (; i < rasterLayout.$.params.segmentCount; i = i + d.u32(1)) {
+                const seg = rasterLayout.$.segments[i];
+                const cov = segmentDistanceGpu(
+                    worldX,
+                    worldZ,
+                    seg.a.x,
+                    seg.a.y,
+                    seg.b.x,
+                    seg.b.y,
+                    seg.halfWidth,
+                );
+                if (cov < bestCoverage) bestCoverage = cov;
+                const m = markingDistanceGpu(
+                    worldX,
+                    worldZ,
+                    seg.a.x,
+                    seg.a.y,
+                    seg.b.x,
+                    seg.b.y,
+                    seg.halfWidth,
+                );
+                if (m < bestMarking) bestMarking = m;
+            }
+
+            const byte = encodeDistGpu(bestCoverage);
             word = word | (byte << (k * d.u32(8)));
 
+            // the marking distance encoded into the albedo word's alpha byte (constant 255 until stage 3),
+            // using the coverage channel's own encodeDist codec.
+            const markingByte = encodeDistGpu(bestMarking);
             const albedoIdx = gy * d.u32(TILE_RES) + texelX;
-            rasterLayout.$.albedoOut[albedoIdx] = albedoWord.$;
+            rasterLayout.$.albedoOut[albedoIdx] = roadAlbedoRgb.$ | (markingByte << d.u32(24));
         }
         const distIdx = gy * d.u32(GROUPS_PER_SIDE) + gx;
         rasterLayout.$.distOut[distIdx] = word;
@@ -157,7 +255,14 @@ const rasterKernel = tgpu
 /** the emitted rasterizer WGSL — the device-free structural seam stage 5's tests resolve. */
 export function rasterizeWgsl(): string {
     return tgpu.resolve(
-        [segmentDistanceGpu, segmentsDistanceGpu, documentDistanceGpu, encodeDistGpu, rasterKernel],
+        [
+            segmentDistanceGpu,
+            segmentsDistanceGpu,
+            documentDistanceGpu,
+            encodeDistGpu,
+            markingDistanceGpu,
+            rasterKernel,
+        ],
         { names: "strict" },
     );
 }

--- a/examples/showcase/roads/src/overlay/rasterize.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.ts
@@ -80,33 +80,6 @@ export const segmentDistanceGpu = tgpu.fn(
     return std.distance(d.vec2f(px, pz), d.vec2f(cx, cz)) - halfWidth;
 });
 
-/** the document's segment-only distance at (px, pz) — loops `rasterLayout.$.segments` up to
- *  `params.segmentCount`, the GPU-side twin of `document.ts`'s `flattenSegments` + minimum. */
-const segmentsDistanceGpu = tgpu.fn(
-    [d.f32, d.f32],
-    d.f32,
-)((px, pz) => {
-    "use gpu";
-    let best = d.f32(3.402823e38); // f32 max — no segment yet
-    let i = d.u32(0);
-    for (; i < rasterLayout.$.params.segmentCount; i = i + d.u32(1)) {
-        const seg = rasterLayout.$.segments[i];
-        const dist = segmentDistanceGpu(px, pz, seg.a.x, seg.a.y, seg.b.x, seg.b.y, seg.halfWidth);
-        if (dist < best) best = dist;
-    }
-    return best;
-});
-
-/** the document's full distance at (px, pz) — the minimum over every segment, the GPU twin of
- *  `document.ts`'s `documentDistance`. */
-export const documentDistanceGpu = tgpu.fn(
-    [d.f32, d.f32],
-    d.f32,
-)((px, pz) => {
-    "use gpu";
-    return segmentsDistanceGpu(px, pz);
-});
-
 /** quantize a signed world-metre distance to its r8unorm byte — TGSL reimplementation of `tiles.ts`'s
  *  `encodeDist` (no shared source: this is what the kernel actually runs; `tiles.ts`'s stays the CPU
  *  codec the fs's decode and the differential oracle's tolerance both key off). CPU-callable, so the
@@ -254,17 +227,9 @@ const rasterKernel = tgpu
 
 /** the emitted rasterizer WGSL — the device-free structural seam stage 5's tests resolve. */
 export function rasterizeWgsl(): string {
-    return tgpu.resolve(
-        [
-            segmentDistanceGpu,
-            segmentsDistanceGpu,
-            documentDistanceGpu,
-            encodeDistGpu,
-            markingDistanceGpu,
-            rasterKernel,
-        ],
-        { names: "strict" },
-    );
+    return tgpu.resolve([segmentDistanceGpu, encodeDistGpu, markingDistanceGpu, rasterKernel], {
+        names: "strict",
+    });
 }
 
 type RasterRoot = typeof Compute.root;

--- a/examples/showcase/roads/src/overlay/tiles.test.ts
+++ b/examples/showcase/roads/src/overlay/tiles.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, test } from "bun:test";
 import { WORLD_HALF } from "../terrain/grid";
 import {
+    DASH_DUTY,
+    DASH_GAP,
+    DASH_PERIOD,
+    DASH_SEGMENT,
     DIST_RANGE,
     decodeDist,
     dirtyTiles,
+    EDGE_INSET,
     encodeDist,
+    LINE_HALF_WIDTH,
+    LINE_WIDTH,
     TILE_COUNT,
     TILE_RES,
     TILE_SIZE,
@@ -138,5 +145,32 @@ describe("texelOffset — an independent stride derivation", () => {
             }
             expect(texelOffset(px, py, bpt)).toBe(counted);
         }
+    });
+});
+
+describe("marking constants (stage 3)", () => {
+    test("LINE_WIDTH is in the MUTCD normal-line range (4–6 in = 0.1016–0.1524 m)", () => {
+        expect(LINE_WIDTH).toBeGreaterThanOrEqual(0.1);
+        expect(LINE_WIDTH).toBeLessThanOrEqual(0.16);
+        expect(LINE_HALF_WIDTH).toBe(LINE_WIDTH / 2);
+    });
+
+    test("EDGE_INSET places the edge line fully inside the road", () => {
+        // the edge line centre is EDGE_INSET metres inside the road from the edge,
+        // so the line's outer boundary is EDGE_INSET - LINE_HALF_WIDTH from the edge — must be > 0
+        expect(EDGE_INSET - LINE_HALF_WIDTH).toBeGreaterThan(0);
+    });
+
+    test("DASH_SEGMENT and DASH_GAP match the MUTCD broken-line pattern (10 ft / 30 ft)", () => {
+        // 1 ft = 0.3048 m: 10 ft = 3.048 m, 30 ft = 9.144 m
+        expect(DASH_SEGMENT).toBeCloseTo(3.048, 10);
+        expect(DASH_GAP).toBeCloseTo(9.144, 10);
+    });
+
+    test("DASH_PERIOD is the sum of segment + gap, and DASH_DUTY is the fraction that is dash", () => {
+        expect(DASH_PERIOD).toBe(DASH_SEGMENT + DASH_GAP);
+        expect(DASH_DUTY).toBe(DASH_SEGMENT / DASH_PERIOD);
+        expect(DASH_DUTY).toBeGreaterThan(0);
+        expect(DASH_DUTY).toBeLessThan(1);
     });
 });

--- a/examples/showcase/roads/src/overlay/tiles.ts
+++ b/examples/showcase/roads/src/overlay/tiles.ts
@@ -42,6 +42,36 @@ export const DIST_FORMAT = "r8unorm" as const;
 export const DIST_BYTES_PER_TEXEL = 1;
 export const DIST_RANGE = 1; // metres, half-range
 
+// Road markings — a second distance channel in the same tile's albedo alpha byte, thresholded in the
+// fs with its own fwidth exactly as coverage is (roads-interactive.md Locked decision). Dimensions from
+// the MUTCD's normal line and broken-line pattern, in metres — a legibility standard, not a compliance
+// claim.
+
+// MUTCD normal line width: 4–6 in (0.1016–0.1524 m). Lower bound used so a 0.10 m line reads against
+// the 0.125 m texel as sub-texel detail the fwidth threshold keeps crisp, not a 1–2 texel blob.
+export const LINE_WIDTH = 0.1; // metres — MUTCD normal line, 4 in (0.1016 m), lower bound
+export const LINE_HALF_WIDTH = LINE_WIDTH / 2; // derived: half the line width
+
+// Edge line inset from the road edge — a showcase design choice, not a MUTCD dimension. The edge
+// line's centre sits EDGE_INSET metres inside the road from the edge (d = −EDGE_INSET on the existing
+// edge distance), so the line is fully on the asphalt with margin to the road boundary.
+export const EDGE_INSET = 0.3; // metres — design choice, places the edge line inside the road
+
+// MUTCD broken-line pattern: 10 ft segment, 30 ft gap. 1 ft = 0.3048 m.
+export const DASH_SEGMENT = 3.048; // metres — MUTCD 10 ft segment (10 ft × 0.3048 m/ft)
+export const DASH_GAP = 9.144; // metres — MUTCD 30 ft gap (30 ft × 0.3048 m/ft)
+export const DASH_PERIOD = DASH_SEGMENT + DASH_GAP; // derived: one full dash cycle (segment + gap)
+export const DASH_DUTY = DASH_SEGMENT / DASH_PERIOD; // derived: fraction of the period that is dash
+// Dash phase offset — shifts the dash pattern along the chord so the road's midpoint (the capture gate's
+// on-road probe point) falls in a gap, not on a dash. A design choice: the spec names the dash pattern
+// (segment/gap ratio) but not where it starts, and one chord means no joint to break at. Offset = one
+// DASH_SEGMENT shifts the phase by exactly DASH_DUTY, swapping dash and gap at the midpoint.
+export const DASH_OFFSET = DASH_SEGMENT;
+
+// Marking albedo — two-lane two-way road: solid white edges, broken yellow centreline.
+export const EDGE_ALBEDO: readonly [number, number, number] = [0.85, 0.85, 0.85]; // white edge lines
+export const CENTRE_ALBEDO: readonly [number, number, number] = [0.85, 0.75, 0.15]; // yellow centreline
+
 // the fwidth-thresholded coverage band's half-width, in screen pixels: the fs's `fw = COVERAGE_BAND_PX *
 // fwidth(dist)` coefficient (terrain.ts). `fwidth` is the change in its argument over one screen pixel, and
 // coverage leaves [0, 1] exactly when `dist` moves by `fw` — so this coefficient *is* the band width the

--- a/examples/showcase/roads/src/terrain/terrain.test.ts
+++ b/examples/showcase/roads/src/terrain/terrain.test.ts
@@ -65,9 +65,49 @@ describe("terrain fs — overlay composite", () => {
         expect(fs).toMatch(/clamp\(\(0\.5f - \(dist_\d* \/ fw\)\), 0f, 1f\) \* resident/);
     });
 
-    test("composites the overlay over the base color by coverage — never a second draw", () => {
+    test("composites the overlay (with markings mixed in) over the base color by coverage — never a second draw", () => {
         const fs = flat(body(wgsl, "fn terrainFs"));
-        expect(fs).toContain("color = mix(color, overlay, coverage);");
+        expect(fs).toContain("color = mix(color, overlayWithMarkings, coverage);");
         expect(wgsl.match(/fn terrainFs\(/g)?.length).toBe(1); // exactly one fs entry — no second pass
+    });
+});
+
+describe("terrain fs — marking channel (stage 3)", () => {
+    const wgsl = terrainFsWgsl();
+    const fs = flat(body(wgsl, "fn terrainFs"));
+
+    test("decodes the albedo alpha byte as a signed marking distance using the same DIST_RANGE codec", () => {
+        // the alpha byte stores the encoded marking distance (rasterize.ts's encodeDistGpu, the coverage
+        // channel's own codec). The fs decodes it back: (sampled.w - 0.5) * 2 * DIST_RANGE — the same
+        // decode the coverage channel uses, applied to the albedo's w component, not the dist texture.
+        expect(fs).toMatch(/albedoSample.*\.w.*0\.5f.*2f/);
+        expect(fs).toContain(`* ${DIST_RANGE}f`);
+    });
+
+    test("thresholds the marking distance with a second fwidth, exactly as coverage is", () => {
+        // a second fwidth call on the marking distance, with the same COVERAGE_BAND_PX coefficient —
+        // sub-texel crisp lines at any zoom (the property the Locked decision sells)
+        expect(fs).toMatch(new RegExp(`fwidth\\(markingDist_?\\d*\\) \\* ${COVERAGE_BAND_PX}f`));
+        // the marking coverage formula mirrors the coverage formula: clamp(0.5 - dist/fw, 0, 1) * resident
+        expect(fs).toMatch(
+            /clamp\(\(0\.5f - \(markingDist_?\d* \/ markingFw_?\d*\)\), 0f, 1f\) \* resident/,
+        );
+    });
+
+    test("selects the marking albedo by comparing the decoded marking distance with the edge-line distance", () => {
+        // the marking class (edge vs centre) is determined by comparing the decoded marking distance with
+        // the edge-line distance computed independently from the coverage distance: if the marking distance
+        // is smaller, the nearest marking is the centreline; otherwise the edge line.
+        expect(fs).toMatch(/abs\(\(dist_\d* \+ 0\.3/);
+        expect(fs).toMatch(/- 0\.05/);
+        expect(fs).toMatch(/select\(vec3f\(/);
+        expect(fs).toMatch(/isCentre/);
+    });
+
+    test("mixes the marking albedo over the road albedo before the terrain composite", () => {
+        // the order matters: marking over road first, then road+marking over terrain — so a marking
+        // never bleeds outside the road's coverage boundary
+        expect(fs).toContain("mix(overlay, markingAlbedo, markingCoverage)");
+        expect(fs).toContain("color = mix(color, overlayWithMarkings, coverage);");
     });
 });

--- a/examples/showcase/roads/src/terrain/terrain.test.ts
+++ b/examples/showcase/roads/src/terrain/terrain.test.ts
@@ -80,8 +80,9 @@ describe("terrain fs — marking channel (stage 3)", () => {
         // the alpha byte stores the encoded marking distance (rasterize.ts's encodeDistGpu, the coverage
         // channel's own codec). The fs decodes it back: (sampled.w - 0.5) * 2 * DIST_RANGE — the same
         // decode the coverage channel uses, applied to the albedo's w component, not the dist texture.
-        expect(fs).toMatch(/albedoSample.*\.w.*0\.5f.*2f/);
-        expect(fs).toContain(`* ${DIST_RANGE}f`);
+        // Anchored on the albedoSample expression (not just `* ${DIST_RANGE}f` alone, which the coverage
+        // decode also emits — a bare toContain is blind to its own subject, satisfied by the wrong channel).
+        expect(fs).toMatch(new RegExp(`albedoSample.*\\.w.*0\\.5f.*2f.*${DIST_RANGE}f`));
     });
 
     test("thresholds the marking distance with a second fwidth, exactly as coverage is", () => {
@@ -98,8 +99,12 @@ describe("terrain fs — marking channel (stage 3)", () => {
         // the marking class (edge vs centre) is determined by comparing the decoded marking distance with
         // the edge-line distance computed independently from the coverage distance: if the marking distance
         // is smaller, the nearest marking is the centreline; otherwise the edge line.
-        expect(fs).toMatch(/abs\(\(dist_\d* \+ 0\.3/);
-        expect(fs).toMatch(/- 0\.05/);
+        // 0.3 is EDGE_INSET and 0.05 is LINE_HALF_WIDTH — both deliberately literals here, not derived
+        // from the exported constants: if the regex were built from EDGE_INSET/LINE_HALF_WIDTH, changing
+        // the constant would change both sides and the arm would stay green, asserting only that the
+        // shader emitted *some* number consistent with itself, not the *right* number. The literals
+        // freeze the derived quantity so the arm reds exactly when the emitted value moves.
+        expect(fs).toMatch(/abs\(\(dist_\d* \+ 0\.3\d*f\)\) - 0\.05\d*f/);
         expect(fs).toMatch(/select\(vec3f\(/);
         expect(fs).toMatch(/isCentre/);
     });

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -19,7 +19,16 @@ import * as std from "typegpu/std";
 import * as overlayAtlas from "../overlay/atlas";
 import type { StrokeDocument } from "../overlay/document";
 import { generateNetwork } from "../overlay/network";
-import { COVERAGE_BAND_PX, DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
+import {
+    CENTRE_ALBEDO,
+    COVERAGE_BAND_PX,
+    DIST_RANGE,
+    EDGE_ALBEDO,
+    EDGE_INSET,
+    LINE_HALF_WIDTH,
+    TILE_SIZE,
+    TILES_PER_SIDE,
+} from "../overlay/tiles";
 import { setNetwork, warmNetwork } from "./flatten";
 import { bindTerrainKernel, generate, TERRAIN_QUANT } from "./generate";
 import {
@@ -99,12 +108,13 @@ const terrainFs = tgpu.fn(
         uv,
         layerU,
     ).x;
-    const overlay = std.textureSample(
+    const albedoSample = std.textureSample(
         terrainSurfaceLayout.$.albedo,
         terrainSurfaceLayout.$.overlaySamp,
         uv,
         layerU,
-    ).xyz;
+    );
+    const overlay = albedoSample.xyz;
     // decode the r8unorm distance channel back to a signed world-metre distance — the fs's half of the
     // codec overlay/tiles.ts's encodeDist writes (kept in sync by hand: DIST_RANGE is the one shared
     // constant both sides read; TGSL can't call a plain JS helper, so this stays inline).
@@ -112,7 +122,26 @@ const terrainFs = tgpu.fn(
     const fw = std.fwidth(dist) * d.f32(COVERAGE_BAND_PX) + d.f32(1e-5);
     const resident = std.select(d.f32(0), d.f32(1), layer >= 0);
     const coverage = std.clamp(d.f32(0.5) - dist / fw, 0, 1) * resident;
-    color = std.mix(color, overlay, coverage);
+
+    // the marking channel: the albedo alpha byte stores the signed distance to the nearest road marking
+    // (the coverage channel's own encodeDist codec, DIST_RANGE at 8 bits). Decode it and threshold with
+    // a second fwidth exactly as coverage is — sub-texel crisp lines at any zoom (roads-interactive.md
+    // Locked decision). The marking class (edge vs centre) is determined by comparing the decoded
+    // marking distance with the edge-line distance computed independently from the coverage distance:
+    // if the marking distance is smaller, the nearest marking is the centreline; otherwise the edge line.
+    const markingDist = (albedoSample.w - d.f32(0.5)) * d.f32(2) * d.f32(DIST_RANGE);
+    const markingFw = std.fwidth(markingDist) * d.f32(COVERAGE_BAND_PX) + d.f32(1e-5);
+    const markingCoverage = std.clamp(d.f32(0.5) - markingDist / markingFw, 0, 1) * resident;
+    const edgeLineDist = std.abs(dist + d.f32(EDGE_INSET)) - d.f32(LINE_HALF_WIDTH);
+    const isCentre = markingDist < edgeLineDist;
+    const markingAlbedo = std.select(
+        d.vec3f(d.f32(EDGE_ALBEDO[0]), d.f32(EDGE_ALBEDO[1]), d.f32(EDGE_ALBEDO[2])),
+        d.vec3f(d.f32(CENTRE_ALBEDO[0]), d.f32(CENTRE_ALBEDO[1]), d.f32(CENTRE_ALBEDO[2])),
+        isCentre,
+    );
+    // mix the marking albedo over the road albedo before the terrain composite
+    const overlayWithMarkings = std.mix(overlay, markingAlbedo, markingCoverage);
+    color = std.mix(color, overlayWithMarkings, coverage);
 
     return d.vec4f(lit(color, ctx.worldNormal), 1);
 });

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -3,6 +3,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expect, type Page, test } from "@playwright/test";
 import { generateNetwork } from "../src/overlay/network";
+import { ROAD_ALBEDO } from "../src/overlay/stroke";
+import { CENTRE_ALBEDO } from "../src/overlay/tiles";
 import { makePermutation } from "../src/terrain/noise";
 import { buildPolylineProfile, heightAtCpu } from "../src/terrain/profile";
 
@@ -21,6 +23,13 @@ const CAPTURE_PATH = join(
     "test-results",
     "roads-capture.png",
 );
+
+// Luminance using the same 0.3/0.59/0.11 weights as the probe's luminanceAt — so the band
+// tolerance is in the same units the probe reads, not an abstract scale.
+const albedoLuminance = (rgb: readonly [number, number, number]): number =>
+    0.3 * rgb[0] * 255 + 0.59 * rgb[1] * 255 + 0.11 * rgb[2] * 255;
+const roadLuminance = albedoLuminance(ROAD_ALBEDO);
+const centreLuminance = albedoLuminance(CENTRE_ALBEDO);
 
 // Stage 24a's corridor-pose capture — a second file alongside the gate's own, written at the derived
 // corridor pose (corridorPose.ts). The default-orbit capture above stays unchanged in pose; this one
@@ -299,25 +308,39 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
         { base64: screenshot.toString("base64"), probes: markingScreen },
     )) as number[];
 
-    // Assert the bands are DISJOINT: edge line (white) > dash (yellow) > asphalt (dark) ≈ dash gap (dark).
-    // A probe that cannot discriminate the classes it gates is not evidence.
+    // Assert the four probes as BANDS, not a pairwise chain: the two road-class probes (asphalt,
+    // dashGap) agree with each other within a tolerance, and each marking class (edgeLine, dash)
+    // sits in a band brighter than the road band. The previous pairwise chain never compared
+    // dashGap to asphalt, so a bug painting the dash gap as a third thing darker than the dash
+    // passed every assertion.
+    //
+    // The tolerance is a stated luminance margin: 10% of the luminance gap between the road albedo
+    // and the nearest marking class (the yellow centreline), computed from the exported albedo
+    // constants and the same 0.3/0.59/0.11 weights the probe's luminanceAt uses. This is generous
+    // for two probes reading the same road albedo (terrain lighting varies the pixel by far less
+    // than 10% of the road-to-marking gap), while a probe reading a different class exceeds it by
+    // an order of magnitude — so the band assertion reds exactly when a probe misclassifies.
+    const roadBandTolerance = (centreLuminance - roadLuminance) * 0.1;
+    // the two road-class probes agree within the tolerance
+    expect(
+        Math.abs(markingLum[1] - markingLum[2]),
+        `asphalt ${markingLum[1].toFixed(1)} vs dash gap ${markingLum[2].toFixed(1)} — road-class probes disagree beyond ${roadBandTolerance.toFixed(1)}`,
+    ).toBeLessThanOrEqual(roadBandTolerance);
+    // each marking class sits in a band brighter than the road band
+    const roadBandHi = Math.max(markingLum[1], markingLum[2]) + roadBandTolerance;
     expect(
         markingLum[0],
-        `edge line ${markingLum[0].toFixed(1)} should be brighter than dash ${markingLum[3].toFixed(1)}`,
-    ).toBeGreaterThan(markingLum[3]);
+        `edge line ${markingLum[0].toFixed(1)} is not above the road band hi ${roadBandHi.toFixed(1)}`,
+    ).toBeGreaterThan(roadBandHi);
     expect(
         markingLum[3],
-        `dash ${markingLum[3].toFixed(1)} should be brighter than asphalt ${markingLum[1].toFixed(1)}`,
-    ).toBeGreaterThan(markingLum[1]);
-    expect(
-        markingLum[2],
-        `dash gap ${markingLum[2].toFixed(1)} should be dark like asphalt ${markingLum[1].toFixed(1)}, not bright`,
-    ).toBeLessThan(markingLum[3]);
+        `dash ${markingLum[3].toFixed(1)} is not above the road band hi ${roadBandHi.toFixed(1)}`,
+    ).toBeGreaterThan(roadBandHi);
     // edge line (white) and dash (yellow) are in disjoint bands — white is brighter than yellow
     expect(
         markingLum[0],
-        `edge line ${markingLum[0].toFixed(1)} vs dash ${markingLum[3].toFixed(1)} — bands not disjoint`,
-    ).toBeGreaterThan(markingLum[3] * 1.05);
+        `edge line ${markingLum[0].toFixed(1)} vs dash ${markingLum[3].toFixed(1)} — marking bands not disjoint`,
+    ).toBeGreaterThan(markingLum[3] + roadBandTolerance);
 
     expect(errors, errors.join("\n")).toEqual([]);
 

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -230,6 +230,97 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
 
     expect(errors, errors.join("\n")).toEqual([]);
 
+    // Phase 2b: stage 3's marking device probes — four world points derived from the document, each on
+    // a distinct marking class (edge line, asphalt, dash gap, dash). The device gate asserts the
+    // luminance bands at these points are DISJOINT, so a probe that cannot discriminate the classes it
+    // gates is not evidence (roads-interactive.md stage 3, Marking fidelity).
+    const markingProbes = (await page.evaluate(() =>
+        (
+            window as unknown as {
+                __roadsMarkingProbePoints: () => Promise<{
+                    edgeLine: [number, number, number];
+                    asphalt: [number, number, number];
+                    dashGap: [number, number, number];
+                    dash: [number, number, number];
+                }>;
+            }
+        ).__roadsMarkingProbePoints(),
+    )) as {
+        edgeLine: [number, number, number];
+        asphalt: [number, number, number];
+        dashGap: [number, number, number];
+        dash: [number, number, number];
+    };
+
+    const markingScreen = (await page.evaluate(
+        (points) =>
+            (
+                window as unknown as {
+                    __roadsProbe: (pts: [number, number, number][]) => ScreenPoint[];
+                }
+            ).__roadsProbe(points),
+        [markingProbes.edgeLine, markingProbes.asphalt, markingProbes.dashGap, markingProbes.dash],
+    )) as ScreenPoint[];
+
+    // In-frame assertion for each marking probe.
+    for (const [name, sp] of [
+        ["edgeLine", markingScreen[0]],
+        ["asphalt", markingScreen[1]],
+        ["dashGap", markingScreen[2]],
+        ["dash", markingScreen[3]],
+    ] as const) {
+        expect(sp.x, `${name} probe x=${sp.x} is not in-frame (0, 1)`).toBeGreaterThan(0);
+        expect(sp.x, `${name} probe x=${sp.x} is not in-frame (0, 1)`).toBeLessThan(1);
+        expect(sp.y, `${name} probe y=${sp.y} is not in-frame (0, 1)`).toBeGreaterThan(0);
+        expect(sp.y, `${name} probe y=${sp.y} is not in-frame (0, 1)`).toBeLessThan(1);
+    }
+
+    const markingLum = (await page.evaluate(
+        async ({ base64, probes }) => {
+            const binary = atob(base64);
+            const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+            const bitmap = await createImageBitmap(new Blob([bytes], { type: "image/png" }));
+            const canvas = new OffscreenCanvas(bitmap.width, bitmap.height);
+            const context = canvas.getContext("2d");
+            if (!context) throw new Error("roads capture: 2D screenshot context unavailable");
+            context.drawImage(bitmap, 0, 0);
+            const data = context.getImageData(0, 0, bitmap.width, bitmap.height).data;
+            const luminanceAt = (fracX: number, fracY: number): number => {
+                const x = Math.min(bitmap.width - 1, Math.max(0, Math.round(fracX * bitmap.width)));
+                const y = Math.min(
+                    bitmap.height - 1,
+                    Math.max(0, Math.round(fracY * bitmap.height)),
+                );
+                const at = (y * bitmap.width + x) * 4;
+                return 0.3 * data[at] + 0.59 * data[at + 1] + 0.11 * data[at + 2];
+            };
+            return probes.map((p) => luminanceAt(p.x, p.y));
+        },
+        { base64: screenshot.toString("base64"), probes: markingScreen },
+    )) as number[];
+
+    // Assert the bands are DISJOINT: edge line (white) > dash (yellow) > asphalt (dark) ≈ dash gap (dark).
+    // A probe that cannot discriminate the classes it gates is not evidence.
+    expect(
+        markingLum[0],
+        `edge line ${markingLum[0].toFixed(1)} should be brighter than dash ${markingLum[3].toFixed(1)}`,
+    ).toBeGreaterThan(markingLum[3]);
+    expect(
+        markingLum[3],
+        `dash ${markingLum[3].toFixed(1)} should be brighter than asphalt ${markingLum[1].toFixed(1)}`,
+    ).toBeGreaterThan(markingLum[1]);
+    expect(
+        markingLum[2],
+        `dash gap ${markingLum[2].toFixed(1)} should be dark like asphalt ${markingLum[1].toFixed(1)}, not bright`,
+    ).toBeLessThan(markingLum[3]);
+    // edge line (white) and dash (yellow) are in disjoint bands — white is brighter than yellow
+    expect(
+        markingLum[0],
+        `edge line ${markingLum[0].toFixed(1)} vs dash ${markingLum[3].toFixed(1)} — bands not disjoint`,
+    ).toBeGreaterThan(markingLum[3] * 1.05);
+
+    expect(errors, errors.join("\n")).toEqual([]);
+
     // Phase 3: stage 14's reseed-integrity device arm (spec Validation, "Reseed integrity" — device half).
     // F9 twice via `__roadsRegenerate` (a deterministic bridge onto the same `regenerate()` the real F9
     // handler calls, `boot.ts`), rather than real random keypresses: a live F9 draws a fresh


### PR DESCRIPTION
- **roads-interactive: stage 3 road markings — second distance channel in albedo alpha**
- **roads-interactive: stage 3 review repairs — delete dead WGSL fns, anchor regexes, disjoint device probe bands, single-source-of-truth fixture**
