### PR TITLE
roads interactive/4

### DIFF
--- a/examples/showcase/roads/shallot.json
+++ b/examples/showcase/roads/shallot.json
@@ -1,11 +1,12 @@
 {
-  "scene": "scenes/roads.scene",
-  "plugins": {
-    "Part": false,
-    "Orbit": true,
-    "Mirror": true,
-    "Profile": true,
-    "Terrain": "./src/terrain/terrain",
-    "RoadsBoot": "./src/boot"
-  }
+    "scene": "scenes/roads.scene",
+    "plugins": {
+        "Part": true,
+        "Orbit": true,
+        "Mirror": true,
+        "Profile": true,
+        "Terrain": "./src/terrain/terrain",
+        "RoadsBoot": "./src/boot",
+        "RoadsEdit": "./src/edit"
+    }
 }

--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -10,7 +10,7 @@ import {
     worldToScreen,
 } from "./capture";
 import { corridorCapture } from "./corridorCapture";
-import { applyEdit, clampToBound, handlePositions, isAdmissibleDrag } from "./edit";
+import { applyEdit, clampDragTarget, clampToBound, handlePositions } from "./edit";
 import { checkSurfaceFlatness } from "./flatness";
 import { gate } from "./gate";
 import type { Check } from "./harness";
@@ -67,11 +67,11 @@ declare global {
             dashGap: [number, number, number];
             dash: [number, number, number];
         }>;
-        // stage 4's edit bridge — drive `__roadsEdit(end, x, z)` to move an endpoint. Returns true if
-        // the edit was applied (admissible — within the `ROAD_MIN_LENGTH`–`ROAD_MAX_LENGTH` band after
-        // clamping to bounds), false if refused (the clamped position leaves the chord outside the
-        // length band). The device gate drives this, waits for overlay idle, and reads the flatness
-        // and handle position back.
+        // stage 4's edit bridge — drive `__roadsEdit(end, x, z)` to move an endpoint. The target is
+        // clamped to the world bounds and then to the `ROAD_MIN_LENGTH` floor (never refused — a
+        // constraint on a dragged quantity clamps, never no-ops). Returns true once the edit is applied.
+        // The device gate drives this, waits for overlay idle, and reads the flatness and handle
+        // position back.
         __roadsEdit?: (end: number, x: number, z: number) => Promise<boolean>;
         // stage 4's flatness bridge — reads `readVertices()` and runs `checkSurfaceFlatness` against the
         // live document, returning the violation counts on both axes.
@@ -81,8 +81,7 @@ declare global {
         }>;
         // stage 4's handle position bridge — returns the two handle entities' world (x, y, z).
         __roadsHandlePos?: () => [[number, number, number], [number, number, number]];
-        // stage 4's vertex fingerprint — a checksum of the raw vertex buffer, for the byte-identical
-        // refused-edit check.
+        // stage 4's vertex fingerprint — a checksum of the raw vertex buffer.
         __roadsVertexFingerprint?: () => Promise<number>;
     }
 }
@@ -111,8 +110,8 @@ const BootSystem: System = {
         window.__roadsEdit = async (end, x, z) => {
             const doc = getDocument();
             const [cx, cz] = clampToBound(x, z);
-            if (!isAdmissibleDrag(doc, end as 0 | 1, cx, cz)) return false;
-            const newDoc = applyEdit(doc, end as 0 | 1, cx, cz);
+            const [fx, fz] = clampDragTarget(doc, end as 0 | 1, cx, cz);
+            const newDoc = applyEdit(doc, end as 0 | 1, fx, fz);
             await editDocument(newDoc);
             return true;
         };
@@ -128,8 +127,7 @@ const BootSystem: System = {
         window.__roadsHandlePos = () => handlePositions();
         window.__roadsVertexFingerprint = async () => {
             const raw = await readVertices();
-            // FNV-1a 32-bit rolling hash over every word of the vertex buffer — order-sensitive, so a
-            // refused edit that leaves `readVertices()` byte-identical produces the same digest while
+            // FNV-1a 32-bit rolling hash over every word of the vertex buffer — order-sensitive, so
             // any change (even one that cancels in a sum) changes it. Kept in `Math.imul`/`>>> 0`
             // integer arithmetic so it stays exact.
             let hash = 0x811c9dc5 >>> 0;

--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -68,9 +68,10 @@ declare global {
             dash: [number, number, number];
         }>;
         // stage 4's edit bridge — drive `__roadsEdit(end, x, z)` to move an endpoint. Returns true if
-        // the edit was applied (admissible), false if refused (outside the length band or clamped to
-        // bounds without changing the document). The device gate drives this, waits for overlay idle,
-        // and reads the flatness and handle position back.
+        // the edit was applied (admissible — within the `ROAD_MIN_LENGTH`–`ROAD_MAX_LENGTH` band after
+        // clamping to bounds), false if refused (the clamped position leaves the chord outside the
+        // length band). The device gate drives this, waits for overlay idle, and reads the flatness
+        // and handle position back.
         __roadsEdit?: (end: number, x: number, z: number) => Promise<boolean>;
         // stage 4's flatness bridge — reads `readVertices()` and runs `checkSurfaceFlatness` against the
         // live document, returning the violation counts on both axes.
@@ -127,9 +128,16 @@ const BootSystem: System = {
         window.__roadsHandlePos = () => handlePositions();
         window.__roadsVertexFingerprint = async () => {
             const raw = await readVertices();
-            let sum = 0;
-            for (let i = 0; i < raw.length; i++) sum += raw[i];
-            return sum;
+            // FNV-1a 32-bit rolling hash over every word of the vertex buffer — order-sensitive, so a
+            // refused edit that leaves `readVertices()` byte-identical produces the same digest while
+            // any change (even one that cancels in a sum) changes it. Kept in `Math.imul`/`>>> 0`
+            // integer arithmetic so it stays exact.
+            let hash = 0x811c9dc5 >>> 0;
+            for (let i = 0; i < raw.length; i++) {
+                hash ^= raw[i] >>> 0;
+                hash = Math.imul(hash, 0x01000193) >>> 0;
+            }
+            return hash;
         };
         // F9 reseeds the live procedural network (`terrain.ts`'s `regenerate`) — the same key voxel's own
         // reseed uses. `{ signal: state.signal }` detaches the listener at `state.dispose()`, no removal

--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -3,15 +3,24 @@ import { Meshes } from "@dylanebert/shallot/render/core";
 import {
     capturePoints,
     markingProbePoints,
+    meshHeightAt,
     type ScreenPoint,
     TRANSITION_TOLERANCE_PX,
     withHeight,
     worldToScreen,
 } from "./capture";
 import { corridorCapture } from "./corridorCapture";
+import { applyEdit, clampToBound, handlePositions, isAdmissibleDrag } from "./edit";
+import { checkSurfaceFlatness } from "./flatness";
 import { gate } from "./gate";
 import type { Check } from "./harness";
-import { overlayIdle, regenerate } from "./terrain/terrain";
+import {
+    editDocument,
+    getDocument,
+    overlayIdle,
+    readVertices,
+    regenerate,
+} from "./terrain/terrain";
 
 // The roads showcase's boot orchestration, as a plugin (a manifest project has no `main.ts` entry) —
 // the same shape as voxel's `boot.ts`. Terrain generation itself runs inside `terrain.ts`'s own `warm()`
@@ -58,6 +67,22 @@ declare global {
             dashGap: [number, number, number];
             dash: [number, number, number];
         }>;
+        // stage 4's edit bridge — drive `__roadsEdit(end, x, z)` to move an endpoint. Returns true if
+        // the edit was applied (admissible), false if refused (outside the length band or clamped to
+        // bounds without changing the document). The device gate drives this, waits for overlay idle,
+        // and reads the flatness and handle position back.
+        __roadsEdit?: (end: number, x: number, z: number) => Promise<boolean>;
+        // stage 4's flatness bridge — reads `readVertices()` and runs `checkSurfaceFlatness` against the
+        // live document, returning the violation counts on both axes.
+        __roadsFlatnessViolations?: () => Promise<{
+            longitudinal: number;
+            crossSection: number;
+        }>;
+        // stage 4's handle position bridge — returns the two handle entities' world (x, y, z).
+        __roadsHandlePos?: () => [[number, number, number], [number, number, number]];
+        // stage 4's vertex fingerprint — a checksum of the raw vertex buffer, for the byte-identical
+        // refused-edit check.
+        __roadsVertexFingerprint?: () => Promise<number>;
     }
 }
 
@@ -82,6 +107,30 @@ const BootSystem: System = {
         window.__roadsRegenerate = (seed) => regenerate(seed);
         window.__roadsHeightAt = (x, z) => withHeight(x, z);
         window.__roadsMarkingProbePoints = () => markingProbePoints();
+        window.__roadsEdit = async (end, x, z) => {
+            const doc = getDocument();
+            const [cx, cz] = clampToBound(x, z);
+            if (!isAdmissibleDrag(doc, end as 0 | 1, cx, cz)) return false;
+            const newDoc = applyEdit(doc, end as 0 | 1, cx, cz);
+            await editDocument(newDoc);
+            return true;
+        };
+        window.__roadsFlatnessViolations = async () => {
+            const raw = await readVertices();
+            const doc = getDocument();
+            const result = checkSurfaceFlatness((x, z) => meshHeightAt(raw, x, z), doc);
+            return {
+                longitudinal: result.longitudinal.length,
+                crossSection: result.crossSection.length,
+            };
+        };
+        window.__roadsHandlePos = () => handlePositions();
+        window.__roadsVertexFingerprint = async () => {
+            const raw = await readVertices();
+            let sum = 0;
+            for (let i = 0; i < raw.length; i++) sum += raw[i];
+            return sum;
+        };
         // F9 reseeds the live procedural network (`terrain.ts`'s `regenerate`) — the same key voxel's own
         // reseed uses. `{ signal: state.signal }` detaches the listener at `state.dispose()`, no removal
         // code needed.
@@ -108,6 +157,10 @@ const BootSystem: System = {
         delete window.__roadsRegenerate;
         delete window.__roadsHeightAt;
         delete window.__roadsMarkingProbePoints;
+        delete window.__roadsEdit;
+        delete window.__roadsFlatnessViolations;
+        delete window.__roadsHandlePos;
+        delete window.__roadsVertexFingerprint;
     },
 };
 

--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -81,8 +81,6 @@ declare global {
         }>;
         // stage 4's handle position bridge — returns the two handle entities' world (x, y, z).
         __roadsHandlePos?: () => [[number, number, number], [number, number, number]];
-        // stage 4's vertex fingerprint — a checksum of the raw vertex buffer.
-        __roadsVertexFingerprint?: () => Promise<number>;
     }
 }
 
@@ -125,18 +123,6 @@ const BootSystem: System = {
             };
         };
         window.__roadsHandlePos = () => handlePositions();
-        window.__roadsVertexFingerprint = async () => {
-            const raw = await readVertices();
-            // FNV-1a 32-bit rolling hash over every word of the vertex buffer — order-sensitive, so
-            // any change (even one that cancels in a sum) changes it. Kept in `Math.imul`/`>>> 0`
-            // integer arithmetic so it stays exact.
-            let hash = 0x811c9dc5 >>> 0;
-            for (let i = 0; i < raw.length; i++) {
-                hash ^= raw[i] >>> 0;
-                hash = Math.imul(hash, 0x01000193) >>> 0;
-            }
-            return hash;
-        };
         // F9 reseeds the live procedural network (`terrain.ts`'s `regenerate`) — the same key voxel's own
         // reseed uses. `{ signal: state.signal }` detaches the listener at `state.dispose()`, no removal
         // code needed.
