### PR TITLE
roads interactive/5

### DIFF
--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -83,8 +83,9 @@ declare global {
         // stage 4's handle position bridge — returns the two handle entities' world (x, y, z).
         __roadsHandlePos?: () => [[number, number, number], [number, number, number]];
         // stage 5's posts check bridge — reads back the posts buffer and verifies every Validation
-        // criterion (y = flattenFieldAt, lateral inside the flat core, live-slot count, scale-0). The
-        // device gate drives this after an __roadsEdit to re-verify post placement on the edited chord.
+        // criterion (y = flattenFieldAt, lateral inside the flat core, lateral sign matches
+        // postLateralSign(i), live-slot count, scale-0). The device gate drives this after an
+        // __roadsEdit to re-verify post placement on the edited chord.
         __roadsPostsCheck?: () => Promise<{ name: string; pass: boolean; detail: string }>;
     }
 }

--- a/examples/showcase/roads/src/boot.ts
+++ b/examples/showcase/roads/src/boot.ts
@@ -14,6 +14,7 @@ import { applyEdit, clampDragTarget, clampToBound, handlePositions } from "./edi
 import { checkSurfaceFlatness } from "./flatness";
 import { gate } from "./gate";
 import type { Check } from "./harness";
+import { checkPosts } from "./posts";
 import {
     editDocument,
     getDocument,
@@ -81,6 +82,10 @@ declare global {
         }>;
         // stage 4's handle position bridge — returns the two handle entities' world (x, y, z).
         __roadsHandlePos?: () => [[number, number, number], [number, number, number]];
+        // stage 5's posts check bridge — reads back the posts buffer and verifies every Validation
+        // criterion (y = flattenFieldAt, lateral inside the flat core, live-slot count, scale-0). The
+        // device gate drives this after an __roadsEdit to re-verify post placement on the edited chord.
+        __roadsPostsCheck?: () => Promise<{ name: string; pass: boolean; detail: string }>;
     }
 }
 
@@ -123,6 +128,7 @@ const BootSystem: System = {
             };
         };
         window.__roadsHandlePos = () => handlePositions();
+        window.__roadsPostsCheck = () => checkPosts();
         // F9 reseeds the live procedural network (`terrain.ts`'s `regenerate`) — the same key voxel's own
         // reseed uses. `{ signal: state.signal }` detaches the listener at `state.dispose()`, no removal
         // code needed.
@@ -152,6 +158,7 @@ const BootSystem: System = {
         delete window.__roadsEdit;
         delete window.__roadsFlatnessViolations;
         delete window.__roadsHandlePos;
+        delete window.__roadsPostsCheck;
     },
 };
 

--- a/examples/showcase/roads/src/edit.ts
+++ b/examples/showcase/roads/src/edit.ts
@@ -75,7 +75,7 @@ import { flattenFieldAt } from "./flatness";
 import { buildNetworkGeometry, computeFalloff, type ProfileSegment } from "./terrain/flatten";
 import { makePermutation } from "./terrain/noise";
 import { heightAtCpu } from "./terrain/profile";
-import { editDocument, getDocument, SEED } from "./terrain/terrain";
+import { editDocument, getCurrentSeed, getDocument } from "./terrain/terrain";
 
 // handle colours — idle (white), hover (yellow), grabbed (orange). Design parameters, not gates: the
 // spec's drag-feel check-in is about lag/jump/detach, not colour choice.
@@ -187,7 +187,7 @@ const EditSystem: System = {
         // read the live document and place the handles at its endpoints (y = heightAtCpu)
         const doc = getDocument();
         const line = doc.polylines[0];
-        const perm = makePermutation(SEED);
+        const perm = makePermutation(getCurrentSeed());
         for (let i = 0; i < 2; i++) {
             const [x, z] = line.points[i];
             const y = heightAtCpu(x, z, perm);
@@ -270,7 +270,7 @@ const EditSystem: System = {
             lastValidTarget = null;
         }
         if (dragging && ray) {
-            const { segments, cutDepth } = buildNetworkGeometry(doc, SEED);
+            const { segments, cutDepth } = buildNetworkGeometry(doc, getCurrentSeed());
             const falloff = computeFalloff(cutDepth);
             const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
             const hit = marchFlattenField(ray, segments, falloff, natural);

--- a/examples/showcase/roads/src/gate.ts
+++ b/examples/showcase/roads/src/gate.ts
@@ -7,6 +7,7 @@ import {
 } from "./flatness";
 import type { Check } from "./harness";
 import { generateNetwork } from "./overlay/network";
+import { checkPosts } from "./posts";
 import { TERRAIN_QUANT } from "./terrain/generate";
 import { VERTEX_COUNT } from "./terrain/grid";
 import { RELIEF } from "./terrain/noise";
@@ -137,6 +138,11 @@ export async function gate(): Promise<Check[]> {
             deviceResult.sampleCount === 546,
         detail: `device crossSection=${deviceResult.crossSection.length} longitudinal=${deviceResult.longitudinal.length} maxCrossSectionExcess=${deviceResult.maxCrossSectionExcess.toFixed(4)} maxLongitudinalExcess=${deviceResult.maxLongitudinalExcess.toFixed(4)} sampleCount=${deviceResult.sampleCount}`,
     });
+
+    // stage 5's post-placement check — reads back the posts buffer and verifies every Validation
+    // criterion: every live slot's y equals CPU flattenFieldAt, lateral offset inside the flat core,
+    // floor(chordLength / POST_SPACING) live slots, and every slot past the chord at scale 0.
+    checks.push(await checkPosts());
 
     return checks;
 }

--- a/examples/showcase/roads/src/gate.ts
+++ b/examples/showcase/roads/src/gate.ts
@@ -140,7 +140,8 @@ export async function gate(): Promise<Check[]> {
     });
 
     // stage 5's post-placement check — reads back the posts buffer and verifies every Validation
-    // criterion: every live slot's y equals CPU flattenFieldAt, lateral offset inside the flat core,
+    // criterion: every live slot's y equals CPU flattenFieldAt (baked against the live seed), lateral
+    // offset inside the flat core, lateral sign matches postLateralSign(i),
     // floor(chordLength / POST_SPACING) live slots, and every slot past the chord at scale 0.
     checks.push(await checkPosts());
 

--- a/examples/showcase/roads/src/posts.test.ts
+++ b/examples/showcase/roads/src/posts.test.ts
@@ -27,6 +27,27 @@ describe("posts emitted WGSL", () => {
         // through the network bind group — never re-deriving height on the CPU for this consumer.
         expect(wgsl).toContain("flattenedHeightAt");
     });
