### PR TITLE
roads interactive/9

### DIFF
--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -6,6 +6,7 @@ import {
     chordLength,
     clampDragTarget,
     clampToBound,
+    projectRayToBound,
     residentTileCount,
 } from "./editPure";
 import { buildLatticeVertices, checkSurfaceFlatness } from "./flatness";
@@ -374,5 +375,114 @@ describe("edit — sticky grab latch (stage 4b)", () => {
         // second press over handle 1
         s = stepGrab(s, true, 1);
         expect(s).toEqual({ dragging: true, dragEnd: 1, prevLeft: true });
+    });
+});
+
+describe("edit — no no-op frames in the drag's target derivation (stage 9)", () => {
+    // The clamp-never-refuse law applied to the drag's whole derivation chain, not just the constraints
+    // at its end. Three no-op paths shipped: stale cursor coordinates (the engine seam, fixed in
+    // `input/index.ts`), a missed march holding `lastValidTarget` (fixed: the miss now projects onto
+    // the world bound), and a null ray skipping the frame outright (fixed: the `if (dragging && ray)`
+    // guard is gone). The contract: while a drag is held, every frame produces a target.
+    //
+    // RED-FIRST WITNESS: against the shipped shape, `marchFlattenField` returned null on a miss and
+    // the caller held `lastValidTarget`. The arm witnesses the red by asserting `projectRayToBound`
+    // returns a target inside the world bound for rays that miss the field entirely (aimed at the
+    // sky, aimed past MARCH_MAX), and that the target differs between ray directions (never the
+    // previous frame's target). The failure text witnessed before the fix:
+    //   "expected null to not be null" (marchFlattenField returned null for a skyward ray)
+    //
+    // The companion arm asserts `lastValidTarget` has no readers — a hold path that still exists
+    // anywhere in `edit.ts` after this stage is the finding.
+
+    const Bound = WORLD_HALF - ROAD_HALF_WIDTH;
+
+    test("projectRayToBound returns a target inside the world bound for every ray direction", () => {
+        // a camera position above the world centre, looking outward
+        const origin: [number, number, number] = [0, 200, 0];
+        // a scan of ray directions: aimed at the sky, aimed past MARCH_MAX, and normal downward rays
+        const directions: { dir: [number, number, number]; label: string }[] = [
+            // aimed at the sky (dy > 0) — the ray goes up, never crosses the ground
+            { dir: [0.3, 0.5, 0.4], label: "skyward (up-right)" },
+            { dir: [-0.2, 0.8, 0.1], label: "skyward (up-left)" },
+            { dir: [0, 1, 0], label: "straight up" },
+            // aimed so the crossing sits past MARCH_MAX — very shallow downward angle
+            { dir: [0.999, -0.001, 0.001], label: "shallow past MARCH_MAX (x-axis)" },
+            { dir: [0.001, -0.001, 0.999], label: "shallow past MARCH_MAX (z-axis)" },
+            // normal downward rays
+            { dir: [0.3, -0.7, 0.4], label: "downward (right-forward)" },
+            { dir: [-0.5, -0.5, -0.5], label: "downward (left-back)" },
+            { dir: [0, -1, 0], label: "straight down" },
+            // horizontal rays
+            { dir: [1, 0, 0], label: "horizontal (x-axis)" },
+            { dir: [0, 0, 1], label: "horizontal (z-axis)" },
+        ];
+
+        for (const { dir, label } of directions) {
+            const [x, z] = projectRayToBound(origin, dir);
+            expect(
+                Math.abs(x),
+                `${label}: |x|=${Math.abs(x)} past bound ${Bound}`,
+            ).toBeLessThanOrEqual(Bound);
+            expect(
+                Math.abs(z),
+                `${label}: |z|=${Math.abs(z)} past bound ${Bound}`,
+            ).toBeLessThanOrEqual(Bound);
+        }
+    });
+
+    test("projectRayToBound never returns the previous frame's target — different rays yield different targets", () => {
+        const origin: [number, number, number] = [0, 200, 0];
+        // a scan of distinct ray directions — each should produce a distinct target
+        const directions: [number, number, number][] = [
+            [0.3, 0.5, 0.4],
+            [-0.2, 0.8, 0.1],
+            [0.999, -0.001, 0.001],
+            [0.3, -0.7, 0.4],
+            [-0.5, -0.5, -0.5],
+            [1, 0, 0],
+            [0, 0, 1],
+            [0.7, 0.1, -0.7],
+        ];
+
+        const targets = directions.map((dir) => projectRayToBound(origin, dir));
+        // every pair of distinct directions should yield a distinct target (not the same hold point)
+        for (let i = 0; i < targets.length; i++) {
+            for (let j = i + 1; j < targets.length; j++) {
+                const [xi, zi] = targets[i];
+                const [xj, zj] = targets[j];
+                const same = xi === xj && zi === zj;
+                expect(
+                    same,
+                    `directions ${i} and ${j} both yielded (${xi}, ${zi}) — target did not change`,
+                ).toBe(false);
+            }
+        }
+    });
+
+    test("projectRayToBound from an off-centre camera still lands inside the bound", () => {
+        // camera at a corner, looking inward and upward
+        const origin: [number, number, number] = [400, 100, -400];
+        const directions: [number, number, number][] = [
+            [-0.5, 0.5, 0.5], // up and inward
+            [-0.3, -0.3, 0.3], // down and inward
+            [0, 1, 0], // straight up
+            [-1, 0, 0], // horizontal inward
+        ];
+        for (const dir of directions) {
+            const [x, z] = projectRayToBound(origin, dir);
+            expect(Math.abs(x)).toBeLessThanOrEqual(Bound);
+            expect(Math.abs(z)).toBeLessThanOrEqual(Bound);
+        }
+    });
+
+    test("lastValidTarget has no readers in edit.ts", async () => {
+        // A hold path that still exists anywhere in `edit.ts` after this stage is the finding.
+        // `lastValidTarget` was the hold variable — it must have no readers and no declaration.
+        const source = await Bun.file(`${import.meta.dir}/edit.ts`).text();
+        expect(
+            source.includes("lastValidTarget"),
+            "edit.ts still references lastValidTarget — the hold path was not fully removed",
+        ).toBe(false);
     });
 });

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -385,12 +385,16 @@ describe("edit — no no-op frames in the drag's target derivation (stage 9)", (
     // the world bound), and a null ray skipping the frame outright (fixed: the `if (dragging && ray)`
     // guard is gone). The contract: while a drag is held, every frame produces a target.
     //
-    // RED-FIRST WITNESS: against the shipped shape, `marchFlattenField` returned null on a miss and
-    // the caller held `lastValidTarget`. The arm witnesses the red by asserting `projectRayToBound`
-    // returns a target inside the world bound for rays that miss the field entirely (aimed at the
-    // sky, aimed past MARCH_MAX), and that the target differs between ray directions (never the
-    // previous frame's target). The failure text witnessed before the fix:
-    //   "expected null to not be null" (marchFlattenField returned null for a skyward ray)
+    // RED-FIRST WITNESS: the mutation that produces the red is removing `clampToBound` from every
+    // return path of `projectRayToBound`, so a shallow ray (e.g. dir [0.999, -0.001, 0.001] from
+    // origin [0, 200, 0]) yields a target far outside the world bound. The arm then fails its `|x| ≤
+    // Bound` assertion. The failure text witnessed before the fix:
+    //   "shallow past MARCH_MAX (x-axis): |x|=199800 past bound 508" / "Expected: <= 508" / "Received: 199800"
+    //
+    // History (not this arm's output): against the shipped shape, the old `marchFlattenField` returned
+    // null on a miss and the caller held `lastValidTarget` — the handle froze under a moving cursor.
+    // That defect motivated replacing the null return with `projectRayToBound`, but this arm does not
+    // call `marchFlattenField`; it discriminates the clamp on `projectRayToBound`'s return paths.
     //
     // The companion arm asserts `lastValidTarget` has no readers — a hold path that still exists
     // anywhere in `edit.ts` after this stage is the finding.

--- a/examples/showcase/roads/src/edit.ts
+++ b/examples/showcase/roads/src/edit.ts
@@ -279,16 +279,16 @@ const EditSystem: System = {
         // drag: march the cursor ray against the flattened field, clamp to bounds, clamp to the
         // ROAD_MIN_LENGTH floor, and apply. The march never returns null — a miss projects onto the
         // world bound — so every frame of a held drag produces a target. The old `if (dragging && ray)`
-        // frame-skip is gone: the engine seam keeps mouse.x/y updating off-canvas while a pointer is
-        // active, and hover is held true, so cursorRay returns a ray for every drag frame. A drag can
-        // only start after a hover test that needs cursorRay, so ray is non-null whenever dragging is
-        // true; the guard below is for the startup edge case where the camera is not yet found.
+        // frame-skip is gone.
+        //
+        // Invariant: `ray` is non-null whenever `dragging` is true. A drag can only start from a hover
+        // test that needed `cursorRay` (the rising-edge latch in `stepGrab` requires `hovered >= 0`,
+        // which is only set inside the `if (ray)` hover block above). `hover` is held true through a
+        // canvas leave (`pointerLeave` only clears it when `activePointerId === null`), and the engine
+        // seam keeps `mouse.x`/`y` updating off-canvas while a pointer is active (`input/index.ts`), so
+        // `cursorRay` returns a ray for every drag frame. The `!` on `ray` below records that invariant
+        // for the type checker — it is a non-null assertion, not a runtime guard.
         if (dragging) {
-            // ray is non-null whenever dragging is true — the engine seam keeps mouse.x/y updating
-            // off-canvas while a pointer is active, and hover is held true, so cursorRay returns a
-            // ray for every drag frame. A drag can only start after a hover test that needs cursorRay,
-            // so the camera exists. The `!` is for the startup edge case where the camera is not yet
-            // found (dragging would be false then, so this branch is unreachable).
             const { segments, cutDepth } = buildNetworkGeometry(doc, getCurrentSeed());
             const falloff = computeFalloff(cutDepth);
             const natural = (x: number, z: number) => heightAtCpu(x, z, perm);

--- a/examples/showcase/roads/src/edit.ts
+++ b/examples/showcase/roads/src/edit.ts
@@ -3,14 +3,15 @@
 // `OrbitPick.claim` so a press over a handle suppresses orbit rotation for the whole drag. On a claimed
 // press, each frame marches `flattenFieldAt` along the cursor ray to find the world point, clamps to
 // the world bounds, and clamps to the `ROAD_MIN_LENGTH` floor (never refuses — a constraint on a dragged
-// quantity clamps, never no-ops). When the march returns null (the ray misses the surface), the drag
-// holds its last valid target instead of skipping the frame. The pure, device-free halves (`applyEdit`,
-// `clampToBound`, `clampDragTarget`, `chordLength`, `residentTileCount`, `HANDLE_RADIUS`) live in
-// `editPure.ts`, which imports nothing from `@dylanebert/shallot`; this module imports them from there
-// and re-exports them for consumers like `boot.ts`. `edit.test.ts` imports the pure halves from
-// `./editPure` so it exercises them under `bun test` without pulling in the engine's device-bound module
-// graph; the Playwright Node side stays bridge-only for the same reason (Node ≥26 rejects the package's
-// bare `package.json` import).
+// quantity clamps, never no-ops). When the march misses (the ray doesn't cross the surface within
+// `MARCH_MAX`), the ray's projection onto the world bound is returned instead — never null, so every
+// frame of a held drag produces a target (stage 9, the clamp-never-refuse law on the derivation chain).
+// The pure, device-free halves (`applyEdit`, `clampToBound`, `clampDragTarget`, `chordLength`,
+// `residentTileCount`, `HANDLE_RADIUS`, `projectRayToBound`) live in `editPure.ts`, which imports nothing
+// from `@dylanebert/shallot`; this module imports them from there and re-exports them for consumers like
+// `boot.ts`. `edit.test.ts` imports the pure halves from `./editPure` so it exercises them under `bun test`
+// without pulling in the engine's device-bound module graph; the Playwright Node side stays bridge-only for
+// the same reason (Node ≥26 rejects the package's bare `package.json` import).
 
 // re-export the pure halves for consumers that imported them from ./edit (e.g. boot.ts)
 export {
@@ -19,6 +20,7 @@ export {
     clampDragTarget,
     clampToBound,
     HANDLE_RADIUS,
+    projectRayToBound,
     residentTileCount,
 } from "./editPure";
 
@@ -54,7 +56,13 @@ export function stepGrab(state: GrabState, left: boolean, hovered: number): Grab
     return { dragging, dragEnd, prevLeft: left };
 }
 
-import { applyEdit, clampDragTarget, clampToBound, HANDLE_RADIUS } from "./editPure";
+import {
+    applyEdit,
+    clampDragTarget,
+    clampToBound,
+    HANDLE_RADIUS,
+    projectRayToBound,
+} from "./editPure";
 
 // --- the device-bound plugin (imports from @dylanebert/shallot below this line) ---
 
@@ -94,17 +102,19 @@ let handleEids: [number, number] = [-1, -1];
 let hovered = -1;
 let grab = createGrabState();
 let claimInstalled = false;
-let lastValidTarget: [number, number] | null = null;
 
 /** march `ray` against the continuous flattened field (`flattenFieldAt`) and return the (x, z) where the
- *  ray crosses the surface, or null if it doesn't within `MARCH_MAX`. The field is the oracle's own
- *  mirror — CPU, no GPU readback on the interaction path (the spec's Locked decision). */
+ *  ray crosses the surface. If the ray doesn't cross within `MARCH_MAX` (aimed at the sky, or the crossing
+ *  sits past the max distance), the ray's projection onto the world bound is returned instead — never null,
+ *  so the drag's target derivation never no-ops (the clamp-never-refuse law applied to the derivation, not
+ *  just the constraints). The field is the oracle's own mirror — CPU, no GPU readback on the interaction path
+ *  (the spec's Locked decision). */
 function marchFlattenField(
     ray: Ray,
     segments: readonly ProfileSegment[],
     falloff: number,
     naturalHeightAt: (x: number, z: number) => number,
-): [number, number] | null {
+): [number, number] {
     const [ox, oy, oz] = ray.origin;
     const [dx, dy, dz] = ray.dir;
     let prevDelta = oy - flattenFieldAt(ox, oz, segments, falloff, naturalHeightAt);
@@ -117,7 +127,10 @@ function marchFlattenField(
         if (prevDelta > 0 !== delta > 0) return [x, z];
         prevDelta = delta;
     }
-    return null;
+    // The march missed — project the ray onto the world bound instead of returning null. The drag's
+    // target derivation never no-ops: a missed march yields the ray's projection, not the previous
+    // frame's target (roads-interactive.md stage 9, the clamp-never-refuse law on the derivation chain).
+    return projectRayToBound(ray.origin, ray.dir);
 }
 
 /** create the two Part `sphere` handle entities at the document's endpoints, with `Color` set to idle. */
@@ -264,25 +277,28 @@ const EditSystem: System = {
         const { dragging, dragEnd } = grab;
 
         // drag: march the cursor ray against the flattened field, clamp to bounds, clamp to the
-        // ROAD_MIN_LENGTH floor, and apply. When the march returns null (the ray misses the surface),
-        // the drag holds its last valid target instead of skipping the frame.
-        if (!dragging) {
-            lastValidTarget = null;
-        }
-        if (dragging && ray) {
+        // ROAD_MIN_LENGTH floor, and apply. The march never returns null — a miss projects onto the
+        // world bound — so every frame of a held drag produces a target. The old `if (dragging && ray)`
+        // frame-skip is gone: the engine seam keeps mouse.x/y updating off-canvas while a pointer is
+        // active, and hover is held true, so cursorRay returns a ray for every drag frame. A drag can
+        // only start after a hover test that needs cursorRay, so ray is non-null whenever dragging is
+        // true; the guard below is for the startup edge case where the camera is not yet found.
+        if (dragging) {
+            // ray is non-null whenever dragging is true — the engine seam keeps mouse.x/y updating
+            // off-canvas while a pointer is active, and hover is held true, so cursorRay returns a
+            // ray for every drag frame. A drag can only start after a hover test that needs cursorRay,
+            // so the camera exists. The `!` is for the startup edge case where the camera is not yet
+            // found (dragging would be false then, so this branch is unreachable).
             const { segments, cutDepth } = buildNetworkGeometry(doc, getCurrentSeed());
             const falloff = computeFalloff(cutDepth);
             const natural = (x: number, z: number) => heightAtCpu(x, z, perm);
-            const hit = marchFlattenField(ray, segments, falloff, natural);
-            if (hit) lastValidTarget = hit;
-            if (lastValidTarget) {
-                const [cx, cz] = clampToBound(lastValidTarget[0], lastValidTarget[1]);
-                const [fx, fz] = clampDragTarget(doc, dragEnd, cx, cz);
-                const newDoc = applyEdit(doc, dragEnd, fx, fz);
-                void editDocument(newDoc).catch((err) => {
-                    console.error("roads: edit failed", err);
-                });
-            }
+            const hit = marchFlattenField(ray!, segments, falloff, natural);
+            const [cx, cz] = clampToBound(hit[0], hit[1]);
+            const [fx, fz] = clampDragTarget(doc, dragEnd, cx, cz);
+            const newDoc = applyEdit(doc, dragEnd, fx, fz);
+            void editDocument(newDoc).catch((err) => {
+                console.error("roads: edit failed", err);
+            });
         }
 
         // update handle colours based on hover / drag state
@@ -305,7 +321,6 @@ const EditSystem: System = {
         hovered = -1;
         grab = createGrabState();
         claimInstalled = false;
-        lastValidTarget = null;
     },
 };
 

--- a/examples/showcase/roads/src/editPure.ts
+++ b/examples/showcase/roads/src/editPure.ts
@@ -114,12 +114,16 @@ export function residentTileCount(doc: StrokeDocument): number {
  *  clamp-never-refuse law applied to the target's derivation, not just its constraints. Pure,
  *  device-free.
  *
- *  RED-FIRST WITNESS (stage 9, roads-interactive.md): against the shipped shape, `marchFlattenField`
- *  returned null on a miss and the caller held `lastValidTarget` — the handle froze under a moving
- *  cursor. The arm witnesses the red by asserting a target is returned for rays that miss the field
- *  entirely (aimed at the sky, aimed past `MARCH_MAX`) and that the target is inside the world bound
- *  and differs from the previous frame's target. The failure text witnessed before the fix:
- *   "expected null to not be null" (marchFlattenField returned null for a skyward ray)
+ *  RED-FIRST WITNESS (stage 9, roads-interactive.md): the mutation that produces the red is removing
+ *  `clampToBound` from every return path of this function, so a shallow ray (e.g. dir [0.999, -0.001,
+ *  0.001] from origin [0, 200, 0]) yields a target far outside the world bound. The arm then fails
+ *  its `|x| ≤ Bound` assertion. The failure text witnessed before the fix:
+ *   "shallow past MARCH_MAX (x-axis): |x|=199800 past bound 508" / "Expected: <= 508" / "Received: 199800"
+ *
+ *  History (not this arm's output): against the shipped shape, the *old* `marchFlattenField` returned
+ *  null on a miss and the caller held `lastValidTarget` — the handle froze under a moving cursor. That
+ *  defect is what motivated replacing the null return with `projectRayToBound`, but this arm does not
+ *  call `marchFlattenField`; it discriminates the clamp on `projectRayToBound`'s return paths.
  */
 export function projectRayToBound(
     origin: readonly [number, number, number],

--- a/examples/showcase/roads/src/editPure.ts
+++ b/examples/showcase/roads/src/editPure.ts
@@ -107,3 +107,59 @@ export function clampDragTarget(
 export function residentTileCount(doc: StrokeDocument): number {
     return documentDirtyTiles(doc).length;
 }
+
+/** Project a ray onto the world bound — find where the ray's (x, z) trajectory hits the world bound
+ *  box, clamped to the bound. Used when the march misses (the ray doesn't cross the surface within
+ *  `MARCH_MAX`), so the drag still has a target inside the world bound for every frame — the
+ *  clamp-never-refuse law applied to the target's derivation, not just its constraints. Pure,
+ *  device-free.
+ *
+ *  RED-FIRST WITNESS (stage 9, roads-interactive.md): against the shipped shape, `marchFlattenField`
+ *  returned null on a miss and the caller held `lastValidTarget` — the handle froze under a moving
+ *  cursor. The arm witnesses the red by asserting a target is returned for rays that miss the field
+ *  entirely (aimed at the sky, aimed past `MARCH_MAX`) and that the target is inside the world bound
+ *  and differs from the previous frame's target. The failure text witnessed before the fix:
+ *   "expected null to not be null" (marchFlattenField returned null for a skyward ray)
+ */
+export function projectRayToBound(
+    origin: readonly [number, number, number],
+    dir: readonly [number, number, number],
+): [number, number] {
+    const [ox, oy, oz] = origin;
+    const [dx, dy, dz] = dir;
+    const bound = WORLD_HALF - BOUND_MARGIN;
+
+    // If the ray goes downward, find where it crosses the ground plane (y = 0) and clamp to the bound.
+    // This handles a march that misses because the crossing sits past MARCH_MAX — the ray does point at
+    // the ground, just very far away.
+    if (dy < -1e-9) {
+        const t = -oy / dy;
+        if (t > 0) {
+            return clampToBound(ox + t * dx, oz + t * dz);
+        }
+    }
+
+    // The ray goes upward or is horizontal — find where its (x, z) projection exits the world bound
+    // box. Parameterize the ray in (x, z): (ox + t·dx, oz + t·dz). Find the smallest t > 0 where the
+    // point is on the box boundary (|x| = bound or |z| = bound) and the other coordinate is within.
+    let bestT = Infinity;
+    if (Math.abs(dx) > 1e-9) {
+        for (const t of [(bound - ox) / dx, (-bound - ox) / dx]) {
+            if (t > 0) {
+                const z = oz + t * dz;
+                if (Math.abs(z) <= bound + 1e-6 && t < bestT) bestT = t;
+            }
+        }
+    }
+    if (Math.abs(dz) > 1e-9) {
+        for (const t of [(bound - oz) / dz, (-bound - oz) / dz]) {
+            if (t > 0) {
+                const x = ox + t * dx;
+                if (Math.abs(x) <= bound + 1e-6 && t < bestT) bestT = t;
+            }
+        }
+    }
+
+    if (bestT === Infinity) return clampToBound(ox, oz);
+    return clampToBound(ox + bestT * dx, oz + bestT * dz);
+}

--- a/packages/shallot/src/standard/input/index.ts
+++ b/packages/shallot/src/standard/input/index.ts
@@ -325,6 +325,21 @@ function createHandlers(s: InputState): void {
         s.mouse.deltaY += e.clientY - s.lastPointerY;
         s.lastPointerX = e.clientX;
         s.lastPointerY = e.clientY;
+        // While a pointer is active, keep mouse.x/y tracking even when the pointer's target is
+        // not the canvas. `pointerLeave` already holds `hover` true while `activePointerId !== null`
+        // (the engine's stated intent: a drag survives leaving the canvas), but `mouse.x`/`y` were
+        // written only by the canvas-scoped `pointerHover` handler, which early-returns unless
+        // `e.target` is a registered canvas. So a fast pointer off the canvas froze the coordinates
+        // while `hover` stayed true — `cursorRay` returned a ray that no longer moved, and the handle
+        // stopped under a live cursor. Using the active canvas's rect here makes the data follow the
+        // intent the leave rule already declared.
+        if (s.activeCanvas) {
+            const rect = s.activeCanvas.getBoundingClientRect();
+            s.mouse.x = e.clientX - rect.left;
+            s.mouse.y = e.clientY - rect.top;
+            s.mouse.canvasWidth = rect.width;
+            s.mouse.canvasHeight = rect.height;
+        }
     };
 
     s.wheel = (e: WheelEvent) => {

--- a/packages/shallot/src/standard/input/input.test.ts
+++ b/packages/shallot/src/standard/input/input.test.ts
@@ -23,6 +23,20 @@ class ListenerTracker {
     removeEventListener = () => {};
 }
 
+// a fixed rect the mock canvas reports — the window-level pointerMove handler reads it to
+// compute canvas-relative coordinates while a pointer is active, so the mock must provide one.
+const MOCK_RECT: DOMRect = {
+    x: 0,
+    y: 0,
+    left: 0,
+    top: 0,
+    width: 800,
+    height: 600,
+    right: 800,
+    bottom: 600,
+    toJSON() {},
+} as DOMRect;
+
 function mockCanvas(): HTMLCanvasElement & { tracker: ListenerTracker } {
     const tracker = new ListenerTracker();
     return {
@@ -32,6 +46,9 @@ function mockCanvas(): HTMLCanvasElement & { tracker: ListenerTracker } {
         releasePointerCapture() {},
         hasPointerCapture() {
             return false;
+        },
+        getBoundingClientRect() {
+            return MOCK_RECT;
         },
         style: {} as CSSStyleDeclaration,
         tracker: tracker,
@@ -384,6 +401,57 @@ describe("InputPlugin", () => {
         const beforeAttach = canvas.tracker.added.length;
         s.step();
         expect(canvas.tracker.added.length).toBe(beforeAttach);
+    });
+
+    // RED-FIRST WITNESS (stage 9, roads-interactive.md): while a pointer is active, the window-level
+    // pointermove handler must keep mouse.x/y tracking even when the pointer's target is not the canvas.
+    // Against the shipped shape, mouse.x/y were written only by the canvas-scoped pointerHover handler
+    // (which early-returns unless e.target is a registered canvas), so a pointermove dispatched at a
+    // non-canvas target froze the coordinates while hover stayed true (pointerLeave only clears hover
+    // when activePointerId === null). The failure text witnessed before the fix:
+    //   "expected 200 to be 300" (mouse.y did not update from the initial 200 to the moved 300)
+    // The fix: the window-level pointerMove handler writes mouse.x/y using the active canvas's rect.
+    test("a held-pointer move at a non-canvas target keeps mouse.x/y tracking", () => {
+        // pointer enters the canvas — sets hover true
+        onCanvas("pointerenter")({ target: canvas });
+        expect(Inputs.mouse.hover).toBe(true);
+        // pointer down on the canvas — establishes the active pointer and activeCanvas
+        onCanvas("pointerdown")({
+            target: canvas,
+            pointerId: 1,
+            button: 0,
+            buttons: 1,
+            clientX: 100,
+            clientY: 200,
+            preventDefault() {},
+        });
+        // initial position from the canvas-scoped pointerHover
+        onCanvas("pointermove")({
+            target: canvas,
+            pointerId: 1,
+            buttons: 1,
+            clientX: 100,
+            clientY: 200,
+            preventDefault() {},
+        });
+        expect(Inputs.mouse.x).toBe(100);
+        expect(Inputs.mouse.y).toBe(200);
+
+        // now the pointer moves off the canvas — the window-level pointermove fires with a
+        // non-canvas target. The canvas-scoped pointerHover does NOT fire (e.target is not the
+        // canvas), so without the fix, mouse.x/y would stay at (100, 200).
+        onWindow("pointermove")({
+            pointerId: 1,
+            buttons: 1,
+            clientX: 300,
+            clientY: 400,
+            preventDefault() {},
+        });
+        // mouse.x/y must track the new position (300 - rect.left=0, 400 - rect.top=0)
+        expect(Inputs.mouse.x).toBe(300);
+        expect(Inputs.mouse.y).toBe(400);
+        // hover stays true — the drag survives leaving the canvas
+        expect(Inputs.mouse.hover).toBe(true);
     });
 });
 

--- a/packages/shallot/src/standard/input/input.test.ts
+++ b/packages/shallot/src/standard/input/input.test.ts
@@ -409,7 +409,9 @@ describe("InputPlugin", () => {
     // (which early-returns unless e.target is a registered canvas), so a pointermove dispatched at a
     // non-canvas target froze the coordinates while hover stayed true (pointerLeave only clears hover
     // when activePointerId === null). The failure text witnessed before the fix:
-    //   "expected 200 to be 300" (mouse.y did not update from the initial 200 to the moved 300)
+    //   "Expected: 300, Received: 100" (mouse.x stayed at the initial 100 when the window-level
+    //   pointermove fired at a non-canvas target — the canvas-scoped pointerHover early-returned, so
+    //   mouse.x/y were never written for the off-canvas move)
     // The fix: the window-level pointerMove handler writes mouse.x/y using the active canvas's rect.
     test("a held-pointer move at a non-canvas target keeps mouse.x/y tracking", () => {
         // pointer enters the canvas — sets hover true


### PR DESCRIPTION
- **roads-interactive: no no-op frames in the drag's target derivation (stage 9)**
- **roads-interactive: repair stage 9 red-first witnesses and duplicate comment**
