### PR TITLE
roads interactive/11

### DIFF
--- a/examples/showcase/roads/src/gate.ts
+++ b/examples/showcase/roads/src/gate.ts
@@ -140,9 +140,11 @@ export async function gate(): Promise<Check[]> {
     });
 
     // stage 5's post-placement check — reads back the posts buffer and verifies every Validation
-    // criterion: every live slot's y equals CPU flattenFieldAt (baked against the live seed), lateral
-    // offset inside the flat core, lateral sign matches postLateralSign(i),
-    // floor(chordLength / POST_SPACING) live slots, and every slot past the chord at scale 0.
+    // criterion: every live slot's y equals CPU flattenFieldAt (baked against the live seed), the lateral
+    // offset pinned at exactly halfWidth + POST_OFFSET (the kerb line, stage 11 — it replaced the old
+    // "somewhere inside the flat core" band, which passed for any offset in a 5.66 m window), lateral sign
+    // matches postLateralSign(i), floor(chordLength / POST_SPACING) live slots, and every slot past the
+    // chord at scale 0.
     checks.push(await checkPosts());
 
     return checks;

--- a/examples/showcase/roads/src/posts.test.ts
+++ b/examples/showcase/roads/src/posts.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { flat } from "../../../../packages/shallot/tests/wgsl";
+import { mulberry32 } from "./dragCorpus";
+import { clampToBound } from "./editPure";
 import { ROAD_MIN_LENGTH } from "./overlay/network";
 import {
     isLiveSlot,
@@ -161,9 +163,10 @@ describe("POST_OFFSET flat-core band", () => {
 
     test("POST_OFFSET is the kerb line (~0.4 m), not stage 5's flat-core convenience (SPACING = 4 m)", () => {
         // the referent's own value, pinned as a literal: a kerbside bollard stands immediately off the
-        // pavement edge. 4 m (13 ft) is what made the row read as posts standing in a field.
+        // pavement edge. 4 m (13 ft) is what made the row read as posts standing in a field. The literal
+        // is the whole assertion — a companion `not.toBe(SPACING)` was dropped at stage 11's repair as
+        // vacuous, since `toBe(0.4)` already refutes every value `SPACING` could hold.
         expect(POST_OFFSET).toBe(0.4);
-        expect(POST_OFFSET).not.toBe(SPACING);
     });
 
     test("FLAT_CORE_MARGIN = √2 * SPACING (flatten-math.ts's own derivation)", () => {
@@ -208,35 +211,40 @@ describe("the footing depth's derivation", () => {
 
     test("no admissible chord's grade exceeds the ceiling the footing is sized against", () => {
         // the measurement the stage reports, asserted: a 5-seed × 400-chord scan of admissible chords
-        // (both endpoints inside the world, length >= ROAD_MIN_LENGTH) against the analytic ceiling. Half
-        // the corpus is drawn as SHORT chords — length in [ROAD_MIN_LENGTH, 2 · ROAD_MIN_LENGTH] — because
-        // grade is |Δh| / length and a uniform endpoint pair is almost always long, so an unbiased scan
-        // reads 0.1092 against this corpus's measured 0.1508. The arm asserts the ceiling holds (a
-        // bound over the domain) and, separately, that the scan really exercises grades worth burying
-        // (or it would pass on a corpus that found nothing).
+        // (both endpoints clamped into the world by the live drag's own `clampToBound`, length >=
+        // ROAD_MIN_LENGTH) against the analytic ceiling. Half the corpus is drawn as SHORT chords — length
+        // in [ROAD_MIN_LENGTH, 2 · ROAD_MIN_LENGTH] — because grade is |Δh| / length and a uniform endpoint
+        // pair is almost always long: measured at stage 11's repair, the corpus reads **0.151686** while
+        // its uniform-endpoint half alone reads **0.123455**.
+        //
+        // **Why this scan and not `dragCorpus`** (stage 12's frozen fixture, the one derivation both
+        // flatness tiers read): `dragCorpus` *filters by* `MAX_GRADE = 0.12` — it rejects exactly the steep
+        // chords this arm exists to find, because the flatness oracle's longitudinal bound is that grade.
+        // A corpus that discards its steepest members cannot measure the steepest member. What this arm
+        // does take from the live path is the **bound**: `clampToBound` (`editPure.ts`), so "admissible"
+        // here means what the drag means by it, rather than the `WORLD_HALF − SPACING` this arm used to
+        // hand-roll (equal at 4 m today by coincidence — `BOUND_MARGIN = ROAD_HALF_WIDTH`, an unrelated
+        // concept). The RNG is the repo's own `mulberry32`, so this file hand-rolls no generator either.
         let worst = 0;
-        let state = 0x9e3779b9;
-        const rand = () => {
-            // a plain LCG — the corpus must be deterministic, and this file owns no generator
-            state = (state * 1664525 + 1013904223) >>> 0;
-            return state / 0x100000000;
-        };
-        const bound = WORLD_HALF - SPACING;
+        const rand = mulberry32(0x9e3779b9);
         for (const seed of [1337, 1, 2, 99, 4242]) {
             const perm = makePermutation(seed);
             for (let n = 0; n < 400; n++) {
-                const ax = (rand() * 2 - 1) * bound;
-                const az = (rand() * 2 - 1) * bound;
+                const [ax, az] = clampToBound(
+                    (rand() * 2 - 1) * WORLD_HALF,
+                    (rand() * 2 - 1) * WORLD_HALF,
+                );
                 let bx: number;
                 let bz: number;
                 if (n % 2 === 0) {
-                    bx = (rand() * 2 - 1) * bound;
-                    bz = (rand() * 2 - 1) * bound;
+                    [bx, bz] = clampToBound(
+                        (rand() * 2 - 1) * WORLD_HALF,
+                        (rand() * 2 - 1) * WORLD_HALF,
+                    );
                 } else {
                     const theta = rand() * Math.PI * 2;
                     const L = ROAD_MIN_LENGTH * (1 + rand());
-                    bx = Math.min(Math.max(ax + Math.cos(theta) * L, -bound), bound);
-                    bz = Math.min(Math.max(az + Math.sin(theta) * L, -bound), bound);
+                    [bx, bz] = clampToBound(ax + Math.cos(theta) * L, az + Math.sin(theta) * L);
                 }
                 const len = Math.hypot(bx - ax, bz - az);
                 if (len < ROAD_MIN_LENGTH) continue;
@@ -245,9 +253,17 @@ describe("the footing depth's derivation", () => {
             }
         }
         expect(worst).toBeLessThanOrEqual(MAX_CHORD_GRADE);
-        // the scan is not vacuous: it finds grades steep enough that the footing matters. The floor is a
-        // literal well under the reading rather than the reading itself — a corpus assertion pinned to
-        // its own output cannot survive a seed change.
+        // a **corpus non-vacuity tripwire**, and nothing more — restated at stage 11's repair, because the
+        // old wording ("grades steep enough that the footing matters") was false at this value: grade 0.1
+        // needs 0.012 m of burial, 5 % of the shipped 0.24 m. **No arm in this file can witness that the
+        // depth is needed**, because the domain it is sized for (grade → MAX_CHORD_GRADE = 1.0) is ~6.6×
+        // outside anything this terrain reaches — the footing is sized against the admissible domain by
+        // construction, which is the trade the derivation states. What this floor catches is a scan that
+        // stopped scanning: a broken RNG, a clamp that collapses every chord, or a filter that rejects the
+        // whole corpus would all read near 0 and are all silent against the ceiling assertion above. The
+        // literal sits well under the reading (0.151686) rather than at it, so a seed change does not red
+        // it — and it is under the uniform half's own 0.123455 too, so it survives losing the short-chord
+        // half entirely.
         expect(worst).toBeGreaterThan(0.1);
     });
 
@@ -278,10 +294,16 @@ describe("the capsule's core/cap decomposition (the VS's own arithmetic)", () =>
         // the bottom cap's highest point is the shaft's base ring (localY = −0.5), and the uphill side of
         // that ring sits MAX_CHORD_GRADE · POST_RADIUS above the sampled centre height — so the ring must
         // sit at least that far below the surface, and the cap's own lowest point below it again.
-        // red-first against the shipped shape, witnessed 2026-08-22: `POST_BURIAL_DEPTH = 0` (stage 5's
-        // mapping, whose lowest mesh point sat ON the surface) puts the base ring flush at y = 0, so the
-        // uphill side of the ring reads 0.12 m ABOVE the surface — `Expected: <= 0, Received: 0.12` — and
-        // three more arms red with it (the depth, the derived shaft length, and the emitted VS literals).
+        // red-first, witnessed 2026-08-22 at `POST_BURIAL_DEPTH = 0`: the base ring sits flush at y = 0, so
+        // the uphill side of the ring reads 0.12 m ABOVE the surface — `Expected: <= 0, Received: 0.12` —
+        // and three more arms red with it (the depth, the derived shaft length, and the emitted VS
+        // literals). **`burial = 0` is NOT the shape stage 5 shipped**, and calling it that would overclaim
+        // the witness: stage 5 mapped the mesh's *lowest point* to the surface, putting the base ring
+        // 0.25 m ABOVE grade with the whole bottom hemisphere on show, so no value of
+        // `POST_BURIAL_DEPTH` reproduces it — `burial = 0` is already a strictly better shape (0.12 m of
+        // exposure against 0.25 m). The pre-image witness is the companion assertion in the emitted-VS arm
+        // below, `not.toContain("input.localPos.y * 0.5f")`, which is stage 5's actual y scale. This arm's
+        // mutation witnesses that the *depth* is load-bearing, not that stage 5 is refuted.
         const baseRing = postVertexOffset(0, -0.5, 0)[1];
         expect(baseRing).toBeCloseTo(-POST_BURIAL_DEPTH, 12);
         expect(baseRing + MAX_CHORD_GRADE * POST_RADIUS).toBeLessThanOrEqual(0);
@@ -314,15 +336,24 @@ describe("the capsule's core/cap decomposition (the VS's own arithmetic)", () =>
     });
 
     test("the shaft is a cylinder of POST_RADIUS — the core term carries the length, the radial term the width", () => {
+        // the discriminating half is the RADIAL one: `side[0] ≈ POST_RADIUS` at every height, which is
+        // what makes the shaft a cylinder rather than a taper. The y half is pinned as **literals** at the
+        // shaft's two ends rather than as the function's own expression — restating
+        // `ly * shaftLength + shaftLength/2 − burial` here would re-derive the subject's own rule and go
+        // green on wrong constants (stage 3's precedent, and the defect this repair closes).
         for (const ly of [-0.5, -0.2, 0, 0.25, 0.5]) {
             const side = postVertexOffset(0.5, ly, 0);
             expect(side[0]).toBeCloseTo(POST_RADIUS, 12);
-            // the shaft spans POST_SHAFT_LENGTH from base ring to dome underside
-            expect(side[1]).toBeCloseTo(
-                ly * POST_SHAFT_LENGTH + POST_SHAFT_LENGTH / 2 - POST_BURIAL_DEPTH,
-                12,
-            );
         }
+        // the base ring sits POST_BURIAL_DEPTH below the surface: −0.24 m.
+        expect(postVertexOffset(0.5, -0.5, 0)[1]).toBeCloseTo(-0.24, 12);
+        // the dome's underside sits at shaftLength − burial = 1.12 − 0.24 = 0.88 m above it.
+        expect(postVertexOffset(0.5, 0.5, 0)[1]).toBeCloseTo(0.88, 12);
+        // and the z factor is the same radial one x takes — asserted at nonzero `lz`, which no other arm
+        // does (every other mesh arm passes `lz = 0`, where a dropped or wrong z factor is invisible).
+        expect(postVertexOffset(0, 0, 0.5)[2]).toBeCloseTo(POST_RADIUS, 12);
+        expect(postVertexOffset(0, 0, -0.5)[2]).toBeCloseTo(-POST_RADIUS, 12);
+        expect(postVertexOffset(0, 0, 0.25)[2]).toBeCloseTo(POST_RADIUS / 2, 12);
     });
 
     test("a scale-0 slot collapses to the record position (the fixed-instanceCount mechanism)", () => {
@@ -344,6 +375,24 @@ describe("the capsule's core/cap decomposition (the VS's own arithmetic)", () =>
         expect(wgsl).toContain("(cap * radial)");
         expect(wgsl).toContain("(input.localPos.x * radial)");
         expect(wgsl).toContain("(input.localPos.z * radial)");
+        // and `radial`'s own VALUE, not just its identifier — added at stage 11's repair, which found that
+        // the three assertions above pin only that one shared factor exists and pass unchanged under any
+        // value for it. Nothing else in the suite reads the VS's numbers: `postVertexOffset` carries its
+        // own `params.radius * 2`, `checkPosts` reads records rather than vertices, and the fs probes are
+        // on-road while the posts are now off it — so the post's rendered width and its cap radius, this
+        // stage's headline property, were unpinned in production. POST_RADIUS * 2 = 0.24 in f32.
+        // red witnessed 2026-08-22 — the VS's own `radial` mutated to `d.f32(POST_RADIUS)` (dropping the
+        // mesh's 0.5-radius compensation, the plausible wrong factor), this file run, the production line
+        // then restored byte-identical. Verbatim, with the emitted WGSL of `Received` elided after the
+        // decomposition:
+        //   error: expect(received).toMatch(expected)
+        //   Expected substring or pattern: /radial = 0\.2399\d*f/
+        //   Received: "... let core = clamp(input.localPos.y, -0.5f, 0.5f); let cap =
+        //   (input.localPos.y - core); const radial = 0.11999999731779099f; let sx =
+        //   ((input.localPos.x * radial) * scale); ..."
+        //   at <anonymous> (.../examples/showcase/roads/src/posts.test.ts, the assertion below)
+        // (26 pass / 1 fail — this arm alone, which is the point: nothing else in the file moved.)
+        expect(wgsl).toMatch(/radial = 0\.2399\d*f/);
         // the shaft length on the core term, and the burial in the translation — f32 roundings of
         // 1.12 and 1.12/2 − 0.24 = 0.32.
         expect(wgsl).toMatch(/core \* 1\.12\d*f/);

--- a/examples/showcase/roads/src/posts.test.ts
+++ b/examples/showcase/roads/src/posts.test.ts
@@ -1,17 +1,29 @@
 import { describe, expect, test } from "bun:test";
 import { flat } from "../../../../packages/shallot/tests/wgsl";
+import { ROAD_MIN_LENGTH } from "./overlay/network";
 import {
     isLiveSlot,
     liveSlotCount,
+    MAX_CHORD_GRADE,
+    POST_BURIAL_DEPTH,
+    POST_COLOR,
     POST_COUNT,
+    POST_HEIGHT,
+    POST_MESH,
     POST_OFFSET,
+    POST_RADIUS,
+    POST_SHAFT_LENGTH,
     POST_SPACING,
     postLateralSign,
     postStation,
+    postsSurfaceWgsl,
     postsWgsl,
+    postVertexOffset,
 } from "./posts";
 import { FLAT_CORE_MARGIN } from "./terrain/flatten-math";
-import { SPACING, WORLD_EXTENT } from "./terrain/grid";
+import { SPACING, WORLD_EXTENT, WORLD_HALF } from "./terrain/grid";
+import { makePermutation, RELIEF } from "./terrain/noise";
+import { heightAtCpu } from "./terrain/profile";
 
 // Stage 5's posts test — the WGSL structural seam plus the plain-TS behavioural witnesses for the
 // station/lateral/slot-count/scale-0 derivations. The structural arm (the resolved WGSL contains
@@ -31,7 +43,7 @@ describe("posts emitted WGSL", () => {
     test("the resolved kernel's station, lateral sign, and slot index are the correct literals", () => {
         // LITERALS, not values re-derived from POST_SPACING/POST_OFFSET — an arm that recomputes its
         // own rule goes green on a wrong constant (this unit's stage-3 precedent). The assertions below
-        // pin the exact emitted WGSL text: the station `(f32(i) + 1f) * 20f` (not `f32(i) * 20f`),
+        // pin the exact emitted WGSL text: the station `(f32(i) + 1f) * 2f` (not `f32(i) * 2f`),
         // the lateral `select(1f, -1f, ((i & 1u) == 1u))` (not a swapped or constant sign), and the slot
         // index `segments[0i]` (not `segments[1i]`). Each would fail under the mutation it names.
         const wgsl = flat(postsWgsl());
@@ -127,24 +139,216 @@ describe("POST_COUNT sizing", () => {
 });
 
 describe("POST_OFFSET flat-core band", () => {
-    test("POST_OFFSET is strictly inside the flat core: 0 < POST_OFFSET < FLAT_CORE_MARGIN", () => {
-        // independently derived from flatten-math.ts:
-        // the flat core extends to halfWidth + FLAT_CORE_MARGIN from the centreline;
-        // a post at halfWidth + POST_OFFSET is inside iff POST_OFFSET < FLAT_CORE_MARGIN;
-        // outside the road iff POST_OFFSET > 0.
-        // red: mutating POST_OFFSET to FLAT_CORE_MARGIN makes this fail (not strictly inside)
-        // red: mutating POST_OFFSET to 0 makes this fail (on the road surface)
-        expect(POST_OFFSET).toBeGreaterThan(0);
-        expect(POST_OFFSET).toBeLessThan(FLAT_CORE_MARGIN);
+    test("the whole footing is strictly inside the flat core: POST_RADIUS < POST_OFFSET < FLAT_CORE_MARGIN − POST_RADIUS", () => {
+        // independently derived from flatten-math.ts: the flat core reaches halfWidth + FLAT_CORE_MARGIN
+        // from the centreline, and the post occupies halfWidth + POST_OFFSET ± POST_RADIUS — so the whole
+        // footing is strictly inside the affine region (where the mesh reproduces the field exactly, the
+        // property the placement oracle reads) and strictly off the pavement iff both bounds below hold.
+        // Stage 11 re-checked the LOWER end on purpose: 0.4 m approaches it, and the older
+        // `0 < POST_OFFSET` form ignored the post's own radius.
+        // red: POST_OFFSET = 0.1 (< POST_RADIUS) fails the lower bound — the footing overhangs the asphalt
+        // red: POST_OFFSET = 5.6 (> FLAT_CORE_MARGIN − POST_RADIUS) fails the upper bound
+        expect(POST_OFFSET).toBeGreaterThan(POST_RADIUS);
+        expect(POST_OFFSET).toBeLessThan(FLAT_CORE_MARGIN - POST_RADIUS);
     });
 
-    test("POST_OFFSET = SPACING (one grid cell from the road edge)", () => {
-        expect(POST_OFFSET).toBe(SPACING);
+    test("the measured margins at the kerb-line offset are the ones written beside the constant", () => {
+        // the measurement the stage reports, asserted rather than printed: 0.28 m of clearance from the
+        // pavement edge to the post's near face, 5.13685 m from its far face to the flat core's edge.
+        expect(POST_OFFSET - POST_RADIUS).toBeCloseTo(0.28, 6);
+        expect(FLAT_CORE_MARGIN - (POST_OFFSET + POST_RADIUS)).toBeCloseTo(5.136854, 5);
+    });
+
+    test("POST_OFFSET is the kerb line (~0.4 m), not stage 5's flat-core convenience (SPACING = 4 m)", () => {
+        // the referent's own value, pinned as a literal: a kerbside bollard stands immediately off the
+        // pavement edge. 4 m (13 ft) is what made the row read as posts standing in a field.
+        expect(POST_OFFSET).toBe(0.4);
+        expect(POST_OFFSET).not.toBe(SPACING);
     });
 
     test("FLAT_CORE_MARGIN = √2 * SPACING (flatten-math.ts's own derivation)", () => {
         // the constant the band is derived against, re-checked here so the band test
         // doesn't silently pass if FLAT_CORE_MARGIN moves
         expect(FLAT_CORE_MARGIN).toBe(Math.SQRT2 * SPACING);
+    });
+});
+
+describe("the referent's own dimensions", () => {
+    test("POST_SPACING is held at the kerb row's 2.0 m upper bound", () => {
+        expect(POST_SPACING).toBe(2);
+    });
+
+    test("POST_HEIGHT is the referent's ~1 m above-grade height and POST_RADIUS its pipe OD/2", () => {
+        expect(POST_HEIGHT).toBe(1);
+        expect(POST_RADIUS).toBe(0.12);
+        // the pipe the referent is made of: 8 in Sch 40 OD 219 mm (r = 0.1095) → 10 in Sch 40 OD 273 mm
+        // (r = 0.1365). The radius sits between the two.
+        expect(POST_RADIUS).toBeGreaterThan(0.1095);
+        expect(POST_RADIUS).toBeLessThan(0.1365);
+    });
+
+    test("POST_COLOR is RAL 1023 traffic yellow, and the emitted FS carries it", () => {
+        // the finish standard, as a literal triple — stage 5's [0.5, 0.4, 0.3] had no referent at all.
+        expect(POST_COLOR).toEqual([0.941, 0.792, 0.0]);
+        // and the FS actually uses it: the resolved surface WGSL carries the f32 rounding of those
+        // components. red: reverting POST_COLOR to [0.5, 0.4, 0.3] emits 0.5/0.4/0.30000001 instead.
+        const wgsl = flat(postsSurfaceWgsl());
+        expect(wgsl).toContain("0.9409999");
+        expect(wgsl).toContain("0.7919999");
+    });
+});
+
+describe("the footing depth's derivation", () => {
+    test("MAX_CHORD_GRADE is the analytic ceiling 2 · RELIEF / ROAD_MIN_LENGTH", () => {
+        // the chord's target height is linear between the endpoints' natural heights, so the along-chord
+        // grade is |Δh| / chordLength; |Δh| <= 2 · RELIEF and chordLength >= ROAD_MIN_LENGTH.
+        expect(MAX_CHORD_GRADE).toBe((2 * RELIEF) / ROAD_MIN_LENGTH);
+        expect(MAX_CHORD_GRADE).toBe(1);
+    });
+
+    test("no admissible chord's grade exceeds the ceiling the footing is sized against", () => {
+        // the measurement the stage reports, asserted: a 5-seed × 400-chord scan of admissible chords
+        // (both endpoints inside the world, length >= ROAD_MIN_LENGTH) against the analytic ceiling. Half
+        // the corpus is drawn as SHORT chords — length in [ROAD_MIN_LENGTH, 2 · ROAD_MIN_LENGTH] — because
+        // grade is |Δh| / length and a uniform endpoint pair is almost always long, so an unbiased scan
+        // reads 0.1092 against this corpus's measured 0.1508. The arm asserts the ceiling holds (a
+        // bound over the domain) and, separately, that the scan really exercises grades worth burying
+        // (or it would pass on a corpus that found nothing).
+        let worst = 0;
+        let state = 0x9e3779b9;
+        const rand = () => {
+            // a plain LCG — the corpus must be deterministic, and this file owns no generator
+            state = (state * 1664525 + 1013904223) >>> 0;
+            return state / 0x100000000;
+        };
+        const bound = WORLD_HALF - SPACING;
+        for (const seed of [1337, 1, 2, 99, 4242]) {
+            const perm = makePermutation(seed);
+            for (let n = 0; n < 400; n++) {
+                const ax = (rand() * 2 - 1) * bound;
+                const az = (rand() * 2 - 1) * bound;
+                let bx: number;
+                let bz: number;
+                if (n % 2 === 0) {
+                    bx = (rand() * 2 - 1) * bound;
+                    bz = (rand() * 2 - 1) * bound;
+                } else {
+                    const theta = rand() * Math.PI * 2;
+                    const L = ROAD_MIN_LENGTH * (1 + rand());
+                    bx = Math.min(Math.max(ax + Math.cos(theta) * L, -bound), bound);
+                    bz = Math.min(Math.max(az + Math.sin(theta) * L, -bound), bound);
+                }
+                const len = Math.hypot(bx - ax, bz - az);
+                if (len < ROAD_MIN_LENGTH) continue;
+                const grade = Math.abs(heightAtCpu(bx, bz, perm) - heightAtCpu(ax, az, perm)) / len;
+                worst = Math.max(worst, grade);
+            }
+        }
+        expect(worst).toBeLessThanOrEqual(MAX_CHORD_GRADE);
+        // the scan is not vacuous: it finds grades steep enough that the footing matters. The floor is a
+        // literal well under the reading rather than the reading itself — a corpus assertion pinned to
+        // its own output cannot survive a seed change.
+        expect(worst).toBeGreaterThan(0.1);
+    });
+
+    test("POST_BURIAL_DEPTH buries the base ring at the worst grade, with the diameter form's 2× margin", () => {
+        // required depth: the base ring's uphill side sits grade · POST_RADIUS above the field height
+        // sampled at the post's centre (the field is exactly flat laterally inside the flat core, so the
+        // along-chord grade is the only rise across the footprint).
+        const required = MAX_CHORD_GRADE * POST_RADIUS;
+        expect(POST_BURIAL_DEPTH).toBe(MAX_CHORD_GRADE * 2 * POST_RADIUS);
+        expect(POST_BURIAL_DEPTH).toBeCloseTo(0.24, 12);
+        expect(POST_BURIAL_DEPTH).toBeCloseTo(2 * required, 12);
+    });
+
+    test("POST_SHAFT_LENGTH is derived so the footing adds below the referent's height, never out of it", () => {
+        expect(POST_SHAFT_LENGTH).toBeCloseTo(POST_HEIGHT + POST_BURIAL_DEPTH - POST_RADIUS, 12);
+        expect(POST_SHAFT_LENGTH).toBeCloseTo(1.12, 12);
+    });
+});
+
+describe("the capsule's core/cap decomposition (the VS's own arithmetic)", () => {
+    test("the above-grade extent is exactly POST_HEIGHT — the footing never eats the referent's height", () => {
+        // the dome's apex is the mesh's highest point (localY = 1).
+        // red: taking the burial out of the height (shaftLength = POST_HEIGHT − POST_RADIUS) reads 0.76.
+        expect(postVertexOffset(0, 1, 0)[1]).toBeCloseTo(POST_HEIGHT, 12);
+    });
+
+    test("the bottom cap's highest point is below the surface for the worst grade the chord allows", () => {
+        // the bottom cap's highest point is the shaft's base ring (localY = −0.5), and the uphill side of
+        // that ring sits MAX_CHORD_GRADE · POST_RADIUS above the sampled centre height — so the ring must
+        // sit at least that far below the surface, and the cap's own lowest point below it again.
+        // red-first against the shipped shape, witnessed 2026-08-22: `POST_BURIAL_DEPTH = 0` (stage 5's
+        // mapping, whose lowest mesh point sat ON the surface) puts the base ring flush at y = 0, so the
+        // uphill side of the ring reads 0.12 m ABOVE the surface — `Expected: <= 0, Received: 0.12` — and
+        // three more arms red with it (the depth, the derived shaft length, and the emitted VS literals).
+        const baseRing = postVertexOffset(0, -0.5, 0)[1];
+        expect(baseRing).toBeCloseTo(-POST_BURIAL_DEPTH, 12);
+        expect(baseRing + MAX_CHORD_GRADE * POST_RADIUS).toBeLessThanOrEqual(0);
+        expect(postVertexOffset(0, -1, 0)[1]).toBeLessThan(baseRing);
+    });
+
+    test("both caps are spheres of exactly POST_RADIUS, independent of the shaft length", () => {
+        // the property an arm over total height alone cannot see — and the defect that shipped: stage 5
+        // scaled y by POST_HEIGHT/2 and x/z by POST_RADIUS · 2, stretching each cap into an ellipsoid
+        // 0.25 m tall and 0.12 m wide (a bullet nose). Here the cap term takes the SAME factor x/z take,
+        // so every cap vertex sits at exactly POST_RADIUS from its cap centre at any radius/length ratio.
+        // red: scaling the cap by shaftLength instead of the radius makes the distance vary with the
+        // shaft length (and differ from POST_RADIUS at every angle but 0).
+        for (const shaftLength of [0.3, POST_SHAFT_LENGTH, 5]) {
+            const params = { ...POST_MESH, shaftLength };
+            const topCentre = shaftLength - POST_MESH.burial;
+            const bottomCentre = -POST_MESH.burial;
+            for (const theta of [0, 0.3, Math.PI / 4, 1.2, Math.PI / 2]) {
+                const lx = 0.5 * Math.cos(theta);
+                const lyTop = 0.5 + 0.5 * Math.sin(theta);
+                const top = postVertexOffset(lx, lyTop, 0, params);
+                expect(Math.hypot(top[0], top[1] - topCentre, top[2])).toBeCloseTo(POST_RADIUS, 12);
+                const bottom = postVertexOffset(lx, -lyTop, 0, params);
+                expect(Math.hypot(bottom[0], bottom[1] - bottomCentre, bottom[2])).toBeCloseTo(
+                    POST_RADIUS,
+                    12,
+                );
+            }
+        }
+    });
+
+    test("the shaft is a cylinder of POST_RADIUS — the core term carries the length, the radial term the width", () => {
+        for (const ly of [-0.5, -0.2, 0, 0.25, 0.5]) {
+            const side = postVertexOffset(0.5, ly, 0);
+            expect(side[0]).toBeCloseTo(POST_RADIUS, 12);
+            // the shaft spans POST_SHAFT_LENGTH from base ring to dome underside
+            expect(side[1]).toBeCloseTo(
+                ly * POST_SHAFT_LENGTH + POST_SHAFT_LENGTH / 2 - POST_BURIAL_DEPTH,
+                12,
+            );
+        }
+    });
+
+    test("a scale-0 slot collapses to the record position (the fixed-instanceCount mechanism)", () => {
+        // component-wise, because a collapsed −z vertex reads as −0 and `toEqual` distinguishes it
+        const collapsed = postVertexOffset(0.5, 1, -0.5, POST_MESH, 0);
+        expect(collapsed[0]).toBeCloseTo(0, 12);
+        expect(collapsed[1]).toBeCloseTo(0, 12);
+        expect(collapsed[2]).toBeCloseTo(0, 12);
+    });
+
+    test("the resolved VS emits the decomposition, with the cap and the radius sharing one factor", () => {
+        // structural, over the emitted text, because the sphericity is a property of WHICH factor the cap
+        // term takes: `cap * radial` and `localPos.x * radial` must be the same `radial`, and only the
+        // core may carry the shaft length. Literals rather than values re-derived from the constants
+        // (stage 3's precedent).
+        const wgsl = flat(postsSurfaceWgsl());
+        expect(wgsl).toContain("clamp(input.localPos.y, -0.5f, 0.5f)");
+        expect(wgsl).toContain("(input.localPos.y - core)");
+        expect(wgsl).toContain("(cap * radial)");
+        expect(wgsl).toContain("(input.localPos.x * radial)");
+        expect(wgsl).toContain("(input.localPos.z * radial)");
+        // the shaft length on the core term, and the burial in the translation — f32 roundings of
+        // 1.12 and 1.12/2 − 0.24 = 0.32.
+        expect(wgsl).toMatch(/core \* 1\.12\d*f/);
+        expect(wgsl).toMatch(/\+ 0\.3199\d*f/);
+        // and the y scale stage 5 shipped (POST_HEIGHT / 2 = 0.5) is gone from the VS
+        expect(wgsl).not.toContain("input.localPos.y * 0.5f");
     });
 });

--- a/examples/showcase/roads/src/posts.ts
+++ b/examples/showcase/roads/src/posts.ts
@@ -1,7 +1,7 @@
 // Stage 5 — posts (`roads-interactive.md` stage 5). A row of abstract posts along the road, positioned
 // entirely on the GPU: a compute kernel writes one `Post` record per slot (station along the chord,
 // lateral offset alternating sides, `y` from `flatten.ts`'s own `flattenedHeightAt` TGSL fn, scale 0 for
-// slots past the chord), and a custom surface's VS scales the standard `capsule` mesh by the post
+// slots past the chord), and a custom surface's VS maps the standard `capsule` mesh onto the post's own
 // dimensions and translates by the record. The fountain showcase's shape: a typed record buffer written
 // by compute, read by a custom surface's VS at `input.iid`, one shared mesh, `Draws.register` with a
 // fixed `instanceCount`. The records never touch Part or the Transform slabs.
@@ -11,6 +11,11 @@
 // across edits and short chords leave most slots at scale 0. Re-dispatched after every `setNetwork` (edit
 // and reseed), never per frame — `terrain.ts`'s `warm`, `regenerate`, and `editDocument` each call
 // `dispatchPosts(seed)` after `setNetwork`.
+//
+// Stage 11 re-derived every constant off **one referent** (see the constant block's header) and rewrote
+// the VS's mesh mapping as a core/cap decomposition with a buried base (see {@link postVertexOffset}).
+// The kernel and the placement record are untouched by that pass, so the placement arms are its null
+// control.
 
 import { Compute, type State } from "@dylanebert/shallot";
 import {
@@ -34,6 +39,7 @@ import * as d from "typegpu/data";
 import * as std from "typegpu/std";
 import { flattenFieldAt } from "./flatness";
 import type { Check } from "./harness";
+import { ROAD_MIN_LENGTH } from "./overlay/network";
 import {
     buildNetworkGeometry,
     computeFalloff,
@@ -42,56 +48,128 @@ import {
     networkLayout,
 } from "./terrain/flatten";
 import { FLAT_CORE_MARGIN } from "./terrain/flatten-math";
-import { SPACING, WORLD_EXTENT } from "./terrain/grid";
-import { makePermutation, noiseLayout, PermData } from "./terrain/noise";
+import { WORLD_EXTENT } from "./terrain/grid";
+import { makePermutation, noiseLayout, PermData, RELIEF } from "./terrain/noise";
 import { heightAtCpu } from "./terrain/profile";
 import { getCurrentSeed, getDocument } from "./terrain/terrain";
 
 // --- constants --------------------------------------------------------------
+//
+// THE REFERENT (stage 11, `roads-interactive.md`'s Locked decision): **one kerbside pipe bollard**, the
+// galvanized/painted steel pipe set in a footing at the kerb line of an urban street edge — a single
+// object, and every `POST_*` constant below is read off that one object rather than off a per-dimension
+// citation. Stage 10 cited a pipe OD for the radius, a foundry catalogue for the height and NACTO
+// channelization for the spacing: three numbers from three different objects, which is what left the row
+// still reading wrong (spec: "a decorative element's referent is a single thing in the world, and every
+// constant describing it is read off that one thing").
+//
+// The referent's own dimensions, as one object (`[snippet]`-grade, 1800bollards.com + the OSHA colour-use
+// interpretation, read 2026-08-22, recorded in the spec's Locked decision): ~1 m tall above grade, set at
+// the **kerb line** rather than out in the grass, **1.5–2.0 m** apart along the kerb, finished in RAL 1023
+// traffic yellow (the high-visibility default), RAL 9005 jet black, or bare galvanized grey. Its shaft is a
+// steel pipe — 8–10 in Schedule 40, OD 219–273 mm — closed with a domed cap and **embedded in a footing**,
+// so it meets the pavement at a line, never at a visible bulge.
+//
+// What that one object fixes, constant by constant: `POST_HEIGHT` (~1 m above grade), `POST_RADIUS`
+// (the pipe's own OD/2), `POST_SPACING` (the kerb row's 2.0 m), `POST_OFFSET` (the kerb line, ~0.4 m off
+// the pavement edge), `POST_COLOR` (RAL 1023), and `POST_BURIAL_DEPTH` (the footing — derived below from
+// the grade the road carries, not chosen by eye).
 
-/** metres between posts along the chord.
+/** metres between posts along the chord — the kerb row's own spacing.
  *
- *  Referent: NACTO Urban Street Design Guide — traffic-calming / channelizing bollards are spaced
- *  1.5–2.0 m apart for pedestrian channelization (nacto.org, accessed 2026-08-22). 2.0 m is the upper
- *  bound of that range, within the spec's ~2 m band. */
+ *  Held at 2 m by stage 11 rather than moved: 2.0 m is the **upper bound of the referent's own 1.5–2.0 m
+ *  kerbside range**, so the value stage 10 shipped is already read off this object and needs no change.
+ *  Below 1.5 m the row reads as a barrier rather than a kerb line; above 2.0 m it stops reading as a row. */
 export const POST_SPACING = 2;
 
-/** the lateral offset from the road edge to the post centre, in metres.
+/** the lateral offset from the road edge (pavement edge) to the post centre, in metres — the **kerb line**.
  *
- *  Derivation of the admissible band. The flat core is the region where `coreDist <= 0`, where
- *  `coreDist = distance(point, segment) − (halfWidth + FLAT_CORE_MARGIN)` (`flatten.ts`'s `networkCore`).
- *  The flat core extends from the centreline (perpendicular distance 0) to `halfWidth + FLAT_CORE_MARGIN`
- *  from it. A post at `halfWidth + POST_OFFSET` from the centreline is inside the flat core iff
- *  `POST_OFFSET <= FLAT_CORE_MARGIN`. For the post to sit outside the road surface (not on the road),
- *  `POST_OFFSET > 0`. For the post's foot to meet the *rendered surface* rather than the field's idea of
- *  it — the property Validation names: inside the flat core the field is affine and the rendered mesh
- *  reproduces it exactly — the post must be strictly inside, so `POST_OFFSET < FLAT_CORE_MARGIN`.
- *  Therefore the admissible band is `0 < POST_OFFSET < FLAT_CORE_MARGIN`.
- *  `FLAT_CORE_MARGIN = √2 · SPACING = √2 · 4 ≈ 5.657 m` (`flatten-math.ts`).
- *  `POST_OFFSET = SPACING = 4 m` sits well inside the band (0 < 4 < 5.657).
+ *  Referent value: a kerbside bollard stands at the kerb, i.e. immediately off the pavement edge, not out
+ *  in the verge. ~0.4 m from the pavement edge puts the post's near face ~0.28 m clear of the asphalt —
+ *  a kerb-and-gutter's own width, which is what "at the kerb line" means in this scene, where the road is
+ *  a bare 8 m strip with no modelled kerb. Stage 5's `POST_OFFSET = SPACING = 4 m` (13 ft) was the flat
+ *  core band's convenience and never a fact about bollards — it is why the row read as posts standing in
+ *  a field.
  *
- *  The spec's Approach wrote the offset as `halfWidth + FLAT_CORE_MARGIN − √2·SPACING` from the
- *  centreline, but `FLAT_CORE_MARGIN = √2 · SPACING`, so that expression reduces to exactly `halfWidth` —
- *  the flat core's *inner* edge, not a point inside it. The real constraint is `0 < POST_OFFSET <
- *  FLAT_CORE_MARGIN`, derived above. (Open question 1 — reported to the spec owner for correction.) */
-export const POST_OFFSET = SPACING;
+ *  Admissibility, re-measured at stage 11's claim against `flatten-math.ts` rather than assumed safer for
+ *  being smaller (the *lower* end of the band is the one 0.4 m approaches). The flat core is the region
+ *  `coreDist <= 0` (`flatten.ts`'s `networkCore`), i.e. perpendicular distance from the centreline up to
+ *  `halfWidth + FLAT_CORE_MARGIN`, where `FLAT_CORE_MARGIN = √2 · SPACING = √2 · 4 = 5.65685 m`. Inside
+ *  it the flatten field is exactly affine, so the rendered mesh reproduces it exactly and a post's foot
+ *  meets the rendered surface — the property the placement oracle reads. A post at `halfWidth +
+ *  POST_OFFSET` occupies the band `[halfWidth + POST_OFFSET − POST_RADIUS, halfWidth + POST_OFFSET +
+ *  POST_RADIUS]`, so the whole footing is strictly inside the flat core and strictly off the pavement iff
+ *
+ *      POST_RADIUS < POST_OFFSET < FLAT_CORE_MARGIN − POST_RADIUS
+ *      0.12 m      < 0.4 m       < 5.53685 m
+ *
+ *  Measured margins at 0.4 m: **0.28 m** of clearance from the pavement edge to the post's near face and
+ *  **5.13685 m** from its far face to the flat core's outer edge. 0.4 m is admissible, so it stands as
+ *  the referent's own value; no smallest-admissible fallback was needed. (The band's earlier statement,
+ *  `0 < POST_OFFSET < FLAT_CORE_MARGIN`, ignored the post's own radius — correct for the record's point,
+ *  too loose for the footing.) */
+export const POST_OFFSET = 0.4;
 
-/** the post's visual height in metres. The capsule mesh spans y ∈ [−1, 1] (height 2), so the VS scales
- *  y by `POST_HEIGHT / 2`.
+/** the post's **above-grade** height in metres — the referent's own quantity ("36 in above grade"), and
+ *  the burial depth below is added *below* it rather than taken out of it, so the height a person sees is
+ *  this number exactly.
  *
- *  Referent: a standard roadside bollard is ~1.0 m above grade. Reliance Foundry R-7181 cast-iron
- *  bollard: 36 in (0.914 m) above grade (reliance-fd.com, accessed 2026-08-22); UK DfT Traffic Signs
- *  Manual Chapter 4 describes traffic bollards at approximately 1.0 m. 1.0 m is within the spec's
- *  ~1 m band. */
-const POST_HEIGHT = 1;
+ *  Referent value: the kerbside pipe bollard stands ~1 m above grade (the R-7181 pipe bollard's 36 in =
+ *  0.914 m is the same object's catalogue instance). Held at 1 m by stage 11. */
+export const POST_HEIGHT = 1;
 
-/** the post's visual radius in metres. The capsule mesh has radius 0.5, so the VS scales x/z by
- *  `POST_RADIUS / 0.5 = POST_RADIUS * 2`.
+/** the post's radius in metres — the referent's pipe OD / 2, and the radius of **both** spherical caps.
  *
- *  Referent: a standard pipe bollard made from 10 in Schedule 40 steel pipe has an OD of 10.75 in
- *  (273 mm, radius 0.137 m); 8 in Schedule 40 has OD 8.625 in (219 mm, radius 0.11 m). 0.12 m (diameter
- *  240 mm) sits between the two, within the spec's ~0.1–0.15 m band. */
-const POST_RADIUS = 0.12;
+ *  Referent value: the same kerbside pipe bollard is 8–10 in Schedule 40 steel pipe, OD 219 mm (r =
+ *  0.110 m) to 273 mm (r = 0.137 m); 0.12 m (OD 240 mm) sits between the two. Held at 0.12 m by stage 11. */
+export const POST_RADIUS = 0.12;
+
+/** the bollard's finish colour, in the same 0–1 linear-albedo convention as `ROAD_ALBEDO`/`EDGE_ALBEDO`
+ *  (unconverted).
+ *
+ *  Referent value: **RAL 1023 traffic yellow** ≈ `[0.941, 0.792, 0.0]` — the high-visibility default
+ *  finish for a kerbside safety bollard. The referent's other two catalogue finishes are the one-constant
+ *  swap if the look prefers them: **RAL 9005 jet black** ≈ `[0.039, 0.039, 0.039]` and **bare galvanized
+ *  grey** ≈ `[0.66, 0.67, 0.68]`. Stage 5's `[0.5, 0.4, 0.3]` was an unexplained brown triple with no
+ *  referent at all, and it is half of why the row read as fence posts. */
+export const POST_COLOR: readonly [number, number, number] = [0.941, 0.792, 0.0];
+
+/** the steepest grade (rise/run) the flatten field can carry *along* a chord the drag admits — the input
+ *  the footing depth is derived from.
+ *
+ *  The chord's target height is linear between its endpoints' natural heights (`buildPolylineProfile`), so
+ *  the field's along-chord grade is exactly `|Δh| / chordLength`. `heightAtCpu` is `GROUND_LEVEL + fbm2 ·
+ *  RELIEF` with `|fbm2| ≤ 1`, so `|Δh| ≤ 2 · RELIEF = 80 m`, and the drag clamps the chord at
+ *  `ROAD_MIN_LENGTH = 80 m` — hence a ceiling of exactly 1.0. This is an analytic ceiling over the whole
+ *  admissible domain, not a fitted number; the *measured* worst case over a 5-seed × 400-chord scan of
+ *  admissible chords (half of them drawn short, since grade is |Δh| / length) is **0.1508** — `posts.test.ts`
+ *  asserts the scan stays under this ceiling and that it reaches grades worth burying. So the ceiling is
+ *  ~6.6× the measurement, and the footing is sized against the domain rather than against a sample. */
+export const MAX_CHORD_GRADE = (2 * RELIEF) / ROAD_MIN_LENGTH;
+
+/** the footing: how far below the surface the shaft's base sits, in metres — so the shaft meets the
+ *  pavement at a **line** and the bottom cap is entirely underground, which is what a bollard set in a
+ *  footing looks like and what stage 5's shipped mapping got wrong (its lowest mesh point sat *on* the
+ *  surface, leaving a 0.25 m dome bulging under the shaft).
+ *
+ *  Derived, not eyeballed. The flatten field is exactly flat *laterally* inside the flat core, so the only
+ *  rise across the post's own footprint is the road's along-chord grade. The base ring's uphill side sits
+ *  `grade · POST_RADIUS` above the field height sampled at the post's centre, so burying the ring needs
+ *  `POST_BURIAL_DEPTH ≥ MAX_CHORD_GRADE · POST_RADIUS = 0.12 m`. Taking the rise across the post's whole
+ *  **diameter** instead of its radius gives exactly 2× that requirement — the margin is that factor of
+ *  two, stated rather than added as an epsilon:
+ *
+ *      POST_BURIAL_DEPTH = MAX_CHORD_GRADE · 2 · POST_RADIUS = 1.0 · 0.24 = 0.24 m
+ *
+ *  It costs nothing visible: the depth is added *below* `POST_HEIGHT` (the shaft grows downward), so the
+ *  above-grade extent stays at the referent's 1 m exactly. */
+export const POST_BURIAL_DEPTH = MAX_CHORD_GRADE * 2 * POST_RADIUS;
+
+/** the cylindrical shaft's length in metres — a derived quantity, not a referent one: the shaft spans from
+ *  the footing's base (`POST_BURIAL_DEPTH` below the surface) to the underside of the `POST_RADIUS` dome,
+ *  and the dome's top is the referent's above-grade height. So
+ *  `POST_SHAFT_LENGTH = POST_HEIGHT + POST_BURIAL_DEPTH − POST_RADIUS` = 1 + 0.24 − 0.12 = 1.12 m. */
+export const POST_SHAFT_LENGTH = POST_HEIGHT + POST_BURIAL_DEPTH - POST_RADIUS;
 
 /** the world's own diagonal — the maximum chord length the world contains (`WORLD_EXTENT · √2` ≈ 1448 m),
  *  since `ROAD_MAX_LENGTH` was deleted in stage 4c. This is the ceiling `POST_COUNT` is sized against. */
@@ -213,9 +291,68 @@ export function postsWgsl(): string {
     return tgpu.resolve([flattenedHeightAt, postsKernel], { names: "strict" });
 }
 
+/** the emitted posts **surface** WGSL — the VS's core/cap decomposition and the FS's finish colour
+ *  (stage 11). A second seam from {@link postsWgsl} because the surface functions resolve on their own
+ *  schemas, not through the compute entry point. */
+export function postsSurfaceWgsl(): string {
+    return tgpu.resolve([postsVs, postsFs], { names: "strict" });
+}
+
 // --- surface (VS + FS) -------------------------------------------------------
 
 const postsPatch = vsPatchSchema({});
+
+/** the core/cap decomposition of the standard `capsule` mesh (stage 11), and the CPU twin of exactly the
+ *  arithmetic {@link postsVs} performs — `posts.test.ts`'s mesh arms read this rather than a
+ *  re-derivation, and the VS's own structural arm pins the emitted WGSL beside it.
+ *
+ *  The mesh (`part/mesh.ts`'s `capsule()`) is `radius = 0.5`, `halfHeight = 0.5`: a cylinder section over
+ *  `y ∈ [−0.5, 0.5]` with a hemisphere cap beyond each end, total extent `[−1, 1]`. Stage 5 scaled the
+ *  whole thing anisotropically — y by `POST_HEIGHT/2`, x/z by `POST_RADIUS · 2` — which stretched both
+ *  caps into ellipsoids taller than they are wide (a bullet nose, not a hemisphere). The decomposition
+ *  fixes that at any radius/length ratio:
+ *
+ *    - **core** `= clamp(localY, −0.5, 0.5)`, the cylinder section, scaled by the **shaft length** — it
+ *      spans one unit, so `core · shaftLength` spans `shaftLength`;
+ *    - **cap** `= localY − core`, the hemisphere remainder (`|cap| ≤ 0.5`), scaled by `radius · 2` — the
+ *      **same factor x/z take**, which is what makes both caps spheres of exactly `radius`, independent of
+ *      the shaft length;
+ *    - **translate** by `shaftLength/2 − burial`, putting the shaft's base ring `burial` below the record's
+ *      own surface height and its top at `shaftLength − burial`, so the dome's apex lands at
+ *      `shaftLength + radius − burial = POST_HEIGHT` above grade exactly.
+ *
+ *  Everything is multiplied by the record's `scale`, so a scale-0 slot collapses to a point at the record
+ *  position (the fixed-`instanceCount` mechanism stage 5 shipped, unchanged). */
+export interface PostMeshParams {
+    readonly shaftLength: number;
+    readonly radius: number;
+    readonly burial: number;
+}
+
+/** the production mesh mapping's parameters — what {@link postsVs} bakes as literals. */
+export const POST_MESH: PostMeshParams = {
+    shaftLength: POST_SHAFT_LENGTH,
+    radius: POST_RADIUS,
+    burial: POST_BURIAL_DEPTH,
+};
+
+/** the CPU twin of {@link postsVs}'s vertex arithmetic: the offset (in metres, relative to the record's
+ *  own world position — i.e. relative to the terrain surface under the post) of the capsule vertex whose
+ *  local position is `(lx, ly, lz)`. Independently parameterized so an arm can vary the shaft length and
+ *  witness that the cap term does not move with it. */
+export function postVertexOffset(
+    lx: number,
+    ly: number,
+    lz: number,
+    params: PostMeshParams = POST_MESH,
+    scale = 1,
+): [number, number, number] {
+    const core = Math.min(Math.max(ly, -0.5), 0.5);
+    const cap = ly - core;
+    const radial = params.radius * 2;
+    const y = core * params.shaftLength + cap * radial + (params.shaftLength / 2 - params.burial);
+    return [lx * radial * scale, y * scale, lz * radial * scale];
+}
 
 const postsVs = tgpu.fn(
     [VsIn],
@@ -226,11 +363,20 @@ const postsVs = tgpu.fn(
     const scale = record.pos.w;
     const worldPos = record.pos.xyz;
 
-    // scale the unit capsule (radius 0.5, y ∈ [−1, 1]) to post dimensions, then translate.
-    // y is offset by POST_HEIGHT/2 so the foot (bottom) sits at worldPos.y (the terrain surface).
-    const sx = input.localPos.x * d.f32(POST_RADIUS * 2) * scale;
-    const sy = input.localPos.y * d.f32(POST_HEIGHT / 2) * scale + d.f32(POST_HEIGHT / 2) * scale;
-    const sz = input.localPos.z * d.f32(POST_RADIUS * 2) * scale;
+    // the core/cap decomposition (see postVertexOffset, the CPU twin of exactly this arithmetic): the
+    // cylinder section scales by the shaft length, the hemisphere remainder by the radius alone — so the
+    // caps stay spherical at POST_RADIUS — and the whole post is translated down by POST_BURIAL_DEPTH so
+    // the shaft meets the ground at a line with the bottom cap buried.
+    const core = std.clamp(input.localPos.y, d.f32(-0.5), d.f32(0.5));
+    const cap = input.localPos.y - core;
+    const radial = d.f32(POST_RADIUS * 2);
+    const sx = input.localPos.x * radial * scale;
+    const sy =
+        (core * d.f32(POST_SHAFT_LENGTH) +
+            cap * radial +
+            d.f32(POST_SHAFT_LENGTH / 2 - POST_BURIAL_DEPTH)) *
+        scale;
+    const sz = input.localPos.z * radial * scale;
 
     return postsPatch({
         world: d.vec4f(sx + worldPos.x, sy + worldPos.y, sz + worldPos.z, d.f32(1)),
@@ -238,8 +384,6 @@ const postsVs = tgpu.fn(
         clip: d.vec4f(0),
     });
 });
-
-const POST_COLOR: readonly [number, number, number] = [0.5, 0.4, 0.3];
 
 const postsFs = tgpu.fn(
     [fsCtxSchema({})],
@@ -494,7 +638,8 @@ function signedPerpDist(
 /** the device gate's posts check: reads back the posts buffer and verifies every Validation criterion —
  *  every live slot's `y` equals CPU `flattenFieldAt` at its `(x, z)` (baked against the live seed via
  *  `getCurrentSeed`, not the boot `SEED` — an F9 reseed changes the permutation and the falloff, so a
- *  stale-seed twin produces a false negative), the lateral offset is inside the flat core, each live
+ *  stale-seed twin produces a false negative), the lateral offset is at the kerb line (`halfWidth +
+ *  POST_OFFSET`, re-anchored by stage 11) with the whole footing inside the flat core, each live
  *  slot is on the side `postLateralSign(i)` predicts (the alternation the distance band alone never
  *  checks), the live-slot count is `floor(chordLength / POST_SPACING)`, and every slot past the chord
  *  is at scale 0. Called from `gate.ts` at boot and from `boot.ts`'s `__roadsPostsCheck` bridge after an
@@ -526,8 +671,15 @@ export async function checkPosts(): Promise<Check> {
             liveCount++;
             const expectedY = flattenFieldAt(rec.x, rec.z, segments, falloff, natural);
             maxDiff = Math.max(maxDiff, Math.abs(rec.y - expectedY));
+            // the lateral band, re-anchored on stage 11's kerb-line offset: the record sits at exactly
+            // `halfWidth + POST_OFFSET` from the centreline (the old assertion — anywhere between
+            // `halfWidth` and `halfWidth + FLAT_CORE_MARGIN` — passed for any offset in a 5.66 m band and
+            // so could not witness the offset at all), and the post's whole footing, ±POST_RADIUS about
+            // that, is strictly inside the flat core and strictly off the pavement.
             const dist = perpDist(rec.x, rec.z, a[0], a[1], b[0], b[1]);
-            if (dist > halfWidth + FLAT_CORE_MARGIN || dist < halfWidth) lateralOk = false;
+            if (Math.abs(dist - (halfWidth + POST_OFFSET)) > 0.01) lateralOk = false;
+            if (dist - POST_RADIUS <= halfWidth) lateralOk = false;
+            if (dist + POST_RADIUS >= halfWidth + FLAT_CORE_MARGIN) lateralOk = false;
             // the alternation check: each live slot must be on the side `postLateralSign(i)` predicts
             // (even → +1, odd → −1). The kernel's `select(1f, -1f, (i & 1u) == 1u)` and this CPU twin
             // must agree on which side of the road every post sits — the distance band alone never

--- a/examples/showcase/roads/src/posts.ts
+++ b/examples/showcase/roads/src/posts.ts
@@ -14,8 +14,12 @@
 //
 // Stage 11 re-derived every constant off **one referent** (see the constant block's header) and rewrote
 // the VS's mesh mapping as a core/cap decomposition with a buried base (see {@link postVertexOffset}).
-// The kernel and the placement record are untouched by that pass, so the placement arms are its null
-// control.
+// **Only the mesh half has the placement arms as its null control.** The kernel's own *code* is untouched
+// — every expression in it (station, lateral sign, slot index, the `flattenedHeightAt` call) and the
+// record's shape are byte-for-byte stage 5's — but `POST_OFFSET` moved 4 → 0.4, and the kernel reads it,
+// so every live record's x/z (and the `y` that follows from them) moved ~3.6 m laterally and
+// `checkPosts`'s lateral assertion had to be re-anchored on the new offset. The mesh rewrite is what the
+// placement arms are blind to; the offset move is not, and it reds the device gate against the pre-image.
 
 import { Compute, type State } from "@dylanebert/shallot";
 import {
@@ -57,23 +61,31 @@ import { getCurrentSeed, getDocument } from "./terrain/terrain";
 //
 // THE REFERENT (stage 11, `roads-interactive.md`'s Locked decision): **one kerbside pipe bollard**, the
 // galvanized/painted steel pipe set in a footing at the kerb line of an urban street edge — a single
-// object, and every `POST_*` constant below is read off that one object rather than off a per-dimension
-// citation. Stage 10 cited a pipe OD for the radius, a foundry catalogue for the height and NACTO
-// channelization for the spacing: three numbers from three different objects, which is what left the row
+// object. Stage 10 cited a pipe OD for the radius, a foundry catalogue for the height and NACTO
+// channelization for the spacing: three numbers from three different *objects*, which is what left the row
 // still reading wrong (spec: "a decorative element's referent is a single thing in the world, and every
 // constant describing it is read off that one thing").
 //
-// The referent's own dimensions, as one object (`[snippet]`-grade, 1800bollards.com + the OSHA colour-use
-// interpretation, read 2026-08-22, recorded in the spec's Locked decision): ~1 m tall above grade, set at
-// the **kerb line** rather than out in the grass, **1.5–2.0 m** apart along the kerb, finished in RAL 1023
-// traffic yellow (the high-visibility default), RAL 9005 jet black, or bare galvanized grey. Its shaft is a
-// steel pipe — 8–10 in Schedule 40, OD 219–273 mm — closed with a domed cap and **embedded in a footing**,
-// so it meets the pavement at a line, never at a visible bulge.
+// **Five constants are read off that object: `POST_HEIGHT`, `POST_RADIUS`, `POST_SPACING`, `POST_OFFSET`,
+// `POST_COLOR`.** The header claims nothing about the rest, because the rest are not the referent's to
+// fix and each carries its own derivation in its own docblock: `POST_COUNT` and `WORLD_DIAGONAL` come from
+// the world's diagonal, `MAX_CHORD_GRADE` from the flatten field and the drag's length floor, and
+// `POST_BURIAL_DEPTH`/`POST_SHAFT_LENGTH` from that grade plus the post's own geometry. The referent says a
+// bollard is *set in a footing*; it does not say how deep, and this scene's grade is what answers that.
 //
-// What that one object fixes, constant by constant: `POST_HEIGHT` (~1 m above grade), `POST_RADIUS`
-// (the pipe's own OD/2), `POST_SPACING` (the kerb row's 2.0 m), `POST_OFFSET` (the kerb line, ~0.4 m off
-// the pavement edge), `POST_COLOR` (RAL 1023), and `POST_BURIAL_DEPTH` (the footing — derived below from
-// the grade the road carries, not chosen by eye).
+// The referent's dimensions, as one object, from two evidence sources for two different kinds of fact —
+// which is not stage 10's defect, since both describe the same object rather than three:
+//   * the **kerbside-bollard snippet** (`[snippet]`-grade, 1800bollards.com + the OSHA colour-use
+//     interpretation, read 2026-08-22, recorded in the spec's Locked decision) records what the object
+//     is *in the street*: ~1 m tall above grade, set at the **kerb line** rather than out in the grass,
+//     **1.5–2.0 m** apart along the kerb, finished in RAL 1023 traffic yellow (the high-visibility
+//     default), RAL 9005 jet black, or bare galvanized grey, closed with a domed cap and **embedded in a
+//     footing**, so it meets the pavement at a line and never at a visible bulge. It records **no pipe
+//     schedule and no OD** — a colour-use interpretation cannot support a pipe dimension.
+//   * the **Schedule 40 NPS pipe dimension table** (ASME B36.10M: 8 NPS OD 8.625 in = 219.1 mm, 10 NPS OD
+//     10.75 in = 273.1 mm) records what the *pipe such a bollard is made from* measures. This is the
+//     source the pipe OD is cited to — a dimension standard for the stock, read for the one constant that
+//     is a property of the stock (`POST_RADIUS`), not folded into the snippet that does not carry it.
 
 /** metres between posts along the chord — the kerb row's own spacing.
  *
@@ -114,14 +126,21 @@ export const POST_OFFSET = 0.4;
  *  the burial depth below is added *below* it rather than taken out of it, so the height a person sees is
  *  this number exactly.
  *
- *  Referent value: the kerbside pipe bollard stands ~1 m above grade (the R-7181 pipe bollard's 36 in =
- *  0.914 m is the same object's catalogue instance). Held at 1 m by stage 11. */
+ *  Referent value: **the kerbside-bollard snippet's own ~1 m above grade** — that is what this constant
+ *  rests on, and it is the snippet's own quantity. Stage 10's Reliance Foundry R-7181 (a cast-iron bollard
+ *  at 36 in / 0.914 m, reliance-fd.com, read 2026-08-22) is kept only as a **corroborating catalogue
+ *  reading in the same class**, not as "the same object": the snippet does not name that catalogue and the
+ *  catalogue names a different casting, so resting the height on it would be stage 10's three-objects
+ *  defect wearing one sentence. Held at 1 m by stage 11. */
 export const POST_HEIGHT = 1;
 
 /** the post's radius in metres — the referent's pipe OD / 2, and the radius of **both** spherical caps.
  *
- *  Referent value: the same kerbside pipe bollard is 8–10 in Schedule 40 steel pipe, OD 219 mm (r =
- *  0.110 m) to 273 mm (r = 0.137 m); 0.12 m (OD 240 mm) sits between the two. Held at 0.12 m by stage 11. */
+ *  Referent value: the referent's shaft is Schedule 40 steel pipe in the 8–10 NPS range, and the OD is
+ *  cited to the **pipe dimension table** rather than to the kerbside snippet, which carries no schedule and
+ *  no OD (see the block header): ASME B36.10M gives 8 NPS OD 8.625 in = 219.1 mm (r = 0.1096 m) and 10 NPS
+ *  OD 10.75 in = 273.1 mm (r = 0.1366 m). 0.12 m (OD 240 mm) sits between the two. Held at 0.12 m by
+ *  stage 11. */
 export const POST_RADIUS = 0.12;
 
 /** the bollard's finish colour, in the same 0–1 linear-albedo convention as `ROAD_ALBEDO`/`EDGE_ALBEDO`
@@ -142,9 +161,18 @@ export const POST_COLOR: readonly [number, number, number] = [0.941, 0.792, 0.0]
  *  RELIEF` with `|fbm2| ≤ 1`, so `|Δh| ≤ 2 · RELIEF = 80 m`, and the drag clamps the chord at
  *  `ROAD_MIN_LENGTH = 80 m` — hence a ceiling of exactly 1.0. This is an analytic ceiling over the whole
  *  admissible domain, not a fitted number; the *measured* worst case over a 5-seed × 400-chord scan of
- *  admissible chords (half of them drawn short, since grade is |Δh| / length) is **0.1508** — `posts.test.ts`
- *  asserts the scan stays under this ceiling and that it reaches grades worth burying. So the ceiling is
- *  ~6.6× the measurement, and the footing is sized against the domain rather than against a sample. */
+ *  admissible chords (half of them drawn short, since grade is |Δh| / length) is **0.151686** —
+ *  `posts.test.ts` asserts the scan stays under this ceiling, and separately keeps a non-vacuity tripwire
+ *  under the reading (that arm does **not** witness that the depth is needed — see its own note). So the
+ *  ceiling is ~6.6× the measurement, and the footing is sized against the domain rather than a sample.
+ *
+ *  **Boundary note — this is the repo's second grade ceiling and they are 8× apart.** `terrain/profile.ts`
+ *  owns `MAX_GRADE = 0.12`, the bound the *sampled centreline profile's* first difference is checked
+ *  against (`flatten.test.ts`'s gated arm). They are not the same quantity and neither subsumes the other:
+ *  `MAX_GRADE` bounds the profile the flattener is allowed to *build* on a chord it accepts, while this
+ *  constant is the analytic worst case over every chord the drag *admits*, which is the domain a footing
+ *  has to survive. The honest cross-reference is one-way from here — `profile.ts` is outside this stage's
+ *  footprint, so the pointer back from `MAX_GRADE` to this constant is unwritten and owed. */
 export const MAX_CHORD_GRADE = (2 * RELIEF) / ROAD_MIN_LENGTH;
 
 /** the footing: how far below the surface the shaft's base sits, in metres — so the shaft meets the
@@ -676,6 +704,20 @@ export async function checkPosts(): Promise<Check> {
             // `halfWidth` and `halfWidth + FLAT_CORE_MARGIN` — passed for any offset in a 5.66 m band and
             // so could not witness the offset at all), and the post's whole footing, ±POST_RADIUS about
             // that, is strictly inside the flat core and strictly off the pavement.
+            //
+            // The `0.01` tolerance is the same f32-readback slack `maxDiff` takes below: the record is a
+            // vec4f written by the kernel from f32 chord endpoints, so the exact-offset comparison needs a
+            // tolerance, and 1 cm is ~4 orders of magnitude above f32 error at these magnitudes (|x| up to
+            // 512 m → ~6e-5 m of representation slack) while being 12× under the smallest offset error
+            // that could matter (POST_RADIUS = 0.12 m, at which the footing overhangs the asphalt).
+            //
+            // The two footing-band predicates that follow **cannot fire given the equality above** — at
+            // `dist = halfWidth + 0.4 ± 0.01` the footing spans 4.27–4.53 m from the centreline, inside
+            // both `halfWidth = 4` and `halfWidth + FLAT_CORE_MARGIN = 9.657`, so anything that failed
+            // them already failed the equality. They are kept as the *stated* band rather than as live
+            // discriminators: they are the two inequalities `POST_OFFSET`'s own docblock derives, written
+            // where a future offset change is read, and they would fire the moment the equality's
+            // tolerance is widened or the offset moves without this file being reread.
             const dist = perpDist(rec.x, rec.z, a[0], a[1], b[0], b[1]);
             if (Math.abs(dist - (halfWidth + POST_OFFSET)) > 0.01) lateralOk = false;
             if (dist - POST_RADIUS <= halfWidth) lateralOk = false;

--- a/examples/showcase/roads/test/roads.spec.ts
+++ b/examples/showcase/roads/test/roads.spec.ts
@@ -697,10 +697,11 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
 
     // Phase 6.5: stage 5's post-placement re-check after an edit. The gate already checked posts at
     // boot (Phase 1); this re-verifies on the edited chord — the Validation criterion "re-read after an
-    // __roadsEdit". The bridge reads back the posts buffer and checks y = flattenFieldAt, lateral
-    // inside the flat core, lateral sign matches postLateralSign(i), live-slot count, and scale-0 —
-    // all in the browser (flattenFieldAt is not Node-safe), so the test only reads the pass/fail
-    // verdict.
+    // __roadsEdit". The bridge reads back the posts buffer and checks y = flattenFieldAt, the lateral
+    // offset pinned at exactly halfWidth + POST_OFFSET (the kerb line, stage 11 — it replaced the old
+    // "somewhere inside the flat core" band), lateral sign matches postLateralSign(i), live-slot count,
+    // and scale-0 — all in the browser (flattenFieldAt is not Node-safe), so the test only reads the
+    // pass/fail verdict.
     const postsCheck = (await page.evaluate(() =>
         (
             window as unknown as {


### PR DESCRIPTION
- **roads-interactive: 11 — the bollard referent, and the capsule's core/cap decomposition**
- **roads-interactive: 11 — repair round 1: scope the null-control claim, pin the VS's radius, cite the pipe to its own source**