@@ -166,7 +152,6 @@ const BootSystem: System = {
         delete window.__roadsEdit;
         delete window.__roadsFlatnessViolations;
         delete window.__roadsHandlePos;
-        delete window.__roadsVertexFingerprint;
     },
 };
 

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -78,28 +78,38 @@ describe("edit — applyEdit", () => {
 });
 
 describe("edit — every drag constraint clamps (stage 4c)", () => {
-    // RED-FIRST WITNESS: against the shipped shape (stage 4 before 4c), a target past ROAD_MAX_LENGTH
-    // (220 m) was *refused* — `isAdmissibleDrag` returned false, `applyEdit` was never called, and the
-    // document came back unchanged. The person read the resulting freeze as "the grab isn't sticky."
-    // This arm replaces the old refusal arms ("a drag shortening under ROAD_MIN_LENGTH is refused",
-    // "a drag lengthening past ROAD_MAX_LENGTH is refused") which encoded the freeze as the contract.
+    // REGRESSION GUARD (not a red-first witness): this arm calls `clampDragTarget`, which did not
+    // exist at the pre-image `3ea0417` (the pre-image had `isAdmissibleDrag`, a refusal predicate), so
+    // it cannot compile against the old shape, let alone fail against it. It is a regression guard over
+    // the new clamp shape: over a scan of drag targets, `applyEdit` (after `clampToBound` +
+    // `clampDragTarget`) always moves the dragged endpoint for every input whose target differs from
+    // the current position, and the resulting chord holds both the bound and the floor.
+    //
+    // The real red-first evidence for the ceiling deletion lives in two other arms: (1) the worst-case
+    // chord capacity arm below (`edit.test.ts`, "the worst-case corner-to-corner chord stays at or under
+    // ATLAS_LAYERS"), which fails at the pre-image because a corner-to-corner chord touches >64 tiles
+    // against ATLAS_LAYERS=64; and (2) the device corner arm (`test/roads.spec.ts`, `cornerApplied ===
+    // false` at the pre-image), where the old `__roadsEdit` bridge refused a target past ROAD_MAX_LENGTH
+    // and returned false instead of applying the clamped edit.
+    //
+    // Historical note: the old arms this replaces ("a drag shortening under ROAD_MIN_LENGTH is refused",
+    // "a drag lengthening past ROAD_MAX_LENGTH is refused") were green while pinning the freeze — they
+    // encoded the refusal as the contract, so the suite passed over the defect the person rejected.
     //
     // The clamp law (`roads-interactive.md`'s Locked decision): a constraint on a dragged quantity is a
-    // projection onto the nearest admissible value, never a no-op. So over a scan of drag targets —
-    // including ones far past the world bound and ones that would shorten the chord under the floor —
-    // `applyEdit` (after `clampToBound` + `clampDragTarget`) always moves the dragged endpoint for every
-    // input whose target differs from the current position, and the resulting chord holds both the bound
-    // and the floor. The one admissible no-op is a target equal to the current position.
+    // projection onto the nearest admissible value, never a no-op. The one admissible no-op is a target
+    // equal to the current position.
 
     const doc = generateNetwork();
     const [ax, az] = doc.polylines[0].points[0] as [number, number];
     const [bx, bz] = doc.polylines[0].points[1] as [number, number];
 
-    // a scan of drag targets for endpoint 1: normal, past world bound, under floor, and the no-op
+    // a scan of drag targets for endpoint 1: normal, past the old 220 m ceiling (inside world),
+    // past the world bound, under floor, and the no-op
     const targets: { x: number; z: number; label: string }[] = [
         { x: 50, z: 30, label: "normal (within bounds and floor)" },
-        { x: 200, z: 200, label: "past world bound" },
-        { x: -200, z: -200, label: "past world bound (negative)" },
+        { x: 200, z: 200, label: "past old 220 m ceiling (inside world bound)" },
+        { x: -200, z: -200, label: "past old 220 m ceiling (inside world bound, negative)" },
         { x: 10000, z: 10000, label: "far past world bound" },
         { x: -90, z: 0, label: "would shorten under floor (chord ~10 m)" },
         { x: -99, z: 0, label: "would shorten under floor (chord ~1 m)" },

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, test } from "bun:test";
+import { meshHeightAt } from "./capture";
+import { applyEdit, chordLength, clampToBound, isAdmissibleDrag, residentTileCount } from "./edit";
+import { buildLatticeVertices, checkSurfaceFlatness } from "./flatness";
+import type { StrokeDocument } from "./overlay/document";
+import { documentDirtyTiles } from "./overlay/document";
+import { generateNetwork, ROAD_HALF_WIDTH, ROAD_MAX_LENGTH } from "./overlay/network";
+import { allocate } from "./overlay/queue";
+import { ATLAS_LAYERS } from "./overlay/tiles";
+import { buildNetworkGeometry, computeFalloff } from "./terrain/flatten";
+import { CELLS, SPACING, WORLD_HALF } from "./terrain/grid";
+import { makePermutation } from "./terrain/noise";
+import { heightAtCpu, MAX_GRADE } from "./terrain/profile";
+import { SEED } from "./terrain/terrain";
+
+// Stage 4's pure-half tests — `applyEdit`, `clampToBound`, `isAdmissibleDrag`, and the flatness scan
+// over 200 random admissible drags. The device-bound halves (the live drag, the handle entity's y, the
+// refused-edit byte-identical readback) live in `test/roads.spec.ts` via the `__roadsEdit` bridge.
+//
+// `applyEdit` and `clampToBound` stay free of `@dylanebert/shallot` imports (the Node ≥26 gotcha), so
+// this file exercises them under `bun test` without pulling in the engine's device-bound module graph.
+
+const BOUND = WORLD_HALF - ROAD_HALF_WIDTH;
+
+// a simple seeded RNG for the 200-random-drag scan — deterministic so a failure reproduces.
+function mulberry32(seed: number): () => number {
+    let a = seed >>> 0;
+    return () => {
+        a = (a + 0x6d2b79f5) | 0;
+        let t = a;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+describe("edit — clampToBound", () => {
+    test("never yields |x| or |z| past the bound", () => {
+        const rng = mulberry32(42);
+        for (let i = 0; i < 1000; i++) {
+            const x = (rng() * 2 - 1) * WORLD_HALF * 2;
+            const z = (rng() * 2 - 1) * WORLD_HALF * 2;
+            const [cx, cz] = clampToBound(x, z);
+            expect(Math.abs(cx)).toBeLessThanOrEqual(BOUND);
+            expect(Math.abs(cz)).toBeLessThanOrEqual(BOUND);
+        }
+    });
+
+    test("a point inside the bounds is unchanged", () => {
+        const [x, z] = clampToBound(0, 0);
+        expect(x).toBe(0);
+        expect(z).toBe(0);
+    });
+});
+
+describe("edit — applyEdit", () => {
+    const doc = generateNetwork();
+
+    test("differs from its input only at the moved endpoint", () => {
+        const edited = applyEdit(doc, 1, 50, 30);
+        expect(edited.polylines[0].points[0]).toEqual(doc.polylines[0].points[0]);
+        expect(edited.polylines[0].points[1]).toEqual([50, 30]);
+        expect(edited.polylines[0].halfWidth).toBe(doc.polylines[0].halfWidth);
+        expect(edited.polylines.length).toBe(1);
+    });
+
+    test("does not mutate the input document", () => {
+        const original = doc.polylines[0].points[1];
+        applyEdit(doc, 1, 50, 30);
+        expect(doc.polylines[0].points[1]).toEqual(original);
+    });
+});
+
+describe("edit — drag admissibility", () => {
+    const doc = generateNetwork();
+
+    test("an admissible drag (within the length band) is accepted", () => {
+        expect(isAdmissibleDrag(doc, 1, 110, 0)).toBe(true);
+    });
+
+    test("a drag shortening the chord under ROAD_MIN_LENGTH is refused", () => {
+        expect(isAdmissibleDrag(doc, 1, -25, 0)).toBe(false);
+    });
+
+    test("a drag lengthening the chord past ROAD_MAX_LENGTH is refused", () => {
+        expect(isAdmissibleDrag(doc, 1, 130, 0)).toBe(false);
+    });
+
+    test("a refused drag leaves the input document unchanged (the guard prevents applyEdit)", () => {
+        // The guard pattern: if !isAdmissibleDrag, don't call applyEdit. applyEdit itself always
+        // returns a new document — the guard is what prevents the edit. Verify the guard catches it:
+        expect(isAdmissibleDrag(doc, 1, 130, 0)).toBe(false);
+        // the input document is unchanged (applyEdit was never called)
+        expect(doc.polylines[0].points[1]).toEqual([100, 0]);
+    });
+
+    // RED-FIRST WITNESS: the ROAD_MAX_LENGTH refusal arm prevents `allocate` from throwing
+    // `capacity exceeded (64 layers)` mid-drag. Without the guard, a long chord touches more than
+    // ATLAS_LAYERS tiles, and the allocator's free list runs dry. The actual error text witnessed
+    // before the guard existed:
+    //   "overlay atlas: capacity exceeded (64 layers) allocating tile 64"
+    // (from `queue.ts`'s `allocate`, when `free.length === 0`).
+    test("ROAD_MAX_LENGTH refusal — witness the throw it prevents", () => {
+        const longDoc = applyEdit(doc, 1, 400, 400);
+        const tiles = documentDirtyTiles(longDoc);
+        expect(tiles.length).toBeGreaterThan(ATLAS_LAYERS);
+
+        const cpu = new Int32Array(256).fill(-1);
+        const free: number[] = [];
+        for (let i = ATLAS_LAYERS - 1; i >= 0; i--) free.push(i);
+        let threw = false;
+        let errMsg = "";
+        try {
+            for (const id of tiles) {
+                allocate(cpu, id, free, ATLAS_LAYERS);
+            }
+        } catch (e) {
+            threw = true;
+            errMsg = String(e);
+        }
+        expect(threw).toBe(true);
+        expect(errMsg).toContain("capacity exceeded (64 layers)");
+    });
+
+    test("a worst-case admissible ROAD_MAX_LENGTH chord stays at or under ATLAS_LAYERS resident tiles", () => {
+        const half = ROAD_MAX_LENGTH / 2;
+        const diag = half / Math.SQRT2;
+        const maxDoc: StrokeDocument = {
+            polylines: [
+                {
+                    points: [
+                        [-diag, -diag],
+                        [diag, diag],
+                    ],
+                    halfWidth: ROAD_HALF_WIDTH,
+                },
+            ],
+        };
+        expect(chordLength(maxDoc)).toBeCloseTo(ROAD_MAX_LENGTH, 0);
+        expect(residentTileCount(maxDoc)).toBeLessThanOrEqual(ATLAS_LAYERS);
+    });
+});
+
+describe("edit — corridor flatness over 200 random admissible drags", () => {
+    // The spec's Validation "Corridor flatness" criterion, extended to edited documents: over a scan of
+    // 200 random admissible drags, `checkSurfaceFlatness` over `buildLatticeVertices` reads exactly
+    // 0 violations / 0.0000 m on both axes at SPACING and SPACING/2. The chord's affine target makes
+    // the in-corridor reconstruction error vanish identically (barycentric interpolation reproduces an
+    // affine field exactly at any cell size and any road angle), so this reads zero on every admissible
+    // drag — not just the boot document.
+    const rng = mulberry32(12345);
+    const perm = makePermutation(SEED);
+    const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
+
+    // generate 200 random admissible drags from the boot document. The flatness oracle's longitudinal
+    // bound is a grade check (gradeBound = MAX_GRADE * ds + 2 * QUANT_TOL), so a drag whose chord grade
+    // exceeds MAX_GRADE produces longitudinal violations by design — not a reconstruction error. The
+    // admissibility check (isAdmissibleDrag) refuses the length band only, never grade (the spec's
+    // "the drag refuses bounds and minimum length only, never cost"), so the scan filters by grade as a
+    // test-selection criterion: the corridor flatness claim is about the mesh's reconstruction of an
+    // affine target, which holds exactly when the grade is within the road-design bound.
+    const drags: { end: 0 | 1; x: number; z: number }[] = [];
+    let attempts = 0;
+    while (drags.length < 200 && attempts < 50000) {
+        attempts++;
+        const end = (rng() < 0.5 ? 0 : 1) as 0 | 1;
+        const x = (rng() * 2 - 1) * BOUND;
+        const z = (rng() * 2 - 1) * BOUND;
+        if (!isAdmissibleDrag(generateNetwork(), end, x, z)) continue;
+        // filter by grade: the flatness oracle's longitudinal bound is MAX_GRADE, so a chord steeper
+        // than that produces violations by design, not by reconstruction error
+        const edited = applyEdit(generateNetwork(), end, x, z);
+        const [a, b] = edited.polylines[0].points;
+        const len = Math.hypot(b[0] - a[0], b[1] - a[1]);
+        const hA = heightAtCpu(a[0], a[1], perm);
+        const hB = heightAtCpu(b[0], b[1], perm);
+        if (Math.abs(hB - hA) / len > MAX_GRADE) continue;
+        drags.push({ end, x, z });
+    }
+    expect(drags.length).toBe(200);
+
+    for (let i = 0; i < drags.length; i++) {
+        const { end, x, z } = drags[i];
+        const edited = applyEdit(generateNetwork(), end, x, z);
+        const { segments, cutDepth } = buildNetworkGeometry(edited, SEED);
+        const falloff = computeFalloff(cutDepth);
+
+        test(`drag ${i + 1}/200: end ${end} → (${x.toFixed(1)}, ${z.toFixed(1)})`, () => {
+            // SPACING resolution
+            const coarseRaw = buildLatticeVertices(SPACING, CELLS, segments, falloff, natural);
+            const coarse = checkSurfaceFlatness(
+                (sx, sz) => meshHeightAt(coarseRaw, sx, sz, SPACING, CELLS),
+                edited,
+            );
+            expect(coarse.crossSection.length).toBe(0);
+            expect(coarse.maxCrossSectionExcess).toBe(0);
+            expect(coarse.longitudinal.length).toBe(0);
+            expect(coarse.maxLongitudinalExcess).toBe(0);
+
+            // SPACING/2 resolution
+            const fineSpacing = SPACING / 2;
+            const fineCells = CELLS * 2;
+            const fineRaw = buildLatticeVertices(
+                fineSpacing,
+                fineCells,
+                segments,
+                falloff,
+                natural,
+            );
+            const fine = checkSurfaceFlatness(
+                (sx, sz) => meshHeightAt(fineRaw, sx, sz, fineSpacing, fineCells),
+                edited,
+            );
+            expect(fine.crossSection.length).toBe(0);
+            expect(fine.maxCrossSectionExcess).toBe(0);
+            expect(fine.longitudinal.length).toBe(0);
+            expect(fine.maxLongitudinalExcess).toBe(0);
+        });
+    }
+});

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -4,25 +4,23 @@ import { createGrabState, stepGrab } from "./edit";
 import {
     applyEdit,
     chordLength,
+    clampDragTarget,
     clampToBound,
-    isAdmissibleDrag,
     residentTileCount,
 } from "./editPure";
 import { buildLatticeVertices, checkSurfaceFlatness } from "./flatness";
 import type { StrokeDocument } from "./overlay/document";
-import { documentDirtyTiles } from "./overlay/document";
-import { generateNetwork, ROAD_HALF_WIDTH, ROAD_MAX_LENGTH } from "./overlay/network";
-import { allocate } from "./overlay/queue";
-import { ATLAS_LAYERS } from "./overlay/tiles";
+import { generateNetwork, ROAD_HALF_WIDTH, ROAD_MIN_LENGTH } from "./overlay/network";
+import { ATLAS_LAYERS, TILE_COUNT } from "./overlay/tiles";
 import { buildNetworkGeometry, computeFalloff } from "./terrain/flatten";
 import { CELLS, SPACING, WORLD_HALF } from "./terrain/grid";
 import { makePermutation } from "./terrain/noise";
 import { heightAtCpu, MAX_GRADE } from "./terrain/profile";
 import { SEED } from "./terrain/terrain";
 
-// Stage 4's pure-half tests — `applyEdit`, `clampToBound`, `isAdmissibleDrag`, and the flatness scan
-// over 200 random admissible drags. The device-bound halves (the live drag, the handle entity's y, the
-// refused-edit byte-identical readback) live in `test/roads.spec.ts` via the `__roadsEdit` bridge.
+// Stage 4's pure-half tests — `applyEdit`, `clampToBound`, `clampDragTarget`, the worst-case capacity
+// arm, and the flatness scan over 200 random clamped drags. The device-bound halves (the live drag,
+// the handle entity's y) live in `test/roads.spec.ts` via the `__roadsEdit` bridge.
 //
 // The pure halves live in `./editPure`, which imports nothing from `@dylanebert/shallot` (the Node ≥26
 // gotcha), so this file exercises them under `bun test` without pulling in the engine's device-bound
@@ -79,111 +77,157 @@ describe("edit — applyEdit", () => {
     });
 });
 
-describe("edit — drag admissibility", () => {
+describe("edit — every drag constraint clamps (stage 4c)", () => {
+    // RED-FIRST WITNESS: against the shipped shape (stage 4 before 4c), a target past ROAD_MAX_LENGTH
+    // (220 m) was *refused* — `isAdmissibleDrag` returned false, `applyEdit` was never called, and the
+    // document came back unchanged. The person read the resulting freeze as "the grab isn't sticky."
+    // This arm replaces the old refusal arms ("a drag shortening under ROAD_MIN_LENGTH is refused",
+    // "a drag lengthening past ROAD_MAX_LENGTH is refused") which encoded the freeze as the contract.
+    //
+    // The clamp law (`roads-interactive.md`'s Locked decision): a constraint on a dragged quantity is a
+    // projection onto the nearest admissible value, never a no-op. So over a scan of drag targets —
+    // including ones far past the world bound and ones that would shorten the chord under the floor —
+    // `applyEdit` (after `clampToBound` + `clampDragTarget`) always moves the dragged endpoint for every
+    // input whose target differs from the current position, and the resulting chord holds both the bound
+    // and the floor. The one admissible no-op is a target equal to the current position.
+
     const doc = generateNetwork();
+    const [ax, az] = doc.polylines[0].points[0] as [number, number];
+    const [bx, bz] = doc.polylines[0].points[1] as [number, number];
 
-    test("an admissible drag (within the length band) is accepted", () => {
-        expect(isAdmissibleDrag(doc, 1, 110, 0)).toBe(true);
-    });
+    // a scan of drag targets for endpoint 1: normal, past world bound, under floor, and the no-op
+    const targets: { x: number; z: number; label: string }[] = [
+        { x: 50, z: 30, label: "normal (within bounds and floor)" },
+        { x: 200, z: 200, label: "past world bound" },
+        { x: -200, z: -200, label: "past world bound (negative)" },
+        { x: 10000, z: 10000, label: "far past world bound" },
+        { x: -90, z: 0, label: "would shorten under floor (chord ~10 m)" },
+        { x: -99, z: 0, label: "would shorten under floor (chord ~1 m)" },
+        { x: bx, z: bz, label: "target equals current position (no-op)" },
+    ];
 
-    test("a drag shortening the chord under ROAD_MIN_LENGTH is refused", () => {
-        expect(isAdmissibleDrag(doc, 1, -25, 0)).toBe(false);
-    });
+    for (const { x, z, label } of targets) {
+        test(`clamp + applyEdit: ${label} → target (${x}, ${z})`, () => {
+            const [cx, cz] = clampToBound(x, z);
+            const [fx, fz] = clampDragTarget(doc, 1, cx, cz);
+            const edited = applyEdit(doc, 1, fx, fz);
 
-    test("a drag lengthening the chord past ROAD_MAX_LENGTH is refused", () => {
-        expect(isAdmissibleDrag(doc, 1, 130, 0)).toBe(false);
-    });
+            // the resulting endpoint is within bounds
+            expect(Math.abs(fx)).toBeLessThanOrEqual(BOUND);
+            expect(Math.abs(fz)).toBeLessThanOrEqual(BOUND);
 
-    test("a refused drag leaves the input document unchanged (the guard prevents applyEdit)", () => {
-        // The guard pattern: if !isAdmissibleDrag, don't call applyEdit. applyEdit itself always
-        // returns a new document — the guard is what prevents the edit. Verify the guard catches it:
-        expect(isAdmissibleDrag(doc, 1, 130, 0)).toBe(false);
-        // the input document is unchanged (applyEdit was never called)
-        expect(doc.polylines[0].points[1]).toEqual([100, 0]);
-    });
+            // the resulting chord holds the floor
+            expect(chordLength(edited)).toBeGreaterThanOrEqual(ROAD_MIN_LENGTH - 1e-6);
 
-    // RED-FIRST WITNESS: the ROAD_MAX_LENGTH refusal arm prevents `allocate` from throwing
-    // `capacity exceeded (64 layers)` mid-drag. Without the guard, a long chord touches more than
-    // ATLAS_LAYERS tiles, and the allocator's free list runs dry. The actual error text witnessed
-    // before the guard existed:
-    //   "overlay atlas: capacity exceeded (64 layers) allocating tile 64"
-    // (from `queue.ts`'s `allocate`, when `free.length === 0`).
-    test("ROAD_MAX_LENGTH refusal — witness the throw it prevents", () => {
-        const longDoc = applyEdit(doc, 1, 400, 400);
-        const tiles = documentDirtyTiles(longDoc);
-        expect(tiles.length).toBeGreaterThan(ATLAS_LAYERS);
+            // the other endpoint is unchanged
+            expect(edited.polylines[0].points[0]).toEqual([ax, az]);
 
-        const cpu = new Int32Array(256).fill(-1);
-        const free: number[] = [];
-        for (let i = ATLAS_LAYERS - 1; i >= 0; i--) free.push(i);
-        let threw = false;
-        let errMsg = "";
-        try {
-            for (const id of tiles) {
-                allocate(cpu, id, free, ATLAS_LAYERS);
+            // if the clamped target differs from the current position, the output differs at endpoint 1
+            const moved = fx !== bx || fz !== bz;
+            const outputDiffers =
+                edited.polylines[0].points[1][0] !== bx || edited.polylines[0].points[1][1] !== bz;
+            expect(outputDiffers).toBe(moved);
+
+            // the one admissible no-op: target equal to current position
+            if (x === bx && z === bz) {
+                expect(fx).toBe(bx);
+                expect(fz).toBe(bz);
             }
-        } catch (e) {
-            threw = true;
-            errMsg = String(e);
-        }
-        expect(threw).toBe(true);
-        expect(errMsg).toContain("capacity exceeded (64 layers)");
-    });
+        });
+    }
 
-    test("a worst-case admissible ROAD_MAX_LENGTH chord stays at or under ATLAS_LAYERS resident tiles", () => {
-        const half = ROAD_MAX_LENGTH / 2;
-        const diag = half / Math.SQRT2;
-        const maxDoc: StrokeDocument = {
+    // property: over 500 random targets (some past bounds, some under floor), the clamp always
+    // produces a valid endpoint and applyEdit always moves it
+    test("500 random targets: clamp always yields a valid endpoint, applyEdit always moves it", () => {
+        const rng = mulberry32(999);
+        for (let i = 0; i < 500; i++) {
+            // sample from a range wider than the world to include past-bound targets
+            const x = (rng() * 2 - 1) * WORLD_HALF * 3;
+            const z = (rng() * 2 - 1) * WORLD_HALF * 3;
+            const [cx, cz] = clampToBound(x, z);
+            const [fx, fz] = clampDragTarget(doc, 1, cx, cz);
+            const edited = applyEdit(doc, 1, fx, fz);
+
+            expect(Math.abs(fx)).toBeLessThanOrEqual(BOUND);
+            expect(Math.abs(fz)).toBeLessThanOrEqual(BOUND);
+            expect(chordLength(edited)).toBeGreaterThanOrEqual(ROAD_MIN_LENGTH - 1e-6);
+
+            // the other endpoint is unchanged
+            expect(edited.polylines[0].points[0]).toEqual([ax, az]);
+
+            // if the clamped target differs from the current position, the output differs
+            const moved = fx !== bx || fz !== bz;
+            const outputDiffers =
+                edited.polylines[0].points[1][0] !== bx || edited.polylines[0].points[1][1] !== bz;
+            expect(outputDiffers).toBe(moved);
+        }
+    });
+});
+
+describe("edit — worst-case chord capacity (stage 4c)", () => {
+    // The arm that survived the ROAD_MAX_LENGTH deletion, re-anchored on the invariant that mattered:
+    // "no admissible drag can throw out of `allocate`". The worst case the world allows is a
+    // corner-to-corner chord across the bounded 1024 m world. Its `documentDirtyTiles` count must be
+    // at or under `ATLAS_LAYERS` (now `TILE_COUNT = 256`, sized by this measurement).
+    test("the worst-case corner-to-corner chord stays at or under ATLAS_LAYERS resident tiles", () => {
+        const bound = WORLD_HALF - ROAD_HALF_WIDTH;
+        const worstDoc: StrokeDocument = {
             polylines: [
                 {
                     points: [
-                        [-diag, -diag],
-                        [diag, diag],
+                        [-bound, -bound],
+                        [bound, bound],
                     ],
                     halfWidth: ROAD_HALF_WIDTH,
                 },
             ],
         };
-        expect(chordLength(maxDoc)).toBeCloseTo(ROAD_MAX_LENGTH, 0);
-        expect(residentTileCount(maxDoc)).toBeLessThanOrEqual(ATLAS_LAYERS);
+        // the chord length is the full diagonal of the bounded region (~1437 m)
+        expect(chordLength(worstDoc)).toBeGreaterThan(1400);
+        // the dirty-tile count is at or under ATLAS_LAYERS
+        const count = residentTileCount(worstDoc);
+        expect(count).toBeLessThanOrEqual(ATLAS_LAYERS);
+        // ATLAS_LAYERS is TILE_COUNT (256) — fully resident
+        expect(ATLAS_LAYERS).toBe(TILE_COUNT);
     });
 });
 
-describe("edit — corridor flatness over 200 random admissible drags", () => {
+describe("edit — corridor flatness over 200 random clamped drags", () => {
     // The spec's Validation "Corridor flatness" criterion, extended to edited documents: over a scan of
-    // 200 random admissible drags, `checkSurfaceFlatness` over `buildLatticeVertices` reads exactly
+    // 200 random clamped drags, `checkSurfaceFlatness` over `buildLatticeVertices` reads exactly
     // 0 violations / 0.0000 m on both axes at SPACING and SPACING/2. The chord's affine target makes
     // the in-corridor reconstruction error vanish identically (barycentric interpolation reproduces an
-    // affine field exactly at any cell size and any road angle), so this reads zero on every admissible
+    // affine field exactly at any cell size and any road angle), so this reads zero on every clamped
     // drag — not just the boot document.
+    //
+    // Stage 4c: the scan now draws from the *unbounded* band — targets past the world bound and past
+    // the old ROAD_MAX_LENGTH ceiling — and clamps via `clampToBound` + `clampDragTarget` before
+    // `applyEdit`. The old scan filtered by `isAdmissibleDrag` (the deleted refusal); the new scan
+    // filters by grade only (the flatness oracle's longitudinal bound is MAX_GRADE, so a chord steeper
+    // than that produces violations by design, not by reconstruction error).
     const rng = mulberry32(12345);
     const perm = makePermutation(SEED);
     const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
 
-    // generate 200 random admissible drags from the boot document. The flatness oracle's longitudinal
-    // bound is a grade check (gradeBound = MAX_GRADE * ds + 2 * QUANT_TOL), so a drag whose chord grade
-    // exceeds MAX_GRADE produces longitudinal violations by design — not a reconstruction error. The
-    // admissibility check (isAdmissibleDrag) refuses the length band only, never grade (the spec's
-    // "the drag refuses bounds and minimum length only, never cost"), so the scan filters by grade as a
-    // test-selection criterion: the corridor flatness claim is about the mesh's reconstruction of an
-    // affine target, which holds exactly when the grade is within the road-design bound.
     const drags: { end: 0 | 1; x: number; z: number }[] = [];
     let attempts = 0;
     while (drags.length < 200 && attempts < 50000) {
         attempts++;
         const end = (rng() < 0.5 ? 0 : 1) as 0 | 1;
-        const x = (rng() * 2 - 1) * BOUND;
-        const z = (rng() * 2 - 1) * BOUND;
-        if (!isAdmissibleDrag(generateNetwork(), end, x, z)) continue;
+        // sample from the unbounded band — wider than the world to include past-bound targets
+        const x = (rng() * 2 - 1) * WORLD_HALF * 3;
+        const z = (rng() * 2 - 1) * WORLD_HALF * 3;
+        const [cx, cz] = clampToBound(x, z);
+        const [fx, fz] = clampDragTarget(generateNetwork(), end, cx, cz);
         // filter by grade: the flatness oracle's longitudinal bound is MAX_GRADE, so a chord steeper
         // than that produces violations by design, not by reconstruction error
-        const edited = applyEdit(generateNetwork(), end, x, z);
+        const edited = applyEdit(generateNetwork(), end, fx, fz);
         const [a, b] = edited.polylines[0].points;
         const len = Math.hypot(b[0] - a[0], b[1] - a[1]);
         const hA = heightAtCpu(a[0], a[1], perm);
         const hB = heightAtCpu(b[0], b[1], perm);
         if (Math.abs(hB - hA) / len > MAX_GRADE) continue;
-        drags.push({ end, x, z });
+        drags.push({ end, x: fx, z: fz });
     }
     expect(drags.length).toBe(200);
 

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { meshHeightAt } from "./capture";
+import { createGrabState, stepGrab } from "./edit";
 import {
     applyEdit,
     chordLength,
@@ -224,4 +225,82 @@ describe("edit — corridor flatness over 200 random admissible drags", () => {
             expect(fine.maxLongitudinalExcess).toBe(0);
         });
     }
+});
+
+describe("edit — sticky grab latch (stage 4b)", () => {
+    // RED-FIRST WITNESS: the shipped shape uses `left && !dragging && hovered >= 0` to start the drag —
+    // not a rising-edge latch. A press with no handle under it latches nothing, but moving the cursor
+    // over a handle while the button is still held *does* start a drag, because `!dragging` is true and
+    // `hovered >= 0` is now satisfied. The failure text witnessed before the rising-edge fix:
+    //   "expected { dragging: true, dragEnd: 0, prevLeft: true } to equal { dragging: false, dragEnd: 0, prevLeft: true }"
+    // (frame 3 of sequence 1 — the old `stepGrab` starts a drag when the cursor reaches a handle
+    // mid-hold, the new one does not because the rising edge already passed).
+    //
+    // The latch is device-free state, so this is a unit arm over a synthetic press → move-off →
+    // move-back → release sequence — not a device probe.
+
+    test("a press with no handle under it latches nothing", () => {
+        let s = createGrabState();
+        // frame 1: idle
+        s = stepGrab(s, false, -1);
+        expect(s).toEqual({ dragging: false, dragEnd: 0, prevLeft: false });
+        // frame 2: press with no handle under it
+        s = stepGrab(s, true, -1);
+        expect(s).toEqual({ dragging: false, dragEnd: 0, prevLeft: true });
+        // frame 3: move over handle 0 while still held — must NOT latch
+        s = stepGrab(s, true, 0);
+        expect(s).toEqual({ dragging: false, dragEnd: 0, prevLeft: true });
+        // frame 4: release
+        s = stepGrab(s, false, 0);
+        expect(s).toEqual({ dragging: false, dragEnd: 0, prevLeft: false });
+    });
+
+    test("latched index is unchanged through press → move-off → move-back → release", () => {
+        let s = createGrabState();
+        // frame 1: idle
+        s = stepGrab(s, false, -1);
+        expect(s).toEqual({ dragging: false, dragEnd: 0, prevLeft: false });
+        // frame 2: press over handle 1 — latches dragEnd=1
+        s = stepGrab(s, true, 1);
+        expect(s).toEqual({ dragging: true, dragEnd: 1, prevLeft: true });
+        // frame 3: move off the handle (hover miss) — dragging stays, dragEnd unchanged
+        s = stepGrab(s, true, -1);
+        expect(s).toEqual({ dragging: true, dragEnd: 1, prevLeft: true });
+        // frame 4: move back over handle 0 — dragEnd stays 1, not 0
+        s = stepGrab(s, true, 0);
+        expect(s).toEqual({ dragging: true, dragEnd: 1, prevLeft: true });
+        // frame 5: release — clears dragging, dragEnd stays at last value
+        s = stepGrab(s, false, 0);
+        expect(s).toEqual({ dragging: false, dragEnd: 1, prevLeft: false });
+    });
+
+    test("the release edge, and only the release edge, clears it", () => {
+        let s = createGrabState();
+        // press over handle 0
+        s = stepGrab(s, true, 0);
+        expect(s.dragging).toBe(true);
+        // move off — still dragging
+        s = stepGrab(s, true, -1);
+        expect(s.dragging).toBe(true);
+        // move over handle 1 — still dragging, still dragEnd 0
+        s = stepGrab(s, true, 1);
+        expect(s.dragging).toBe(true);
+        expect(s.dragEnd).toBe(0);
+        // release — clears
+        s = stepGrab(s, false, -1);
+        expect(s.dragging).toBe(false);
+    });
+
+    test("a second press after release latches fresh", () => {
+        let s = createGrabState();
+        // first press over handle 0
+        s = stepGrab(s, true, 0);
+        expect(s).toEqual({ dragging: true, dragEnd: 0, prevLeft: true });
+        // release
+        s = stepGrab(s, false, -1);
+        expect(s.dragging).toBe(false);
+        // second press over handle 1
+        s = stepGrab(s, true, 1);
+        expect(s).toEqual({ dragging: true, dragEnd: 1, prevLeft: true });
+    });
 });

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -174,11 +174,17 @@ describe("edit — every drag constraint clamps (stage 4c)", () => {
     });
 });
 
-describe("edit — worst-case chord capacity (stage 4c)", () => {
+describe("edit — worst-case chord capacity (stage 4d)", () => {
     // The arm that survived the ROAD_MAX_LENGTH deletion, re-anchored on the invariant that mattered:
     // "no admissible drag can throw out of `allocate`". The worst case the world allows is a
     // corner-to-corner chord across the bounded 1024 m world. Its `documentDirtyTiles` count must be
-    // at or under `ATLAS_LAYERS` (now `TILE_COUNT = 256`, sized by this measurement).
+    // at or under `ATLAS_LAYERS` (now 64, sized by the stage 4d capsule-test measurement of 46 + headroom).
+    //
+    // Stage 4d narrowed the dirty set from the segment's AABB to its capsule (swath): the diagonal's
+    // count dropped from 256 (the whole grid under the AABB) to 46 (the true swath). ATLAS_LAYERS fell
+    // from TILE_COUNT (256, full residency) back to 64 — the original pre-4c value — with ~39% headroom
+    // over the measured 46. The capacity arms in `queue.test.ts` are witnesses again: with capacity
+    // below full residency, `allocate` can throw if `release` breaks.
     test("the worst-case corner-to-corner chord stays at or under ATLAS_LAYERS resident tiles", () => {
         const bound = WORLD_HALF - ROAD_HALF_WIDTH;
         const worstDoc: StrokeDocument = {
@@ -194,11 +200,13 @@ describe("edit — worst-case chord capacity (stage 4c)", () => {
         };
         // the chord length is the full diagonal of the bounded region (~1437 m)
         expect(chordLength(worstDoc)).toBeGreaterThan(1400);
-        // the dirty-tile count is at or under ATLAS_LAYERS
+        // the dirty-tile count (capsule swath) is at or under ATLAS_LAYERS
         const count = residentTileCount(worstDoc);
         expect(count).toBeLessThanOrEqual(ATLAS_LAYERS);
-        // ATLAS_LAYERS is TILE_COUNT (256) — fully resident
-        expect(ATLAS_LAYERS).toBe(TILE_COUNT);
+        // the measured worst-case swath is 46 (stage 4d), ATLAS_LAYERS is 64 with headroom
+        expect(count).toBe(46);
+        expect(ATLAS_LAYERS).toBe(64);
+        expect(ATLAS_LAYERS).toBeLessThan(TILE_COUNT);
     });
 });
 

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { meshHeightAt } from "./capture";
-import { applyEdit, chordLength, clampToBound, isAdmissibleDrag, residentTileCount } from "./edit";
+import {
+    applyEdit,
+    chordLength,
+    clampToBound,
+    isAdmissibleDrag,
+    residentTileCount,
+} from "./editPure";
 import { buildLatticeVertices, checkSurfaceFlatness } from "./flatness";
 import type { StrokeDocument } from "./overlay/document";
 import { documentDirtyTiles } from "./overlay/document";
@@ -17,8 +23,9 @@ import { SEED } from "./terrain/terrain";
 // over 200 random admissible drags. The device-bound halves (the live drag, the handle entity's y, the
 // refused-edit byte-identical readback) live in `test/roads.spec.ts` via the `__roadsEdit` bridge.
 //
-// `applyEdit` and `clampToBound` stay free of `@dylanebert/shallot` imports (the Node ≥26 gotcha), so
-// this file exercises them under `bun test` without pulling in the engine's device-bound module graph.
+// The pure halves live in `./editPure`, which imports nothing from `@dylanebert/shallot` (the Node ≥26
+// gotcha), so this file exercises them under `bun test` without pulling in the engine's device-bound
+// module graph.
 
 const BOUND = WORLD_HALF - ROAD_HALF_WIDTH;
 

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -233,8 +233,18 @@ describe("edit — sticky grab latch (stage 4b)", () => {
     // over a handle while the button is still held *does* start a drag, because `!dragging` is true and
     // `hovered >= 0` is now satisfied. The failure text witnessed before the rising-edge fix:
     //   "expected { dragging: true, dragEnd: 0, prevLeft: true } to equal { dragging: false, dragEnd: 0, prevLeft: true }"
-    // (frame 3 of sequence 1 — the old `stepGrab` starts a drag when the cursor reaches a handle
-    // mid-hold, the new one does not because the rising edge already passed).
+    // (frame 3 of sequence 1 — the old inline gate in `update()` starts a drag when the cursor reaches
+    // a handle mid-hold, the new one does not because the rising edge already passed). There was no
+    // `stepGrab` before this stage: the old logic was inline in `update()`, and the pre-image is
+    // `git show a3827a7:examples/showcase/roads/src/edit.ts`.
+    //
+    // Only THIS first arm discriminates the new shape from the old. The other three produce identical
+    // traces under both shapes, because the old gate's `dragging` already survived hover misses (once
+    // true, only `!left` cleared it) — the real shipped defect was the mid-hold *start* plus an
+    // `OrbitPick.claim` that re-ran a fresh hover test every frame and so released orbit suppression
+    // mid-drag, which is what the person saw as "grab/ungrab mid movement". The remaining three arms
+    // are regression guards over the new shape, not red-first witnesses; keeping that distinction
+    // explicit is why this note exists.
     //
     // The latch is device-free state, so this is a unit arm over a synthetic press → move-off →
     // move-back → release sequence — not a device probe.

--- a/examples/showcase/roads/src/edit.ts
+++ b/examples/showcase/roads/src/edit.ts
@@ -2,21 +2,23 @@
 // endpoints, a `Color` slab carrying idle / hover / grabbed, hover via `cursorRay` → `raySphere`, and
 // `OrbitPick.claim` so a press over a handle suppresses orbit rotation for the whole drag. On a claimed
 // press, each frame marches `flattenFieldAt` along the cursor ray to find the world point, clamps to
-// the world bounds, and refuses a drag leaving the `ROAD_MIN_LENGTH`–`ROAD_MAX_LENGTH` band in both
-// directions. The pure, device-free halves (`applyEdit`, `clampToBound`, `isAdmissibleDrag`,
-// `chordLength`, `residentTileCount`, `HANDLE_RADIUS`) live in `editPure.ts`, which imports nothing
-// from `@dylanebert/shallot`; this module imports them from there and re-exports them for consumers
-// like `boot.ts`. `edit.test.ts` imports the pure halves from `./editPure` so it exercises them under
-// `bun test` without pulling in the engine's device-bound module graph; the Playwright Node side stays
-// bridge-only for the same reason (Node ≥26 rejects the package's bare `package.json` import).
+// the world bounds, and clamps to the `ROAD_MIN_LENGTH` floor (never refuses — a constraint on a dragged
+// quantity clamps, never no-ops). When the march returns null (the ray misses the surface), the drag
+// holds its last valid target instead of skipping the frame. The pure, device-free halves (`applyEdit`,
+// `clampToBound`, `clampDragTarget`, `chordLength`, `residentTileCount`, `HANDLE_RADIUS`) live in
+// `editPure.ts`, which imports nothing from `@dylanebert/shallot`; this module imports them from there
+// and re-exports them for consumers like `boot.ts`. `edit.test.ts` imports the pure halves from
+// `./editPure` so it exercises them under `bun test` without pulling in the engine's device-bound module
+// graph; the Playwright Node side stays bridge-only for the same reason (Node ≥26 rejects the package's
+// bare `package.json` import).
 
 // re-export the pure halves for consumers that imported them from ./edit (e.g. boot.ts)
 export {
     applyEdit,
     chordLength,
+    clampDragTarget,
     clampToBound,
     HANDLE_RADIUS,
-    isAdmissibleDrag,
     residentTileCount,
 } from "./editPure";
 
@@ -52,7 +54,7 @@ export function stepGrab(state: GrabState, left: boolean, hovered: number): Grab
     return { dragging, dragEnd, prevLeft: left };
 }
 
-import { applyEdit, clampToBound, HANDLE_RADIUS, isAdmissibleDrag } from "./editPure";
+import { applyEdit, clampDragTarget, clampToBound, HANDLE_RADIUS } from "./editPure";
 
 // --- the device-bound plugin (imports from @dylanebert/shallot below this line) ---
 
@@ -92,6 +94,7 @@ let handleEids: [number, number] = [-1, -1];
 let hovered = -1;
 let grab = createGrabState();
 let claimInstalled = false;
+let lastValidTarget: [number, number] | null = null;
 
 /** march `ray` against the continuous flattened field (`flattenFieldAt`) and return the (x, z) where the
  *  ray crosses the surface, or null if it doesn't within `MARCH_MAX`. The field is the oracle's own
@@ -260,20 +263,25 @@ const EditSystem: System = {
         grab = stepGrab(grab, Inputs.mouse.left, hovered);
         const { dragging, dragEnd } = grab;
 
-        // drag: march the cursor ray against the flattened field, clamp, refuse the length band, apply
+        // drag: march the cursor ray against the flattened field, clamp to bounds, clamp to the
+        // ROAD_MIN_LENGTH floor, and apply. When the march returns null (the ray misses the surface),
+        // the drag holds its last valid target instead of skipping the frame.
+        if (!dragging) {
+            lastValidTarget = null;
+        }
         if (dragging && ray) {
             const { segments, cutDepth } = buildNetworkGeometry(doc, SEED);
             const falloff = computeFalloff(cutDepth);
             const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
             const hit = marchFlattenField(ray, segments, falloff, natural);
-            if (hit) {
-                const [cx, cz] = clampToBound(hit[0], hit[1]);
-                if (isAdmissibleDrag(doc, dragEnd, cx, cz)) {
-                    const newDoc = applyEdit(doc, dragEnd, cx, cz);
-                    void editDocument(newDoc).catch((err) => {
-                        console.error("roads: edit failed", err);
-                    });
-                }
+            if (hit) lastValidTarget = hit;
+            if (lastValidTarget) {
+                const [cx, cz] = clampToBound(lastValidTarget[0], lastValidTarget[1]);
+                const [fx, fz] = clampDragTarget(doc, dragEnd, cx, cz);
+                const newDoc = applyEdit(doc, dragEnd, fx, fz);
+                void editDocument(newDoc).catch((err) => {
+                    console.error("roads: edit failed", err);
+                });
             }
         }
 
@@ -297,6 +305,7 @@ const EditSystem: System = {
         hovered = -1;
         grab = createGrabState();
         claimInstalled = false;
+        lastValidTarget = null;
     },
 };
 

--- a/examples/showcase/roads/src/edit.ts
+++ b/examples/showcase/roads/src/edit.ts
@@ -3,68 +3,24 @@
 // `OrbitPick.claim` so a press over a handle suppresses orbit rotation for the whole drag. On a claimed
 // press, each frame marches `flattenFieldAt` along the cursor ray to find the world point, clamps to
 // the world bounds, and refuses a drag leaving the `ROAD_MIN_LENGTH`–`ROAD_MAX_LENGTH` band in both
-// directions. `applyEdit` and the clamp are pure and device-free (no `@dylanebert/shallot` imports) so
-// `edit.test.ts` exercises them under `bun test` without pulling in the engine's device-bound module
-// graph; the Playwright Node side stays bridge-only for the same reason (Node ≥26 rejects the package's
-// bare `package.json` import).
+// directions. The pure, device-free halves (`applyEdit`, `clampToBound`, `isAdmissibleDrag`,
+// `chordLength`, `residentTileCount`, `HANDLE_RADIUS`) live in `editPure.ts`, which imports nothing
+// from `@dylanebert/shallot`; this module imports them from there and re-exports them for consumers
+// like `boot.ts`. `edit.test.ts` imports the pure halves from `./editPure` so it exercises them under
+// `bun test` without pulling in the engine's device-bound module graph; the Playwright Node side stays
+// bridge-only for the same reason (Node ≥26 rejects the package's bare `package.json` import).
 
-import type { StrokeDocument } from "./overlay/document";
-import { documentDirtyTiles } from "./overlay/document";
-import { ROAD_HALF_WIDTH, ROAD_MAX_LENGTH, ROAD_MIN_LENGTH } from "./overlay/network";
-import { WORLD_HALF } from "./terrain/grid";
+// re-export the pure halves for consumers that imported them from ./edit (e.g. boot.ts)
+export {
+    applyEdit,
+    chordLength,
+    clampToBound,
+    HANDLE_RADIUS,
+    isAdmissibleDrag,
+    residentTileCount,
+} from "./editPure";
 
-// --- pure, device-free helpers (no @dylanebert/shallot imports) ---
-
-/** the world-bound margin: keeps the handle sphere (radius `halfWidth/2`) and the road's own half-width
- *  inside the grid so the road never extends past the terrain's edge. Derived from the road, like the
- *  handle radius. */
-const BOUND_MARGIN = ROAD_HALF_WIDTH;
-
-/** the handle's world-space radius — half the road's half-width, so the handle sits on the road without
- *  dwarfing it. The sphere mesh has radius 0.5, so the Transform scale is `HANDLE_RADIUS / 0.5`. */
-export const HANDLE_RADIUS = ROAD_HALF_WIDTH / 2;
-
-/** clamp (x, z) to the world bounds so the handle never leaves the grid: `|x|, |z| ≤ WORLD_HALF − margin`.
- *  Pure, device-free. */
-export function clampToBound(x: number, z: number): [number, number] {
-    const bound = WORLD_HALF - BOUND_MARGIN;
-    return [Math.max(-bound, Math.min(bound, x)), Math.max(-bound, Math.min(bound, z))];
-}
-
-/** the chord length of a one-road document — the distance between its two endpoints. */
-export function chordLength(doc: StrokeDocument): number {
-    const [a, b] = doc.polylines[0].points;
-    return Math.hypot(b[0] - a[0], b[1] - a[1]);
-}
-
-/** pure, device-free: return a new document with endpoint `end` (0 or 1) moved to `(x, z)`. The input
- *  document is not mutated — a new `StrokeDocument` is returned with the moved endpoint replacing the
- *  original, every other point unchanged. */
-export function applyEdit(doc: StrokeDocument, end: 0 | 1, x: number, z: number): StrokeDocument {
-    const line = doc.polylines[0];
-    const points = [...line.points] as [number, number][];
-    points[end] = [x, z];
-    return {
-        polylines: [{ points, halfWidth: line.halfWidth }],
-    };
-}
-
-/** whether moving endpoint `end` to `(x, z)` keeps the chord within the `ROAD_MIN_LENGTH`–`ROAD_MAX_LENGTH`
- *  band. The ceiling is atlas capacity, not taste: a chord past `ROAD_MAX_LENGTH` touches more than
- *  `ATLAS_LAYERS` tiles, and `allocate` throws `capacity exceeded (64 layers)` mid-drag. Pure,
- *  device-free. */
-export function isAdmissibleDrag(doc: StrokeDocument, end: 0 | 1, x: number, z: number): boolean {
-    const edited = applyEdit(doc, end, x, z);
-    const len = chordLength(edited);
-    return len >= ROAD_MIN_LENGTH && len <= ROAD_MAX_LENGTH;
-}
-
-/** the number of atlas tiles a document touches — `documentDirtyTiles`'s count, which is the exact
- *  per-primitive union the overlay's own oracle pins. Device-free (delegates to `document.ts`'s pure
- *  math). */
-export function residentTileCount(doc: StrokeDocument): number {
-    return documentDirtyTiles(doc).length;
-}
+import { applyEdit, clampToBound, HANDLE_RADIUS, isAdmissibleDrag } from "./editPure";
 
 // --- the device-bound plugin (imports from @dylanebert/shallot below this line) ---
 

--- a/examples/showcase/roads/src/edit.ts
+++ b/examples/showcase/roads/src/edit.ts
@@ -20,6 +20,38 @@ export {
     residentTileCount,
 } from "./editPure";
 
+// --- the grab latch (pure, device-free state machine) ---
+//
+// `stepGrab` is the press-edge latch the spec's stage 4b names: on the rising edge of `left` while
+// `hovered >= 0`, record the handle index and set `dragging`; `dragging` survives every subsequent
+// frame regardless of hover and clears only on the falling edge; a press with no handle under it
+// latches nothing. Extracted as a pure function so `edit.test.ts` can drive a synthetic press →
+// move-off → move-back → release sequence without a device.
+
+export interface GrabState {
+    dragging: boolean;
+    dragEnd: 0 | 1;
+    prevLeft: boolean;
+}
+
+export function createGrabState(): GrabState {
+    return { dragging: false, dragEnd: 0, prevLeft: false };
+}
+
+export function stepGrab(state: GrabState, left: boolean, hovered: number): GrabState {
+    const rising = left && !state.prevLeft;
+    let dragging = state.dragging;
+    let dragEnd = state.dragEnd;
+    if (rising && hovered >= 0) {
+        dragging = true;
+        dragEnd = hovered as 0 | 1;
+    }
+    if (!left) {
+        dragging = false;
+    }
+    return { dragging, dragEnd, prevLeft: left };
+}
+
 import { applyEdit, clampToBound, HANDLE_RADIUS, isAdmissibleDrag } from "./editPure";
 
 // --- the device-bound plugin (imports from @dylanebert/shallot below this line) ---
@@ -58,8 +90,7 @@ let liveState: State | null = null;
 let camEid = -1;
 let handleEids: [number, number] = [-1, -1];
 let hovered = -1;
-let dragging = false;
-let dragEnd: 0 | 1 = 0;
+let grab = createGrabState();
 let claimInstalled = false;
 
 /** march `ray` against the continuous flattened field (`flattenFieldAt`) and return the (x, z) where the
@@ -189,11 +220,13 @@ const EditSystem: System = {
         }
 
         // install the OrbitPick.claim once — the closure reads live Transform positions at call time, so
-        // it stays correct across edits without re-installation. The claim returns true when a handle is
-        // hovered, suppressing orbit rotation for the whole drag (pan and zoom untouched).
+        // it stays correct across edits without re-installation. The claim reads the latch when a drag is
+        // held (so orbit stays suppressed for the whole drag even when the cursor leaves the handle), and
+        // runs a fresh hover test only when no drag is held.
         if (!claimInstalled) {
             OrbitPick.claim = () => {
                 if (!liveState || camEid < 0 || handleEids[0] < 0) return false;
+                if (grab.dragging) return true;
                 const claimRay = cursorRay(liveState, camEid);
                 if (!claimRay) return false;
                 for (let i = 0; i < 2; i++) {
@@ -222,16 +255,10 @@ const EditSystem: System = {
             claimInstalled = true;
         }
 
-        // drag state: the orbit button is left (button 0). Start a drag on the press edge over a handle;
-        // end on release.
-        const orbitHeld = Inputs.mouse.left;
-        if (orbitHeld && !dragging && hovered >= 0) {
-            dragging = true;
-            dragEnd = hovered as 0 | 1;
-        }
-        if (!orbitHeld) {
-            dragging = false;
-        }
+        // grab latch: the orbit button is left (button 0). `stepGrab` latches on the rising edge over a
+        // handle and holds until the falling edge — hover feeds only the colour, never the drag.
+        grab = stepGrab(grab, Inputs.mouse.left, hovered);
+        const { dragging, dragEnd } = grab;
 
         // drag: march the cursor ray against the flattened field, clamp, refuse the length band, apply
         if (dragging && ray) {
@@ -268,7 +295,7 @@ const EditSystem: System = {
         camEid = -1;
         liveState = null;
         hovered = -1;
-        dragging = false;
+        grab = createGrabState();
         claimInstalled = false;
     },
 };

--- a/examples/showcase/roads/src/edit.ts
+++ b/examples/showcase/roads/src/edit.ts
@@ -28,7 +28,7 @@ export {
 // latches nothing. Extracted as a pure function so `edit.test.ts` can drive a synthetic press →
 // move-off → move-back → release sequence without a device.
 
-export interface GrabState {
+interface GrabState {
     dragging: boolean;
     dragEnd: 0 | 1;
     prevLeft: boolean;

--- a/examples/showcase/roads/src/edit.ts
+++ b/examples/showcase/roads/src/edit.ts
@@ -1,0 +1,325 @@
+// Stage 4 — handles and drag (`roads-interactive.md` stage 4). Two Part `sphere` entities at the
+// endpoints, a `Color` slab carrying idle / hover / grabbed, hover via `cursorRay` → `raySphere`, and
+// `OrbitPick.claim` so a press over a handle suppresses orbit rotation for the whole drag. On a claimed
+// press, each frame marches `flattenFieldAt` along the cursor ray to find the world point, clamps to
+// the world bounds, and refuses a drag leaving the `ROAD_MIN_LENGTH`–`ROAD_MAX_LENGTH` band in both
+// directions. `applyEdit` and the clamp are pure and device-free (no `@dylanebert/shallot` imports) so
+// `edit.test.ts` exercises them under `bun test` without pulling in the engine's device-bound module
+// graph; the Playwright Node side stays bridge-only for the same reason (Node ≥26 rejects the package's
+// bare `package.json` import).
+
+import type { StrokeDocument } from "./overlay/document";
+import { documentDirtyTiles } from "./overlay/document";
+import { ROAD_HALF_WIDTH, ROAD_MAX_LENGTH, ROAD_MIN_LENGTH } from "./overlay/network";
+import { WORLD_HALF } from "./terrain/grid";
+
+// --- pure, device-free helpers (no @dylanebert/shallot imports) ---
+
+/** the world-bound margin: keeps the handle sphere (radius `halfWidth/2`) and the road's own half-width
+ *  inside the grid so the road never extends past the terrain's edge. Derived from the road, like the
+ *  handle radius. */
+const BOUND_MARGIN = ROAD_HALF_WIDTH;
+
+/** the handle's world-space radius — half the road's half-width, so the handle sits on the road without
+ *  dwarfing it. The sphere mesh has radius 0.5, so the Transform scale is `HANDLE_RADIUS / 0.5`. */
+export const HANDLE_RADIUS = ROAD_HALF_WIDTH / 2;
+
+/** clamp (x, z) to the world bounds so the handle never leaves the grid: `|x|, |z| ≤ WORLD_HALF − margin`.
+ *  Pure, device-free. */
+export function clampToBound(x: number, z: number): [number, number] {
+    const bound = WORLD_HALF - BOUND_MARGIN;
+    return [Math.max(-bound, Math.min(bound, x)), Math.max(-bound, Math.min(bound, z))];
+}
+
+/** the chord length of a one-road document — the distance between its two endpoints. */
+export function chordLength(doc: StrokeDocument): number {
+    const [a, b] = doc.polylines[0].points;
+    return Math.hypot(b[0] - a[0], b[1] - a[1]);
+}
+
+/** pure, device-free: return a new document with endpoint `end` (0 or 1) moved to `(x, z)`. The input
+ *  document is not mutated — a new `StrokeDocument` is returned with the moved endpoint replacing the
+ *  original, every other point unchanged. */
+export function applyEdit(doc: StrokeDocument, end: 0 | 1, x: number, z: number): StrokeDocument {
+    const line = doc.polylines[0];
+    const points = [...line.points] as [number, number][];
+    points[end] = [x, z];
+    return {
+        polylines: [{ points, halfWidth: line.halfWidth }],
+    };
+}
+
+/** whether moving endpoint `end` to `(x, z)` keeps the chord within the `ROAD_MIN_LENGTH`–`ROAD_MAX_LENGTH`
+ *  band. The ceiling is atlas capacity, not taste: a chord past `ROAD_MAX_LENGTH` touches more than
+ *  `ATLAS_LAYERS` tiles, and `allocate` throws `capacity exceeded (64 layers)` mid-drag. Pure,
+ *  device-free. */
+export function isAdmissibleDrag(doc: StrokeDocument, end: 0 | 1, x: number, z: number): boolean {
+    const edited = applyEdit(doc, end, x, z);
+    const len = chordLength(edited);
+    return len >= ROAD_MIN_LENGTH && len <= ROAD_MAX_LENGTH;
+}
+
+/** the number of atlas tiles a document touches — `documentDirtyTiles`'s count, which is the exact
+ *  per-primitive union the overlay's own oracle pins. Device-free (delegates to `document.ts`'s pure
+ *  math). */
+export function residentTileCount(doc: StrokeDocument): number {
+    return documentDirtyTiles(doc).length;
+}
+
+// --- the device-bound plugin (imports from @dylanebert/shallot below this line) ---
+
+import {
+    Camera,
+    Color,
+    Inputs,
+    Part,
+    type Plugin,
+    type State,
+    type System,
+    Transform,
+} from "@dylanebert/shallot";
+import { OrbitPick } from "@dylanebert/shallot/extras";
+import { cursorRay, type Ray, raySphere } from "@dylanebert/shallot/physics/core";
+import { Meshes, Surfaces } from "@dylanebert/shallot/render/core";
+import { flattenFieldAt } from "./flatness";
+import { buildNetworkGeometry, computeFalloff, type ProfileSegment } from "./terrain/flatten";
+import { makePermutation } from "./terrain/noise";
+import { heightAtCpu } from "./terrain/profile";
+import { editDocument, getDocument, SEED } from "./terrain/terrain";
+
+// handle colours — idle (white), hover (yellow), grabbed (orange). Design parameters, not gates: the
+// spec's drag-feel check-in is about lag/jump/detach, not colour choice.
+const IDLE_COLOR: readonly [number, number, number] = [0.85, 0.85, 0.85];
+const HOVER_COLOR: readonly [number, number, number] = [0.9, 0.8, 0.2];
+const GRABBED_COLOR: readonly [number, number, number] = [0.95, 0.55, 0.1];
+
+// the cursor-ray march: step size and max distance. 1 m steps are finer than the grid's 4 m spacing, so
+// the march catches the surface within one cell; 2000 m reaches past the orbit's max distance.
+const MARCH_STEP = 1;
+const MARCH_MAX = 2000;
+
+let liveState: State | null = null;
+let camEid = -1;
+let handleEids: [number, number] = [-1, -1];
+let hovered = -1;
+let dragging = false;
+let dragEnd: 0 | 1 = 0;
+let claimInstalled = false;
+
+/** march `ray` against the continuous flattened field (`flattenFieldAt`) and return the (x, z) where the
+ *  ray crosses the surface, or null if it doesn't within `MARCH_MAX`. The field is the oracle's own
+ *  mirror — CPU, no GPU readback on the interaction path (the spec's Locked decision). */
+function marchFlattenField(
+    ray: Ray,
+    segments: readonly ProfileSegment[],
+    falloff: number,
+    naturalHeightAt: (x: number, z: number) => number,
+): [number, number] | null {
+    const [ox, oy, oz] = ray.origin;
+    const [dx, dy, dz] = ray.dir;
+    let prevDelta = oy - flattenFieldAt(ox, oz, segments, falloff, naturalHeightAt);
+    for (let t = MARCH_STEP; t <= MARCH_MAX; t += MARCH_STEP) {
+        const x = ox + dx * t;
+        const y = oy + dy * t;
+        const z = oz + dz * t;
+        const fieldY = flattenFieldAt(x, z, segments, falloff, naturalHeightAt);
+        const delta = y - fieldY;
+        if (prevDelta > 0 !== delta > 0) return [x, z];
+        prevDelta = delta;
+    }
+    return null;
+}
+
+/** create the two Part `sphere` handle entities at the document's endpoints, with `Color` set to idle. */
+function createHandles(state: State): [number, number] {
+    const sphereMesh = Meshes.id("sphere");
+    const unlitSurface = Surfaces.id("unlit");
+    const scale = HANDLE_RADIUS / 0.5; // sphere mesh radius 0.5 → world radius HANDLE_RADIUS
+    const eids: [number, number] = [-1, -1];
+    for (let i = 0; i < 2; i++) {
+        const eid = state.create();
+        state.add(eid, Transform);
+        Transform.scale.set(eid, scale, scale, scale, 0);
+        state.add(eid, Part);
+        if (sphereMesh !== undefined) Part.mesh.set(eid, sphereMesh);
+        if (unlitSurface !== undefined) Part.surface.set(eid, unlitSurface);
+        state.add(eid, Color);
+        Color.rgba.set(eid, IDLE_COLOR[0], IDLE_COLOR[1], IDLE_COLOR[2], 1);
+        eids[i] = eid;
+    }
+    return eids;
+}
+
+/** the handle entities' world positions — the device gate reads this to assert the handle's `y` equals
+ *  `heightAtCpu` at its `(x, z)` after an edit. */
+export function handlePositions(): [[number, number, number], [number, number, number]] {
+    if (handleEids[0] < 0 || handleEids[1] < 0) {
+        throw new Error("roads: handles not yet created");
+    }
+    return [
+        [
+            Transform.pos.x.get(handleEids[0]),
+            Transform.pos.y.get(handleEids[0]),
+            Transform.pos.z.get(handleEids[0]),
+        ],
+        [
+            Transform.pos.x.get(handleEids[1]),
+            Transform.pos.y.get(handleEids[1]),
+            Transform.pos.z.get(handleEids[1]),
+        ],
+    ];
+}
+
+const EditSystem: System = {
+    name: "roads-edit",
+    group: "simulation",
+    annotations: { mode: "always" },
+
+    update(state) {
+        liveState = state;
+        // find the canvas-presenting camera once
+        if (camEid < 0) {
+            for (const eid of state.query([Camera])) {
+                if (state.has(eid, Transform)) {
+                    camEid = eid;
+                    break;
+                }
+            }
+        }
+        if (camEid < 0) return;
+
+        // create the handle entities once the sphere mesh is registered
+        if (handleEids[0] < 0 && Meshes.id("sphere") !== undefined) {
+            handleEids = createHandles(state);
+        }
+        if (handleEids[0] < 0) return;
+
+        // read the live document and place the handles at its endpoints (y = heightAtCpu)
+        const doc = getDocument();
+        const line = doc.polylines[0];
+        const perm = makePermutation(SEED);
+        for (let i = 0; i < 2; i++) {
+            const [x, z] = line.points[i];
+            const y = heightAtCpu(x, z, perm);
+            Transform.pos.set(handleEids[i], x, y, z, 0);
+        }
+
+        // hover test: cursorRay → raySphere against both handle spheres
+        const ray = cursorRay(state, camEid);
+        hovered = -1;
+        if (ray) {
+            for (let i = 0; i < 2; i++) {
+                const hx = Transform.pos.x.get(handleEids[i]);
+                const hy = Transform.pos.y.get(handleEids[i]);
+                const hz = Transform.pos.z.get(handleEids[i]);
+                if (
+                    raySphere(
+                        ray.origin[0],
+                        ray.origin[1],
+                        ray.origin[2],
+                        ray.dir[0],
+                        ray.dir[1],
+                        ray.dir[2],
+                        hx,
+                        hy,
+                        hz,
+                        HANDLE_RADIUS,
+                    ) !== null
+                ) {
+                    hovered = i;
+                    break;
+                }
+            }
+        }
+
+        // install the OrbitPick.claim once — the closure reads live Transform positions at call time, so
+        // it stays correct across edits without re-installation. The claim returns true when a handle is
+        // hovered, suppressing orbit rotation for the whole drag (pan and zoom untouched).
+        if (!claimInstalled) {
+            OrbitPick.claim = () => {
+                if (!liveState || camEid < 0 || handleEids[0] < 0) return false;
+                const claimRay = cursorRay(liveState, camEid);
+                if (!claimRay) return false;
+                for (let i = 0; i < 2; i++) {
+                    const hx = Transform.pos.x.get(handleEids[i]);
+                    const hy = Transform.pos.y.get(handleEids[i]);
+                    const hz = Transform.pos.z.get(handleEids[i]);
+                    if (
+                        raySphere(
+                            claimRay.origin[0],
+                            claimRay.origin[1],
+                            claimRay.origin[2],
+                            claimRay.dir[0],
+                            claimRay.dir[1],
+                            claimRay.dir[2],
+                            hx,
+                            hy,
+                            hz,
+                            HANDLE_RADIUS,
+                        ) !== null
+                    ) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+            claimInstalled = true;
+        }
+
+        // drag state: the orbit button is left (button 0). Start a drag on the press edge over a handle;
+        // end on release.
+        const orbitHeld = Inputs.mouse.left;
+        if (orbitHeld && !dragging && hovered >= 0) {
+            dragging = true;
+            dragEnd = hovered as 0 | 1;
+        }
+        if (!orbitHeld) {
+            dragging = false;
+        }
+
+        // drag: march the cursor ray against the flattened field, clamp, refuse the length band, apply
+        if (dragging && ray) {
+            const { segments, cutDepth } = buildNetworkGeometry(doc, SEED);
+            const falloff = computeFalloff(cutDepth);
+            const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
+            const hit = marchFlattenField(ray, segments, falloff, natural);
+            if (hit) {
+                const [cx, cz] = clampToBound(hit[0], hit[1]);
+                if (isAdmissibleDrag(doc, dragEnd, cx, cz)) {
+                    const newDoc = applyEdit(doc, dragEnd, cx, cz);
+                    void editDocument(newDoc).catch((err) => {
+                        console.error("roads: edit failed", err);
+                    });
+                }
+            }
+        }
+
+        // update handle colours based on hover / drag state
+        for (let i = 0; i < 2; i++) {
+            const color =
+                dragging && i === dragEnd
+                    ? GRABBED_COLOR
+                    : i === hovered
+                      ? HOVER_COLOR
+                      : IDLE_COLOR;
+            Color.rgba.set(handleEids[i], color[0], color[1], color[2], 1);
+        }
+    },
+
+    dispose() {
+        OrbitPick.claim = undefined;
+        handleEids = [-1, -1];
+        camEid = -1;
+        liveState = null;
+        hovered = -1;
+        dragging = false;
+        claimInstalled = false;
+    },
+};
+
+const RoadsEditPlugin: Plugin = {
+    name: "RoadsEdit",
+    systems: [EditSystem],
+};
+
+export default RoadsEditPlugin;

--- a/examples/showcase/roads/src/editPure.ts
+++ b/examples/showcase/roads/src/editPure.ts
@@ -1,5 +1,5 @@
-// The pure, device-free halves of the edit plugin — `applyEdit`, `clampToBound`, the admissibility
-// predicate, and the chord-length / tile-count helpers. This module imports nothing from
+// The pure, device-free halves of the edit plugin — `applyEdit`, `clampToBound`, the drag-floor clamp,
+// and the chord-length / tile-count helpers. This module imports nothing from
 // `@dylanebert/shallot`, so importing it under `bun test` (or under Playwright's Node side) does not
 // pull in the engine's device-bound module graph — the Node ≥26 hazard Approach stage 4 names (the
 // package's bare `package.json` import is rejected there). The device-bound plugin (`edit.ts`) imports
@@ -7,7 +7,7 @@
 
 import type { StrokeDocument } from "./overlay/document";
 import { documentDirtyTiles } from "./overlay/document";
-import { ROAD_HALF_WIDTH, ROAD_MAX_LENGTH, ROAD_MIN_LENGTH } from "./overlay/network";
+import { ROAD_HALF_WIDTH, ROAD_MIN_LENGTH } from "./overlay/network";
 import { WORLD_HALF } from "./terrain/grid";
 
 // --- pure, device-free helpers (no @dylanebert/shallot imports) ---
@@ -46,14 +46,58 @@ export function applyEdit(doc: StrokeDocument, end: 0 | 1, x: number, z: number)
     };
 }
 
-/** whether moving endpoint `end` to `(x, z)` keeps the chord within the `ROAD_MIN_LENGTH`–`ROAD_MAX_LENGTH`
- *  band. The ceiling is atlas capacity, not taste: a chord past `ROAD_MAX_LENGTH` touches more than
- *  `ATLAS_LAYERS` tiles, and `allocate` throws `capacity exceeded (64 layers)` mid-drag. Pure,
- *  device-free. */
-export function isAdmissibleDrag(doc: StrokeDocument, end: 0 | 1, x: number, z: number): boolean {
-    const edited = applyEdit(doc, end, x, z);
-    const len = chordLength(edited);
-    return len >= ROAD_MIN_LENGTH && len <= ROAD_MAX_LENGTH;
+/** clamp a drag target so the resulting chord holds the {@link ROAD_MIN_LENGTH} floor. If moving
+ *  endpoint `end` to `(x, z)` would shorten the chord under `ROAD_MIN_LENGTH`, the target is projected
+ *  along the drag direction (from the endpoint's current position toward `(x, z)`) to the nearest point
+ *  that maintains the floor — the last valid position on the drag ray. A target already at or above the
+ *  floor is returned unchanged. Pure, device-free.
+ *
+ *  The ceiling (`ROAD_MAX_LENGTH`) is deleted: a chord is any length the world contains, and capacity is
+ *  sized by measurement (`ATLAS_LAYERS = TILE_COUNT`), not by a refusal (`roads-interactive.md`'s Locked
+ *  decision). */
+export function clampDragTarget(
+    doc: StrokeDocument,
+    end: 0 | 1,
+    x: number,
+    z: number,
+): [number, number] {
+    const line = doc.polylines[0];
+    const other = (end === 0 ? line.points[1] : line.points[0]) as [number, number];
+    const current = line.points[end] as [number, number];
+    const [ox, oz] = other;
+    const [px, pz] = current;
+
+    // distance from target to the other endpoint
+    const tdx = x - ox;
+    const tdz = z - oz;
+    const tdist = Math.hypot(tdx, tdz);
+    if (tdist >= ROAD_MIN_LENGTH) return [x, z];
+
+    // drag direction: from current position toward target
+    const ddx = x - px;
+    const ddz = z - pz;
+    const dlen = Math.hypot(ddx, ddz);
+    if (dlen < 1e-9) return [x, z]; // target equals current — no-op
+
+    // solve |V + s*D|^2 = ROAD_MIN_LENGTH^2 for s, where V = P - O, D = (ddx, ddz)
+    // the chord is valid at s=0 (current) and invalid at s=1 (target), so the crossing in (0, 1] is
+    // the smaller root — the last valid point along the drag ray
+    const vx = px - ox;
+    const vz = pz - oz;
+    const a = ddx * ddx + ddz * ddz;
+    const b = 2 * (vx * ddx + vz * ddz);
+    const c = vx * vx + vz * vz - ROAD_MIN_LENGTH * ROAD_MIN_LENGTH;
+    const disc = b * b - 4 * a * c;
+    if (disc < 0) {
+        // no intersection — shouldn't happen if current is valid and target is invalid;
+        // fallback: project target onto the floor circle
+        return [ox + (tdx / tdist) * ROAD_MIN_LENGTH, oz + (tdz / tdist) * ROAD_MIN_LENGTH];
+    }
+    const s = (-b - Math.sqrt(disc)) / (2 * a);
+    if (s < 0) {
+        return [ox + (tdx / tdist) * ROAD_MIN_LENGTH, oz + (tdz / tdist) * ROAD_MIN_LENGTH];
+    }
+    return [px + ddx * s, pz + ddz * s];
 }
 
 /** the number of atlas tiles a document touches — `documentDirtyTiles`'s count, which is the exact

--- a/examples/showcase/roads/src/editPure.ts
+++ b/examples/showcase/roads/src/editPure.ts
@@ -1,0 +1,64 @@
+// The pure, device-free halves of the edit plugin — `applyEdit`, `clampToBound`, the admissibility
+// predicate, and the chord-length / tile-count helpers. This module imports nothing from
+// `@dylanebert/shallot`, so importing it under `bun test` (or under Playwright's Node side) does not
+// pull in the engine's device-bound module graph — the Node ≥26 hazard Approach stage 4 names (the
+// package's bare `package.json` import is rejected there). The device-bound plugin (`edit.ts`) imports
+// these and re-exports them for its own consumers; `edit.test.ts` exercises the pure halves from here.
+
+import type { StrokeDocument } from "./overlay/document";
+import { documentDirtyTiles } from "./overlay/document";
+import { ROAD_HALF_WIDTH, ROAD_MAX_LENGTH, ROAD_MIN_LENGTH } from "./overlay/network";
+import { WORLD_HALF } from "./terrain/grid";
+
+// --- pure, device-free helpers (no @dylanebert/shallot imports) ---
+
+/** the world-bound margin: keeps the handle sphere (radius `halfWidth/2`) and the road's own half-width
+ *  inside the grid so the road never extends past the terrain's edge. Derived from the road, like the
+ *  handle radius. */
+const BOUND_MARGIN = ROAD_HALF_WIDTH;
+
+/** the handle's world-space radius — half the road's half-width, so the handle sits on the road without
+ *  dwarfing it. The sphere mesh has radius 0.5, so the Transform scale is `HANDLE_RADIUS / 0.5`. */
+export const HANDLE_RADIUS = ROAD_HALF_WIDTH / 2;
+
+/** clamp (x, z) to the world bounds so the handle never leaves the grid: `|x|, |z| ≤ WORLD_HALF − margin`.
+ *  Pure, device-free. */
+export function clampToBound(x: number, z: number): [number, number] {
+    const bound = WORLD_HALF - BOUND_MARGIN;
+    return [Math.max(-bound, Math.min(bound, x)), Math.max(-bound, Math.min(bound, z))];
+}
+
+/** the chord length of a one-road document — the distance between its two endpoints. */
+export function chordLength(doc: StrokeDocument): number {
+    const [a, b] = doc.polylines[0].points;
+    return Math.hypot(b[0] - a[0], b[1] - a[1]);
+}
+
+/** pure, device-free: return a new document with endpoint `end` (0 or 1) moved to `(x, z)`. The input
+ *  document is not mutated — a new `StrokeDocument` is returned with the moved endpoint replacing the
+ *  original, every other point unchanged. */
+export function applyEdit(doc: StrokeDocument, end: 0 | 1, x: number, z: number): StrokeDocument {
+    const line = doc.polylines[0];
+    const points = [...line.points] as [number, number][];
+    points[end] = [x, z];
+    return {
+        polylines: [{ points, halfWidth: line.halfWidth }],
+    };
+}
+
+/** whether moving endpoint `end` to `(x, z)` keeps the chord within the `ROAD_MIN_LENGTH`–`ROAD_MAX_LENGTH`
+ *  band. The ceiling is atlas capacity, not taste: a chord past `ROAD_MAX_LENGTH` touches more than
+ *  `ATLAS_LAYERS` tiles, and `allocate` throws `capacity exceeded (64 layers)` mid-drag. Pure,
+ *  device-free. */
+export function isAdmissibleDrag(doc: StrokeDocument, end: 0 | 1, x: number, z: number): boolean {
+    const edited = applyEdit(doc, end, x, z);
+    const len = chordLength(edited);
+    return len >= ROAD_MIN_LENGTH && len <= ROAD_MAX_LENGTH;
+}
+
+/** the number of atlas tiles a document touches — `documentDirtyTiles`'s count, which is the exact
+ *  per-primitive union the overlay's own oracle pins. Device-free (delegates to `document.ts`'s pure
+ *  math). */
+export function residentTileCount(doc: StrokeDocument): number {
+    return documentDirtyTiles(doc).length;
+}

--- a/examples/showcase/roads/src/editPure.ts
+++ b/examples/showcase/roads/src/editPure.ts
@@ -53,8 +53,9 @@ export function applyEdit(doc: StrokeDocument, end: 0 | 1, x: number, z: number)
  *  floor is returned unchanged. Pure, device-free.
  *
  *  The ceiling (`ROAD_MAX_LENGTH`) is deleted: a chord is any length the world contains, and capacity is
- *  sized by measurement (`ATLAS_LAYERS = TILE_COUNT`), not by a refusal (`roads-interactive.md`'s Locked
- *  decision). */
+ *  sized by measurement — the worst-case single-document swath under the capsule dirty-set test, sized
+ *  with headroom over the measured worst case — not by a refusal (`roads-interactive.md`'s Locked
+ *  decision). See `overlay/tiles.ts`'s `ATLAS_LAYERS` for the derivation and the measured number. */
 export function clampDragTarget(
     doc: StrokeDocument,
     end: 0 | 1,

--- a/examples/showcase/roads/src/overlay/atlas.ts
+++ b/examples/showcase/roads/src/overlay/atlas.ts
@@ -36,14 +36,12 @@ import {
 // isn't tuned away, it has no surface to occur on.
 //
 // The overlay atlas's GPU state: two texture-2d-arrays (albedo + boundary distance, `tiles.ts`'s formats)
-// sized to {@link ATLAS_LAYERS} — equal to {@link TILE_COUNT} (256), so every tile is fully resident and
-// the indirection table is a 1:1 tile→layer map with no compaction — plus the indirection storage buffer
-// the terrain fs (`terrain/terrain.ts`) looks tile id up in. The indirection is retained (the fs still
-// reads it as "which layer holds this tile?"), but it no longer packs a larger tile space into a smaller
-// atlas: it is an identity map, since stage 4c raised capacity to full residency to cover the worst-case
-// corner-to-corner chord. A tile's layer is allocated the first time it's marked dirty and never evicted
-// within one
-// document's lifetime (per-tile eviction/paging is out of scope, see tiles.ts) — but a document *swap*
+// sized to {@link ATLAS_LAYERS} — 64 layers (measured worst-case swath 46 + headroom, stage 4d), so
+// the indirection table maps 256 tile ids into 64 atlas layers with compaction — plus the indirection
+// storage buffer the terrain fs (`terrain/terrain.ts`) looks tile id up in. The indirection is retained
+// (the fs still reads it as "which layer holds this tile?"), and it packs a larger tile space into a
+// smaller atlas: a tile's layer is allocated the first time it's marked dirty and never evicted within
+// one document's lifetime (per-tile eviction/paging is out of scope, see tiles.ts) — but a document *swap*
 // (`terrain.ts`'s `regenerate`, the F9 reseed control) is a coarser event: {@link invalidate} releases
 // every resident layer at once, so the incoming document allocates into a fresh atlas rather than
 // accreting on top of the outgoing one. `redraw` drains the dirty queue at a fixed per-frame throttle, so

--- a/examples/showcase/roads/src/overlay/atlas.ts
+++ b/examples/showcase/roads/src/overlay/atlas.ts
@@ -36,9 +36,13 @@ import {
 // isn't tuned away, it has no surface to occur on.
 //
 // The overlay atlas's GPU state: two texture-2d-arrays (albedo + boundary distance, `tiles.ts`'s formats)
-// sized to {@link ATLAS_LAYERS} — smaller than {@link TILE_COUNT}, the "small indirection" the spec's
-// Approach names — plus the indirection storage buffer the terrain fs (`terrain/terrain.ts`) looks tile id
-// up in. A tile's layer is allocated the first time it's marked dirty and never evicted within one
+// sized to {@link ATLAS_LAYERS} — equal to {@link TILE_COUNT} (256), so every tile is fully resident and
+// the indirection table is a 1:1 tile→layer map with no compaction — plus the indirection storage buffer
+// the terrain fs (`terrain/terrain.ts`) looks tile id up in. The indirection is retained (the fs still
+// reads it as "which layer holds this tile?"), but it no longer packs a larger tile space into a smaller
+// atlas: it is an identity map, since stage 4c raised capacity to full residency to cover the worst-case
+// corner-to-corner chord. A tile's layer is allocated the first time it's marked dirty and never evicted
+// within one
 // document's lifetime (per-tile eviction/paging is out of scope, see tiles.ts) — but a document *swap*
 // (`terrain.ts`'s `regenerate`, the F9 reseed control) is a coarser event: {@link invalidate} releases
 // every resident layer at once, so the incoming document allocates into a fresh atlas rather than

--- a/examples/showcase/roads/src/overlay/document.test.ts
+++ b/examples/showcase/roads/src/overlay/document.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { WORLD_HALF } from "../terrain/grid";
 import {
     documentDirtyTiles,
     documentDistance,
@@ -9,9 +10,21 @@ import {
     type Segment,
     type StrokeDocument,
     segmentDistance,
+    segmentRectDistance,
 } from "./document";
+import { ROAD_HALF_WIDTH } from "./network";
 import { strokeDistance, strokeDocument } from "./stroke";
-import { EDGE_INSET, LINE_HALF_WIDTH } from "./tiles";
+import {
+    dirtyTiles,
+    EDGE_INSET,
+    LINE_HALF_WIDTH,
+    type Rect,
+    TEXEL_SIZE,
+    TILE_SIZE,
+    TILES_PER_SIDE,
+    tileCoordOf,
+    tileOrigin,
+} from "./tiles";
 
 describe("flattenSegments", () => {
     test("one polyline with N points yields N-1 segments, in order", () => {
@@ -257,5 +270,121 @@ describe("markingDistance", () => {
         expect(markingDistance(0, 0, doc)).toBeGreaterThan(0);
         // on the edge line → negative. Derived from the doc's own halfWidth, not ROAD_HALF_WIDTH.
         expect(markingDistance(0, doc.polylines[0].halfWidth - EDGE_INSET, doc)).toBeLessThan(0);
+    });
+});
+
+describe("dirty set is the swath (stage 4d)", () => {
+    // The capsule (swath) dirty-set test replaces the segment's axis-aligned bounding box. Three arms:
+    // (1) the axis-aligned null control — the AABB was already exact there, so the count is unchanged at
+    // 32; (2) the diagonal's drop — the AABB read 256 (the whole grid), the capsule reads the true swath;
+    // (3) the one that matters — every tile the narrowing drops is verified to contain no point within
+    // halfWidth + margin of the chord, so the narrowing produces no unbaked hole.
+    //
+    // RED-FIRST against 4c's shape (the AABB): a corner-to-corner diagonal read 256 under the AABB —
+    // `git show 3bc5d55:examples/showcase/roads/src/overlay/document.ts` is the pre-image. The capsule
+    // test narrows it to 46, the measured worst case over a scan of orientations.
+
+    const halfWidth = ROAD_HALF_WIDTH;
+    const margin = TEXEL_SIZE;
+    const bound = WORLD_HALF - ROAD_HALF_WIDTH; // 508 — the admissible endpoint bound
+
+    /** the old AABB dirty set for one segment — the pre-4d shape, reconstructed in the test so the
+     *  narrowing can be verified against it. */
+    function aabbDirtySet(seg: Segment): Set<number> {
+        const rect: Rect = {
+            minX: Math.min(seg.ax, seg.bx) - seg.halfWidth - margin,
+            maxX: Math.max(seg.ax, seg.bx) + seg.halfWidth + margin,
+            minZ: Math.min(seg.az, seg.bz) - seg.halfWidth - margin,
+            maxZ: Math.max(seg.az, seg.bz) + seg.halfWidth + margin,
+        };
+        return new Set(dirtyTiles(rect));
+    }
+
+    /** a tile column's world-space rect, computed from exported tiles.ts helpers. */
+    function tileRect(tx: number, tz: number): Rect {
+        const [ox, oz] = tileOrigin(tx, tz);
+        return { minX: ox, minZ: oz, maxX: ox + TILE_SIZE, maxZ: oz + TILE_SIZE };
+    }
+
+    test("an axis-aligned full-width chord reads exactly 32 (the AABB was already exact there)", () => {
+        const doc: StrokeDocument = {
+            polylines: [
+                {
+                    points: [
+                        [-bound, 0],
+                        [bound, 0],
+                    ],
+                    halfWidth,
+                },
+            ],
+        };
+        const count = documentDirtyTiles(doc).length;
+        expect(count).toBe(32); // the null control — the capsule test did not narrow the common case
+    });
+
+    test("a corner-to-corner diagonal drops from 256 (AABB) to the swath count", () => {
+        const doc: StrokeDocument = {
+            polylines: [
+                {
+                    points: [
+                        [-bound, -bound],
+                        [bound, bound],
+                    ],
+                    halfWidth,
+                },
+            ],
+        };
+        const seg = flattenSegments(doc)[0];
+        const aabbCount = aabbDirtySet(seg).size;
+        const swathCount = documentDirtyTiles(doc).length;
+
+        // the AABB read 256 — the whole grid (the pre-4d shape)
+        expect(aabbCount).toBe(256);
+        // the capsule reads the true swath — 46, the measured worst case
+        expect(swathCount).toBe(46);
+        // the narrowing dropped the count
+        expect(swathCount).toBeLessThan(aabbCount);
+        // a straight chord crosses at most 2 * TILES_PER_SIDE - 1 = 31 tiles before width, so 46 is
+        // 1.48× the bound (the extra tiles are the halfWidth + margin band), not ~8× — the instrument
+        // is measuring the real footprint, not the AABB
+        expect(swathCount).toBeLessThanOrEqual(
+            2 * TILES_PER_SIDE -
+                1 +
+                2 * Math.ceil((halfWidth + margin) / TILE_SIZE) * TILES_PER_SIDE,
+        );
+    });
+
+    test("every tile the narrowing drops contains no point within halfWidth + margin of the chord", () => {
+        const doc: StrokeDocument = {
+            polylines: [
+                {
+                    points: [
+                        [-bound, -bound],
+                        [bound, bound],
+                    ],
+                    halfWidth,
+                },
+            ],
+        };
+        const seg = flattenSegments(doc)[0];
+        const aabbSet = aabbDirtySet(seg);
+        const swathSet = new Set(documentDirtyTiles(doc));
+
+        // the dropped tiles: in the AABB set but not in the capsule set
+        const dropped: number[] = [];
+        for (const id of aabbSet) {
+            if (!swathSet.has(id)) dropped.push(id);
+        }
+        expect(dropped.length).toBeGreaterThan(0); // the narrowing actually dropped tiles
+
+        // the one that matters: every dropped tile must contain no point within halfWidth + margin of
+        // the segment. If a dropped tile's rect has a point within that distance, the capsule test
+        // incorrectly excluded a tile the road actually touches — an unbaked hole.
+        for (const id of dropped) {
+            const [tx, tz] = tileCoordOf(id);
+            const rect = tileRect(tx, tz);
+            const dist = segmentRectDistance(seg, rect);
+            expect(dist).toBeGreaterThan(halfWidth + margin);
+        }
     });
 });

--- a/examples/showcase/roads/src/overlay/document.test.ts
+++ b/examples/showcase/roads/src/overlay/document.test.ts
@@ -10,11 +10,11 @@ import {
     type Segment,
     type StrokeDocument,
     segmentDistance,
-    segmentRectDistance,
 } from "./document";
 import { ROAD_HALF_WIDTH } from "./network";
 import { strokeDistance, strokeDocument } from "./stroke";
 import {
+    ATLAS_LAYERS,
     dirtyTiles,
     EDGE_INSET,
     LINE_HALF_WIDTH,
@@ -306,6 +306,24 @@ describe("dirty set is the swath (stage 4d)", () => {
         return { minX: ox, minZ: oz, maxX: ox + TILE_SIZE, maxZ: oz + TILE_SIZE };
     }
 
+    /** whether a dropped tile is adjacent (4-neighbour) to any tile in the swath set — the only
+     *  dropped tiles that could contain a point within halfWidth + margin of the chord, since the
+     *  swath is thin against 64 m tiles. */
+    function isBoundaryDropped(id: number, swathSet: Set<number>): boolean {
+        const [tx, tz] = tileCoordOf(id);
+        const neighbors = [
+            [tx - 1, tz],
+            [tx + 1, tz],
+            [tx, tz - 1],
+            [tx, tz + 1],
+        ];
+        for (const [nx, nz] of neighbors) {
+            if (nx < 0 || nx >= TILES_PER_SIDE || nz < 0 || nz >= TILES_PER_SIDE) continue;
+            if (swathSet.has(nz * TILES_PER_SIDE + nx)) return true;
+        }
+        return false;
+    }
+
     test("an axis-aligned full-width chord reads exactly 32 (the AABB was already exact there)", () => {
         const doc: StrokeDocument = {
             polylines: [
@@ -354,13 +372,106 @@ describe("dirty set is the swath (stage 4d)", () => {
         );
     });
 
-    test("every tile the narrowing drops contains no point within halfWidth + margin of the chord", () => {
+    // B2 repair: the original arm asserted `segmentRectDistance(seg, tileRect(...)) > halfWidth +
+    // margin` for each dropped tile — but `documentDirtyTiles` emits a tile iff
+    // `segmentRectDistance(seg, tileWorldRect(...)) <= halfWidth + MARGIN`, and the test's `tileRect`
+    // was byte-identical to production's `tileWorldRect`. So a dropped tile satisfied the assertion by
+    // definition: if `segmentRectDistance` over-estimates distance and drops a tile the road actually
+    // touches — the unbaked hole this arm exists to refuse — the arm still passed. The rewritten arm
+    // derives its expectation independently: for each dropped tile, sample a dense grid of points over
+    // the tile's rect and compute each point's distance to the segment by a brute-force parametric
+    // sweep (march t over [0, 1], min Euclidean distance to lerp(a, b, t)) — never calling
+    // `pointToSegmentDistance`, `pointToRectDistance`, `segmentRectDistance` or
+    // `segmentIntersectsRect`, and importing nothing from `document.ts` for the distance itself.
+    //
+    // Chord: a 10° chord (not the 45° diagonal). The 45° diagonal is degenerate for this arm: the
+    // segment passes through tile corners, so `segmentRectDistance` is 0 for every swath tile, and
+    // no threshold-based over-narrowing mutation can drop any of them — the arm cannot red. A 10°
+    // chord has swath tiles with non-zero `segmentRectDistance` (tiles in the halfWidth band, not
+    // intersected by the centreline), so a threshold mutation can incorrectly drop them.
+    //
+    // WITNESSED RED: to prove the arm can red, the production threshold in `documentDirtyTiles`
+    // (document.ts: `seg.halfWidth + MARGIN`) was mutated to `seg.halfWidth * 0.5` (over-narrowing the
+    // dirty set from 4.125 m to 2.0 m). The rewritten arm went red with:
+    //   "expect(received).toBeGreaterThan(expected)
+    //        Expected: > 4.125
+    //        Received: 3.66888"
+    // (a dropped tile whose brute-force sampled minimum was 3.67 m — within the 4.125 m the road
+    // actually covers — proving the arm catches an over-narrowing that the tautological original
+    // could not). The mutation was then reverted.
+    //
+    // Sampling: 128×128 grid per tile (0.5 m spacing over the 64 m tile), 1000 parametric-sweep steps
+    // over [0, 1]. The brute-force minimum is an overestimate of the true minimum (it checks a
+    // subset of tile points and segment points), so a passing assertion (brute > threshold) is
+    // conservative — the true minimum is also above threshold. Only tiles adjacent to the swath
+    // boundary are sampled — the swath is thin (8.25 m) against 64 m tiles, so the only dropped
+    // tiles that could contain a point within halfWidth + margin of the chord are those next to a
+    // kept tile; tiles deep in the AABB (far from the swath) are trivially far from the chord.
+
+    /** brute-force parametric sweep: the minimum Euclidean distance from (px, pz) to the segment
+     *  (ax, az)→(bx, bz), computed by marching t over [0, 1] in `steps` increments and taking the
+     *  min distance to lerp(a, b, t). Deliberately independent of document.ts's distance helpers
+     *  — no shared helper, no import — so the unbaked-hole arm's expectation is derived from first
+     *  principles, not a re-spelling of the production capsule test. */
+    function brutePointToSegment(
+        px: number,
+        pz: number,
+        ax: number,
+        az: number,
+        bx: number,
+        bz: number,
+        steps: number,
+    ): number {
+        let best = Infinity;
+        for (let i = 0; i <= steps; i++) {
+            const t = i / steps;
+            const qx = ax + (bx - ax) * t;
+            const qz = az + (bz - az) * t;
+            const d = Math.hypot(px - qx, pz - qz);
+            if (d < best) best = d;
+        }
+        return best;
+    }
+
+    /** the minimum brute-force distance from any sampled grid point in `rect` to the segment — a
+     *  dense grid of (gridSteps+1)² points over the tile's world rect, each swept parametrically. */
+    function bruteTileMinDistance(
+        rect: Rect,
+        ax: number,
+        az: number,
+        bx: number,
+        bz: number,
+        gridSteps: number,
+        sweepSteps: number,
+    ): number {
+        let best = Infinity;
+        const w = rect.maxX - rect.minX;
+        const h = rect.maxZ - rect.minZ;
+        for (let i = 0; i <= gridSteps; i++) {
+            const px = rect.minX + w * (i / gridSteps);
+            for (let j = 0; j <= gridSteps; j++) {
+                const pz = rect.minZ + h * (j / gridSteps);
+                const d = brutePointToSegment(px, pz, ax, az, bx, bz, sweepSteps);
+                if (d < best) best = d;
+            }
+        }
+        return best;
+    }
+
+    test("every dropped tile's brute-force sampled minimum exceeds halfWidth + margin — no unbaked hole", () => {
+        // A 10° chord: non-degenerate for the unbaked-hole test (the 45° diagonal has all swath
+        // tiles at distance 0, so no threshold mutation can over-narrow — see the docblock above).
+        const deg = 10;
+        const rad = (deg * Math.PI) / 180;
+        const cos = Math.cos(rad);
+        const sin = Math.sin(rad);
+        const halfLen = bound / Math.max(Math.abs(cos), Math.abs(sin));
         const doc: StrokeDocument = {
             polylines: [
                 {
                     points: [
-                        [-bound, -bound],
-                        [bound, bound],
+                        [-halfLen * cos, -halfLen * sin],
+                        [halfLen * cos, halfLen * sin],
                     ],
                     halfWidth,
                 },
@@ -377,14 +488,89 @@ describe("dirty set is the swath (stage 4d)", () => {
         }
         expect(dropped.length).toBeGreaterThan(0); // the narrowing actually dropped tiles
 
-        // the one that matters: every dropped tile must contain no point within halfWidth + margin of
-        // the segment. If a dropped tile's rect has a point within that distance, the capsule test
-        // incorrectly excluded a tile the road actually touches — an unbaked hole.
+        // the one that matters: every boundary-adjacent dropped tile must contain no point within
+        // halfWidth + margin of the segment, derived by brute-force parametric sweep (not
+        // segmentRectDistance). If a dropped tile has a sampled point within that distance, the
+        // capsule test incorrectly excluded a tile the road actually touches — an unbaked hole.
+        // Only tiles adjacent to the swath boundary are sampled: the swath is thin (8.25 m) against
+        // 64 m tiles, so only tiles next to a kept tile could contain a point within the threshold;
+        // tiles deep in the AABB are trivially far from the chord.
+        const gridSteps = 128; // 0.5 m spacing over the 64 m tile
+        const sweepSteps = 1000; // parametric sweep resolution
         for (const id of dropped) {
+            if (!isBoundaryDropped(id, swathSet)) continue;
             const [tx, tz] = tileCoordOf(id);
             const rect = tileRect(tx, tz);
-            const dist = segmentRectDistance(seg, rect);
-            expect(dist).toBeGreaterThan(halfWidth + margin);
+            const minDist = bruteTileMinDistance(
+                rect,
+                seg.ax,
+                seg.az,
+                seg.bx,
+                seg.bz,
+                gridSteps,
+                sweepSteps,
+            );
+            expect(minDist).toBeGreaterThan(halfWidth + margin);
         }
+    });
+});
+
+describe("worst-case swath over a scan of orientations (stage 4d, N1)", () => {
+    // N1: ATLAS_LAYERS = 64 rests on a worst case of 46 that a scratch script measured over
+    // orientations and was then deleted, so nothing shipped re-derives it. This arm ships the scan:
+    // over a scan of chord orientations across the admissible domain, assert the maximum
+    // documentDirtyTiles count is <= ATLAS_LAYERS and pin the maximum found and the orientation
+    // that produced it. The pinned literal stays a literal (so the arm reds when the subject moves)
+    // while the arm re-derives its own inputs — the assertion does not re-derive the rule it checks.
+    //
+    // Step: 1° from 0° to 180° (181 orientations). A chord at angle θ is the same as θ + 180°
+    // (same segment, reversed endpoints), so [0°, 180°) covers every unique orientation. 1° is fine
+    // because the swath count changes slowly with angle — the capsule test is a continuous function
+    // of the chord's geometry, and the worst case (45°, the corner-to-corner diagonal) is a broad
+    // maximum, not a narrow spike that a coarser step would miss.
+
+    const halfWidth = ROAD_HALF_WIDTH;
+    const bound = WORLD_HALF - ROAD_HALF_WIDTH; // 508 — the admissible endpoint bound
+
+    test("the maximum documentDirtyTiles over all orientations is <= ATLAS_LAYERS, pinned at 46 / 45°", () => {
+        let maxCount = 0;
+        let maxAngle = 0;
+
+        for (let deg = 0; deg < 180; deg++) {
+            const rad = (deg * Math.PI) / 180;
+            const cos = Math.cos(rad);
+            const sin = Math.sin(rad);
+            // the longest chord at this orientation within the bounded square [-bound, bound]²:
+            // half-length = bound / max(|cos|, |sin|), centred at the origin
+            const halfLen = bound / Math.max(Math.abs(cos), Math.abs(sin));
+            const ax = -halfLen * cos;
+            const az = -halfLen * sin;
+            const bx = halfLen * cos;
+            const bz = halfLen * sin;
+            const doc: StrokeDocument = {
+                polylines: [
+                    {
+                        points: [
+                            [ax, az],
+                            [bx, bz],
+                        ],
+                        halfWidth,
+                    },
+                ],
+            };
+            const count = documentDirtyTiles(doc).length;
+            if (count > maxCount) {
+                maxCount = count;
+                maxAngle = deg;
+            }
+        }
+
+        // the rule: the worst-case swath fits within ATLAS_LAYERS
+        expect(maxCount).toBeLessThanOrEqual(ATLAS_LAYERS);
+        // the pinned literal: the measured worst case is 46 at 45° (the corner-to-corner diagonal).
+        // This reds if the subject moves — e.g. if ATLAS_LAYERS or the dirty-set test changes —
+        // while the arm re-derives maxCount from the scan, not from the constant.
+        expect(maxCount).toBe(46);
+        expect(maxAngle).toBe(45);
     });
 });

--- a/examples/showcase/roads/src/overlay/document.ts
+++ b/examples/showcase/roads/src/overlay/document.ts
@@ -7,6 +7,9 @@ import {
     LINE_HALF_WIDTH,
     type Rect,
     TEXEL_SIZE,
+    TILE_SIZE,
+    tileCoordOf,
+    tileOrigin,
 } from "./tiles";
 
 // The stroke document: pure data (one road's polyline + width) plus the CPU analytic distance math
@@ -152,7 +155,9 @@ export function markingDistance(px: number, pz: number, doc: StrokeDocument): nu
 const MARGIN = TEXEL_SIZE; // the one-texel margin `stroke.ts`'s `strokeRect` used, so the fwidth-
 // antialiased edge (terrain.ts's fs) never samples a texel this document didn't write.
 
-/** one segment's world-space AABB, expanded by its half-width plus {@link MARGIN}. */
+/** one segment's world-space AABB, expanded by its half-width plus {@link MARGIN} — the cheap candidate
+ *  prefilter for the capsule test: every tile the capsule touches is inside this rect, so it narrows the
+ *  per-tile test to a small set without walking the whole grid. */
 function segmentRect(seg: Segment): Rect {
     return {
         minX: Math.min(seg.ax, seg.bx) - seg.halfWidth - MARGIN,
@@ -160,6 +165,78 @@ function segmentRect(seg: Segment): Rect {
         minZ: Math.min(seg.az, seg.bz) - seg.halfWidth - MARGIN,
         maxZ: Math.max(seg.az, seg.bz) + seg.halfWidth + MARGIN,
     };
+}
+
+/** raw (no halfWidth subtraction) distance from (px, pz) to the segment's centreline — the nearest
+ *  point on the infinite line clamped to the segment's endpoints. */
+function pointToSegmentDistance(px: number, pz: number, seg: Segment): number {
+    const { ax, az, bx, bz } = seg;
+    const abx = bx - ax;
+    const abz = bz - az;
+    const len = Math.hypot(abx, abz);
+    if (len === 0) return Math.hypot(px - ax, pz - az);
+    const ux = abx / len;
+    const uz = abz / len;
+    const along = (px - ax) * ux + (pz - az) * uz;
+    if (along <= 0) return Math.hypot(px - ax, pz - az);
+    if (along >= len) return Math.hypot(px - bx, pz - bz);
+    const cross = (px - ax) * uz - (pz - az) * ux;
+    return Math.abs(cross);
+}
+
+/** distance from (px, pz) to an axis-aligned rect — 0 inside, the nearest edge distance outside. */
+function pointToRectDistance(px: number, pz: number, rect: Rect): number {
+    const dx = Math.max(rect.minX - px, 0, px - rect.maxX);
+    const dz = Math.max(rect.minZ - pz, 0, pz - rect.maxZ);
+    return Math.hypot(dx, dz);
+}
+
+/** whether a segment intersects an axis-aligned rect — the separating-axis theorem over the X axis,
+ *  the Z axis, and the segment's own normal. */
+function segmentIntersectsRect(seg: Segment, rect: Rect): boolean {
+    const segMinX = Math.min(seg.ax, seg.bx);
+    const segMaxX = Math.max(seg.ax, seg.bx);
+    const segMinZ = Math.min(seg.az, seg.bz);
+    const segMaxZ = Math.max(seg.az, seg.bz);
+    if (segMaxX < rect.minX || segMinX > rect.maxX || segMaxZ < rect.minZ || segMinZ > rect.maxZ)
+        return false;
+    // separating axis along the segment's normal: (-dz, dx)
+    const dx = seg.bx - seg.ax;
+    const dz = seg.bz - seg.az;
+    const na = -dz * seg.ax + dx * seg.az;
+    const nb = -dz * seg.bx + dx * seg.bz;
+    const segLo = Math.min(na, nb);
+    const segHi = Math.max(na, nb);
+    const r0 = -dz * rect.minX + dx * rect.minZ;
+    const r1 = -dz * rect.maxX + dx * rect.minZ;
+    const r2 = -dz * rect.minX + dx * rect.maxZ;
+    const r3 = -dz * rect.maxX + dx * rect.maxZ;
+    const rectLo = Math.min(r0, r1, r2, r3);
+    const rectHi = Math.max(r0, r1, r2, r3);
+    return segHi >= rectLo && segLo <= rectHi;
+}
+
+/** the minimum distance from a world-space rect to a segment's centreline — 0 if they intersect,
+ *  otherwise the nearest point-to-point distance (min of rect-corner-to-segment and
+ *  segment-endpoint-to-rect). Exported so {@link document.test.ts} can verify the capsule test's
+ *  correctness: every tile the narrowing drops must have `segmentRectDistance > halfWidth + margin`. */
+export function segmentRectDistance(seg: Segment, rect: Rect): number {
+    if (segmentIntersectsRect(seg, rect)) return 0;
+    let best = Math.min(
+        pointToRectDistance(seg.ax, seg.az, rect),
+        pointToRectDistance(seg.bx, seg.bz, rect),
+    );
+    best = Math.min(best, pointToSegmentDistance(rect.minX, rect.minZ, seg));
+    best = Math.min(best, pointToSegmentDistance(rect.maxX, rect.minZ, seg));
+    best = Math.min(best, pointToSegmentDistance(rect.minX, rect.maxZ, seg));
+    best = Math.min(best, pointToSegmentDistance(rect.maxX, rect.maxZ, seg));
+    return best;
+}
+
+/** the tile columns (tx, tz) → the tile's world-space rect. */
+function tileWorldRect(tx: number, tz: number): Rect {
+    const [ox, oz] = tileOrigin(tx, tz);
+    return { minX: ox, minZ: oz, maxX: ox + TILE_SIZE, maxZ: oz + TILE_SIZE };
 }
 
 /** whether (px, pz) sits on a road — the same coverage region the overlay's fwidth-thresholded composite
@@ -171,17 +248,32 @@ export function drivable(px: number, pz: number, doc: StrokeDocument): boolean {
 }
 
 /**
- * the document's exact dirty-tile set: the union, over every segment *individually*, of `dirtyTiles` on
- * that one primitive's own AABB (`tiles.ts`). Deliberately not one bounding rect over the whole document —
- * two primitives far apart would otherwise mark every tile *between* them too, which is exactly the
- * over-approximation the spec's "only-touched-tiles oracle" (assert the redrawn set equals the analytic
- * set, not the visual) rules out. Sorted ascending by tile id, de-duplicated. Empty documents throw — an
- * empty edit (`markDirty` on nothing) is a caller bug, not a valid zero-tile mark.
+ * the document's exact dirty-tile set: the union, over every segment *individually*, of the tiles whose
+ * rect is within `halfWidth + margin` of the segment — a capsule (offset-rectangle) test, not the
+ * segment's axis-aligned bounding box. The AABB is kept as a cheap candidate prefilter
+ * ({@link segmentRect} → {@link dirtyTiles}), but the emitted set is the capsule test's: a tile is dirty
+ * iff the distance from that tile's rect to the segment is `<= halfWidth + margin`.
+ *
+ * Why the capsule and not the AABB: for an axis-aligned chord the AABB *is* the swath and the count is
+ * exact (a full-width chord reads 32 tiles); for a diagonal chord the AABB is the whole enclosing rect,
+ * so a corner-to-corner chord reads 256 — every tile in the world — against a true swath of at most
+ * `2 × TILES_PER_SIDE − 1 = 31` tiles before width. The AABB was a dirty-set coarseness hiding behind the
+ * deleted `ROAD_MAX_LENGTH` ceiling; the capsule narrows it to the chord's actual footprint
+ * (`roads-interactive.md` stage 4d).
+ *
+ * Deliberately not one bounding rect over the whole document — two primitives far apart would otherwise
+ * mark every tile *between* them too, which is exactly the over-approximation the spec's
+ * "only-touched-tiles oracle" rules out. Sorted ascending by tile id, de-duplicated. Empty documents
+ * throw — an empty edit (`markDirty` on nothing) is a caller bug, not a valid zero-tile mark.
  */
 export function documentDirtyTiles(doc: StrokeDocument): number[] {
     const ids = new Set<number>();
     for (const seg of flattenSegments(doc))
-        for (const id of dirtyTiles(segmentRect(seg))) ids.add(id);
+        for (const id of dirtyTiles(segmentRect(seg))) {
+            const [tx, tz] = tileCoordOf(id);
+            if (segmentRectDistance(seg, tileWorldRect(tx, tz)) <= seg.halfWidth + MARGIN)
+                ids.add(id);
+        }
     if (ids.size === 0) {
         throw new Error("documentDirtyTiles: an empty document (no polylines) touches no tile");
     }

--- a/examples/showcase/roads/src/overlay/document.ts
+++ b/examples/showcase/roads/src/overlay/document.ts
@@ -219,8 +219,10 @@ function segmentIntersectsRect(seg: Segment, rect: Rect): boolean {
 /** the minimum distance from a world-space rect to a segment's centreline — 0 if they intersect,
  *  otherwise the nearest point-to-point distance (min of rect-corner-to-segment and
  *  segment-endpoint-to-rect). Used by {@link documentDirtyTiles}'s capsule test to decide whether a
- *  tile is within `halfWidth + margin` of the segment. */
-export function segmentRectDistance(seg: Segment, rect: Rect): number {
+ *  tile is within `halfWidth + margin` of the segment. Module-local: the unbaked-hole arm deliberately
+ *  derives its own distance by brute-force sweep rather than calling this, so exporting it would leave an
+ *  export with no outside reader. */
+function segmentRectDistance(seg: Segment, rect: Rect): number {
     if (segmentIntersectsRect(seg, rect)) return 0;
     let best = Math.min(
         pointToRectDistance(seg.ax, seg.az, rect),

--- a/examples/showcase/roads/src/overlay/document.ts
+++ b/examples/showcase/roads/src/overlay/document.ts
@@ -218,8 +218,8 @@ function segmentIntersectsRect(seg: Segment, rect: Rect): boolean {
 
 /** the minimum distance from a world-space rect to a segment's centreline — 0 if they intersect,
  *  otherwise the nearest point-to-point distance (min of rect-corner-to-segment and
- *  segment-endpoint-to-rect). Exported so {@link document.test.ts} can verify the capsule test's
- *  correctness: every tile the narrowing drops must have `segmentRectDistance > halfWidth + margin`. */
+ *  segment-endpoint-to-rect). Used by {@link documentDirtyTiles}'s capsule test to decide whether a
+ *  tile is within `halfWidth + margin` of the segment. */
 export function segmentRectDistance(seg: Segment, rect: Rect): number {
     if (segmentIntersectsRect(seg, rect)) return 0;
     let best = Math.min(

--- a/examples/showcase/roads/src/overlay/network.ts
+++ b/examples/showcase/roads/src/overlay/network.ts
@@ -18,12 +18,13 @@ import { documentDistance, type Polyline, type StrokeDocument } from "./document
 
 export const ROAD_COUNT = 1;
 export const ROAD_HALF_WIDTH = 4; // metres — matches terrain/grid.ts's SPACING, `overlay/stroke.ts`'s own convention
-export const ROAD_MIN_LENGTH = 80; // metres — the drag's own refused-shortening floor (stage 4)
-export const ROAD_MAX_LENGTH = 220; // metres — keeps a single road well under the world's 1024 m span
+export const ROAD_MIN_LENGTH = 80; // metres — the drag's clamp floor: a drag that would shorten past
+// this clamps the endpoint to the closest point holding the floor (stage 4c). Its reason is the artifact
+// (a degenerate chord, an unreadable dash phase), not a buffer size — so it survives as a clamp.
 
-/** the boot road's fixed standard chord — centred on the origin, along +X, length 200 m (inside
- *  [{@link ROAD_MIN_LENGTH}, {@link ROAD_MAX_LENGTH}]). Not seeded, not searched: a person's drag is what
- *  picks a route that needs less earthwork now (`roads-interactive.md`'s locked decision). */
+/** the boot road's fixed standard chord — centred on the origin, along +X, length 200 m (above
+ *  {@link ROAD_MIN_LENGTH}). Not seeded, not searched: a person's drag is what picks a route that needs
+ *  less earthwork now (`roads-interactive.md`'s locked decision). */
 const STANDARD_CHORD: readonly [readonly [number, number], readonly [number, number]] = [
     [-100, 0],
     [100, 0],

--- a/examples/showcase/roads/src/overlay/queue.test.ts
+++ b/examples/showcase/roads/src/overlay/queue.test.ts
@@ -328,18 +328,20 @@ describe("property: tile release over random edit sequences", () => {
         }
     });
 
-    // The specific red-first input: ≥65 edits each touching a fresh tile. With the free list's release
-    // between edits, this never throws — the old counter threw at the 65th (see the docblock above).
+    // The specific red-first input: ATLAS_LAYERS + 1 edits each touching a fresh tile (derived from
+    // ATLAS_LAYERS, not a hardcoded 65 — the arm's subject is release/allocate, not the constant, so
+    // the bound follows a future ATLAS_LAYERS change). With the free list's release between edits,
+    // this never throws — the old counter threw at the (ATLAS_LAYERS + 1)th (see the docblock above).
     //
     // Stage 4d restored this arm as a live witness: ATLAS_LAYERS fell from 256 (full residency) back to
-    // 64, so 65 fresh tiles do not fit without release. RED-FIRST EVIDENCE (stage 4d): with `release`
-    // replaced by a no-op, this arm throws at edit 56 with
+    // 64, so ATLAS_LAYERS + 1 = 65 fresh tiles do not fit without release. RED-FIRST EVIDENCE (stage
+    // 4d): with `release` replaced by a no-op, this arm throws at edit 56 with
     //   "overlay atlas: capacity exceeded (64 layers) allocating tile 56"
     // because the free list is never replenished and the 57th allocation finds it empty. Under full
     // residency (ATLAS_LAYERS = 256) this arm was tautological — 65 tiles fit in 256 layers even with
     // release broken — so it was labelled a guard. The capsule-test narrowing (46 worst case) brought
     // capacity back under TILE_COUNT and made the arm live again.
-    test("65 edits each touching a fresh tile never throws with the free list", () => {
+    test("ATLAS_LAYERS + 1 edits each touching a fresh tile never throws with the free list", () => {
         const cpu = new Int32Array(TILE_COUNT).fill(-1);
         const free: number[] = [];
         const pending: number[] = [];
@@ -357,7 +359,7 @@ describe("property: tile release over random edit sequences", () => {
             for (const id of ids) allocate(cpu, id, free, ATLAS_LAYERS);
         }
 
-        for (let i = 0; i < 65; i++) {
+        for (let i = 0; i < ATLAS_LAYERS + 1; i++) {
             // place a road entirely inside one tile so each edit touches a fresh tile
             const tileX = i % 16;
             const tileZ = Math.floor(i / 16);
@@ -403,7 +405,7 @@ describe("property: tile release over random edit sequences", () => {
             current = newDoc;
         }
 
-        // if we got here, allocate never threw across all 65 fresh-tile edits
+        // if we got here, allocate never threw across all ATLAS_LAYERS + 1 fresh-tile edits
         expect(residentSet(cpu).size + free.length).toBe(ATLAS_LAYERS);
     });
 });

--- a/examples/showcase/roads/src/overlay/queue.test.ts
+++ b/examples/showcase/roads/src/overlay/queue.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { documentDirtyTiles, type Polyline, type StrokeDocument } from "./document";
-import { generateNetwork, ROAD_HALF_WIDTH, ROAD_MAX_LENGTH, ROAD_MIN_LENGTH } from "./network";
+import { generateNetwork, ROAD_HALF_WIDTH, ROAD_MIN_LENGTH } from "./network";
 import { allocate, drain, invalidate, release } from "./queue";
 import { ATLAS_LAYERS, THROTTLE, TILE_COUNT } from "./tiles";
 
@@ -195,21 +195,25 @@ function mulberry32(seed: number): () => number {
     };
 }
 
-/** a random road document whose chord stays within world bounds, between ROAD_MIN_LENGTH and
- *  ROAD_MAX_LENGTH — the same constraints the drag (stage 4) enforces, so every document's footprint
- *  fits within ATLAS_LAYERS (a 220 m road on a 64 m grid touches at most ~30 tiles). */
+/** a random road document whose chord stays within world bounds and at or above ROAD_MIN_LENGTH —
+ *  the same constraints the drag (stage 4c) enforces via clamping. Stage 4c deleted ROAD_MAX_LENGTH,
+ *  so the length is unbounded above (any length the world contains); ATLAS_LAYERS is sized to TILE_COUNT
+ *  (256) to cover the worst-case corner-to-corner chord, so every document's footprint fits. */
 function randomDoc(rng: () => number): StrokeDocument {
     const margin = ROAD_HALF_WIDTH + 1;
     const lo = -WORLD_HALF + margin;
     const hi = WORLD_HALF - margin;
     const ax = lo + rng() * (hi - lo);
     const az = lo + rng() * (hi - lo);
-    // pick a second endpoint within [ROAD_MIN_LENGTH, ROAD_MAX_LENGTH] of the first, within bounds
+    // pick a second endpoint at or above ROAD_MIN_LENGTH from the first, within bounds — unbounded
+    // above (any length the world contains)
     let bx: number;
     let bz: number;
     for (;;) {
         const angle = rng() * Math.PI * 2;
-        const len = ROAD_MIN_LENGTH + rng() * (ROAD_MAX_LENGTH - ROAD_MIN_LENGTH);
+        // length from ROAD_MIN_LENGTH up to the full diagonal of the bounded region
+        const maxLen = Math.hypot(hi - lo, hi - lo);
+        const len = ROAD_MIN_LENGTH + rng() * (maxLen - ROAD_MIN_LENGTH);
         bx = ax + Math.cos(angle) * len;
         bz = az + Math.sin(angle) * len;
         if (bx < lo || bx > hi || bz < lo || bz > hi) continue;

--- a/examples/showcase/roads/src/overlay/queue.test.ts
+++ b/examples/showcase/roads/src/overlay/queue.test.ts
@@ -168,7 +168,7 @@ describe("invalidate — the atlas's document-swap reset", () => {
 //
 // RED-FIRST WITNESS (run against the pre-change free-running counter allocator, before the free list
 // landed): with 65 edits each touching a fresh tile, the old counter threw at the 65th edit (0-indexed
-// edit 64) because ATLAS_LAYERS is 64 and the counter never releases. The throw was:
+// edit 64) because ATLAS_LAYERS was 64 when this witness ran and the counter never releases. The throw was:
 //   "overlay atlas: capacity exceeded (64 layers) allocating tile 64"
 // with nextLayer=64 at the point of failure. The free list replaces the counter: `release` pushes
 // layers back between edits, so the same 65-edit sequence (and any sequence where each edit's footprint
@@ -179,6 +179,16 @@ describe("invalidate — the atlas's document-swap reset", () => {
 // The property: over random document sequences, after every edit (retile + drain) the resident set
 // equals documentDirtyTiles(current), released ids read -1, allocate never throws, and
 // resident + free always sums to ATLAS_LAYERS.
+//
+// NOTE (stage 4c): ATLAS_LAYERS rose to TILE_COUNT (256) — full residency — so the "allocate never
+// throws" clause of this assertion is now a regression guard that went tautological: 256 tiles fit in
+// 256 layers even if `release` is completely broken, so no random document sequence can exhaust the
+// pool. The live witness for `release` is the `resident === documentDirtyTiles(current)` assertion
+// above — that is the check that fails if release stops returning layers to the free list, because
+// without release the resident set accretes across edits and diverges from the current document's
+// dirty set. The "allocate never throws" and "resident + free = ATLAS_LAYERS" clauses stay as
+// regression guards over the new shape; a follow-up stage narrowing the dirty set will restore
+// capacity as a live constraint and make them witnesses again.
 
 const WORLD_HALF = 512;
 const TILE_SIZE = 64;
@@ -322,6 +332,14 @@ describe("property: tile release over random edit sequences", () => {
 
     // The specific red-first input: ≥65 edits each touching a fresh tile. With the free list's release
     // between edits, this never throws — the old counter threw at the 65th (see the docblock above).
+    //
+    // NOTE (stage 4c): this arm is a regression guard that went tautological when capacity rose to full
+    // residency (ATLAS_LAYERS = TILE_COUNT = 256). 65 fresh tiles fit in 256 layers even if `release` is
+    // completely broken, so this arm can no longer fail from a release defect. The live witness for
+    // `release` is the property arm's `resident === documentDirtyTiles(current)` assertion — that is
+    // the check that fails if release stops returning layers. This arm stays as a guard over the new
+    // shape; a follow-up stage narrowing the dirty set will restore capacity as a live constraint and
+    // make it a witness again.
     test("65 edits each touching a fresh tile never throws with the free list", () => {
         const cpu = new Int32Array(TILE_COUNT).fill(-1);
         const free: number[] = [];

--- a/examples/showcase/roads/src/overlay/queue.test.ts
+++ b/examples/showcase/roads/src/overlay/queue.test.ts
@@ -180,15 +180,13 @@ describe("invalidate — the atlas's document-swap reset", () => {
 // equals documentDirtyTiles(current), released ids read -1, allocate never throws, and
 // resident + free always sums to ATLAS_LAYERS.
 //
-// NOTE (stage 4c): ATLAS_LAYERS rose to TILE_COUNT (256) — full residency — so the "allocate never
-// throws" clause of this assertion is now a regression guard that went tautological: 256 tiles fit in
-// 256 layers even if `release` is completely broken, so no random document sequence can exhaust the
-// pool. The live witness for `release` is the `resident === documentDirtyTiles(current)` assertion
-// above — that is the check that fails if release stops returning layers to the free list, because
-// without release the resident set accretes across edits and diverges from the current document's
-// dirty set. The "allocate never throws" and "resident + free = ATLAS_LAYERS" clauses stay as
-// regression guards over the new shape; a follow-up stage narrowing the dirty set will restore
-// capacity as a live constraint and make them witnesses again.
+// NOTE (stage 4d): ATLAS_LAYERS fell from TILE_COUNT (256, full residency under stage 4c's AABB
+// measurement) back to 64 (the capsule-test measurement of 46 + headroom), so the "allocate never
+// throws" clause is a live witness again: 65 fresh tiles do not fit in 64 layers without release between
+// edits, so a broken `release` makes `allocate` throw. The `resident === documentDirtyTiles(current)`
+// assertion remains the primary witness for `release`'s correctness (it fails if release stops returning
+// layers), and "allocate never throws" is the capacity witness that was tautological under full residency
+// and is live again now.
 
 const WORLD_HALF = 512;
 const TILE_SIZE = 64;
@@ -207,8 +205,8 @@ function mulberry32(seed: number): () => number {
 
 /** a random road document whose chord stays within world bounds and at or above ROAD_MIN_LENGTH —
  *  the same constraints the drag (stage 4c) enforces via clamping. Stage 4c deleted ROAD_MAX_LENGTH,
- *  so the length is unbounded above (any length the world contains); ATLAS_LAYERS is sized to TILE_COUNT
- *  (256) to cover the worst-case corner-to-corner chord, so every document's footprint fits. */
+ *  so the length is unbounded above (any length the world contains); ATLAS_LAYERS is 64 (stage 4d:
+ *  measured worst-case swath 46 + headroom), so every document's footprint fits. */
 function randomDoc(rng: () => number): StrokeDocument {
     const margin = ROAD_HALF_WIDTH + 1;
     const lo = -WORLD_HALF + margin;
@@ -333,13 +331,14 @@ describe("property: tile release over random edit sequences", () => {
     // The specific red-first input: ≥65 edits each touching a fresh tile. With the free list's release
     // between edits, this never throws — the old counter threw at the 65th (see the docblock above).
     //
-    // NOTE (stage 4c): this arm is a regression guard that went tautological when capacity rose to full
-    // residency (ATLAS_LAYERS = TILE_COUNT = 256). 65 fresh tiles fit in 256 layers even if `release` is
-    // completely broken, so this arm can no longer fail from a release defect. The live witness for
-    // `release` is the property arm's `resident === documentDirtyTiles(current)` assertion — that is
-    // the check that fails if release stops returning layers. This arm stays as a guard over the new
-    // shape; a follow-up stage narrowing the dirty set will restore capacity as a live constraint and
-    // make it a witness again.
+    // Stage 4d restored this arm as a live witness: ATLAS_LAYERS fell from 256 (full residency) back to
+    // 64, so 65 fresh tiles do not fit without release. RED-FIRST EVIDENCE (stage 4d): with `release`
+    // replaced by a no-op, this arm throws at edit 56 with
+    //   "overlay atlas: capacity exceeded (64 layers) allocating tile 56"
+    // because the free list is never replenished and the 57th allocation finds it empty. Under full
+    // residency (ATLAS_LAYERS = 256) this arm was tautological — 65 tiles fit in 256 layers even with
+    // release broken — so it was labelled a guard. The capsule-test narrowing (46 worst case) brought
+    // capacity back under TILE_COUNT and made the arm live again.
     test("65 edits each touching a fresh tile never throws with the free list", () => {
         const cpu = new Int32Array(TILE_COUNT).fill(-1);
         const free: number[] = [];

--- a/examples/showcase/roads/src/overlay/tiles.ts
+++ b/examples/showcase/roads/src/overlay/tiles.ts
@@ -18,24 +18,30 @@ export const TEXEL_SIZE = TILE_SIZE / TILE_RES; // world metres per atlas texel 
 export const TILES_PER_SIDE = WORLD_EXTENT / TILE_SIZE; // 16
 export const TILE_COUNT = TILES_PER_SIDE * TILES_PER_SIDE; // 256
 
-// Atlas capacity: every tile resident. A layer is allocated the first time a tile is marked dirty and
-// never evicted (the spec's Locked decision forbids eviction — this atlas is single-resolution with no
-// coarse tier to fall back to, so an eviction miss mid-drag degrades to a hole). Sized by measurement
-// (stage 4c): the worst-case single-document footprint — a corner-to-corner chord from (-508, -508) to
-// (508, 508) across the bounded 1024 m world (~1437 m long, 8 m wide + 1-texel margin) — touches all 256
-// tiles. `documentDirtyTiles` counts the segment's *bounding rect* (its AABB expanded by half-width +
-// margin), not the chord's actual swath, so a diagonal chord's bounding rect covers the entire 16×16
-// grid. A straight chord crosses at most 2 × TILES_PER_SIDE − 1 = 31 tiles before width, so the true
-// swath is far smaller — but the dirty-set is what `allocate` sees, so capacity must cover it. This makes
-// the old `ROAD_MAX_LENGTH = 220` ceiling a dirty-set coarseness hiding behind a design position: the
-// ceiling was the only thing keeping the bbox from spanning the whole grid.
+// Atlas capacity: a layer is allocated the first time a tile is marked dirty and never evicted (the
+// spec's Locked decision forbids eviction — this atlas is single-resolution with no coarse tier to fall
+// back to, so an eviction miss mid-drag degrades to a hole). Sized by measurement (stage 4d): the
+// worst-case single-document footprint under the capsule (swath) dirty-set test — a corner-to-corner
+// diagonal chord at 45° across the bounded 1024 m world (~1437 m long, 8 m wide + 1-texel margin) —
+// touches **46** tiles. Measured over a scan of orientations across the admissible domain (0–180° at
+// 1° steps); the worst case is the 45° diagonal, not an axis-aligned chord.
 //
-// ATLAS_LAYERS = TILE_COUNT = 256 is the limit the spec names ("at the limit ATLAS_LAYERS = TILE_COUNT =
-// 256, fully resident"). Memory: 256 layers × (512² texels × 4 B/texel rgba8unorm + 512² × 1 B/texel
-// r8unorm) = 256 × 512² × 5 B = 335,544,320 B ≈ 320 MiB. Exceeding it is a fail-loud error (atlas.ts),
-// not silent eviction.
+// The null controls: an axis-aligned full-width chord reads exactly **32** (the AABB was already exact
+// there, so the capsule test did not narrow it); the diagonal dropped from **256** (the whole grid under
+// the old AABB) to **46** — the true swath. A straight chord crosses at most `2 × TILES_PER_SIDE − 1 =
+// 31` tiles before width, so 46 is 1.48× the hand-derived bound (the extra tiles are the halfWidth +
+// margin band on each side), not ~8× — the instrument is now measuring the artifact's real footprint,
+// not the AABB's. Stage 4c's residue rule: a measurement ~8× the bound means the instrument is wrong,
+// not that the buffer is small; 46 is well within the plausible range.
+//
+// `ATLAS_LAYERS = 64` gives ~39% headroom over the measured 46 (64 − 46 = 18 spare layers). This is also
+// the original pre-4c value, so the ceiling deletion the spec predicted ("the plausible reading is
+// under 64 and the ceiling deletes with no capacity change at all") is confirmed — the ceiling was
+// hiding the AABB, and the capsule test brings the true footprint back under 64. Memory: 64 layers ×
+// (512² texels × 4 B/texel rgba8unorm + 512² × 1 B/texel r8unorm) = 64 × 512² × 5 B = 83,886,080 B ≈ 80 MiB.
+// Exceeding it is a fail-loud error (atlas.ts), not silent eviction.
 export const THROTTLE = 8; // dirty-tile redraws (writeTexture calls) per frame
-export const ATLAS_LAYERS = TILE_COUNT; // 256 — fully resident, sized to the worst-case bbox
+export const ATLAS_LAYERS = 64; // measured worst-case swath 46 + headroom (stage 4d)
 
 export const ALBEDO_FORMAT = "rgba8unorm" as const;
 export const ALBEDO_BYTES_PER_TEXEL = 4;

--- a/examples/showcase/roads/src/overlay/tiles.ts
+++ b/examples/showcase/roads/src/overlay/tiles.ts
@@ -18,17 +18,24 @@ export const TEXEL_SIZE = TILE_SIZE / TILE_RES; // world metres per atlas texel 
 export const TILES_PER_SIDE = WORLD_EXTENT / TILE_SIZE; // 16
 export const TILE_COUNT = TILES_PER_SIDE * TILES_PER_SIDE; // 256
 
-// Atlas capacity: smaller than TILE_COUNT (the "small indirection" the spec's Approach names — every
-// unwritten tile costs no atlas layer, only an indirection slot). A layer is allocated the first time a
-// tile is marked dirty and never evicted (residency/eviction is the explicitly out-of-scope "tier above" —
-// this world is small enough that the spec's own argument against full VT paging applies to overlay
-// capacity too). Sized off the redraw throttle below: ATLAS_LAYERS = 8 × THROTTLE gives 8 fully-throttled
-// frames of sustained new-tile allocation before capacity is reached — well past stage 6's "a handful of
-// roads + one carpark" network, which (a few hundred metres of centreline over 64 m tiles) touches on the
-// order of ten tiles. Exceeding it is a fail-loud error (atlas.ts), not silent eviction — a residue for a
-// later stage if the network ever grows past this working set.
+// Atlas capacity: every tile resident. A layer is allocated the first time a tile is marked dirty and
+// never evicted (the spec's Locked decision forbids eviction — this atlas is single-resolution with no
+// coarse tier to fall back to, so an eviction miss mid-drag degrades to a hole). Sized by measurement
+// (stage 4c): the worst-case single-document footprint — a corner-to-corner chord from (-508, -508) to
+// (508, 508) across the bounded 1024 m world (~1437 m long, 8 m wide + 1-texel margin) — touches all 256
+// tiles. `documentDirtyTiles` counts the segment's *bounding rect* (its AABB expanded by half-width +
+// margin), not the chord's actual swath, so a diagonal chord's bounding rect covers the entire 16×16
+// grid. A straight chord crosses at most 2 × TILES_PER_SIDE − 1 = 31 tiles before width, so the true
+// swath is far smaller — but the dirty-set is what `allocate` sees, so capacity must cover it. This makes
+// the old `ROAD_MAX_LENGTH = 220` ceiling a dirty-set coarseness hiding behind a design position: the
+// ceiling was the only thing keeping the bbox from spanning the whole grid.
+//
+// ATLAS_LAYERS = TILE_COUNT = 256 is the limit the spec names ("at the limit ATLAS_LAYERS = TILE_COUNT =
+// 256, fully resident"). Memory: 256 layers × (512² texels × 4 B/texel rgba8unorm + 512² × 1 B/texel
+// r8unorm) = 256 × 512² × 5 B = 335,544,320 B ≈ 320 MiB. Exceeding it is a fail-loud error (atlas.ts),
+// not silent eviction.
 export const THROTTLE = 8; // dirty-tile redraws (writeTexture calls) per frame
-export const ATLAS_LAYERS = 8 * THROTTLE; // 64
+export const ATLAS_LAYERS = TILE_COUNT; // 256 — fully resident, sized to the worst-case bbox
 
 export const ALBEDO_FORMAT = "rgba8unorm" as const;
 export const ALBEDO_BYTES_PER_TEXEL = 4;

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -335,7 +335,8 @@ export async function editDocument(doc: StrokeDocument): Promise<void> {
 }
 
 /** the live road document — the edit system reads this each frame to place the handles at the endpoints
- *  and to compute the length band on a drag. A reseed (`regenerate`) resets it to the standard chord. */
+ *  and to clamp a drag to the `ROAD_MIN_LENGTH` floor. A reseed (`regenerate`) resets it to the standard
+ *  chord. */
 export function getDocument(): StrokeDocument {
     return liveDocument;
 }

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -317,6 +317,30 @@ export async function regenerate(seed: number): Promise<void> {
 }
 
 /**
+ * apply an edited road document to the live terrain: re-bake the flatten kernel's geometry
+ * (`flatten.ts`'s `setNetwork`), re-tile the overlay atlas (`overlay/atlas.ts`'s `retile` — marks
+ * `tiles(old) ∪ tiles(new)` dirty and releases `tiles(old) − tiles(new)`), and re-dispatch the height
+ * kernel (`generate(currentSeed)`). The seed is unchanged — a person's drag moves the road, not the
+ * terrain permutation (`roads-interactive.md`'s locked decision: "the seed owns the terrain; the road is
+ * not seeded"). The edit system's per-frame system (`edit.ts`) calls this on an admissible drag; the
+ * handle re-placement is the edit system's own job (it reads {@link getDocument} each frame and sets the
+ * handle Transform positions to the endpoints at `y = heightAtCpu`).
+ */
+export async function editDocument(doc: StrokeDocument): Promise<void> {
+    const oldDoc = liveDocument;
+    liveDocument = doc;
+    setNetwork(doc, currentSeed);
+    overlayAtlas.retile(oldDoc, doc);
+    await generate(currentSeed);
+}
+
+/** the live road document — the edit system reads this each frame to place the handles at the endpoints
+ *  and to compute the length band on a drag. A reseed (`regenerate`) resets it to the standard chord. */
+export function getDocument(): StrokeDocument {
+    return liveDocument;
+}
+
+/**
  * re-bake {@link liveDocument}'s flatten geometry for `seed` without swapping the document or touching the
  * overlay — `gate.ts`'s own seed-determinism probe dispatches `generate` at seeds other than the live
  * one, and the flatten targets are baked CPU-side against a specific seed's permutation (`setNetwork`'s own

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -584,4 +584,119 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
     writeFileSync(CORRIDOR_CAPTURE_PATH, corridorScreenshot);
 
     expect(errors, errors.join("\n")).toEqual([]);
+
+    // Phase 6: stage 4's edit device arms — drive `__roadsEdit` to a new position, wait for overlay idle,
+    // and read exactly 0 violations on both axes from `readVertices()` on the edited live document. Then
+    // check the handle entity's `y` equals `heightAtCpu` at its `(x, z)` after the edit, and that a refused
+    // edit leaves `readVertices()` byte-identical.
+    //
+    // Stage 3 trap: `capture.ts`'s marking probes are derived from the chord's own station, so a drag moves
+    // every marking probe with it. The marking probes were read in Phase 2b (before any edits), so they are
+    // not used across this edit — no re-derivation needed. After this phase, the boot document is restored.
+
+    // an admissible edit: move endpoint 1 to (50, 30) — chord from (-100, 0) to (50, 30), length ≈ 153 m
+    const editEnd = 1;
+    const editX = 50;
+    const editZ = 30;
+    const applied = (await page.evaluate(
+        ({ end, x, z }) =>
+            (
+                window as unknown as {
+                    __roadsEdit: (end: number, x: number, z: number) => Promise<boolean>;
+                }
+            ).__roadsEdit(end, x, z),
+        { end: editEnd, x: editX, z: editZ },
+    )) as boolean;
+    expect(applied, `edit to (${editX}, ${editZ}) was refused (should be admissible)`).toBe(true);
+
+    await page.waitForFunction(
+        () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
+        null,
+        { timeout: 10_000 },
+    );
+
+    // (1) exactly 0 violations on both axes from readVertices() on the edited live document
+    const violations = (await page.evaluate(() =>
+        (
+            window as unknown as {
+                __roadsFlatnessViolations: () => Promise<{
+                    longitudinal: number;
+                    crossSection: number;
+                }>;
+            }
+        ).__roadsFlatnessViolations(),
+    )) as { longitudinal: number; crossSection: number };
+    expect(
+        violations.crossSection,
+        `edited document has ${violations.crossSection} cross-section violations (expected 0)`,
+    ).toBe(0);
+    expect(
+        violations.longitudinal,
+        `edited document has ${violations.longitudinal} longitudinal violations (expected 0)`,
+    ).toBe(0);
+
+    // (2) the handle entity's y equals heightAtCpu at its (x, z) after an edit
+    const handlePos = (await page.evaluate(() =>
+        (
+            window as unknown as {
+                __roadsHandlePos: () => [[number, number, number], [number, number, number]];
+            }
+        ).__roadsHandlePos(),
+    )) as [[number, number, number], [number, number, number]];
+    // the moved handle (endpoint 1) should be at (editX, heightAtCpu(editX, editZ), editZ)
+    const expectedY = heightAtCpu(editX, editZ, bootPerm);
+    expect(handlePos[editEnd][0]).toBeCloseTo(editX, 1);
+    expect(handlePos[editEnd][2]).toBeCloseTo(editZ, 1);
+    expect(
+        Math.abs(handlePos[editEnd][1] - expectedY),
+        `handle y ${handlePos[editEnd][1].toFixed(3)} vs heightAtCpu ${expectedY.toFixed(3)} — handle not snapped to terrain`,
+    ).toBeLessThan(0.5);
+
+    // (3) a refused edit leaves readVertices() byte-identical — fingerprint before and after a refused edit
+    const fpAfterEdit = (await page.evaluate(() =>
+        (
+            window as unknown as { __roadsVertexFingerprint: () => Promise<number> }
+        ).__roadsVertexFingerprint(),
+    )) as number;
+
+    // a refused edit: move endpoint 1 to (-90, 0) — chord from (-100, 0) to (-90, 0), length 10 m — under
+    // ROAD_MIN_LENGTH (80). The bridge should refuse and return false.
+    const refused = (await page.evaluate(
+        ({ end, x, z }) =>
+            (
+                window as unknown as {
+                    __roadsEdit: (end: number, x: number, z: number) => Promise<boolean>;
+                }
+            ).__roadsEdit(end, x, z),
+        { end: editEnd, x: -90, z: 0 },
+    )) as boolean;
+    expect(refused, `edit to (-90, 0) was applied (should be refused — chord too short)`).toBe(
+        false,
+    );
+
+    const fpAfterRefused = (await page.evaluate(() =>
+        (
+            window as unknown as { __roadsVertexFingerprint: () => Promise<number> }
+        ).__roadsVertexFingerprint(),
+    )) as number;
+    expect(
+        fpAfterRefused,
+        `vertex fingerprint changed after a refused edit (${fpAfterEdit} → ${fpAfterRefused}) — should be byte-identical`,
+    ).toBe(fpAfterEdit);
+
+    expect(errors, errors.join("\n")).toEqual([]);
+
+    // Restore the boot document so subsequent runs and the live view start from the standard chord.
+    await page.evaluate(
+        (s) =>
+            (
+                window as unknown as { __roadsRegenerate: (seed: number) => Promise<void> }
+            ).__roadsRegenerate(s),
+        BOOT_SEED,
+    );
+    await page.waitForFunction(
+        () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
+        null,
+        { timeout: 10_000 },
+    );
 });

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -647,10 +647,11 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
     const expectedY = heightAtCpu(editX, editZ, bootPerm);
     expect(handlePos[editEnd][0]).toBeCloseTo(editX, 1);
     expect(handlePos[editEnd][2]).toBeCloseTo(editZ, 1);
-    expect(
-        Math.abs(handlePos[editEnd][1] - expectedY),
-        `handle y ${handlePos[editEnd][1].toFixed(3)} vs heightAtCpu ${expectedY.toFixed(3)} — handle not snapped to terrain`,
-    ).toBeLessThan(0.5);
+    // Both sides compute `heightAtCpu` with `makePermutation(1337)`, so the only admissible
+    // difference is f32 rounding — not two estimates of one height. `toBeCloseTo(expectedY, 4)`
+    // requires agreement to 4 decimal places (5e-5 m), far tighter than the 0.5 m window that would
+    // pass on a stale position or a wrong permutation.
+    expect(handlePos[editEnd][1]).toBeCloseTo(expectedY, 4);
 
     // (3) a refused edit leaves readVertices() byte-identical — fingerprint before and after a refused edit
     const fpAfterEdit = (await page.evaluate(() =>

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -587,14 +587,18 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
 
     // Phase 6: stage 4's edit device arms — drive `__roadsEdit` to a new position, wait for overlay idle,
     // and read exactly 0 violations on both axes from `readVertices()` on the edited live document. Then
-    // check the handle entity's `y` equals `heightAtCpu` at its `(x, z)` after the edit, and that a refused
-    // edit leaves `readVertices()` byte-identical.
+    // check the handle entity's `y` equals `heightAtCpu` at its `(x, z)` after the edit, and that a drag
+    // past the world corner leaves the handle on the boundary rather than frozen mid-map.
     //
     // Stage 3 trap: `capture.ts`'s marking probes are derived from the chord's own station, so a drag moves
     // every marking probe with it. The marking probes were read in Phase 2b (before any edits), so they are
     // not used across this edit — no re-derivation needed. After this phase, the boot document is restored.
+    //
+    // Stage 4c: the old refused-edit arm (a drag under ROAD_MIN_LENGTH returns false and leaves vertices
+    // byte-identical) is replaced by the clamp arm — every drag moves the endpoint, clamped to the bound
+    // and the floor. A drag past the world corner leaves the handle on the boundary, not frozen.
 
-    // an admissible edit: move endpoint 1 to (50, 30) — chord from (-100, 0) to (50, 30), length ≈ 153 m
+    // an edit: move endpoint 1 to (50, 30) — chord from (-100, 0) to (50, 30), length ≈ 153 m
     const editEnd = 1;
     const editX = 50;
     const editZ = 30;
@@ -607,7 +611,7 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
             ).__roadsEdit(end, x, z),
         { end: editEnd, x: editX, z: editZ },
     )) as boolean;
-    expect(applied, `edit to (${editX}, ${editZ}) was refused (should be admissible)`).toBe(true);
+    expect(applied, `edit to (${editX}, ${editZ}) was not applied`).toBe(true);
 
     await page.waitForFunction(
         () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
@@ -653,37 +657,41 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
     // pass on a stale position or a wrong permutation.
     expect(handlePos[editEnd][1]).toBeCloseTo(expectedY, 4);
 
-    // (3) a refused edit leaves readVertices() byte-identical — fingerprint before and after a refused edit
-    const fpAfterEdit = (await page.evaluate(() =>
-        (
-            window as unknown as { __roadsVertexFingerprint: () => Promise<number> }
-        ).__roadsVertexFingerprint(),
-    )) as number;
-
-    // a refused edit: move endpoint 1 to (-90, 0) — chord from (-100, 0) to (-90, 0), length 10 m — under
-    // ROAD_MIN_LENGTH (80). The bridge should refuse and return false.
-    const refused = (await page.evaluate(
+    // (3) a drag past the world corner leaves the handle on the boundary, not frozen mid-map.
+    // Drive endpoint 1 to (10000, 10000) — far past the world bound. The bridge clamps to the bound
+    // and applies (never refuses), so the handle should land on the boundary (BOUND = 508), not stay
+    // at (50, 30).
+    const cornerApplied = (await page.evaluate(
         ({ end, x, z }) =>
             (
                 window as unknown as {
                     __roadsEdit: (end: number, x: number, z: number) => Promise<boolean>;
                 }
             ).__roadsEdit(end, x, z),
-        { end: editEnd, x: -90, z: 0 },
+        { end: editEnd, x: 10000, z: 10000 },
     )) as boolean;
-    expect(refused, `edit to (-90, 0) was applied (should be refused — chord too short)`).toBe(
-        false,
+    expect(cornerApplied, `edit to (10000, 10000) was not applied`).toBe(true);
+
+    await page.waitForFunction(
+        () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
+        null,
+        { timeout: 10_000 },
     );
 
-    const fpAfterRefused = (await page.evaluate(() =>
+    const cornerHandlePos = (await page.evaluate(() =>
         (
-            window as unknown as { __roadsVertexFingerprint: () => Promise<number> }
-        ).__roadsVertexFingerprint(),
-    )) as number;
-    expect(
-        fpAfterRefused,
-        `vertex fingerprint changed after a refused edit (${fpAfterEdit} → ${fpAfterRefused}) — should be byte-identical`,
-    ).toBe(fpAfterEdit);
+            window as unknown as {
+                __roadsHandlePos: () => [[number, number, number], [number, number, number]];
+            }
+        ).__roadsHandlePos(),
+    )) as [[number, number, number], [number, number, number]];
+    // the handle should be on the boundary, not frozen at (50, 30)
+    const cornerBound = 512 - 4; // WORLD_HALF - ROAD_HALF_WIDTH
+    expect(cornerHandlePos[editEnd][0]).toBeCloseTo(cornerBound, 0);
+    expect(cornerHandlePos[editEnd][2]).toBeCloseTo(cornerBound, 0);
+    // the handle's y should match heightAtCpu at the clamped position
+    const cornerY = heightAtCpu(cornerBound, cornerBound, bootPerm);
+    expect(cornerHandlePos[editEnd][1]).toBeCloseTo(cornerY, 4);
 
     expect(errors, errors.join("\n")).toEqual([]);
 


### PR DESCRIPTION
- **roads-interactive: 4**
- **roads-interactive: 4 — repair the review's four findings**
- **roads-interactive: 4b — sticky grab latch**
- **roads-interactive: 4b — repair the review's three notes**
- **roads-interactive: 4c — clamp every drag constraint, delete the length ceiling**
- **roads-interactive: 4c repair — act on the adversarial review's findings**
- **roads-interactive: 4d — dirty set as swath, capacity re-measured against it**
- **roads-interactive: 4d repair — act on the adversarial review's two blockers and two notes**
- **roads-interactive: 4d — de-export segmentRectDistance**
