### PR TITLE
roads-interactive: stage 10 — bollard scale

### DIFF
--- a/examples/showcase/roads/src/posts.test.ts
+++ b/examples/showcase/roads/src/posts.test.ts
@@ -36,9 +36,9 @@ describe("posts emitted WGSL", () => {
         // index `segments[0i]` (not `segments[1i]`). Each would fail under the mutation it names.
         const wgsl = flat(postsWgsl());
 
-        // station: (i + 1) * POST_SPACING emits as `(f32(i) + 1f) * 20f` — the `+ 1f` is what
-        // discriminates from `i * POST_SPACING` which emits `(f32(i) * 20f)` with no `+ 1f`.
-        expect(wgsl).toContain("(f32(i) + 1f) * 20f");
+        // station: (i + 1) * POST_SPACING emits as `(f32(i) + 1f) * 2f` — the `+ 1f` is what
+        // discriminates from `i * POST_SPACING` which emits `(f32(i) * 2f)` with no `+ 1f`.
+        expect(wgsl).toContain("(f32(i) + 1f) * 2f");
 
         // lateral sign: even → +1, odd → −1, emitted as `select(1f, -1f, ((i & 1u) == 1u))` —
         // a swapped sign emits `select(-1f, 1f, ...)` and a constant sign emits no `select` at all.
@@ -53,7 +53,7 @@ describe("posts emitted WGSL", () => {
 describe("post station derivation", () => {
     test("postStation(i) = (i + 1) * POST_SPACING — first post at POST_SPACING, not station 0", () => {
         // independently derived: (i + 1) * POST_SPACING, not i * POST_SPACING
-        // red: mutating postStation to return i * POST_SPACING makes postStation(0) = 0 (not 20)
+        // red: mutating postStation to return i * POST_SPACING makes postStation(0) = 0 (not 2)
         for (const i of [0, 1, 2, 5, 10, 72]) {
             expect(postStation(i)).toBe((i + 1) * POST_SPACING);
         }
@@ -80,10 +80,10 @@ describe("post lateral derivation", () => {
 describe("live-slot count derivation", () => {
     test("liveSlotCount = floor(chordLength / POST_SPACING) — not ceil or floor + 1", () => {
         // independently derived: Math.floor(chordLength / POST_SPACING)
-        // red: mutating liveSlotCount to Math.ceil makes liveSlotCount(201) = 11 (not 10)
-        expect(liveSlotCount(200)).toBe(10);
-        expect(liveSlotCount(201)).toBe(10);
-        expect(liveSlotCount(199)).toBe(9);
+        // red: mutating liveSlotCount to Math.ceil makes liveSlotCount(201) = 101 (not 100)
+        expect(liveSlotCount(200)).toBe(100);
+        expect(liveSlotCount(201)).toBe(100);
+        expect(liveSlotCount(199)).toBe(99);
         expect(liveSlotCount(0)).toBe(0);
         expect(liveSlotCount(POST_SPACING)).toBe(1);
         expect(liveSlotCount(POST_SPACING - 0.001)).toBe(0);

--- a/examples/showcase/roads/src/posts.ts
+++ b/examples/showcase/roads/src/posts.ts
@@ -49,8 +49,12 @@ import { getCurrentSeed, getDocument } from "./terrain/terrain";
 
 // --- constants --------------------------------------------------------------
 
-/** metres between posts along the chord. */
-export const POST_SPACING = 20;
+/** metres between posts along the chord.
+ *
+ *  Referent: NACTO Urban Street Design Guide — traffic-calming / channelizing bollards are spaced
+ *  1.5–2.0 m apart for pedestrian channelization (nacto.org, accessed 2026-08-22). 2.0 m is the upper
+ *  bound of that range, within the spec's ~2 m band. */
+export const POST_SPACING = 2;
 
 /** the lateral offset from the road edge to the post centre, in metres.
  *
@@ -73,19 +77,30 @@ export const POST_SPACING = 20;
 export const POST_OFFSET = SPACING;
 
 /** the post's visual height in metres. The capsule mesh spans y ∈ [−1, 1] (height 2), so the VS scales
- *  y by `POST_HEIGHT / 2`. */
-const POST_HEIGHT = 4;
+ *  y by `POST_HEIGHT / 2`.
+ *
+ *  Referent: a standard roadside bollard is ~1.0 m above grade. Reliance Foundry R-7181 cast-iron
+ *  bollard: 36 in (0.914 m) above grade (reliance-fd.com, accessed 2026-08-22); UK DfT Traffic Signs
+ *  Manual Chapter 4 describes traffic bollards at approximately 1.0 m. 1.0 m is within the spec's
+ *  ~1 m band. */
+const POST_HEIGHT = 1;
 
 /** the post's visual radius in metres. The capsule mesh has radius 0.5, so the VS scales x/z by
- *  `POST_RADIUS / 0.5 = POST_RADIUS * 2`. */
-const POST_RADIUS = 0.3;
+ *  `POST_RADIUS / 0.5 = POST_RADIUS * 2`.
+ *
+ *  Referent: a standard pipe bollard made from 10 in Schedule 40 steel pipe has an OD of 10.75 in
+ *  (273 mm, radius 0.137 m); 8 in Schedule 40 has OD 8.625 in (219 mm, radius 0.11 m). 0.12 m (diameter
+ *  240 mm) sits between the two, within the spec's ~0.1–0.15 m band. */
+const POST_RADIUS = 0.12;
 
 /** the world's own diagonal — the maximum chord length the world contains (`WORLD_EXTENT · √2` ≈ 1448 m),
  *  since `ROAD_MAX_LENGTH` was deleted in stage 4c. This is the ceiling `POST_COUNT` is sized against. */
 const WORLD_DIAGONAL = WORLD_EXTENT * Math.SQRT2;
 
 /** the fixed slot count — sized off the world's own diagonal divided by `POST_SPACING`, so `instanceCount`
- *  stays fixed across edits and short chords leave most slots at scale 0. */
+ *  stays fixed across edits and short chords leave most slots at scale 0. At `POST_SPACING = 2` this is
+ *  ≈725 slots (up from ~73 at 20 m spacing); the instanced draw handles this trivially — 725 instances of
+ *  a capsule mesh is well within WebGPU's instancing limits, and the record buffer is 725 × 16 B ≈ 11 KB. */
 export const POST_COUNT = Math.ceil(WORLD_DIAGONAL / POST_SPACING);
 
 const POST_WORKGROUP = 64;


### PR DESCRIPTION
Re-scale posts to real bollards with cited referents:
- POST_HEIGHT 4 -> 1 m (Reliance Foundry R-7181, UK DfT Traffic Signs Manual Ch 4)
- POST_RADIUS 0.3 -> 0.12 m (10in / 8in Schedule 40 steel pipe bollard)
- POST_SPACING 20 -> 2 m (NACTO Urban Street Design Guide)
- POST_COUNT auto-derives: ~725 slots at 2 m spacing (was ~73)
- Re-anchor structural arm station literal: (f32(i) + 1f) * 20f -> * 2f
- POST_OFFSET unchanged (new radius does not force it)