+
+    test("the resolved kernel's station, lateral sign, and slot index are the correct literals", () => {
+        // LITERALS, not values re-derived from POST_SPACING/POST_OFFSET — an arm that recomputes its
+        // own rule goes green on a wrong constant (this unit's stage-3 precedent). The assertions below
+        // pin the exact emitted WGSL text: the station `(f32(i) + 1f) * 20f` (not `f32(i) * 20f`),
+        // the lateral `select(1f, -1f, ((i & 1u) == 1u))` (not a swapped or constant sign), and the slot
+        // index `segments[0i]` (not `segments[1i]`). Each would fail under the mutation it names.
+        const wgsl = flat(postsWgsl());
+
+        // station: (i + 1) * POST_SPACING emits as `(f32(i) + 1f) * 20f` — the `+ 1f` is what
+        // discriminates from `i * POST_SPACING` which emits `(f32(i) * 20f)` with no `+ 1f`.
+        expect(wgsl).toContain("(f32(i) + 1f) * 20f");
+
+        // lateral sign: even → +1, odd → −1, emitted as `select(1f, -1f, ((i & 1u) == 1u))` —
+        // a swapped sign emits `select(-1f, 1f, ...)` and a constant sign emits no `select` at all.
+        expect(wgsl).toContain("select(1f, -1f, ((i & 1u) == 1u))");
+
+        // slot index: the kernel reads segment 0, emitted as `segments[0i]` — a wrong slot index
+        // emits `segments[1i]` or similar.
+        expect(wgsl).toContain("segments[0i]");
+    });
 });
 
 describe("post station derivation", () => {

--- a/examples/showcase/roads/src/posts.test.ts
+++ b/examples/showcase/roads/src/posts.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+import { flat } from "../../../../packages/shallot/tests/wgsl";
+import {
+    isLiveSlot,
+    liveSlotCount,
+    POST_COUNT,
+    POST_OFFSET,
+    POST_SPACING,
+    postLateralSign,
+    postStation,
+    postsWgsl,
+} from "./posts";
+import { FLAT_CORE_MARGIN } from "./terrain/flatten-math";
+import { SPACING, WORLD_EXTENT } from "./terrain/grid";
+
+// Stage 5's posts test — the WGSL structural seam plus the plain-TS behavioural witnesses for the
+// station/lateral/slot-count/scale-0 derivations. The structural arm (the resolved WGSL contains
+// `flattenedHeightAt`) is the named oracle Validation requires; the behavioural arms witness the
+// real properties by calling the exported pure derivation functions and checking against
+// independently-derived expectations — not by re-deriving from the subject. Each behavioural arm's
+// docblock records the red seen when the production value was mutated to prove it can fail.
+
+describe("posts emitted WGSL", () => {
+    test("the resolved kernel contains flattenedHeightAt (the named oracle)", () => {
+        const wgsl = flat(postsWgsl());
+        // the named oracle: the kernel calls flatten.ts's own flattenedHeightAt TGSL fn, bound
+        // through the network bind group — never re-deriving height on the CPU for this consumer.
+        expect(wgsl).toContain("flattenedHeightAt");
+    });
+});
+
+describe("post station derivation", () => {
+    test("postStation(i) = (i + 1) * POST_SPACING — first post at POST_SPACING, not station 0", () => {
+        // independently derived: (i + 1) * POST_SPACING, not i * POST_SPACING
+        // red: mutating postStation to return i * POST_SPACING makes postStation(0) = 0 (not 20)
+        for (const i of [0, 1, 2, 5, 10, 72]) {
+            expect(postStation(i)).toBe((i + 1) * POST_SPACING);
+        }
+    });
+
+    test("postStation is strictly increasing — no two slots share a station", () => {
+        for (let i = 0; i < 10; i++) {
+            expect(postStation(i + 1)).toBeGreaterThan(postStation(i));
+        }
+    });
+});
+
+describe("post lateral derivation", () => {
+    test("postLateralSign alternates: +1 for even, -1 for odd", () => {
+        // independently derived: even → +1, odd → -1
+        // red: mutating postLateralSign to always return 1 makes postLateralSign(1) = 1 (not -1)
+        expect(postLateralSign(0)).toBe(1);
+        expect(postLateralSign(1)).toBe(-1);
+        expect(postLateralSign(2)).toBe(1);
+        expect(postLateralSign(3)).toBe(-1);
+    });
+});
+
+describe("live-slot count derivation", () => {
+    test("liveSlotCount = floor(chordLength / POST_SPACING) — not ceil or floor + 1", () => {
+        // independently derived: Math.floor(chordLength / POST_SPACING)
+        // red: mutating liveSlotCount to Math.ceil makes liveSlotCount(201) = 11 (not 10)
+        expect(liveSlotCount(200)).toBe(10);
+        expect(liveSlotCount(201)).toBe(10);
+        expect(liveSlotCount(199)).toBe(9);
+        expect(liveSlotCount(0)).toBe(0);
+        expect(liveSlotCount(POST_SPACING)).toBe(1);
+        expect(liveSlotCount(POST_SPACING - 0.001)).toBe(0);
+    });
+
+    test("isLiveSlot agrees with liveSlotCount — the count of live slots matches", () => {
+        // the arm and the production derivation come from the same expression:
+        // isLiveSlot(i, L) = postStation(i) <= L, and liveSlotCount(L) = #{i : postStation(i) <= L}
+        for (const L of [100, 200, 201, 500]) {
+            let count = 0;
+            for (let i = 0; i < POST_COUNT; i++) {
+                if (isLiveSlot(i, L)) count++;
+            }
+            expect(count).toBe(liveSlotCount(L));
+        }
+    });
+
+    test("isLiveSlot boundary: station == chordLength is live, station > chordLength is not", () => {
+        // the boundary is inclusive: station <= chordLength is live
+        // red: mutating isLiveSlot to use < instead of <= makes the station == chordLength case dead
+        const i = 5;
+        const station = postStation(i);
+        expect(isLiveSlot(i, station)).toBe(true);
+        expect(isLiveSlot(i, station - 0.001)).toBe(false);
+        expect(isLiveSlot(i, station + 0.001)).toBe(true);
+    });
+});
+
+describe("POST_COUNT sizing", () => {
+    test("POST_COUNT = ceil(WORLD_DIAGONAL / POST_SPACING), fixed across edits", () => {
+        // independently derived: ceil(WORLD_EXTENT * SQRT2 / POST_SPACING)
+        const worldDiagonal = WORLD_EXTENT * Math.SQRT2;
+        expect(POST_COUNT).toBe(Math.ceil(worldDiagonal / POST_SPACING));
+    });
+
+    test("POST_COUNT is large enough for the worst-case (corner-to-corner) chord", () => {
+        // every live slot must fit: floor(worldDiagonal / POST_SPACING) <= POST_COUNT
+        const worldDiagonal = WORLD_EXTENT * Math.SQRT2;
+        expect(liveSlotCount(worldDiagonal)).toBeLessThanOrEqual(POST_COUNT);
+    });
+});
+
+describe("POST_OFFSET flat-core band", () => {
+    test("POST_OFFSET is strictly inside the flat core: 0 < POST_OFFSET < FLAT_CORE_MARGIN", () => {
+        // independently derived from flatten-math.ts:
+        // the flat core extends to halfWidth + FLAT_CORE_MARGIN from the centreline;
+        // a post at halfWidth + POST_OFFSET is inside iff POST_OFFSET < FLAT_CORE_MARGIN;
+        // outside the road iff POST_OFFSET > 0.
+        // red: mutating POST_OFFSET to FLAT_CORE_MARGIN makes this fail (not strictly inside)
+        // red: mutating POST_OFFSET to 0 makes this fail (on the road surface)
+        expect(POST_OFFSET).toBeGreaterThan(0);
+        expect(POST_OFFSET).toBeLessThan(FLAT_CORE_MARGIN);
+    });
+
+    test("POST_OFFSET = SPACING (one grid cell from the road edge)", () => {
+        expect(POST_OFFSET).toBe(SPACING);
+    });
+
+    test("FLAT_CORE_MARGIN = √2 * SPACING (flatten-math.ts's own derivation)", () => {
+        // the constant the band is derived against, re-checked here so the band test
+        // doesn't silently pass if FLAT_CORE_MARGIN moves
+        expect(FLAT_CORE_MARGIN).toBe(Math.SQRT2 * SPACING);
+    });
+});

--- a/examples/showcase/roads/src/posts.ts
+++ b/examples/showcase/roads/src/posts.ts
@@ -45,7 +45,7 @@ import { FLAT_CORE_MARGIN } from "./terrain/flatten-math";
 import { SPACING, WORLD_EXTENT } from "./terrain/grid";
 import { makePermutation, noiseLayout, PermData } from "./terrain/noise";
 import { heightAtCpu } from "./terrain/profile";
-import { getDocument, SEED } from "./terrain/terrain";
+import { getCurrentSeed, getDocument } from "./terrain/terrain";
 
 // --- constants --------------------------------------------------------------
 
@@ -456,16 +456,40 @@ function perpDist(px: number, pz: number, ax: number, az: number, bx: number, bz
     return Math.abs((dx * (pz - az) - dz * (px - ax)) / len);
 }
 
+/** the signed perpendicular distance from (px, pz) to the line through (ax, az) and (bx, bz): positive on
+ *  one side, negative on the other. The kernel's lateral normal is `(-uz, ux)` (the left normal of the
+ *  chord direction), so a post with `lateral > 0` (even slot, `postLateralSign = +1`) lands on the
+ *  positive side and vice versa — the sign of this value is what `checkPosts` compares against
+ *  `postLateralSign(i)`. */
+function signedPerpDist(
+    px: number,
+    pz: number,
+    ax: number,
+    az: number,
+    bx: number,
+    bz: number,
+): number {
+    const dx = bx - ax;
+    const dz = bz - az;
+    const len = Math.hypot(dx, dz);
+    if (len === 0) return 0;
+    return (dx * (pz - az) - dz * (px - ax)) / len;
+}
+
 /** the device gate's posts check: reads back the posts buffer and verifies every Validation criterion —
- *  every live slot's `y` equals CPU `flattenFieldAt` at its `(x, z)`, the lateral offset is inside the
- *  flat core, the live-slot count is `floor(chordLength / POST_SPACING)`, and every slot past the chord
+ *  every live slot's `y` equals CPU `flattenFieldAt` at its `(x, z)` (baked against the live seed via
+ *  `getCurrentSeed`, not the boot `SEED` — an F9 reseed changes the permutation and the falloff, so a
+ *  stale-seed twin produces a false negative), the lateral offset is inside the flat core, each live
+ *  slot is on the side `postLateralSign(i)` predicts (the alternation the distance band alone never
+ *  checks), the live-slot count is `floor(chordLength / POST_SPACING)`, and every slot past the chord
  *  is at scale 0. Called from `gate.ts` at boot and from `boot.ts`'s `__roadsPostsCheck` bridge after an
  *  edit. */
 export async function checkPosts(): Promise<Check> {
     const posts = await readPosts();
     const doc = getDocument();
-    const perm = makePermutation(SEED);
-    const { segments, cutDepth } = buildNetworkGeometry(doc, SEED);
+    const seed = getCurrentSeed();
+    const perm = makePermutation(seed);
+    const { segments, cutDepth } = buildNetworkGeometry(doc, seed);
     const falloff = computeFalloff(cutDepth);
     const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
 
@@ -477,6 +501,7 @@ export async function checkPosts(): Promise<Check> {
     let liveCount = 0;
     let maxDiff = 0;
     let lateralOk = true;
+    let lateralSignOk = true;
     let scale0Ok = true;
 
     for (let i = 0; i < posts.length; i++) {
@@ -488,16 +513,23 @@ export async function checkPosts(): Promise<Check> {
             maxDiff = Math.max(maxDiff, Math.abs(rec.y - expectedY));
             const dist = perpDist(rec.x, rec.z, a[0], a[1], b[0], b[1]);
             if (dist > halfWidth + FLAT_CORE_MARGIN || dist < halfWidth) lateralOk = false;
+            // the alternation check: each live slot must be on the side `postLateralSign(i)` predicts
+            // (even → +1, odd → −1). The kernel's `select(1f, -1f, (i & 1u) == 1u)` and this CPU twin
+            // must agree on which side of the road every post sits — the distance band alone never
+            // catches a swapped or constant sign. This gives `postLateralSign` a production reader.
+            const signed = signedPerpDist(rec.x, rec.z, a[0], a[1], b[0], b[1]);
+            if (Math.sign(signed) !== postLateralSign(i)) lateralSignOk = false;
         } else {
             if (station <= chordLength) scale0Ok = false;
         }
     }
 
     const expectedLive = liveSlotCount(chordLength);
-    const pass = maxDiff < 0.01 && liveCount === expectedLive && lateralOk && scale0Ok;
+    const pass =
+        maxDiff < 0.01 && liveCount === expectedLive && lateralOk && lateralSignOk && scale0Ok;
     return {
         name: "post-placement",
         pass,
-        detail: `live=${liveCount}/${expectedLive} maxDiff=${maxDiff.toFixed(6)} lateralOk=${lateralOk} scale0Ok=${scale0Ok}`,
+        detail: `live=${liveCount}/${expectedLive} maxDiff=${maxDiff.toFixed(6)} lateralOk=${lateralOk} lateralSignOk=${lateralSignOk} scale0Ok=${scale0Ok}`,
     };
 }

--- a/examples/showcase/roads/src/posts.ts
+++ b/examples/showcase/roads/src/posts.ts
@@ -1,0 +1,503 @@
+// Stage 5 — posts (`roads-interactive.md` stage 5). A row of abstract posts along the road, positioned
+// entirely on the GPU: a compute kernel writes one `Post` record per slot (station along the chord,
+// lateral offset alternating sides, `y` from `flatten.ts`'s own `flattenedHeightAt` TGSL fn, scale 0 for
+// slots past the chord), and a custom surface's VS scales the standard `capsule` mesh by the post
+// dimensions and translates by the record. The fountain showcase's shape: a typed record buffer written
+// by compute, read by a custom surface's VS at `input.iid`, one shared mesh, `Draws.register` with a
+// fixed `instanceCount`. The records never touch Part or the Transform slabs.
+//
+// `POST_COUNT` is sized off the world's own diagonal (`WORLD_EXTENT · √2` ≈ 1448 m, since
+// `ROAD_MAX_LENGTH` was deleted in stage 4c) divided by `POST_SPACING`, so `instanceCount` stays fixed
+// across edits and short chords leave most slots at scale 0. Re-dispatched after every `setNetwork` (edit
+// and reseed), never per frame — `terrain.ts`'s `warm`, `regenerate`, and `editDocument` each call
+// `dispatchPosts(seed)` after `setNetwork`.
+
+import { Compute, type State } from "@dylanebert/shallot";
+import {
+    type Draw,
+    DrawIndexedIndirect,
+    type DrawIndirectBuffer,
+    Draws,
+    Meshes,
+} from "@dylanebert/shallot/render/core";
+import { precompile, precompileScope } from "@dylanebert/shallot/runtime";
+import {
+    fsCtxSchema,
+    lit,
+    registerSurface,
+    surfaceLayout,
+    VsIn,
+    vsPatchSchema,
+} from "@dylanebert/shallot/sear/core";
+import tgpu, { type StorageFlag, type TgpuBuffer } from "typegpu";
+import * as d from "typegpu/data";
+import * as std from "typegpu/std";
+import { flattenFieldAt } from "./flatness";
+import type { Check } from "./harness";
+import {
+    buildNetworkGeometry,
+    computeFalloff,
+    flattenedHeightAt,
+    networkBindGroup,
+    networkLayout,
+} from "./terrain/flatten";
+import { FLAT_CORE_MARGIN } from "./terrain/flatten-math";
+import { SPACING, WORLD_EXTENT } from "./terrain/grid";
+import { makePermutation, noiseLayout, PermData } from "./terrain/noise";
+import { heightAtCpu } from "./terrain/profile";
+import { getDocument, SEED } from "./terrain/terrain";
+
+// --- constants --------------------------------------------------------------
+
+/** metres between posts along the chord. */
+export const POST_SPACING = 20;
+
+/** the lateral offset from the road edge to the post centre, in metres.
+ *
+ *  Derivation of the admissible band. The flat core is the region where `coreDist <= 0`, where
+ *  `coreDist = distance(point, segment) − (halfWidth + FLAT_CORE_MARGIN)` (`flatten.ts`'s `networkCore`).
+ *  The flat core extends from the centreline (perpendicular distance 0) to `halfWidth + FLAT_CORE_MARGIN`
+ *  from it. A post at `halfWidth + POST_OFFSET` from the centreline is inside the flat core iff
+ *  `POST_OFFSET <= FLAT_CORE_MARGIN`. For the post to sit outside the road surface (not on the road),
+ *  `POST_OFFSET > 0`. For the post's foot to meet the *rendered surface* rather than the field's idea of
+ *  it — the property Validation names: inside the flat core the field is affine and the rendered mesh
+ *  reproduces it exactly — the post must be strictly inside, so `POST_OFFSET < FLAT_CORE_MARGIN`.
+ *  Therefore the admissible band is `0 < POST_OFFSET < FLAT_CORE_MARGIN`.
+ *  `FLAT_CORE_MARGIN = √2 · SPACING = √2 · 4 ≈ 5.657 m` (`flatten-math.ts`).
+ *  `POST_OFFSET = SPACING = 4 m` sits well inside the band (0 < 4 < 5.657).
+ *
+ *  The spec's Approach wrote the offset as `halfWidth + FLAT_CORE_MARGIN − √2·SPACING` from the
+ *  centreline, but `FLAT_CORE_MARGIN = √2 · SPACING`, so that expression reduces to exactly `halfWidth` —
+ *  the flat core's *inner* edge, not a point inside it. The real constraint is `0 < POST_OFFSET <
+ *  FLAT_CORE_MARGIN`, derived above. (Open question 1 — reported to the spec owner for correction.) */
+export const POST_OFFSET = SPACING;
+
+/** the post's visual height in metres. The capsule mesh spans y ∈ [−1, 1] (height 2), so the VS scales
+ *  y by `POST_HEIGHT / 2`. */
+const POST_HEIGHT = 4;
+
+/** the post's visual radius in metres. The capsule mesh has radius 0.5, so the VS scales x/z by
+ *  `POST_RADIUS / 0.5 = POST_RADIUS * 2`. */
+const POST_RADIUS = 0.3;
+
+/** the world's own diagonal — the maximum chord length the world contains (`WORLD_EXTENT · √2` ≈ 1448 m),
+ *  since `ROAD_MAX_LENGTH` was deleted in stage 4c. This is the ceiling `POST_COUNT` is sized against. */
+const WORLD_DIAGONAL = WORLD_EXTENT * Math.SQRT2;
+
+/** the fixed slot count — sized off the world's own diagonal divided by `POST_SPACING`, so `instanceCount`
+ *  stays fixed across edits and short chords leave most slots at scale 0. */
+export const POST_COUNT = Math.ceil(WORLD_DIAGONAL / POST_SPACING);
+
+const POST_WORKGROUP = 64;
+const POST_DISPATCH = Math.ceil(POST_COUNT / POST_WORKGROUP);
+
+// --- pure derivation functions (device-free, for the test seam and the gate) -----
+
+/** the station (metres along the chord from endpoint A) of slot `i`. The first post sits at
+ *  `POST_SPACING` (not station 0, the endpoint), so the live-slot count is
+ *  `floor(chordLength / POST_SPACING)` — matching Validation's assertion, not `floor(...) + 1`.
+ *  (Open question 2 — reported to the spec owner for correction: Approach wrote `i · POST_SPACING`,
+ *  which puts a post at station 0 and makes the count `floor(...) + 1`.) */
+export function postStation(i: number): number {
+    return (i + 1) * POST_SPACING;
+}
+
+/** the lateral offset sign for slot `i`: +1 for even slots, −1 for odd — alternating sides of the road. */
+export function postLateralSign(i: number): number {
+    return i % 2 === 0 ? 1 : -1;
+}
+
+/** the number of live (non-zero-scale) slots for a chord of `chordLength` metres:
+ *  `floor(chordLength / POST_SPACING)`. */
+export function liveSlotCount(chordLength: number): number {
+    return Math.floor(chordLength / POST_SPACING);
+}
+
+/** whether slot `i` is live (scale ≠ 0) for a chord of `chordLength` metres: the station is within the
+ *  chord (`station <= chordLength`). Slots past the chord are scale 0. */
+export function isLiveSlot(i: number, chordLength: number): boolean {
+    return postStation(i) <= chordLength;
+}
+
+// --- Post record + layouts ---------------------------------------------------
+
+/** the compute kernel's output / the surface VS's input: world position (x, y, z) + scale in `w`
+ *  (0 = hidden, 1 = visible). The fountain's `Particle` shape — a typed record buffer written by
+ *  compute, read by a custom surface's VS at `input.iid`. */
+const Post = d.struct({ pos: d.vec4f }).$name("Post");
+const PostArray = d.arrayOf(Post, POST_COUNT);
+const POST_BYTES = d.sizeOf(PostArray);
+
+/** the compute kernel's bind group layout — one mutable storage buffer of `POST_COUNT` `Post` records. */
+const postsComputeLayout = tgpu.bindGroupLayout({
+    posts: { storage: PostArray, access: "mutable" },
+});
+
+/** the surface's bind group layout — the VS reads the same buffer by instance id. The binding name
+ *  matches the `Compute.buffers`/`Compute.typed` key the renderer resolves by name (fountain's shape). */
+const postsSurfaceLayout = surfaceLayout({
+    posts: { type: "storage", element: Post },
+});
+
+// --- compute kernel ---------------------------------------------------------
+
+/** one thread per slot: read the chord from `networkLayout`'s segment 0, compute station and lateral
+ *  offset, get `y` from `flattenedHeightAt` (the height kernel's own TGSL fn, bound through the same
+ *  network bind group — never re-derived on the CPU for this consumer), and write scale 0 for slots past
+ *  the chord's length. */
+const postsKernel = tgpu
+    .computeFn({
+        workgroupSize: [POST_WORKGROUP],
+        in: { gid: d.builtin.globalInvocationId },
+    })((input) => {
+        "use gpu";
+        const i = input.gid.x;
+        if (i >= d.u32(POST_COUNT)) return;
+
+        const seg = networkLayout.$.segments[0];
+        const ax = seg.a.x;
+        const az = seg.a.y;
+        const bx = seg.b.x;
+        const bz = seg.b.y;
+        const halfWidth = seg.halfWidth;
+
+        const abx = bx - ax;
+        const abz = bz - az;
+        const chordLength = std.sqrt(abx * abx + abz * abz);
+
+        const station = (d.f32(i) + d.f32(1)) * d.f32(POST_SPACING);
+
+        if (station > chordLength) {
+            postsComputeLayout.$.posts[i] = Post({ pos: d.vec4f(0, 0, 0, 0) });
+            return;
+        }
+
+        const ux = abx / chordLength;
+        const uz = abz / chordLength;
+        const nx = -uz;
+        const nz = ux;
+
+        const cx = ax + ux * station;
+        const cz = az + uz * station;
+
+        const sign = std.select(d.f32(1), d.f32(-1), (i & d.u32(1)) === d.u32(1));
+        const lateral = (halfWidth + d.f32(POST_OFFSET)) * sign;
+
+        const px = cx + nx * lateral;
+        const pz = cz + nz * lateral;
+        const py = flattenedHeightAt(px, pz);
+
+        postsComputeLayout.$.posts[i] = Post({ pos: d.vec4f(px, py, pz, d.f32(1)) });
+    })
+    .$name("posts-kernel");
+
+/** the emitted posts WGSL — the device-free structural seam `posts.test.ts` resolves. Contains
+ *  `flattenedHeightAt` (the named oracle, Validation's "the resolved posts WGSL contains
+ *  `flattenedHeightAt`"). */
+export function postsWgsl(): string {
+    return tgpu.resolve([flattenedHeightAt, postsKernel], { names: "strict" });
+}
+
+// --- surface (VS + FS) -------------------------------------------------------
+
+const postsPatch = vsPatchSchema({});
+
+const postsVs = tgpu.fn(
+    [VsIn],
+    postsPatch,
+)((input) => {
+    "use gpu";
+    const record = postsSurfaceLayout.$.posts[input.iid];
+    const scale = record.pos.w;
+    const worldPos = record.pos.xyz;
+
+    // scale the unit capsule (radius 0.5, y ∈ [−1, 1]) to post dimensions, then translate.
+    // y is offset by POST_HEIGHT/2 so the foot (bottom) sits at worldPos.y (the terrain surface).
+    const sx = input.localPos.x * d.f32(POST_RADIUS * 2) * scale;
+    const sy = input.localPos.y * d.f32(POST_HEIGHT / 2) * scale + d.f32(POST_HEIGHT / 2) * scale;
+    const sz = input.localPos.z * d.f32(POST_RADIUS * 2) * scale;
+
+    return postsPatch({
+        world: d.vec4f(sx + worldPos.x, sy + worldPos.y, sz + worldPos.z, d.f32(1)),
+        worldNormal: input.worldNormal,
+        clip: d.vec4f(0),
+    });
+});
+
+const POST_COLOR: readonly [number, number, number] = [0.5, 0.4, 0.3];
+
+const postsFs = tgpu.fn(
+    [fsCtxSchema({})],
+    d.vec4f,
+)((ctx) => {
+    "use gpu";
+    const color = d.vec3f(d.f32(POST_COLOR[0]), d.f32(POST_COLOR[1]), d.f32(POST_COLOR[2]));
+    return d.vec4f(lit(color, ctx.worldNormal), d.f32(1));
+});
+
+// --- lifecycle ---------------------------------------------------------------
+
+type PostsRoot = typeof Compute.root;
+type PostsPipeline = ReturnType<PostsRoot["createComputePipeline"]>;
+type PostsBindGroup = ReturnType<PostsRoot["createBindGroup"]>;
+type PostBuffer = TgpuBuffer<typeof PostArray> & StorageFlag;
+
+let postsRaw: GPUBuffer | null = null;
+let postsTyped: PostBuffer | null = null;
+let postsPermRaw: GPUBuffer | null = null;
+let argsRaw: GPUBuffer | null = null;
+let argsTyped: DrawIndirectBuffer | null = null;
+let pipeline: PostsPipeline | null = null;
+let bindGroup: PostsBindGroup | null = null;
+let draw: Draw | null = null;
+
+function teardown(): void {
+    if (draw) Draws.delete(draw.name);
+    postsRaw?.destroy();
+    postsPermRaw?.destroy();
+    argsRaw?.destroy();
+    postsRaw = null;
+    postsTyped = null;
+    postsPermRaw = null;
+    argsRaw = null;
+    argsTyped = null;
+    pipeline = null;
+    bindGroup = null;
+    draw = null;
+    postsWarmed = false;
+}
+
+/** allocate the posts buffer, pipeline, bind group, and registered draw. Call once from
+ *  `terrain.ts`'s `warm()`, after the capsule mesh is registered (Part plugin). Ties cleanup to
+ *  `state.onDispose` (the same in-place-rebuild-safe pattern `terrain.ts` uses). */
+export function warmPosts(state: State): void {
+    teardown();
+    state.onDispose(teardown);
+    const { device, root } = Compute;
+
+    postsRaw = device.createBuffer({
+        label: "posts-records",
+        size: POST_BYTES,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    postsTyped = root.createBuffer(PostArray, postsRaw).$usage("storage");
+
+    argsRaw = device.createBuffer({
+        label: "posts-draw-args",
+        size: d.sizeOf(DrawIndexedIndirect),
+        usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST,
+    });
+    argsTyped = root.createBuffer(DrawIndexedIndirect, argsRaw).$usage("indirect");
+
+    const capsule = Meshes.get("capsule");
+    if (!capsule) throw new Error("posts: capsule mesh not registered");
+    argsTyped.write({
+        indexCount: capsule.indexCount,
+        instanceCount: POST_COUNT,
+        firstIndex: capsule.indexBase,
+        baseVertex: 0,
+        firstInstance: 0,
+    });
+
+    pipeline = root.createComputePipeline({ compute: postsKernel }).$name("posts-dispatch");
+    bindGroup = root.createBindGroup(postsComputeLayout, { posts: postsTyped });
+
+    const drawSpec: Draw = {
+        name: "posts",
+        surface: "posts",
+        mesh: "capsule",
+        args: { indirect: argsTyped },
+    };
+    draw = drawSpec;
+    Draws.register(drawSpec);
+
+    registerSurface(state, {
+        name: "posts",
+        layout: postsSurfaceLayout,
+        vs: postsVs,
+        fs: postsFs,
+    });
+
+    // publish the posts buffer so the surface renderer resolves the "posts" binding by name
+    Compute.buffers.set("posts", postsRaw);
+    Compute.typed.set("posts", postsTyped);
+}
+
+let postsWarmed = false;
+
+/** dispatch the posts compute kernel — one thread per slot, writing every `Post` record. Call after
+ *  every `setNetwork` (the network bind group must be up-to-date so the kernel reads the current chord
+ *  and `flattenedHeightAt` uses the current falloff). Never per frame. Precompiles the pipeline on the
+ *  first call (the same `precompile` pattern `generate.ts`'s `run` uses), binding all three layouts the
+ *  kernel closes over — `postsComputeLayout`, `networkLayout`, and `noiseLayout` (through
+ *  `flattenedHeightAt` → `heightAt`) — with temporary warm buffers that are destroyed after. */
+export async function dispatchPosts(seed: number): Promise<void> {
+    if (!pipeline || !bindGroup) throw new Error("posts: dispatch before warmPosts");
+    const activePipeline = pipeline;
+    const activeBindGroup = bindGroup;
+    const { device, root } = Compute;
+
+    if (!postsWarmed) {
+        const warmLabel = precompileScope("posts-dispatch");
+        const owned: { raw: GPUBuffer | null } = { raw: null };
+        try {
+            await precompile(warmLabel, () => {
+                owned.raw = device.createBuffer({
+                    label: `${warmLabel}-perm`,
+                    size: d.sizeOf(PermData),
+                    usage: GPUBufferUsage.STORAGE,
+                });
+                const warmPerm = root.createBuffer(PermData, owned.raw).$usage("storage");
+                const noiseGroup = root.createBindGroup(noiseLayout, { perm: warmPerm });
+                const enc = device.createCommandEncoder({ label: warmLabel });
+                const pass = enc.beginComputePass({ label: warmLabel });
+                activePipeline
+                    .with(noiseGroup)
+                    .with(activeBindGroup)
+                    .with(networkBindGroup())
+                    .with(pass)
+                    .dispatchWorkgroups(0);
+                pass.end();
+                device.queue.submit([enc.finish()]);
+                return activePipeline;
+            });
+        } finally {
+            owned.raw?.destroy();
+        }
+        postsWarmed = true;
+    }
+
+    // The kernel closes over three layouts: postsComputeLayout (the output buffer), networkLayout
+    // (the chord segments + falloff, set by setNetwork), and noiseLayout (the permutation, through
+    // flattenedHeightAt → heightAt). The precompile above attaches all three; the actual dispatch must
+    // attach all three too — the noise bind group carries the seed's permutation so heightAt matches
+    // the CPU twin flattenFieldAt's makePermutation(seed). Mirrors generate.ts's run(), which creates
+    // a fresh permutation buffer per dispatch and keeps it alive until the next one.
+    const perm = makePermutation(seed);
+    const nextRaw = device.createBuffer({
+        label: "posts-perm",
+        size: perm.byteLength,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    try {
+        const nextPerm = root.createBuffer(PermData, nextRaw).$usage("storage");
+        device.queue.writeBuffer(nextRaw, 0, perm as Uint32Array<ArrayBuffer>);
+        const noiseGroup = root.createBindGroup(noiseLayout, { perm: nextPerm });
+        const enc = device.createCommandEncoder({ label: "posts-dispatch" });
+        const pass = enc.beginComputePass({ label: "posts-dispatch" });
+        activePipeline
+            .with(noiseGroup)
+            .with(activeBindGroup)
+            .with(networkBindGroup())
+            .with(pass)
+            .dispatchWorkgroups(POST_DISPATCH);
+        pass.end();
+        device.queue.submit([enc.finish()]);
+    } catch (cause) {
+        nextRaw.destroy();
+        throw cause;
+    }
+    postsPermRaw?.destroy();
+    postsPermRaw = nextRaw;
+}
+
+// --- readback + gate --------------------------------------------------------
+
+/** one post record as read back from the GPU — the bridge's return shape. */
+interface PostRecord {
+    x: number;
+    y: number;
+    z: number;
+    scale: number;
+}
+
+/** one-shot GPU→CPU readback of the posts buffer — the device gate's readback arm. Mirrors the
+ *  fountain's `readParticles` and `terrain.ts`'s `readVertices`; an assert-only bridge, never a
+ *  per-frame readback. */
+async function readPosts(): Promise<PostRecord[]> {
+    if (!postsRaw) throw new Error("posts: readPosts before warmPosts");
+    const { device } = Compute;
+    const staging = device.createBuffer({
+        label: "posts-readback",
+        size: POST_BYTES,
+        usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    });
+    let mapped = false;
+    try {
+        const enc = device.createCommandEncoder({ label: "posts-readback" });
+        enc.copyBufferToBuffer(postsRaw, 0, staging, 0, POST_BYTES);
+        device.queue.submit([enc.finish()]);
+        await staging.mapAsync(GPUMapMode.READ);
+        mapped = true;
+        const data = new Float32Array(staging.getMappedRange().slice(0));
+        const records: PostRecord[] = [];
+        for (let i = 0; i < POST_COUNT; i++) {
+            const off = i * 4;
+            records.push({
+                x: data[off],
+                y: data[off + 1],
+                z: data[off + 2],
+                scale: data[off + 3],
+            });
+        }
+        return records;
+    } finally {
+        if (mapped) staging.unmap();
+        staging.destroy();
+    }
+}
+
+/** the perpendicular distance from (px, pz) to the line through (ax, az) and (bx, bz). */
+function perpDist(px: number, pz: number, ax: number, az: number, bx: number, bz: number): number {
+    const dx = bx - ax;
+    const dz = bz - az;
+    const len = Math.hypot(dx, dz);
+    if (len === 0) return Math.hypot(px - ax, pz - az);
+    return Math.abs((dx * (pz - az) - dz * (px - ax)) / len);
+}
+
+/** the device gate's posts check: reads back the posts buffer and verifies every Validation criterion —
+ *  every live slot's `y` equals CPU `flattenFieldAt` at its `(x, z)`, the lateral offset is inside the
+ *  flat core, the live-slot count is `floor(chordLength / POST_SPACING)`, and every slot past the chord
+ *  is at scale 0. Called from `gate.ts` at boot and from `boot.ts`'s `__roadsPostsCheck` bridge after an
+ *  edit. */
+export async function checkPosts(): Promise<Check> {
+    const posts = await readPosts();
+    const doc = getDocument();
+    const perm = makePermutation(SEED);
+    const { segments, cutDepth } = buildNetworkGeometry(doc, SEED);
+    const falloff = computeFalloff(cutDepth);
+    const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
+
+    const line = doc.polylines[0];
+    const [a, b] = line.points;
+    const chordLength = Math.hypot(b[0] - a[0], b[1] - a[1]);
+    const halfWidth = line.halfWidth;
+
+    let liveCount = 0;
+    let maxDiff = 0;
+    let lateralOk = true;
+    let scale0Ok = true;
+
+    for (let i = 0; i < posts.length; i++) {
+        const rec = posts[i];
+        const station = postStation(i);
+        if (rec.scale !== 0) {
+            liveCount++;
+            const expectedY = flattenFieldAt(rec.x, rec.z, segments, falloff, natural);
+            maxDiff = Math.max(maxDiff, Math.abs(rec.y - expectedY));
+            const dist = perpDist(rec.x, rec.z, a[0], a[1], b[0], b[1]);
+            if (dist > halfWidth + FLAT_CORE_MARGIN || dist < halfWidth) lateralOk = false;
+        } else {
+            if (station <= chordLength) scale0Ok = false;
+        }
+    }
+
+    const expectedLive = liveSlotCount(chordLength);
+    const pass = maxDiff < 0.01 && liveCount === expectedLive && lateralOk && scale0Ok;
+    return {
+        name: "post-placement",
+        pass,
+        detail: `live=${liveCount}/${expectedLive} maxDiff=${maxDiff.toFixed(6)} lateralOk=${lateralOk} scale0Ok=${scale0Ok}`,
+    };
+}

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -499,6 +499,16 @@ export function getDocument(): StrokeDocument {
     return liveDocument;
 }
 
+/** the seed the height kernel was last dispatched with — the live permutation seed, not the boot
+ *  constant `SEED`. After an F9 reseed (`regenerate`) this differs from `SEED`, and a CPU twin that
+ *  bakes against `SEED` instead of this accessor (e.g. `checkPosts`'s `makePermutation`/
+ *  `buildNetworkGeometry`, which formerly used `SEED`) diverges from the GPU output — the permutation
+ *  and the falloff change with the seed. An accessor rather than exporting `currentSeed` directly so the
+ *  mutable module state stays write-only from outside this module. */
+export function getCurrentSeed(): number {
+    return currentSeed;
+}
+
 /**
  * re-bake {@link liveDocument}'s flatten geometry for `seed` without swapping the document or touching the
  * overlay — `gate.ts`'s own seed-determinism probe dispatches `generate` at seeds other than the live

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -33,6 +33,7 @@ import {
     TILE_SIZE,
     TILES_PER_SIDE,
 } from "../overlay/tiles";
+import { dispatchPosts, warmPosts } from "../posts";
 import { setNetwork, warmNetwork } from "./flatten";
 import { bindTerrainKernel, generate, TERRAIN_QUANT } from "./generate";
 import {
@@ -423,9 +424,11 @@ async function warm(state: State): Promise<void> {
 
     bindTerrainKernel(vertices, position);
     warmNetwork(state); // its own onDispose registration, the same pattern
+    warmPosts(state); // posts buffer + surface + registered draw (stage 5)
     setNetwork(liveDocument, currentSeed); // the flatten kernel's geometry input, kept in sync with
     // the overlay's own document and the height kernel's own permutation seed
     overlayAtlas.updateChord(liveDocument); // the fs's marking geometry input (stage 8)
+    await dispatchPosts(currentSeed); // write post positions for the boot chord (stage 5)
     if (state.signal.aborted) return;
     await generate(SEED);
 }
@@ -462,6 +465,7 @@ export async function regenerate(seed: number): Promise<void> {
     currentSeed = seed;
     liveDocument = generateNetwork();
     setNetwork(liveDocument, seed);
+    await dispatchPosts(seed); // re-write post positions for the reset chord (stage 5)
     overlayAtlas.updateChord(liveDocument);
     overlayAtlas.invalidate();
     overlayAtlas.markDirty(liveDocument);
@@ -482,6 +486,7 @@ export async function editDocument(doc: StrokeDocument): Promise<void> {
     const oldDoc = liveDocument;
     liveDocument = doc;
     setNetwork(doc, currentSeed);
+    await dispatchPosts(currentSeed); // re-write post positions for the edited chord (stage 5)
     overlayAtlas.updateChord(doc);
     overlayAtlas.retile(oldDoc, doc);
     await generate(currentSeed);

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -698,8 +698,9 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
     // Phase 6.5: stage 5's post-placement re-check after an edit. The gate already checked posts at
     // boot (Phase 1); this re-verifies on the edited chord — the Validation criterion "re-read after an
     // __roadsEdit". The bridge reads back the posts buffer and checks y = flattenFieldAt, lateral
-    // inside the flat core, live-slot count, and scale-0 — all in the browser (flattenFieldAt is not
-    // Node-safe), so the test only reads the pass/fail verdict.
+    // inside the flat core, lateral sign matches postLateralSign(i), live-slot count, and scale-0 —
+    // all in the browser (flattenFieldAt is not Node-safe), so the test only reads the pass/fail
+    // verdict.
     const postsCheck = (await page.evaluate(() =>
         (
             window as unknown as {

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -716,6 +716,71 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
 
     expect(errors, errors.join("\n")).toEqual([]);
 
+    // Phase 7: reseed-then-drag handle-height arm — the witnessing arm for the edit.ts CPU-twin fix
+    // (edit.ts's `makePermutation`/`buildNetworkGeometry` now bake against `getCurrentSeed()` instead
+    // of the boot `SEED`). After an F9 reseed the GPU terrain is at the reseeded seed, so the handle's
+    // `y` — set by `EditSystem.update` as `heightAtCpu(x, z, makePermutation(getCurrentSeed()))` — must
+    // match `heightAtCpu` at the reseeded seed's permutation, not the boot seed's. Against the pre-fix
+    // code (which used `SEED = 1337`), the handle's `y` would be `heightAtCpu(x, z, makePermutation(1337))`
+    // while the terrain is at the reseeded seed — a device-visible divergence after every reseed.
+    const reseedSeed = 77777;
+    await page.evaluate(
+        (s) =>
+            (
+                window as unknown as { __roadsRegenerate: (seed: number) => Promise<void> }
+            ).__roadsRegenerate(s),
+        reseedSeed,
+    );
+    await page.waitForFunction(
+        () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
+        null,
+        { timeout: 10_000 },
+    );
+
+    // drive an edit on the reseeded terrain: move endpoint 1 to (60, -40) — within bounds, chord
+    // length ≈ 165 m (well above ROAD_MIN_LENGTH = 80), so no clamping intervenes.
+    const reseedEditEnd = 1;
+    const reseedEditX = 60;
+    const reseedEditZ = -40;
+    const reseedApplied = (await page.evaluate(
+        ({ end, x, z }) =>
+            (
+                window as unknown as {
+                    __roadsEdit: (end: number, x: number, z: number) => Promise<boolean>;
+                }
+            ).__roadsEdit(end, x, z),
+        { end: reseedEditEnd, x: reseedEditX, z: reseedEditZ },
+    )) as boolean;
+    expect(reseedApplied, `reseed edit to (${reseedEditX}, ${reseedEditZ}) was not applied`).toBe(
+        true,
+    );
+
+    await page.waitForFunction(
+        () => (window as unknown as { __roadsOverlayIdle: () => boolean }).__roadsOverlayIdle(),
+        null,
+        { timeout: 10_000 },
+    );
+
+    // read the handle position and assert y matches heightAtCpu at the reseeded seed's permutation
+    const reseedHandlePos = (await page.evaluate(() =>
+        (
+            window as unknown as {
+                __roadsHandlePos: () => [[number, number, number], [number, number, number]];
+            }
+        ).__roadsHandlePos(),
+    )) as [[number, number, number], [number, number, number]];
+    const reseedPerm = makePermutation(reseedSeed);
+    const reseedExpectedY = heightAtCpu(reseedEditX, reseedEditZ, reseedPerm);
+    expect(reseedHandlePos[reseedEditEnd][0]).toBeCloseTo(reseedEditX, 1);
+    expect(reseedHandlePos[reseedEditEnd][2]).toBeCloseTo(reseedEditZ, 1);
+    // f32 tolerance (4 decimal places, ~5e-5 m) — the handle's y is heightAtCpu at the reseeded
+    // seed, not the boot seed. Against the pre-fix code this reds because edit.ts baked against
+    // SEED = 1337 while the terrain is at reseedSeed = 77777 — the permutations differ, so the
+    // heights differ by far more than f32 rounding.
+    expect(reseedHandlePos[reseedEditEnd][1]).toBeCloseTo(reseedExpectedY, 4);
+
+    expect(errors, errors.join("\n")).toEqual([]);
+
     // Restore the boot document so subsequent runs and the live view start from the standard chord.
     await page.evaluate(
         (s) =>

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -695,6 +695,26 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
 
     expect(errors, errors.join("\n")).toEqual([]);
 
+    // Phase 6.5: stage 5's post-placement re-check after an edit. The gate already checked posts at
+    // boot (Phase 1); this re-verifies on the edited chord — the Validation criterion "re-read after an
+    // __roadsEdit". The bridge reads back the posts buffer and checks y = flattenFieldAt, lateral
+    // inside the flat core, live-slot count, and scale-0 — all in the browser (flattenFieldAt is not
+    // Node-safe), so the test only reads the pass/fail verdict.
+    const postsCheck = (await page.evaluate(() =>
+        (
+            window as unknown as {
+                __roadsPostsCheck: () => Promise<{
+                    name: string;
+                    pass: boolean;
+                    detail: string;
+                }>;
+            }
+        ).__roadsPostsCheck(),
+    )) as { name: string; pass: boolean; detail: string };
+    expect(postsCheck.pass, `post-placement check after edit: ${postsCheck.detail}`).toBe(true);
+
+    expect(errors, errors.join("\n")).toEqual([]);
+
     // Restore the boot document so subsequent runs and the live view start from the standard chord.
     await page.evaluate(
         (s) =>


### PR DESCRIPTION
- **roads-interactive: 5 — posts as GPU-owned instanced draw**
- **roads-interactive: 5 — posts repair pass (live seed, structural arm, lateral sign oracle)**
- **roads-interactive: 5 — fix edit.ts CPU twin to bake at getCurrentSeed() not SEED**
