### PR TITLE
roads interactive/8

### DIFF
--- a/examples/showcase/roads/src/overlay/atlas.ts
+++ b/examples/showcase/roads/src/overlay/atlas.ts
@@ -1,8 +1,9 @@
 import { Compute, type State } from "@dylanebert/shallot";
 import type { MeshBinding } from "@dylanebert/shallot/render/core";
-import type { StorageFlag, TgpuBuffer } from "typegpu";
+import type { StorageFlag, TgpuBuffer, UniformFlag } from "typegpu";
 import * as d from "typegpu/data";
 import { documentDirtyTiles, type StrokeDocument } from "./document";
+import { chordOf } from "./network";
 import { allocate, drain, invalidate as invalidateQueue, release } from "./queue";
 import { rasterizeTile, warm as rasterizeWarm } from "./rasterize";
 import {
@@ -56,11 +57,22 @@ import {
  *  own typed buffer agree on one schema, never two independently-constructed `d.arrayOf` calls. */
 export const Indirection = d.arrayOf(d.i32, TILE_COUNT);
 
+/** the chord uniform's schema: two endpoints (vec2f, world x/z) + halfWidth — the analytic fs's marking
+ *  geometry input (stage 8). Exported so `terrain.ts`'s surface layout and this module's typed buffer
+ *  agree on one struct, never two independently-constructed `d.struct` calls. */
+export const ChordUniform = d.struct({
+    a: d.vec2f,
+    b: d.vec2f,
+    halfWidth: d.f32,
+});
+
 let albedoTex: GPUTexture | null = null;
 let distTex: GPUTexture | null = null;
 let sampler: GPUSampler | null = null;
 let indirectionRaw: GPUBuffer | null = null;
 let indirectionTyped: (TgpuBuffer<typeof Indirection> & StorageFlag) | null = null;
+let chordRaw: GPUBuffer | null = null;
+let chordTyped: (TgpuBuffer<typeof ChordUniform> & UniformFlag) | null = null;
 
 // the indirection table's CPU mirror (so allocate can read "already resident?" without a GPU
 // readback) + the free list of available atlas layers. Reset to full capacity at warm.
@@ -76,11 +88,14 @@ function teardown(): void {
     albedoTex?.destroy();
     distTex?.destroy();
     indirectionRaw?.destroy();
+    chordRaw?.destroy();
     albedoTex = null;
     distTex = null;
     sampler = null;
     indirectionRaw = null;
     indirectionTyped = null;
+    chordRaw = null;
+    chordTyped = null;
     invalidateQueue(indirectionCpu, free, ATLAS_LAYERS, pending, pendingSet);
 }
 
@@ -122,6 +137,15 @@ export function warm(state: State): void {
     invalidateQueue(indirectionCpu, free, ATLAS_LAYERS, pending, pendingSet);
     device.queue.writeBuffer(indirectionRaw, 0, indirectionCpu as Int32Array<ArrayBuffer>);
     indirectionTyped = root.createBuffer(Indirection, indirectionRaw).$usage("storage");
+
+    // the chord uniform — the analytic fs's marking geometry input (stage 8). Written once at warm
+    // and re-written on every document change via updateChord.
+    chordRaw = device.createBuffer({
+        label: "overlay-chord",
+        size: d.sizeOf(ChordUniform),
+        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    chordTyped = root.createBuffer(ChordUniform, chordRaw).$usage("uniform");
 }
 
 /**
@@ -146,7 +170,7 @@ export function invalidate(): void {
  *  (`terrain.ts`). Reads live GPU resource identities — the renderer resolves a texture binding to a view
  *  each frame, so no bind group here needs manual (re)construction. */
 export function bindings(): Record<string, MeshBinding> {
-    if (!albedoTex || !distTex || !sampler || !indirectionTyped) {
+    if (!albedoTex || !distTex || !sampler || !indirectionTyped || !chordTyped) {
         throw new Error("overlay atlas: bindings() read before warm()");
     }
     return {
@@ -154,7 +178,21 @@ export function bindings(): Record<string, MeshBinding> {
         dist: distTex,
         overlaySamp: sampler,
         indirection: indirectionTyped,
+        chord: chordTyped,
     };
+}
+
+/** write the chord uniform from `doc`'s one road — call wherever the live document changes
+ *  (`terrain.ts`'s `warm`, `regenerate`, `editDocument`), or the fs renders markings for the old chord
+ *  and the drag's markings lag behind the handle. */
+export function updateChord(doc: StrokeDocument): void {
+    if (!chordTyped || !chordRaw) return;
+    const { a, b, halfWidth } = chordOf(doc);
+    chordTyped.write({
+        a: d.vec2f(a[0], a[1]),
+        b: d.vec2f(b[0], b[1]),
+        halfWidth,
+    });
 }
 
 /** mark every tile `doc` touches dirty (`document.ts`'s exact per-primitive union, not one bounding rect

--- a/examples/showcase/roads/src/overlay/document.test.ts
+++ b/examples/showcase/roads/src/overlay/document.test.ts
@@ -226,7 +226,7 @@ describe("markingDistanceForSegment", () => {
 
     test("zero at the edge line boundary (LINE_HALF_WIDTH from the centre)", () => {
         const edgeLineZ = seg.halfWidth - EDGE_INSET; // 3.7
-        const boundary = edgeLineZ + LINE_HALF_WIDTH; // 3.75
+        const boundary = edgeLineZ + LINE_HALF_WIDTH; // 3.7762 (3.7 + 0.0762, with stage 8's 6 in line width)
         expect(markingDistanceForSegment(0, boundary, seg)).toBeCloseTo(0, 6);
     });
 

--- a/examples/showcase/roads/src/overlay/document.ts
+++ b/examples/showcase/roads/src/overlay/document.ts
@@ -99,7 +99,7 @@ export function documentDistance(px: number, pz: number, doc: StrokeDocument): n
  *  (centred at d = −EDGE_INSET on the existing edge distance) and a broken centreline (perpendicular
  *  distance to the centreline via d + halfWidth, station along the chord via fract(s / DASH_PERIOD) <
  *  DASH_DUTY). Cross-product derivation, like {@link segmentDistance} — the CPU twin the GPU's
- *  `markingDistanceGpu` (rasterize.ts, clamped-projection form) is checked against, independently.
+ *  `markingDistanceFromChord` (terrain/terrain.ts, clamped-projection form) is checked against, independently.
  *
  *  Geometry per the Locked decision: one chord, so the dash phase has no joint to break at.
  *  Two-lane two-way: broken yellow centreline, solid white edges. */
@@ -142,7 +142,7 @@ export function markingDistanceForSegment(px: number, pz: number, seg: Segment):
 }
 
 /** the document's analytic marking distance at (px, pz) — the minimum (nearest) signed distance to any
- *  road marking over every segment. The CPU half of stage 3's marking differential oracle. */
+ *  road marking over every segment. The CPU half of stage 8's marking differential oracle. */
 export function markingDistance(px: number, pz: number, doc: StrokeDocument): number {
     let best = Number.POSITIVE_INFINITY;
     for (const seg of flattenSegments(doc)) {

--- a/examples/showcase/roads/src/overlay/network.ts
+++ b/examples/showcase/roads/src/overlay/network.ts
@@ -30,6 +30,22 @@ const STANDARD_CHORD: readonly [readonly [number, number], readonly [number, num
     [100, 0],
 ];
 
+/** the chord (endpoints + halfWidth) of the one road in `doc` — the analytic fs's marking geometry
+ *  input. One road means one chord; the fs receives this as a uniform and computes marking distances
+ *  from it directly, without decoding a texel. */
+export function chordOf(doc: StrokeDocument): {
+    a: readonly [number, number];
+    b: readonly [number, number];
+    halfWidth: number;
+} {
+    const line = doc.polylines[0];
+    return {
+        a: line.points[0],
+        b: line.points[1],
+        halfWidth: line.halfWidth,
+    };
+}
+
 /** the road network: {@link ROAD_COUNT} (one) straight single-segment road at the fixed
  *  {@link STANDARD_CHORD}. One road cannot contend with itself, so this carries no clearance/non-overlap
  *  machinery — that non-overlap guarantee, and every arm that existed to witness it, belonged to the

--- a/examples/showcase/roads/src/overlay/rasterize.test.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { body, flat, integerDiscipline } from "../../../../../packages/shallot/tests/wgsl";
-import { markingDistanceForSegment, type Segment, segmentDistance } from "./document";
-import { encodeDistGpu, markingDistanceGpu, rasterizeWgsl, segmentDistanceGpu } from "./rasterize";
+import { type Segment, segmentDistance } from "./document";
+import { encodeDistGpu, rasterizeWgsl, segmentDistanceGpu } from "./rasterize";
 import { DIST_RANGE, decodeDist, encodeDist, TEXEL_SIZE } from "./tiles";
 
 // Stage 5's differential oracle: `segmentDistanceGpu` (rasterize.ts, clamped-projection form, CPU-called
@@ -110,10 +110,10 @@ describe("emitted WGSL — structural", () => {
         expect(kernel).toContain("word = (word | (byte << (k * 8u)))");
     });
 
-    test("albedo rgb is a precomputed constant; the per-texel alpha carries the encoded marking distance", () => {
+    test("albedo rgb is a precomputed constant with constant 255 alpha (stage 8: marking channel moved to analytic fs)", () => {
         expect(flat(wgsl)).toContain("const roadAlbedoRgb: u32 =");
         const kernel = flat(body(wgsl, "@compute @workgroup_size(8, 8, 1) fn roadsrasterize"));
-        expect(kernel).toContain("albedoOut[albedoIdx] = (roadAlbedoRgb | (markingByte << 24u))");
+        expect(kernel).toContain("albedoOut[albedoIdx] = roadAlbedoRgb");
     });
 
     describe("texel-group column ↔ world-x ↔ byte-column correspondence", () => {
@@ -200,103 +200,5 @@ describe("emitted WGSL — structural", () => {
         test("the packing expression itself (a cheap structural sentinel, in addition to the eval-based pins above — never the only one)", () => {
             expect(kernel).toContain("let texelX = ((gx * 4u) + k);");
         });
-    });
-});
-
-// Stage 3's marking differential oracle: `markingDistanceGpu` (rasterize.ts, clamped-projection form,
-// CPU-called through TypeGPU's dual execution) against `document.ts`'s `markingDistanceForSegment`
-// (cross-product form) — two independently written derivations of the same geometric quantity, the
-// signed distance to the nearest road marking (edge lines + broken centreline). The GPU side is
-// quantized through `encodeDistGpu` + `tiles.ts`'s `decodeDist`, the exact byte round-trip the real
-// kernel's output goes through, so the tolerance is the same r8unorm quantization step as the coverage
-// differential above. `rasterize.ts` never imports `markingDistance` — the two derivations are
-// independent by contract, because the differential arm is worthless if one side calls the other.
-//
-// RED-FIRST CONTROL: mutating one side's dash duty (DASH_DUTY) was witnessed red — changing the CPU
-// side's DASH_DUTY to DASH_DUTY * 0.5 (halving the dash fraction) while leaving the GPU side unchanged
-// produces disagreement at points inside a dash whose phase falls in the second half of the original
-// duty cycle: the CPU side now reads those points as in a gap (marking distance positive) while the GPU
-// side still reads them as in a dash (marking distance negative), exceeding the tolerance. This was
-// confirmed by running the mutated comparison and observing the failure before restoring the real duty.
-describe("marking differential oracle — markingDistanceGpu vs document.ts's markingDistanceForSegment", () => {
-    test("agree within one quantization step over random segments and sample points", () => {
-        const rng = mulberry32(42);
-        const rand = (lo: number, hi: number) => lo + rng() * (hi - lo);
-        for (let i = 0; i < 200; i++) {
-            const seg: Segment = {
-                ax: rand(-100, 100),
-                az: rand(-100, 100),
-                bx: rand(-100, 100),
-                bz: rand(-100, 100),
-                halfWidth: rand(1, 8),
-            };
-            const px = rand(-120, 120);
-            const pz = rand(-120, 120);
-
-            const cpu = markingDistanceForSegment(px, pz, seg);
-            const gpuRaw = markingDistanceGpu(
-                px,
-                pz,
-                seg.ax,
-                seg.az,
-                seg.bx,
-                seg.bz,
-                seg.halfWidth,
-            );
-            const gpuQuantized = decodeDist(encodeDistGpu(gpuRaw));
-            const cpuQuantized = quantizeCpu(cpu);
-            expect(Math.abs(gpuQuantized - cpuQuantized)).toBeLessThanOrEqual(TOLERANCE);
-            // and the raw (unquantized) forms agree far tighter — same geometric quantity, f32 roundoff only
-            expect(Math.abs(gpuRaw - cpu)).toBeLessThan(1e-4);
-        }
-    });
-
-    test("agree on the centreline (where the dash phase is the nearest marking), inside a dash and in a gap", () => {
-        // a horizontal road from (-100, 0) to (100, 0), halfWidth 4 — the standard chord's shape.
-        // Points on the centreline (z=0) are where the centreline marking is nearest, so the dash
-        // duty actually determines the distance — this is the axis the red-first control mutates.
-        const seg: Segment = { ax: -100, az: 0, bx: 100, bz: 0, halfWidth: 4 };
-        // station 100: phase = fract((100 + DASH_OFFSET) / DASH_PERIOD) ≈ 0.45 >= DASH_DUTY (0.25) → in a gap (offset shifts midpoint into gap)
-        // station 120: phase = fract((120 + DASH_OFFSET) / DASH_PERIOD) ≈ 0.09 < DASH_DUTY → in a dash
-        const inDash: Array<[number, number]> = [
-            [20, 0], // station 120, on the centreline, in a dash
-            [70, 0.01], // station 170, near the centreline, in a dash
-        ];
-        // station 100 (midpoint): phase ≈ 0.45 >= DASH_DUTY → in a gap (the offset's purpose)
-        // station 50: phase = fract((50 + DASH_OFFSET) / DASH_PERIOD) ≈ 0.35 >= DASH_DUTY → in a gap
-        const inGap: Array<[number, number]> = [
-            [0, 0], // station 100, on the centreline, in a gap
-            [-50, 0.01], // station 50, near the centreline, in a gap
-        ];
-        for (const [px, pz] of inDash) {
-            const cpu = markingDistanceForSegment(px, pz, seg);
-            const gpuRaw = markingDistanceGpu(
-                px,
-                pz,
-                seg.ax,
-                seg.az,
-                seg.bx,
-                seg.bz,
-                seg.halfWidth,
-            );
-            expect(Math.abs(gpuRaw - cpu)).toBeLessThan(1e-4);
-            // inside a dash → marking distance should be negative (inside the marking)
-            expect(cpu).toBeLessThan(0);
-        }
-        for (const [px, pz] of inGap) {
-            const cpu = markingDistanceForSegment(px, pz, seg);
-            const gpuRaw = markingDistanceGpu(
-                px,
-                pz,
-                seg.ax,
-                seg.az,
-                seg.bx,
-                seg.bz,
-                seg.halfWidth,
-            );
-            expect(Math.abs(gpuRaw - cpu)).toBeLessThan(1e-4);
-            // in a gap → marking distance should be positive (outside the marking)
-            expect(cpu).toBeGreaterThan(0);
-        }
     });
 });

--- a/examples/showcase/roads/src/overlay/rasterize.ts
+++ b/examples/showcase/roads/src/overlay/rasterize.ts
@@ -23,17 +23,7 @@ import * as d from "typegpu/data";
 import * as std from "typegpu/std";
 import { flattenSegments, type StrokeDocument } from "./document";
 import { ROAD_ALBEDO } from "./stroke";
-import {
-    DASH_DUTY,
-    DASH_OFFSET,
-    DASH_PERIOD,
-    DIST_RANGE,
-    EDGE_INSET,
-    LINE_HALF_WIDTH,
-    TEXEL_SIZE,
-    TILE_RES,
-    tileOrigin,
-} from "./tiles";
+import { DIST_RANGE, TEXEL_SIZE, TILE_RES, tileOrigin } from "./tiles";
 
 const GROUP_TEXELS = 4; // texels packed per output distance/index word (4 × r8 = one u32, little-endian)
 const GROUPS_PER_SIDE = TILE_RES / GROUP_TEXELS; // 128 — TILE_RES is a multiple of 4 by construction
@@ -95,8 +85,9 @@ export const encodeDistGpu = tgpu.fn(
     return d.u32(std.round(unit * d.f32(255)));
 });
 
-/** pack ROAD_ALBEDO's rgb into rgba8unorm's little-endian byte order — the alpha byte is now per-texel
- *  (the encoded marking distance, not the constant 255 it used to be). Computed once at module load. */
+/** pack ROAD_ALBEDO's rgb into rgba8unorm's little-endian byte order — the alpha byte is constant
+ *  255 (stage 8 moved the marking channel to analytic fs evaluation, so the alpha no longer carries
+ *  the encoded marking distance). Computed once at module load. */
 function packAlbedoRgb(rgb: readonly [number, number, number]): number {
     const r = Math.round(rgb[0] * 255);
     const g = Math.round(rgb[1] * 255);
@@ -104,63 +95,9 @@ function packAlbedoRgb(rgb: readonly [number, number, number]): number {
     return (r | (g << 8) | (b << 16)) >>> 0;
 }
 
-const roadAlbedoRgb = tgpu.const(d.u32, packAlbedoRgb(ROAD_ALBEDO)).$name("roadAlbedoRgb");
-
-/** the signed distance to the nearest road marking for one segment — the GPU twin of
- *  `document.ts`'s `markingDistanceForSegment`, independently derived via the clamped-projection form
- *  (same split as `segmentDistanceGpu` vs `segmentDistance`). Two solid edge lines inset from the road
- *  edge (centred at d = −EDGE_INSET on the existing edge distance) and a broken centreline (perpendicular
- *  distance via the cross product, station along the chord via fract(s / DASH_PERIOD) < DASH_DUTY).
- *  CPU-callable so `bun test` exercises this exact math with no device — the GPU half of stage 3's
- *  marking differential oracle. `rasterize.ts` never imports `markingDistance` — the two derivations are
- *  independent by contract.
- * @example markingDistanceGpu(0, 0, -100, 0, 100, 0, 4) // on the centreline, inside a dash → negative */
-export const markingDistanceGpu = tgpu.fn(
-    [d.f32, d.f32, d.f32, d.f32, d.f32, d.f32, d.f32],
-    d.f32,
-)((px, pz, ax, az, bx, bz, halfWidth) => {
-    "use gpu";
-    const abx = bx - ax;
-    const abz = bz - az;
-    const apx = px - ax;
-    const apz = pz - az;
-    const dd = abx * abx + abz * abz;
-    let t = d.f32(0);
-    let tRaw = d.f32(0);
-    if (dd > 0) {
-        tRaw = (apx * abx + apz * abz) / dd;
-        t = std.clamp(tRaw, 0, 1);
-    }
-    const cx = ax + t * abx;
-    const cz = az + t * abz;
-    const dist = std.distance(d.vec2f(px, pz), d.vec2f(cx, cz));
-    const edgeDist = dist - halfWidth;
-
-    // edge line: solid, centred at d = −EDGE_INSET, width LINE_WIDTH
-    const edgeLineDist = std.abs(edgeDist + d.f32(EDGE_INSET)) - d.f32(LINE_HALF_WIDTH);
-
-    // centreline: broken, lateral from the cross product, longitudinal from the dash phase
-    const len = std.sqrt(dd);
-    const cross = len > 0 ? (apx * abz - apz * abx) / len : 0;
-    const lateral = std.abs(cross) - d.f32(LINE_HALF_WIDTH);
-    const along = t * len;
-    let longitudinal = d.f32(0);
-    if (tRaw < 0) {
-        longitudinal = -tRaw * len;
-    } else if (tRaw > 1) {
-        longitudinal = (tRaw - 1) * len;
-    } else {
-        const phase = std.fract((along + d.f32(DASH_OFFSET)) / d.f32(DASH_PERIOD));
-        if (phase < d.f32(DASH_DUTY)) {
-            longitudinal = -std.min(phase, d.f32(DASH_DUTY) - phase) * d.f32(DASH_PERIOD);
-        } else {
-            longitudinal = std.min(phase - d.f32(DASH_DUTY), d.f32(1) - phase) * d.f32(DASH_PERIOD);
-        }
-    }
-    const centreDist = std.max(lateral, longitudinal);
-
-    return std.min(edgeLineDist, centreDist);
-});
+const roadAlbedoRgb = tgpu
+    .const(d.u32, (packAlbedoRgb(ROAD_ALBEDO) | (255 << 24)) >>> 0)
+    .$name("roadAlbedoRgb");
 
 const rasterKernel = tgpu
     .computeFn({
@@ -181,11 +118,10 @@ const rasterKernel = tgpu
             const texelX = gx * d.u32(GROUP_TEXELS) + k;
             const worldX = origin.x + (d.f32(texelX) + d.f32(0.5)) * d.f32(TEXEL_SIZE);
 
-            // nearest-segment tracking: loop over segments once, carrying both the coverage distance
-            // and the marking distance — the two derivations are independent (this kernel never imports
-            // `markingDistance`), but they share the same segment loop so one dispatch computes both.
+            // nearest-segment tracking: loop over segments once, carrying the coverage distance
+            // — the marking channel is now analytic in the fs from the chord uniform (stage 8),
+            // so the kernel no longer computes a marking distance.
             let bestCoverage = d.f32(3.402823e38);
-            let bestMarking = d.f32(3.402823e38);
             let i = d.u32(0);
             for (; i < rasterLayout.$.params.segmentCount; i = i + d.u32(1)) {
                 const seg = rasterLayout.$.segments[i];
@@ -199,26 +135,15 @@ const rasterKernel = tgpu
                     seg.halfWidth,
                 );
                 if (cov < bestCoverage) bestCoverage = cov;
-                const m = markingDistanceGpu(
-                    worldX,
-                    worldZ,
-                    seg.a.x,
-                    seg.a.y,
-                    seg.b.x,
-                    seg.b.y,
-                    seg.halfWidth,
-                );
-                if (m < bestMarking) bestMarking = m;
             }
 
             const byte = encodeDistGpu(bestCoverage);
             word = word | (byte << (k * d.u32(8)));
 
-            // the marking distance encoded into the albedo word's alpha byte (constant 255 until stage 3),
-            // using the coverage channel's own encodeDist codec.
-            const markingByte = encodeDistGpu(bestMarking);
+            // the albedo word: road rgb + constant 255 alpha (stage 8 moved the marking channel to
+            // analytic fs evaluation, so the alpha byte no longer carries an encoded marking distance).
             const albedoIdx = gy * d.u32(TILE_RES) + texelX;
-            rasterLayout.$.albedoOut[albedoIdx] = roadAlbedoRgb.$ | (markingByte << d.u32(24));
+            rasterLayout.$.albedoOut[albedoIdx] = roadAlbedoRgb.$;
         }
         const distIdx = gy * d.u32(GROUPS_PER_SIDE) + gx;
         rasterLayout.$.distOut[distIdx] = word;
@@ -227,7 +152,7 @@ const rasterKernel = tgpu
 
 /** the emitted rasterizer WGSL — the device-free structural seam stage 5's tests resolve. */
 export function rasterizeWgsl(): string {
-    return tgpu.resolve([segmentDistanceGpu, encodeDistGpu, markingDistanceGpu, rasterKernel], {
+    return tgpu.resolve([segmentDistanceGpu, encodeDistGpu, rasterKernel], {
         names: "strict",
     });
 }

--- a/examples/showcase/roads/src/overlay/tiles.ts
+++ b/examples/showcase/roads/src/overlay/tiles.ts
@@ -8,8 +8,9 @@ import { WORLD_EXTENT, WORLD_HALF } from "../terrain/grid";
 // exactly (grid.ts's WORLD_EXTENT), so the tile grid tiles the terrain footprint with no partial edge tile
 // — a round number a reader can check, not a fit. Atlas resolution: 512² texels/tile (Anno precedent,
 // spec's Locked decision) — one row is 512 texels regardless of TILE_SIZE, so a texel is
-// TILE_SIZE / TILE_RES = 0.125 m, the sub-texel-crisp unit the fwidth-thresholded distance channel
-// (terrain.ts's fs) reads against.
+// TILE_SIZE / TILE_RES = 0.125 m, the sub-texel-crisp unit the fwidth-thresholded coverage distance
+// channel (terrain.ts's fs) reads against. The marking channel is no longer baked into a texel —
+// stage 8 moved it to analytic fs evaluation from the chord uniform.
 
 export const TILE_SIZE = 64; // world metres per tile side
 export const TILE_RES = 512; // atlas texels per tile side (Anno's 512² slices)
@@ -50,19 +51,23 @@ export const ALBEDO_BYTES_PER_TEXEL = 4;
 // fwidth-thresholded composite (terrain.ts) only ever reads distance within a few texels of its zero
 // crossing (0.125 m/texel × a handful of texels), so saturating the unorm range at ±1 m spends every
 // quantization step (2 m / 255 ≈ 0.0078 m ≈ 0.06 texel) where the antialiasing actually samples, instead of
-// wasting range on interior distances no reader needs precisely.
+// wasting range on interior distances no reader needs precisely. The marking channel no longer uses this
+// codec — stage 8 moved markings to analytic fs evaluation.
 export const DIST_FORMAT = "r8unorm" as const;
 export const DIST_BYTES_PER_TEXEL = 1;
 export const DIST_RANGE = 1; // metres, half-range
 
-// Road markings — a second distance channel in the same tile's albedo alpha byte, thresholded in the
-// fs with its own fwidth exactly as coverage is (roads-interactive.md Locked decision). Dimensions from
-// the MUTCD's normal line and broken-line pattern, in metres — a legibility standard, not a compliance
-// claim.
+// Road markings — evaluated analytically in the fs from the chord uniform (endpoints + halfWidth),
+// not baked into a texel (roads-interactive.md Locked decision, stage 8). The marking channel is a
+// two-edge analytic pixel-coverage form, not a distance threshold — a feature narrower than a texel is
+// a regime mismatch to bake, not a tuning problem. Dimensions from the MUTCD's normal line and
+// broken-line pattern, in metres — a legibility standard, not a compliance claim.
 
-// MUTCD normal line width: 4–6 in (0.1016–0.1524 m). Lower bound used so a 0.10 m line reads against
-// the 0.125 m texel as sub-texel detail the fwidth threshold keeps crisp, not a 1–2 texel blob.
-export const LINE_WIDTH = 0.1; // metres — MUTCD normal line, 4 in (0.1016 m), lower bound
+// MUTCD normal line width: 4–6 in (0.1016–0.1524 m). Upper bound (6 in = 0.1524 m) — the lower bound was
+// chosen to survive the 0.125 m texel the bake stored the marking in, and stage 8 removes that texel
+// from the path entirely, so the parameter is free to take the standard's upper bound: 50 % more pixel
+// coverage at every distance, still inside the standard.
+export const LINE_WIDTH = 0.1524; // metres — MUTCD normal line, 6 in (0.1524 m), upper bound
 export const LINE_HALF_WIDTH = LINE_WIDTH / 2; // derived: half the line width
 
 // Edge line inset from the road edge — a showcase design choice, not a MUTCD dimension. The edge

--- a/examples/showcase/roads/src/terrain/grid.ts
+++ b/examples/showcase/roads/src/terrain/grid.ts
@@ -8,8 +8,8 @@ import * as d from "typegpu/data";
 // "~1 km² showcase scale" (the voxel-example spirit: round numbers a reader can check, not a tuned
 // figure). 4 m spacing keeps the vertex count small (257×257 = 66,049 verts, well under any storage-
 // binding pressure) while staying fine enough to read the rolling hills at showcase camera distances —
-// a road's own texel density is stage 3's problem, not this stage's. CELLS must be even so the grid
-// centres exactly on the world origin (HALF is a whole number of cells).
+// a road's own marking legibility is stage 8's problem (analytic fs evaluation, not this grid), not this
+// stage's. CELLS must be even so the grid centres exactly on the world origin (HALF is a whole number of cells).
 
 export const SPACING = 4; // world metres per grid cell
 export const CELLS = 256; // quads per side

--- a/examples/showcase/roads/src/terrain/terrain.test.ts
+++ b/examples/showcase/roads/src/terrain/terrain.test.ts
@@ -1,8 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import { body, flat } from "../../../../../packages/shallot/tests/wgsl";
 import { markingDistanceForSegment, type Segment } from "../overlay/document";
-import { COVERAGE_BAND_PX, DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
-import { markingDistanceFromChord, terrainFsWgsl } from "./terrain";
+import {
+    COVERAGE_BAND_PX,
+    DASH_DUTY,
+    DASH_GAP,
+    DASH_PERIOD,
+    DASH_SEGMENT,
+    DIST_RANGE,
+    LINE_HALF_WIDTH,
+    TILE_SIZE,
+    TILES_PER_SIDE,
+} from "../overlay/tiles";
+import { coverFn, markingDistanceFromChord, terrainFsWgsl } from "./terrain";
 
 // The overlay composite's structural gate — the device-free seam this stage's `bun test` relies on for the
 // fs's atlas-sampling half (CPU-callable/resolved-WGSL first, never a bound device). The composite's
@@ -230,5 +240,157 @@ describe("marking differential oracle — markingDistanceFromChord vs document.t
             // in a gap → marking distance should be positive (outside the marking)
             expect(cpu).toBeGreaterThan(0);
         }
+    });
+});
+
+// R3 behavioural arms — the two-edge coverage integral and the dash's Nyquist convergence are the
+// whole point of stage 8, and the existing arms above are structural (toContain/toMatch over resolved
+// WGSL text) or distance differentials that never call the coverage function. These arms call the
+// production `coverFn` (a `tgpu.fn`, CPU-callable through TypeGPU's dual execution — the same path
+// `markingDistanceFromChord` uses in the differential oracle above) so they witness the shipped fs's
+// exact math with no device. The dash-convergence arm re-derives the fs's dash-coverage pipeline
+// (coverFn calls + the Nyquist blend) in TS from the spec's stated form, since `fwidth(s)` is GPU-only
+// and cannot be called from plain TS — the arm witnesses the formula, not the shipped fs's fwidth path,
+// and the docblock says exactly that.
+
+describe("two-edge analytic pixel coverage — cover(h) - cover(-h) [behavioural]", () => {
+    // Witnesses the shipped `coverFn` (terrain.ts, exported `tgpu.fn`) called directly in TS — the
+    // same function the fs resolves into WGSL. cover(e, x, p) = clamp((e - x)/p + 0.5, 0, 1),
+    // alpha = cover(h) - cover(-h).
+    //
+    // WITNESSED RED: changing `coverFn`'s body from `clamp((e - x) / p + 0.5, 0, 1)` to
+    // `clamp((e - x) / p, 0, 1)` (dropping the +0.5 offset) reds the sub-pixel proportionality arm:
+    //   Expected: 0.5  (cov * p / (2h) ≈ 1)
+    //   Received: 0    (coverage collapses to 0 when both edges are inside the pixel, because
+    //   cover(h) and cover(-h) both clamp to the same value without the +0.5 centring)
+    // Confirmed by running the mutated coverFn, observing the failure, then restoring by hand.
+
+    const h = LINE_HALF_WIDTH; // 0.0762 m — the stripe half-width the fs uses
+
+    test("coverage is 1 well inside the stripe and 0 well outside", () => {
+        const p = 0.001; // tiny footprint — the stripe is many pixels wide
+        const inside = coverFn(h, 0, p) - coverFn(-h, 0, p);
+        expect(inside).toBeCloseTo(1, 5);
+        const outside = coverFn(h, 10 * h, p) - coverFn(-h, 10 * h, p);
+        expect(outside).toBeCloseTo(0, 5);
+    });
+
+    test("coverage is monotone as x sweeps across one edge (decreasing outside the right edge)", () => {
+        // the spec says "monotone as x sweeps across the edge" — one edge, not the whole stripe.
+        // alpha = cover(h) - cover(-h) is a bump: 0 outside, 1 inside, 0 outside. Across one edge
+        // (e.g. the right edge at x = h) it is monotone decreasing from 1 to 0.
+        const p = 0.01;
+        let prev = Infinity;
+        for (let i = 0; i <= 200; i++) {
+            const x = 0 + (4 * h * i) / 200; // from x=0 (inside) to x=4h (outside)
+            const cov = coverFn(h, x, p) - coverFn(-h, x, p);
+            expect(cov).toBeLessThanOrEqual(prev + 1e-9);
+            prev = cov;
+        }
+    });
+
+    test("coverage is exactly 0.5 at the edge for a small p", () => {
+        // at x = h (the right edge): cover(h, h, p) = clamp(0/p + 0.5, 0, 1) = 0.5,
+        // cover(-h, h, p) = clamp(-2h/p + 0.5, 0, 1) ≈ 0 for small p, so alpha ≈ 0.5
+        const p = 0.001;
+        const cov = coverFn(h, h, p) - coverFn(-h, h, p);
+        expect(cov).toBeCloseTo(0.5, 2);
+    });
+
+    test("sub-pixel regime: when p exceeds 2h, coverage is a proper fraction that decays as ~2h/p", () => {
+        // THE arm: when the pixel footprint p exceeds the stripe width 2h, both edges land inside one
+        // pixel and the coverage terms subtract to the stripe's true fractional coverage ~2h/p —
+        // neither 0 nor 1, and decaying proportionally as p grows. This is the property that makes a
+        // distant line fade instead of vanishing or popping.
+        const p1 = 4 * 2 * h; // p = 8h, well into sub-pixel
+        const p2 = 8 * 2 * h; // p = 16h
+        const p3 = 16 * 2 * h; // p = 32h
+        const cov1 = coverFn(h, 0, p1) - coverFn(-h, 0, p1);
+        const cov2 = coverFn(h, 0, p2) - coverFn(-h, 0, p2);
+        const cov3 = coverFn(h, 0, p3) - coverFn(-h, 0, p3);
+        // proper fractions, not 0 or 1
+        for (const c of [cov1, cov2, cov3]) {
+            expect(c).toBeGreaterThan(0);
+            expect(c).toBeLessThan(1);
+        }
+        // proportional decay: cov ∝ 1/p, so cov1/cov2 ≈ p2/p1
+        expect(cov1 / cov2).toBeCloseTo(p2 / p1, 2);
+        expect(cov2 / cov3).toBeCloseTo(p3 / p2, 2);
+        // the proportionality constant is 2h: cov ≈ 2h/p
+        expect((cov1 * p1) / (2 * h)).toBeCloseTo(1, 2);
+        expect((cov2 * p2) / (2 * h)).toBeCloseTo(1, 2);
+        expect((cov3 * p3) / (2 * h)).toBeCloseTo(1, 2);
+    });
+});
+
+describe("dash Nyquist convergence [behavioural]", () => {
+    // Re-derives the fs's dash-coverage pipeline in TS from the spec's stated form. `coverFn` is the
+    // production `tgpu.fn` (CPU-callable), but `fwidth(s)` is GPU-only and cannot be called from TS,
+    // so the footprint `sP` is a parameter, not a live fwidth read. The arm witnesses the formula
+    // (coverFn calls + the Nyquist blend), not the shipped fs's fwidth path — the docblock says exactly
+    // that rather than overclaiming.
+    //
+    // WITNESSED RED: changing the Nyquist blend from the half-period threshold
+    //   `(sP - DASH_PERIOD * 0.5) / (DASH_PERIOD * 0.5)` back to the old linear-from-zero
+    //   `sP / DASH_PERIOD` reds the "blend inactive below half period" arm:
+    //   Expected: 0  (nyquist at sP = DASH_PERIOD * 0.25 — blend must be inactive)
+    //   Received: 0.25  (the old formula starts blending at sP = 0, so at quarter-period it is
+    //   already 25% washed toward continuous)
+    // Confirmed by running the mutated blend, observing the failure, then restoring by hand.
+
+    /** the fs's dash-coverage pipeline, re-derived in TS: two-edge coverFn calls along the station
+     *  axis (with wrap), clamped, then the Nyquist blend toward DASH_DUTY. `sP` stands in for
+     *  `fwidth(s)`, which is GPU-only. */
+    function dashCoverage(sRel: number, sP: number): number {
+        const dashCov = coverFn(DASH_SEGMENT, sRel, sP) - coverFn(0, sRel, sP);
+        const dashCovWrap =
+            coverFn(DASH_PERIOD + DASH_SEGMENT, sRel, sP) - coverFn(DASH_PERIOD, sRel, sP);
+        let cov = Math.max(0, Math.min(1, dashCov + dashCovWrap));
+        const nyquist = Math.max(0, Math.min(1, (sP - DASH_PERIOD * 0.5) / (DASH_PERIOD * 0.5)));
+        cov = cov * (1 - nyquist) + DASH_DUTY * nyquist;
+        return cov;
+    }
+
+    test("at a small footprint, coverage is ~1 inside a segment and ~0 in a gap", () => {
+        const sP = 0.001; // tiny footprint — the dash pattern is many pixels wide
+        // middle of a dash segment
+        const inSeg = DASH_SEGMENT / 2;
+        expect(dashCoverage(inSeg, sP)).toBeCloseTo(1, 3);
+        // middle of a gap
+        const inGap = DASH_SEGMENT + DASH_GAP / 2;
+        expect(dashCoverage(inGap, sP)).toBeCloseTo(0, 3);
+    });
+
+    test("the Nyquist blend is inactive below half a period — coverage equals the raw dash coverage", () => {
+        // below half a period, nyquist = 0, so the blend is a no-op and the result is the raw
+        // two-edge dash coverage. This is the property R4 buys: the dash reads crisp where it can.
+        const sRel = DASH_SEGMENT / 2; // inside a segment
+        const sP = DASH_PERIOD * 0.25; // well below the Nyquist threshold
+        const rawDashCov = (() => {
+            const dashCov = coverFn(DASH_SEGMENT, sRel, sP) - coverFn(0, sRel, sP);
+            const dashCovWrap =
+                coverFn(DASH_PERIOD + DASH_SEGMENT, sRel, sP) - coverFn(DASH_PERIOD, sRel, sP);
+            return Math.max(0, Math.min(1, dashCov + dashCovWrap));
+        })();
+        expect(dashCoverage(sRel, sP)).toBeCloseTo(rawDashCov, 6);
+        // and the nyquist factor itself is exactly 0
+        const nyquist = Math.max(0, Math.min(1, (sP - DASH_PERIOD * 0.5) / (DASH_PERIOD * 0.5)));
+        expect(nyquist).toBe(0);
+    });
+
+    test("as footprint grows toward DASH_PERIOD, coverage converges to DASH_DUTY, monotonically", () => {
+        // scan sP from half a period to one period — the coverage should converge to DASH_DUTY
+        // and |coverage - DASH_DUTY| should be non-increasing (monotone convergence)
+        const sRel = DASH_SEGMENT / 2; // inside a segment (raw coverage starts above DASH_DUTY)
+        let prevDelta = Infinity;
+        for (let i = 0; i <= 50; i++) {
+            const sP = DASH_PERIOD * 0.5 + (DASH_PERIOD * 0.5 * i) / 50;
+            const cov = dashCoverage(sRel, sP);
+            const delta = Math.abs(cov - DASH_DUTY);
+            expect(delta).toBeLessThanOrEqual(prevDelta + 1e-9);
+            prevDelta = delta;
+        }
+        // at one full period, coverage is exactly DASH_DUTY (nyquist = 1 → mix = DASH_DUTY)
+        expect(dashCoverage(sRel, DASH_PERIOD)).toBeCloseTo(DASH_DUTY, 5);
     });
 });

--- a/examples/showcase/roads/src/terrain/terrain.test.ts
+++ b/examples/showcase/roads/src/terrain/terrain.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { body, flat } from "../../../../../packages/shallot/tests/wgsl";
+import { markingDistanceForSegment, type Segment } from "../overlay/document";
 import { COVERAGE_BAND_PX, DIST_RANGE, TILE_SIZE, TILES_PER_SIDE } from "../overlay/tiles";
-import { terrainFsWgsl } from "./terrain";
+import { markingDistanceFromChord, terrainFsWgsl } from "./terrain";
 
 // The overlay composite's structural gate — the device-free seam this stage's `bun test` relies on for the
 // fs's atlas-sampling half (CPU-callable/resolved-WGSL first, never a bound device). The composite's
@@ -9,16 +10,29 @@ import { terrainFsWgsl } from "./terrain";
 // granularity: the compute-write half is proven by the seeded-tile readback oracle (`overlay/stroke.test.ts`),
 // this half by resolution + the capture, neither alone.
 
+function mulberry32(seed: number): () => number {
+    let s = seed >>> 0;
+    return () => {
+        s = (s + 0x6d2b79f5) | 0;
+        let t = s;
+        t = Math.imul(t ^ (t >>> 15), t | 1);
+        t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
 describe("terrain fs — overlay composite", () => {
     const wgsl = terrainFsWgsl();
 
-    test("declares the four overlay bindings the surface layout adds", () => {
+    test("declares the five overlay bindings the surface layout adds", () => {
         expect(flat(wgsl)).toContain(
             "@group(2) @binding(3) var<storage, read> indirection: array<i32>;",
         );
         expect(wgsl).toContain("var albedo: texture_2d_array<f32>;");
         expect(wgsl).toContain("var dist: texture_2d_array<f32>;");
         expect(wgsl).toContain("var overlaySamp: sampler;");
+        // the chord uniform (stage 8) — the analytic fs's marking geometry input
+        expect(wgsl).toContain("var<uniform> chord");
     });
 
     test("addresses the tile grid from world (x, z) using the documented constants", () => {
@@ -72,39 +86,49 @@ describe("terrain fs — overlay composite", () => {
     });
 });
 
-describe("terrain fs — marking channel (stage 3)", () => {
+describe("terrain fs — marking channel (stage 8: analytic from chord uniform)", () => {
     const wgsl = terrainFsWgsl();
     const fs = flat(body(wgsl, "fn terrainFs"));
 
-    test("decodes the albedo alpha byte as a signed marking distance using the same DIST_RANGE codec", () => {
-        // the alpha byte stores the encoded marking distance (rasterize.ts's encodeDistGpu, the coverage
-        // channel's own codec). The fs decodes it back: (sampled.w - 0.5) * 2 * DIST_RANGE — the same
-        // decode the coverage channel uses, applied to the albedo's w component, not the dist texture.
-        // Anchored on the albedoSample expression (not just `* ${DIST_RANGE}f` alone, which the coverage
-        // decode also emits — a bare toContain is blind to its own subject, satisfied by the wrong channel).
-        expect(fs).toMatch(new RegExp(`albedoSample.*\\.w.*0\\.5f.*2f.*${DIST_RANGE}f`));
+    test("reads the chord uniform (endpoints + halfWidth) for marking geometry, not the albedo alpha", () => {
+        // stage 8 moved the marking channel from a baked texel (albedo alpha byte) to analytic fs
+        // evaluation from the chord uniform. The fs must read the chord uniform, not decode alpha.
+        expect(fs).toContain("(*chord).a");
+        expect(fs).toContain("(*chord).b");
+        expect(fs).toContain("(*chord).halfWidth");
+        // the old alpha decode (albedoSample.w - 0.5) * 2 * DIST_RANGE must NOT survive
+        expect(fs).not.toMatch(/albedoSample.*\.w.*0\.5f.*2f.*DIST_RANGEf/);
     });
 
-    test("thresholds the marking distance with a second fwidth, exactly as coverage is", () => {
-        // a second fwidth call on the marking distance, with the same COVERAGE_BAND_PX coefficient —
-        // sub-texel crisp lines at any zoom (the property the Locked decision sells)
-        expect(fs).toMatch(new RegExp(`fwidth\\(markingDist_?\\d*\\) \\* ${COVERAGE_BAND_PX}f`));
-        // the marking coverage formula mirrors the coverage formula: clamp(0.5 - dist/fw, 0, 1) * resident
-        expect(fs).toMatch(
-            /clamp\(\(0\.5f - \(markingDist_?\d* \/ markingFw_?\d*\)\), 0f, 1f\) \* resident/,
-        );
+    test("uses two-edge analytic pixel coverage (cover(h) - cover(-h)), not a smoothstep threshold", () => {
+        // the coverage form: cover(e) = clamp((e - x)/p + 0.5, 0, 1), alpha = cover(h) - cover(-h)
+        // — not the old clamp(0.5 - dist/fw, 0, 1) threshold. The coverFn helper is resolved into the WGSL.
+        expect(flat(wgsl)).toContain("fn coverFn");
+        // edge line coverage uses coverFn with LINE_HALF_WIDTH (0.0762 = 0.1524/2, the stage 8 upper bound)
+        expect(fs).toMatch(/coverFn\(/);
+        // the old threshold form must NOT survive
+        expect(fs).not.toMatch(/clamp\(0\.5f - \(markingDist/);
     });
 
-    test("selects the marking albedo by comparing the decoded marking distance with the edge-line distance", () => {
-        // the marking class (edge vs centre) is determined by comparing the decoded marking distance with
-        // the edge-line distance computed independently from the coverage distance: if the marking distance
-        // is smaller, the nearest marking is the centreline; otherwise the edge line.
-        // 0.3 is EDGE_INSET and 0.05 is LINE_HALF_WIDTH — both deliberately literals here, not derived
-        // from the exported constants: if the regex were built from EDGE_INSET/LINE_HALF_WIDTH, changing
-        // the constant would change both sides and the arm would stay green, asserting only that the
-        // shader emitted *some* number consistent with itself, not the *right* number. The literals
+    test("dash coverage converges to DASH_DUTY opacity as fwidth(s) approaches DASH_PERIOD", () => {
+        // the dash uses two-edge coverage along the station axis, plus a Nyquist convergence blend
+        // toward DASH_DUTY — a far dashed line reads as a faint continuous line, never resolved dots.
+        expect(fs).toContain("nyquist");
+        // DASH_DUTY resolves to 0.25f in the WGSL — the literal freezes the constant so the
+        // arm reds if the duty changes, not just if the mix expression changes shape.
+        expect(fs).toMatch(/mix\(.*dashCoverage.*0\.25f.*nyquist/);
+    });
+
+    test("selects the marking albedo by comparing the chord-derived marking distance with the edge-line distance", () => {
+        // the marking class (edge vs centre) is determined by comparing the chord-derived marking
+        // distance with the edge-line distance computed from the chord: if the marking distance is
+        // smaller, the nearest marking is the centreline; otherwise the edge line.
+        // 0.3 is EDGE_INSET and 0.0762 is LINE_HALF_WIDTH (0.1524/2) — both deliberately literals here,
+        // not derived from the exported constants: if the regex were built from EDGE_INSET/LINE_HALF_WIDTH,
+        // changing the constant would change both sides and the arm would stay green, asserting only that
+        // the shader emitted *some* number consistent with itself, not the *right* number. The literals
         // freeze the derived quantity so the arm reds exactly when the emitted value moves.
-        expect(fs).toMatch(/abs\(\(dist_\d* \+ 0\.3\d*f\)\) - 0\.05\d*f/);
+        expect(fs).toMatch(/abs\(.*\+ 0\.3\d*f\)\) - 0\.0762\d*f/);
         expect(fs).toMatch(/select\(vec3f\(/);
         expect(fs).toMatch(/isCentre/);
     });
@@ -114,5 +138,97 @@ describe("terrain fs — marking channel (stage 3)", () => {
         // never bleeds outside the road's coverage boundary
         expect(fs).toContain("mix(overlay, markingAlbedo, markingCoverage)");
         expect(fs).toContain("color = mix(color, overlayWithMarkings, coverage);");
+    });
+});
+
+// Stage 8's marking differential oracle: `markingDistanceFromChord` (terrain.ts, clamped-projection form,
+// CPU-called through TypeGPU's dual execution) against `document.ts`'s `markingDistanceForSegment`
+// (cross-product form) — two independently written derivations of the same geometric quantity, the
+// signed distance to the nearest road marking (edge lines + broken centreline). The GPU side is the
+// analytic form the fs uses to compute marking geometry from the chord uniform; the CPU side is the
+// independently-derived `markingDistance` in `document.ts`. `terrain.ts` never imports `markingDistance` —
+// the two derivations are independent by contract, because the differential arm is worthless if one side
+// calls the other.
+//
+// RED-FIRST CONTROL: mutating one side's dash duty (DASH_DUTY) was witnessed red — changing the CPU
+// side's DASH_DUTY to DASH_DUTY * 0.5 (halving the dash fraction) while leaving the GPU side unchanged
+// produces disagreement at points inside a dash whose phase falls in the second half of the original
+// duty cycle: the CPU side now reads those points as in a gap (marking distance positive) while the GPU
+// side still reads them as in a dash (marking distance negative), exceeding the tolerance. This was
+// confirmed by running the mutated comparison and observing the failure before restoring the real duty.
+describe("marking differential oracle — markingDistanceFromChord vs document.ts's markingDistanceForSegment", () => {
+    test("agree within f32 roundoff over random segments and sample points", () => {
+        const rng = mulberry32(42);
+        const rand = (lo: number, hi: number) => lo + rng() * (hi - lo);
+        for (let i = 0; i < 200; i++) {
+            const seg: Segment = {
+                ax: rand(-100, 100),
+                az: rand(-100, 100),
+                bx: rand(-100, 100),
+                bz: rand(-100, 100),
+                halfWidth: rand(1, 8),
+            };
+            const px = rand(-120, 120);
+            const pz = rand(-120, 120);
+
+            const cpu = markingDistanceForSegment(px, pz, seg);
+            const gpu = markingDistanceFromChord(
+                px,
+                pz,
+                seg.ax,
+                seg.az,
+                seg.bx,
+                seg.bz,
+                seg.halfWidth,
+            );
+            // same geometric quantity, f32 roundoff only — no quantization step (the fs computes from
+            // the chord uniform directly, not through an encoded byte)
+            expect(Math.abs(gpu - cpu)).toBeLessThan(1e-4);
+        }
+    });
+
+    test("agree on the centreline (where the dash phase is the nearest marking), inside a dash and in a gap", () => {
+        // a horizontal road from (-100, 0) to (100, 0), halfWidth 4 — the standard chord's shape.
+        // Points on the centreline (z=0) are where the centreline marking is nearest, so the dash
+        // duty actually determines the distance — this is the axis the red-first control mutates.
+        const seg: Segment = { ax: -100, az: 0, bx: 100, bz: 0, halfWidth: 4 };
+        const inDash: Array<[number, number]> = [
+            [20, 0], // station 120, on the centreline, in a dash
+            [70, 0.01], // station 170, near the centreline, in a dash
+        ];
+        const inGap: Array<[number, number]> = [
+            [0, 0], // station 100, on the centreline, in a gap
+            [-50, 0.01], // station 50, near the centreline, in a gap
+        ];
+        for (const [px, pz] of inDash) {
+            const cpu = markingDistanceForSegment(px, pz, seg);
+            const gpu = markingDistanceFromChord(
+                px,
+                pz,
+                seg.ax,
+                seg.az,
+                seg.bx,
+                seg.bz,
+                seg.halfWidth,
+            );
+            expect(Math.abs(gpu - cpu)).toBeLessThan(1e-4);
+            // inside a dash → marking distance should be negative (inside the marking)
+            expect(cpu).toBeLessThan(0);
+        }
+        for (const [px, pz] of inGap) {
+            const cpu = markingDistanceForSegment(px, pz, seg);
+            const gpu = markingDistanceFromChord(
+                px,
+                pz,
+                seg.ax,
+                seg.az,
+                seg.bx,
+                seg.bz,
+                seg.halfWidth,
+            );
+            expect(Math.abs(gpu - cpu)).toBeLessThan(1e-4);
+            // in a gap → marking distance should be positive (outside the marking)
+            expect(cpu).toBeGreaterThan(0);
+        }
     });
 });

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -251,9 +251,17 @@ const terrainFs = tgpu.fn(
         coverFn(d.f32(DASH_PERIOD + DASH_SEGMENT), sRel, sP) -
         coverFn(d.f32(DASH_PERIOD), sRel, sP);
     let dashCoverage = std.clamp(dashCov + dashCovWrap, 0, 1);
-    // converge to DASH_DUTY opacity as fwidth(s) approaches DASH_PERIOD — a far dashed line reads as a
-    // faint continuous line, never as resolved flickering dots (roads-interactive.md Locked decision).
-    const nyquist = std.clamp(sP / d.f32(DASH_PERIOD), 0, 1);
+    // Nyquist blend: aliasing begins when the sample footprint passes half the dash period — the
+    // highest frequency a signal can represent is 2 samples per cycle, so below half a period the dash
+    // is still fully resolvable and the blend must be inactive (otherwise the pattern washes toward
+    // continuous inside the regime where it still reads crisp). The blend starts at half a period and
+    // reaches full convergence at one period: a far dashed line reads as a faint continuous line at
+    // DASH_DUTY opacity, never as resolved flickering dots (roads-interactive.md Locked decision).
+    const nyquist = std.clamp(
+        (sP - d.f32(DASH_PERIOD) * d.f32(0.5)) / (d.f32(DASH_PERIOD) * d.f32(0.5)),
+        0,
+        1,
+    );
     dashCoverage = std.mix(dashCoverage, d.f32(DASH_DUTY), nyquist);
 
     // endpoint: the centreline exists only for station in [0, len]

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -22,6 +22,10 @@ import { generateNetwork } from "../overlay/network";
 import {
     CENTRE_ALBEDO,
     COVERAGE_BAND_PX,
+    DASH_DUTY,
+    DASH_OFFSET,
+    DASH_PERIOD,
+    DASH_SEGMENT,
     DIST_RANGE,
     EDGE_ALBEDO,
     EDGE_INSET,
@@ -58,6 +62,76 @@ const terrainSurfaceLayout = surfaceLayout({
     dist: { type: "texture-2d-array" },
     overlaySamp: { type: "sampler" },
     indirection: { type: "storage", element: d.i32 },
+    chord: { type: "uniform", struct: overlayAtlas.ChordUniform },
+});
+
+/** two-edge analytic pixel coverage — the fraction of a pixel a stripe of half-width `h` covers
+ *  on signed cross-coordinate `x` with pixel footprint `p`. `cover(e) = clamp((e - x)/p + 0.5, 0, 1)`,
+ *  `alpha = cover(h) - cover(-h)`. Correct through the sub-pixel regime by construction: when both
+ *  edges land inside one pixel the terms subtract to the stripe's true fractional coverage, so the line
+ *  fades proportionally instead of snapping to fully-opaque or vanishing (roads-interactive.md Locked
+ *  decision, stage 8). CPU-callable so `bun test` exercises this exact math with no device. */
+export const coverFn = tgpu.fn(
+    [d.f32, d.f32, d.f32],
+    d.f32,
+)((e, x, p) => {
+    "use gpu";
+    return std.clamp((e - x) / p + d.f32(0.5), 0, 1);
+});
+
+/** the signed distance to the nearest road marking from the chord — the GPU twin of `document.ts`'s
+ *  `markingDistanceForSegment`, independently derived via the clamped-projection form (same split as
+ *  `segmentDistanceGpu` vs `segmentDistance`). Two solid edge lines inset from the road edge (centred
+ *  at d = −EDGE_INSET on the existing edge distance) and a broken centreline (perpendicular distance via
+ *  the cross product, station along the chord via fract(s / DASH_PERIOD) < DASH_DUTY). CPU-callable so
+ *  `bun test` exercises this exact math with no device — the GPU half of stage 8's marking differential
+ *  oracle. `terrain.ts` never imports `markingDistance` — the two derivations are independent by contract.
+ * @example markingDistanceFromChord(0, 0, -100, 0, 100, 0, 4) // on the centreline, in a gap → positive */
+export const markingDistanceFromChord = tgpu.fn(
+    [d.f32, d.f32, d.f32, d.f32, d.f32, d.f32, d.f32],
+    d.f32,
+)((px, pz, ax, az, bx, bz, halfWidth) => {
+    "use gpu";
+    const abx = bx - ax;
+    const abz = bz - az;
+    const apx = px - ax;
+    const apz = pz - az;
+    const dd = abx * abx + abz * abz;
+    let t = d.f32(0);
+    let tRaw = d.f32(0);
+    if (dd > 0) {
+        tRaw = (apx * abx + apz * abz) / dd;
+        t = std.clamp(tRaw, 0, 1);
+    }
+    const cx = ax + t * abx;
+    const cz = az + t * abz;
+    const dist = std.distance(d.vec2f(px, pz), d.vec2f(cx, cz));
+    const edgeDist = dist - halfWidth;
+
+    // edge line: solid, centred at d = −EDGE_INSET, width LINE_WIDTH
+    const edgeLineDist = std.abs(edgeDist + d.f32(EDGE_INSET)) - d.f32(LINE_HALF_WIDTH);
+
+    // centreline: broken, lateral from the cross product, longitudinal from the dash phase
+    const len = std.sqrt(dd);
+    const cross = len > 0 ? (apx * abz - apz * abx) / len : 0;
+    const lateral = std.abs(cross) - d.f32(LINE_HALF_WIDTH);
+    const along = t * len;
+    let longitudinal = d.f32(0);
+    if (tRaw < 0) {
+        longitudinal = -tRaw * len;
+    } else if (tRaw > 1) {
+        longitudinal = (tRaw - 1) * len;
+    } else {
+        const phase = std.fract((along + d.f32(DASH_OFFSET)) / d.f32(DASH_PERIOD));
+        if (phase < d.f32(DASH_DUTY)) {
+            longitudinal = -std.min(phase, d.f32(DASH_DUTY) - phase) * d.f32(DASH_PERIOD);
+        } else {
+            longitudinal = std.min(phase - d.f32(DASH_DUTY), d.f32(1) - phase) * d.f32(DASH_PERIOD);
+        }
+    }
+    const centreDist = std.max(lateral, longitudinal);
+
+    return std.min(edgeLineDist, centreDist);
 });
 
 const terrainFs = tgpu.fn(
@@ -123,22 +197,90 @@ const terrainFs = tgpu.fn(
     const resident = std.select(d.f32(0), d.f32(1), layer >= 0);
     const coverage = std.clamp(d.f32(0.5) - dist / fw, 0, 1) * resident;
 
-    // the marking channel: the albedo alpha byte stores the signed distance to the nearest road marking
-    // (the coverage channel's own encodeDist codec, DIST_RANGE at 8 bits). Decode it and threshold with
-    // a second fwidth exactly as coverage is — sub-texel crisp lines at any zoom (roads-interactive.md
-    // Locked decision). The marking class (edge vs centre) is determined by comparing the decoded
-    // marking distance with the edge-line distance computed independently from the coverage distance:
-    // if the marking distance is smaller, the nearest marking is the centreline; otherwise the edge line.
-    const markingDist = (albedoSample.w - d.f32(0.5)) * d.f32(2) * d.f32(DIST_RANGE);
-    const markingFw = std.fwidth(markingDist) * d.f32(COVERAGE_BAND_PX) + d.f32(1e-5);
-    const markingCoverage = std.clamp(d.f32(0.5) - markingDist / markingFw, 0, 1) * resident;
-    const edgeLineDist = std.abs(dist + d.f32(EDGE_INSET)) - d.f32(LINE_HALF_WIDTH);
+    // the marking channel: analytic in the fs from the chord uniform (stage 8), not baked into a texel.
+    // Two-edge pixel coverage — the fraction of the pixel the marking covers — not a smoothstep threshold.
+    // For a stripe of half-width h on signed cross-coordinate x with p = max(fwidth(x), 1e-6):
+    //   cover(e) = clamp((e - x)/p + 0.5, 0, 1),  alpha = cover(h) - cover(-h)
+    // This is correct through the sub-pixel regime by construction (roads-interactive.md Locked decision).
+    const chord = terrainSurfaceLayout.$.chord;
+    const ax = chord.a.x;
+    const az = chord.a.y;
+    const bx = chord.b.x;
+    const bz = chord.b.y;
+    const halfWidth = chord.halfWidth;
+
+    // chord projection
+    const abx = bx - ax;
+    const abz = bz - az;
+    const apx = ctx.world.x - ax;
+    const apz = ctx.world.z - az;
+    const dd = abx * abx + abz * abz;
+    let tRaw = d.f32(0);
+    if (dd > 0) tRaw = (apx * abx + apz * abz) / dd;
+    const t = std.clamp(tRaw, 0, 1);
+    const cx = ax + t * abx;
+    const cz = az + t * abz;
+    const distToSegment = std.distance(d.vec2f(ctx.world.x, ctx.world.z), d.vec2f(cx, cz));
+    const len = std.sqrt(dd);
+    const cross = len > 0 ? (apx * abz - apz * abx) / len : 0;
+
+    // edge line: solid, two-edge coverage on the edge cross-coordinate
+    // (centred at d = −EDGE_INSET on the edge distance, half-width LINE_HALF_WIDTH)
+    const edgeX = distToSegment - halfWidth + d.f32(EDGE_INSET);
+    const edgeP = std.max(std.fwidth(edgeX), d.f32(1e-6));
+    const edgeAlpha =
+        coverFn(d.f32(LINE_HALF_WIDTH), edgeX, edgeP) -
+        coverFn(-d.f32(LINE_HALF_WIDTH), edgeX, edgeP);
+
+    // centreline: broken, lateral coverage * dash coverage * endpoint coverage
+    // lateral: two-edge coverage on the signed perpendicular distance (cross)
+    const centreP = std.max(std.fwidth(cross), d.f32(1e-6));
+    const lateralAlpha =
+        coverFn(d.f32(LINE_HALF_WIDTH), cross, centreP) -
+        coverFn(-d.f32(LINE_HALF_WIDTH), cross, centreP);
+
+    // dash: two-edge coverage along the station axis, converging to DASH_DUTY past Nyquist
+    const s = tRaw * len;
+    const sP = std.max(std.fwidth(s), d.f32(1e-6));
+    const sRel =
+        s +
+        d.f32(DASH_OFFSET) -
+        std.floor((s + d.f32(DASH_OFFSET)) / d.f32(DASH_PERIOD)) * d.f32(DASH_PERIOD);
+    const dashCov = coverFn(d.f32(DASH_SEGMENT), sRel, sP) - coverFn(d.f32(0), sRel, sP);
+    const dashCovWrap =
+        coverFn(d.f32(DASH_PERIOD + DASH_SEGMENT), sRel, sP) -
+        coverFn(d.f32(DASH_PERIOD), sRel, sP);
+    let dashCoverage = std.clamp(dashCov + dashCovWrap, 0, 1);
+    // converge to DASH_DUTY opacity as fwidth(s) approaches DASH_PERIOD — a far dashed line reads as a
+    // faint continuous line, never as resolved flickering dots (roads-interactive.md Locked decision).
+    const nyquist = std.clamp(sP / d.f32(DASH_PERIOD), 0, 1);
+    dashCoverage = std.mix(dashCoverage, d.f32(DASH_DUTY), nyquist);
+
+    // endpoint: the centreline exists only for station in [0, len]
+    const endpointAlpha = coverFn(d.f32(len), s, sP) - coverFn(d.f32(0), s, sP);
+
+    const centreAlpha = lateralAlpha * dashCoverage * endpointAlpha;
+
+    // select the marking class: the nearest marking (edge vs centre) determines the albedo
+    const markingDist = markingDistanceFromChord(
+        ctx.world.x,
+        ctx.world.z,
+        ax,
+        az,
+        bx,
+        bz,
+        halfWidth,
+    );
+    const edgeLineDist =
+        std.abs(distToSegment - halfWidth + d.f32(EDGE_INSET)) - d.f32(LINE_HALF_WIDTH);
     const isCentre = markingDist < edgeLineDist;
     const markingAlbedo = std.select(
         d.vec3f(d.f32(EDGE_ALBEDO[0]), d.f32(EDGE_ALBEDO[1]), d.f32(EDGE_ALBEDO[2])),
         d.vec3f(d.f32(CENTRE_ALBEDO[0]), d.f32(CENTRE_ALBEDO[1]), d.f32(CENTRE_ALBEDO[2])),
         isCentre,
     );
+    const markingCoverage = std.max(edgeAlpha, centreAlpha);
+
     // mix the marking albedo over the road albedo before the terrain composite
     const overlayWithMarkings = std.mix(overlay, markingAlbedo, markingCoverage);
     color = std.mix(color, overlayWithMarkings, coverage);
@@ -149,7 +291,7 @@ const terrainFs = tgpu.fn(
 /** the emitted terrain fs WGSL — the device-free structural seam the overlay composite tests resolve
  *  (`terrain.test.ts`, the `generate.test.ts`/`noise.test.ts` idiom). */
 export function terrainFsWgsl(): string {
-    return tgpu.resolve([terrainFs], { names: "strict" });
+    return tgpu.resolve([coverFn, markingDistanceFromChord, terrainFs], { names: "strict" });
 }
 
 /** the terrain mesh's local-space bounding sphere: the grid's XZ half-extent + the relief's half-height,
@@ -261,7 +403,7 @@ async function warm(state: State): Promise<void> {
         indexCount: INDEX_COUNT,
         bounds: terrainBounds(),
         dynamic: true, // content (not topology) is compute-rewritten on reseed — a stale BLAS would cast wrong
-        bindings: overlayAtlas.bindings(), // the four overlay entries terrainSurfaceLayout declares
+        bindings: overlayAtlas.bindings(), // the overlay entries terrainSurfaceLayout declares
     };
     Meshes.register(mesh);
     Draws.register({ name: "terrain", surface: "terrain", mesh: "terrain", args: { indirect } });
@@ -275,6 +417,7 @@ async function warm(state: State): Promise<void> {
     warmNetwork(state); // its own onDispose registration, the same pattern
     setNetwork(liveDocument, currentSeed); // the flatten kernel's geometry input, kept in sync with
     // the overlay's own document and the height kernel's own permutation seed
+    overlayAtlas.updateChord(liveDocument); // the fs's marking geometry input (stage 8)
     if (state.signal.aborted) return;
     await generate(SEED);
 }
@@ -311,6 +454,7 @@ export async function regenerate(seed: number): Promise<void> {
     currentSeed = seed;
     liveDocument = generateNetwork();
     setNetwork(liveDocument, seed);
+    overlayAtlas.updateChord(liveDocument);
     overlayAtlas.invalidate();
     overlayAtlas.markDirty(liveDocument);
     await generate(seed);
@@ -330,6 +474,7 @@ export async function editDocument(doc: StrokeDocument): Promise<void> {
     const oldDoc = liveDocument;
     liveDocument = doc;
     setNetwork(doc, currentSeed);
+    overlayAtlas.updateChord(doc);
     overlayAtlas.retile(oldDoc, doc);
     await generate(currentSeed);
 }


### PR DESCRIPTION
- **roads-interactive: stage 8 — analytic marking in the fs from the chord uniform**
- **roads-interactive: stage 8 repair — fix false comment, stale stage label, Nyquist blend, add behavioural coverage arms**
