### PR TITLE
shallot untested paths/s3

### DIFF
--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -15,6 +15,8 @@ import {
     resolveFor,
 } from "../../../scripts/bench";
 import { parsePhases, parseResources, parseTransformLine } from "../../../scripts/boot-cost";
+import { verifyDiagnostic } from "../../../scripts/install-test";
+import type { ShaderArtifactSummary, VerifyResult } from "../../../scripts/verify";
 import {
     batchPass,
     bootArm,
@@ -1595,5 +1597,159 @@ describe("report — the unrendered arms (⚠ LEAK, compilationError)", () => {
         } finally {
             console.log = original;
         }
+    });
+});
+
+// S3: the ejected boot arm's diagnostic reporter. `verifyDiagnostic` is the function the ejected boot
+// check calls instead of printing `JSON.stringify(green.errors ?? green.error ?? green)` — the old form
+// that printed `[]` for an empty errors array and was once dismissed as a flake. The arm feeds
+// synthetic `VerifyResult` values through every diagnostic bin the function reads (page errors, setup
+// error, verdict checks, shader artifacts) and the empty-diagnostic fallthrough, pinning that each
+// names its diagnostic and that the empty case reports a named instrument fault rather than an empty
+// container. A pass never reports an instrument fault. The red-when-broken witness (revert-the-behavior)
+// is run inline: a mutated copy of the function with the empty-diagnostic branch removed returns the
+// wrong thing, proving the arm discriminates.
+describe("verifyDiagnostic — the ejected boot arm's diagnostic reporter", () => {
+    /** construct a minimal VerifyResult with the given overrides. */
+    const mk = (overrides: Partial<VerifyResult>): VerifyResult => ({
+        pass: false,
+        ...overrides,
+    });
+
+    test("a red carrying page errors names them (joined with |)", () => {
+        const result = mk({ pass: false, errors: ["shader compile failed", "binding mismatch"] });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toBe("shader compile failed | binding mismatch");
+        expect(diag).not.toContain("instrument fault");
+    });
+
+    test("a red carrying only a setup error names it", () => {
+        const result = mk({ pass: false, error: "port 5191 already in use" });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toBe("port 5191 already in use");
+        expect(diag).not.toContain("instrument fault");
+    });
+
+    test("a red carrying only failed verdict checks names them", () => {
+        const result = mk({
+            pass: false,
+            verdict: {
+                ok: false,
+                checks: [
+                    { name: "ready", ok: true },
+                    { name: "render", ok: false, detail: "blank canvas" },
+                ],
+            },
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("render");
+        expect(diag).toContain("blank canvas");
+        expect(diag).not.toContain("instrument fault");
+    });
+
+    test("a red carrying only a shader artifacts compilation error names it", () => {
+        const artifacts: ShaderArtifactSummary[] = [
+            {
+                label: "forward",
+                stage: "vertex+fragment",
+                compilationError: { errorClass: "validation", message: "bad binding" },
+                messages: [],
+            },
+        ];
+        const result = mk({ pass: false, artifacts });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("forward");
+        expect(diag).toContain("bad binding");
+        expect(diag).not.toContain("instrument fault");
+    });
+
+    test("a red carrying only shader artifact messages (no compilationError) names them", () => {
+        const artifacts: ShaderArtifactSummary[] = [
+            {
+                label: "post",
+                stage: "fragment",
+                messages: [
+                    { type: "error", message: "undeclared variable x", lineNum: 3, linePos: 8 },
+                ],
+            },
+        ];
+        const result = mk({ pass: false, artifacts });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("post");
+        expect(diag).toContain("undeclared variable x");
+        expect(diag).not.toContain("instrument fault");
+    });
+
+    test("a red carrying none of those returns the named instrument fault", () => {
+        const result = mk({ pass: false });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("instrument fault");
+        expect(diag).toContain("no diagnostic");
+    });
+
+    test("a pass never reports an instrument fault", () => {
+        const result = mk({ pass: true, errors: [] });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toBe("pass");
+        expect(diag).not.toContain("instrument fault");
+    });
+
+    test("a pass with errors still names the errors, never an instrument fault", () => {
+        // a pass carrying errors is unusual but the function must not hide them behind "pass"
+        const result = mk({ pass: true, errors: ["a warning"] });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toBe("a warning");
+        expect(diag).not.toContain("instrument fault");
+    });
+
+    test("null result returns a named absence, not an instrument fault", () => {
+        const diag = verifyDiagnostic(null);
+        expect(diag).toBe("no verify result");
+        expect(diag).not.toContain("instrument fault");
+    });
+
+    // RED-WHEN-BROKEN WITNESS: a mutated copy of verifyDiagnostic with the empty-diagnostic
+    // fallthrough removed (the last `return` line deleted, so the function returns an empty string
+    // instead of the named instrument fault) must produce a value the instrument-fault arm above does
+    // NOT accept — proving the arm discriminates the empty-diagnostic branch. If the arm still passed
+    // with the branch broken, it would pin nothing about the instrument-fault path.
+    test("red-when-broken: removing the empty-diagnostic fallthrough breaks the instrument-fault arm", () => {
+        // the production function, with the final return replaced — the defect this arm exists to catch
+        function brokenVerifyDiagnostic(result: VerifyResult | null): string {
+            if (!result) return "no verify result";
+            const errors = result.errors ?? [];
+            if (errors.length > 0) return errors.join(" | ");
+            if (result.error) return result.error;
+            if (result.pass) return "pass";
+            const failedChecks = (result.verdict?.checks ?? []).filter((c) => !c.ok);
+            if (failedChecks.length > 0) return JSON.stringify(failedChecks);
+            const artifacts = result.artifacts ?? [];
+            const diagArtifacts = artifacts.filter(
+                (a: ShaderArtifactSummary) =>
+                    a.compilationError || (a.messages && a.messages.length > 0),
+            );
+            if (diagArtifacts.length > 0)
+                return JSON.stringify(
+                    diagArtifacts.map((a) => ({
+                        label: a.label,
+                        compilationError: a.compilationError,
+                        messages: a.messages,
+                    })),
+                );
+            // THE BROKEN BRANCH: the `return "instrument fault: ..."` line is replaced with "".
+            return "";
+        }
+
+        const emptyResult = mk({ pass: false });
+        const broken = brokenVerifyDiagnostic(emptyResult);
+        const correct = verifyDiagnostic(emptyResult);
+
+        // the broken version does NOT report the instrument fault — it returns an empty string
+        expect(broken).toBe("");
+        expect(broken).not.toContain("instrument fault");
+        // the correct version DOES report it
+        expect(correct).toContain("instrument fault");
+        // the arm discriminates: the broken and correct outputs differ
+        expect(broken).not.toBe(correct);
     });
 });

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -1680,11 +1680,85 @@ describe("verifyDiagnostic — the ejected boot arm's diagnostic reporter", () =
         expect(diag).not.toContain("instrument fault");
     });
 
-    test("a red carrying none of those returns the named instrument fault", () => {
+    test("a red carrying none of those returns the named instrument fault with field state", () => {
         const result = mk({ pass: false });
         const diag = verifyDiagnostic(result);
+        // the instrument-fault wording is kept
         expect(diag).toContain("instrument fault");
         expect(diag).toContain("no diagnostic");
+        // the failing predicates are named — all three failed since none are true
+        expect(diag).toContain("failed predicates: pass===true, booted===true, rendered===true");
+        // the field state is reported
+        expect(diag).toContain("pass=false");
+        expect(diag).toContain("booted=undefined");
+        expect(diag).toContain("rendered=undefined");
+        expect(diag).toContain("hardware=undefined");
+        expect(diag).toContain("verdict=absent");
+        expect(diag).toContain("memory=absent");
+    });
+
+    // the exact case the coordinator hit: red, no errors, no error, no verdict, no artifacts —
+    // a boot that loaded (booted) but never rendered (rendered=false), carrying no diagnostic at
+    // all. This is the string a future reader will actually see on a genuine red of this shape, so
+    // its content is pinned, not merely that it is non-empty.
+    test("the coordinator's case: booted=true, rendered=false, no diagnostic — pins the exact string", () => {
+        const result = mk({
+            pass: false,
+            booted: true,
+            rendered: false,
+            hardware: "apple / metal / apple m2 / apple m2",
+            errors: [],
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toBe(
+            "instrument fault: verify red with no diagnostic (no page errors, no verdict checks, no shader artifacts); " +
+                "failed predicates: pass===true, rendered===true; " +
+                "pass=false, booted=true, rendered=false, hardware=apple / metal / apple m2 / apple m2, verdict=absent, memory=absent",
+        );
+    });
+
+    test("a red with booted=false names all three predicates as failed", () => {
+        const result = mk({
+            pass: false,
+            booted: false,
+            rendered: false,
+            hardware: "unknown",
+            errors: [],
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("failed predicates: pass===true, booted===true, rendered===true");
+        expect(diag).toContain("pass=false, booted=false, rendered=false, hardware=unknown");
+    });
+
+    test("a red carrying a verdict with no failed checks still reports the verdict state", () => {
+        const result = mk({
+            pass: false,
+            booted: true,
+            rendered: true,
+            hardware: "test-gpu",
+            verdict: { ok: true, checks: [{ name: "ready", ok: true }] },
+            errors: [],
+        });
+        const diag = verifyDiagnostic(result);
+        // pass is false but verdict.ok is true and no checks failed — still an instrument fault
+        expect(diag).toContain("instrument fault");
+        expect(diag).toContain("failed predicates: pass===true");
+        expect(diag).toContain("verdict.ok=true");
+        expect(diag).toContain("verdict.checks=1");
+    });
+
+    test("a red carrying memory=present reports memory=present, not memory=absent", () => {
+        const result = mk({
+            pass: false,
+            booted: true,
+            rendered: false,
+            hardware: "test-gpu",
+            memory: null,
+            errors: [],
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("memory=present");
+        expect(diag).not.toContain("memory=absent");
     });
 
     test("a pass never reports an instrument fault", () => {
@@ -1736,7 +1810,7 @@ describe("verifyDiagnostic — the ejected boot arm's diagnostic reporter", () =
                         messages: a.messages,
                     })),
                 );
-            // THE BROKEN BRANCH: the `return "instrument fault: ..."` line is replaced with "".
+            // THE BROKEN BRANCH: the instrument-fault return with field state is replaced with "".
             return "";
         }
 
@@ -1747,8 +1821,9 @@ describe("verifyDiagnostic — the ejected boot arm's diagnostic reporter", () =
         // the broken version does NOT report the instrument fault — it returns an empty string
         expect(broken).toBe("");
         expect(broken).not.toContain("instrument fault");
-        // the correct version DOES report it
+        // the correct version DOES report it with field state
         expect(correct).toContain("instrument fault");
+        expect(correct).toContain("failed predicates");
         // the arm discriminates: the broken and correct outputs differ
         expect(broken).not.toBe(correct);
     });

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -20,7 +20,13 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { skipReason, teardownBridge, type VerifyResult, verify } from "./verify";
+import {
+    type ShaderArtifactSummary,
+    skipReason,
+    teardownBridge,
+    type VerifyResult,
+    verify,
+} from "./verify";
 
 const ENGINE_DIR = resolve(import.meta.dir, "../packages/shallot");
 const WIDGET_DIR = resolve(import.meta.dir, "install-test/widget");
@@ -58,6 +64,35 @@ const check = (name: string, cond: boolean, detail = "") => {
     console.log(`  ${cond ? "✓" : "✗"} ${name}${detail ? ` — ${detail}` : ""}`);
     if (!cond) fails.push(name);
 };
+
+/** extract the page's diagnostic from a verify result so a red is legible, or name the absence as an
+ *  instrument fault. The ejected boot arm was once dismissed as a flake because its detail printed `[]`
+ *  — an empty `errors` array that a future reader can wave away. This surfaces the diagnostic wherever
+ *  it landed (page errors, setup error, verdict checks, shader artifacts) and, when none carried one,
+ *  reports a named instrument fault rather than an empty container. On a pass the errors array is the
+ *  detail (empty = no errors), never an instrument fault. */
+function verifyDiagnostic(result: VerifyResult | null): string {
+    if (!result) return "no verify result";
+    const errors = result.errors ?? [];
+    if (errors.length > 0) return errors.join(" | ");
+    if (result.error) return result.error;
+    if (result.pass) return "pass";
+    const failedChecks = (result.verdict?.checks ?? []).filter((c) => !c.ok);
+    if (failedChecks.length > 0) return JSON.stringify(failedChecks);
+    const artifacts = result.artifacts ?? [];
+    const diagArtifacts = artifacts.filter(
+        (a: ShaderArtifactSummary) => a.compilationError || (a.messages && a.messages.length > 0),
+    );
+    if (diagArtifacts.length > 0)
+        return JSON.stringify(
+            diagArtifacts.map((a) => ({
+                label: a.label,
+                compilationError: a.compilationError,
+                messages: a.messages,
+            })),
+        );
+    return "instrument fault: verify red with no diagnostic (no page errors, no verdict checks, no shader artifacts)";
+}
 
 /** the `identity-check.ts` probe body — brand-checks the engine-built canary against the app's own
  * `typegpu` resolution (`GREEN`) and a second physical copy (`RED`); `ejectedFlow`, `identityFlow`, and
@@ -351,7 +386,7 @@ async function ejectedFlow(work: string, engineTgz: string) {
     check(
         "the documented ejected recipe boots and warms its pipelines as written",
         green?.pass === true && green.booted === true && green.rendered === true,
-        green ? JSON.stringify(green.errors ?? green.error ?? green) : "no verify result",
+        verifyDiagnostic(green),
     );
 
     // No red-proof mutant here (found investigating 5b-2f-6, after the check above went green for the

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -69,8 +69,11 @@ const check = (name: string, cond: boolean, detail = "") => {
  *  instrument fault. The ejected boot arm was once dismissed as a flake because its detail printed `[]`
  *  — an empty `errors` array that a future reader can wave away. This surfaces the diagnostic wherever
  *  it landed (page errors, setup error, verdict checks, shader artifacts) and, when none carried one,
- *  reports a named instrument fault rather than an empty container. On a pass the errors array is the
- *  detail (empty = no errors), never an instrument fault. */
+ *  reports a named instrument fault with the full field state rather than an empty container. The arm
+ *  asserts `pass === true && booted === true && rendered === true`, so the instrument-fault string names
+ *  which of those three predicates failed alongside the result's own field values — a reader is never
+ *  at a dead end. On a pass the errors array is the detail (empty = no errors), never an instrument
+ *  fault. */
 export function verifyDiagnostic(result: VerifyResult | null): string {
     if (!result) return "no verify result";
     const errors = result.errors ?? [];
@@ -91,7 +94,30 @@ export function verifyDiagnostic(result: VerifyResult | null): string {
                 messages: a.messages,
             })),
         );
-    return "instrument fault: verify red with no diagnostic (no page errors, no verdict checks, no shader artifacts)";
+    // Instrument fault: the result is red but carries no diagnostic text — no page errors, no setup
+    // error, no failed verdict checks, no shader artifacts. Name which of the arm's three predicates
+    // (pass===true, booted===true, rendered===true) failed and the full field state, so a reader can
+    // see what the instrument saw rather than staring at an empty container.
+    const failed: string[] = [];
+    // `pass` is always false here — the `if (result.pass) return "pass"` guard above returned
+    // early — so it always names a failed predicate without a comparison TS would flag as tautological.
+    failed.push("pass===true");
+    if (result.booted !== true) failed.push("booted===true");
+    if (result.rendered !== true) failed.push("rendered===true");
+    const fields: string[] = [
+        `pass=${result.pass}`,
+        `booted=${result.booted ?? "undefined"}`,
+        `rendered=${result.rendered ?? "undefined"}`,
+        `hardware=${result.hardware ?? "undefined"}`,
+    ];
+    if (result.verdict) {
+        fields.push(`verdict.ok=${result.verdict.ok ?? "undefined"}`);
+        fields.push(`verdict.checks=${result.verdict.checks?.length ?? 0}`);
+    } else {
+        fields.push("verdict=absent");
+    }
+    fields.push(result.memory !== undefined ? "memory=present" : "memory=absent");
+    return `instrument fault: verify red with no diagnostic (no page errors, no verdict checks, no shader artifacts); failed predicates: ${failed.join(", ")}; ${fields.join(", ")}`;
 }
 
 /** the `identity-check.ts` probe body — brand-checks the engine-built canary against the app's own

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -71,7 +71,7 @@ const check = (name: string, cond: boolean, detail = "") => {
  *  it landed (page errors, setup error, verdict checks, shader artifacts) and, when none carried one,
  *  reports a named instrument fault rather than an empty container. On a pass the errors array is the
  *  detail (empty = no errors), never an instrument fault. */
-function verifyDiagnostic(result: VerifyResult | null): string {
+export function verifyDiagnostic(result: VerifyResult | null): string {
     if (!result) return "no verify result";
     const errors = result.errors ?? [];
     if (errors.length > 0) return errors.join(" | ");
@@ -203,7 +203,7 @@ function createShallotFlow(work: string, engineTgz: string) {
 // the copy's engine dep is version-pinned by the CLI, so here we point it back at the packed tarball
 // (as a real user's registry install would resolve) and build it headlessly. Guards the whole copy-out
 // path: recipe present in the pack, CLI copies it, the pinned dep installs, the project builds.
-function recipeFlow(work: string, engineTgz: string) {
+function recipeFlow(work: string, engineTgz: string, sandbox: string) {
     console.log("shallot recipe (copy a recipe out → install → build)…");
     const dest = join(work, "recipe-out", "joints");
     const copied = run(["bun", CLI, "recipe", "joints", dest], sandbox);
@@ -1031,338 +1031,346 @@ function tgslFlow(sandbox: string, dist: string) {
 
 // realpath: macOS tmpdir is a symlink (/var → /private/var); vite realpaths files before the
 // fs.allow prefix check, so the sandbox paths must be the resolved form or /@fs requests 403
-const work = realpathSync(mkdtempSync(join(tmpdir(), "shallot-install-")));
-const sandbox = join(work, "app");
-try {
-    console.log("packing engine + widget…");
-    const engineTgz = pack(ENGINE_DIR, join(work, "engine-pack"));
-    const widgetTgz = pack(WIDGET_DIR, join(work, "widget-pack"));
+if (import.meta.main) {
+    const work = realpathSync(mkdtempSync(join(tmpdir(), "shallot-install-")));
+    const sandbox = join(work, "app");
+    try {
+        console.log("packing engine + widget…");
+        const engineTgz = pack(ENGINE_DIR, join(work, "engine-pack"));
+        const widgetTgz = pack(WIDGET_DIR, join(work, "widget-pack"));
 
-    // display-independent, so it runs first: no GPU, no `skipReason()` guard anywhere above it
-    identityFlow(work, engineTgz);
-    pmIdentityFlow(work, engineTgz, "npm");
-    pmIdentityFlow(work, engineTgz, "pnpm");
+        // display-independent, so it runs first: no GPU, no `skipReason()` guard anywhere above it
+        identityFlow(work, engineTgz);
+        pmIdentityFlow(work, engineTgz, "npm");
+        pmIdentityFlow(work, engineTgz, "pnpm");
 
-    // a real manifest project: installed engine + an installed plugin library + a local plugin, the
-    // audio plugin pulling its wasm in. No vite.config, no index.html — the CLI supplies the harness.
-    for (const d of ["scenes", "src", "public"]) mkdirSync(join(sandbox, d), { recursive: true });
-    writeFileSync(
-        join(sandbox, "package.json"),
-        `${JSON.stringify(
-            {
-                name: "install-sandbox",
-                private: true,
-                type: "module",
-                dependencies: {
-                    "@dylanebert/shallot": `file:${engineTgz}`,
-                    "shallot-widget-fixture": `file:${widgetTgz}`,
-                    // the shape a real consumer actually ships: a consumer's own source imports
-                    // `typegpu/data` directly (not just transitively through the engine peer dep) —
-                    // src/spin.ts below exercises it, so the prebundle-exclusion rung covers it too.
-                    typegpu: "~0.12.0",
+        // a real manifest project: installed engine + an installed plugin library + a local plugin, the
+        // audio plugin pulling its wasm in. No vite.config, no index.html — the CLI supplies the harness.
+        for (const d of ["scenes", "src", "public"])
+            mkdirSync(join(sandbox, d), { recursive: true });
+        writeFileSync(
+            join(sandbox, "package.json"),
+            `${JSON.stringify(
+                {
+                    name: "install-sandbox",
+                    private: true,
+                    type: "module",
+                    dependencies: {
+                        "@dylanebert/shallot": `file:${engineTgz}`,
+                        "shallot-widget-fixture": `file:${widgetTgz}`,
+                        // the shape a real consumer actually ships: a consumer's own source imports
+                        // `typegpu/data` directly (not just transitively through the engine peer dep) —
+                        // src/spin.ts below exercises it, so the prebundle-exclusion rung covers it too.
+                        typegpu: "~0.12.0",
+                    },
                 },
-            },
-            null,
-            2,
-        )}\n`,
-    );
-    writeFileSync(
-        join(sandbox, "shallot.json"),
-        `${JSON.stringify(
-            {
-                scene: "scenes/main.scene",
-                plugins: {
-                    Audio: true, // an engine extra whose wasm must ship
-                    Widget: "shallot-widget-fixture/widget", // an installed plugin by subpath
-                    Spin: "./src/spin", // a local plugin
+                null,
+                2,
+            )}\n`,
+        );
+        writeFileSync(
+            join(sandbox, "shallot.json"),
+            `${JSON.stringify(
+                {
+                    scene: "scenes/main.scene",
+                    plugins: {
+                        Audio: true, // an engine extra whose wasm must ship
+                        Widget: "shallot-widget-fixture/widget", // an installed plugin by subpath
+                        Spin: "./src/spin", // a local plugin
+                    },
                 },
-            },
-            null,
-            2,
-        )}\n`,
-    );
-    writeFileSync(
-        join(sandbox, "scenes", "main.scene"),
-        `<scene>\n    <a ambient-light="intensity: 0.6" />\n    <a camera sear transform />\n    <a part transform color="rgba: 0.8 0.5 0.3" />\n</scene>\n`,
-    );
-    writeFileSync(
-        join(sandbox, "src", "spin.ts"),
-        // the `typegpu/data` import is load-bearing, not decoration: a consumer whose own source
-        // imports typegpu directly (a real consumer's shape) is a second entry into Vite's dep
-        // scanner distinct from the engine's own bare specifier — the browser-boot rung below only
-        // covers this shape because this file reaches it.
-        `import type { Plugin, State, System } from "@dylanebert/shallot";\nimport * as d from "typegpu/data";\nconst SpinSystem: System = { group: "simulation", update(_s: State) {} };\nconst SpinPlugin: Plugin = { name: "Spin", systems: [SpinSystem] };\nconsole.log(d.f32);\nexport default SpinPlugin;\n`,
-    );
-    writeFileSync(
-        join(sandbox, "public", "icon.svg"),
-        `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>\n`,
-    );
+                null,
+                2,
+            )}\n`,
+        );
+        writeFileSync(
+            join(sandbox, "scenes", "main.scene"),
+            `<scene>\n    <a ambient-light="intensity: 0.6" />\n    <a camera sear transform />\n    <a part transform color="rgba: 0.8 0.5 0.3" />\n</scene>\n`,
+        );
+        writeFileSync(
+            join(sandbox, "src", "spin.ts"),
+            // the `typegpu/data` import is load-bearing, not decoration: a consumer whose own source
+            // imports typegpu directly (a real consumer's shape) is a second entry into Vite's dep
+            // scanner distinct from the engine's own bare specifier — the browser-boot rung below only
+            // covers this shape because this file reaches it.
+            `import type { Plugin, State, System } from "@dylanebert/shallot";\nimport * as d from "typegpu/data";\nconst SpinSystem: System = { group: "simulation", update(_s: State) {} };\nconst SpinPlugin: Plugin = { name: "Spin", systems: [SpinSystem] };\nconsole.log(d.f32);\nexport default SpinPlugin;\n`,
+        );
+        writeFileSync(
+            join(sandbox, "public", "icon.svg"),
+            `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/></svg>\n`,
+        );
 
-    console.log("bun install (the engine + widget tarballs + their deps)…");
-    const install = run(["bun", "install"], sandbox);
-    check(
-        "bun install succeeds from the packed tarballs",
-        install.ok,
-        install.ok ? "" : install.out.slice(-600),
-    );
-    check(
-        "the engine's audio wasm shipped in the tarball (files surface)",
-        existsSync(
-            join(sandbox, "node_modules/@dylanebert/shallot/rust/audio/pkg/shallot_audio.wasm"),
-        ),
-    );
-    check(
-        "the schema shipped in the tarball",
-        existsSync(join(sandbox, "node_modules/@dylanebert/shallot/shallot.schema.json")),
-    );
-    // the version-matched agent context: the prepack projection must ship (engine AGENTS.md + the
-    // examples index + the recipes corpus), and the shipped index must not dangle at tiers the tarball
-    // omits (gym/showcase live in the repo only).
-    const shipped = join(sandbox, "node_modules/@dylanebert/shallot");
-    check("the engine AGENTS.md shipped in the tarball", existsSync(join(shipped, "AGENTS.md")));
-    check(
-        "the 0.9 migration guide shipped in the tarball",
-        existsSync(join(shipped, "MIGRATION.md")),
-    );
-    check(
-        "the recipes corpus shipped in the tarball (prepack projection)",
-        existsSync(join(shipped, "examples/AGENTS.md")) &&
-            existsSync(join(shipped, "examples/recipes/build-a-scene/src/build.ts")) &&
-            existsSync(join(shipped, "examples/recipes/save-and-restore/shallot.json")),
-    );
-    check(
-        "a shipped recipe carries its package.json (the copy-out project surface)",
-        existsSync(join(shipped, "examples/recipes/build-a-scene/package.json")),
-    );
-    check(
-        "no monorepo-only plumbing leaked into a shipped recipe (tsconfig / node_modules)",
-        !existsSync(join(shipped, "examples/recipes/build-a-scene/tsconfig.json")) &&
-            !existsSync(join(shipped, "examples/recipes/build-a-scene/node_modules")),
-    );
-    // repo test files import across the monorepo root (scripts/, examples/gym), paths that dangle
-    // in a consumer install — the `files` surface must exclude every *.test.ts, bin included.
-    const leakedTests = [...new Bun.Glob("**/*.test.ts").scanSync({ cwd: shipped })];
-    check(
-        "no test files shipped in the tarball (files surface excludes *.test.ts)",
-        leakedTests.length === 0,
-        leakedTests.slice(0, 5).join(", "),
-    );
-    // the dynamics-smoke plugins are CI scaffolding — stripped from the shipped corpus (file + manifest
-    // entry) so a copied-out physics recipe carries no `./src/smoke` reference that would fail to build.
-    check(
-        "the shipped physics recipe dropped its smoke plugin (file + manifest entry)",
-        !existsSync(join(shipped, "examples/recipes/joints/src/smoke.ts")) &&
-            !/smoke/.test(
-                readFileSync(join(shipped, "examples/recipes/joints/shallot.json"), "utf8"),
+        console.log("bun install (the engine + widget tarballs + their deps)…");
+        const install = run(["bun", "install"], sandbox);
+        check(
+            "bun install succeeds from the packed tarballs",
+            install.ok,
+            install.ok ? "" : install.out.slice(-600),
+        );
+        check(
+            "the engine's audio wasm shipped in the tarball (files surface)",
+            existsSync(
+                join(sandbox, "node_modules/@dylanebert/shallot/rust/audio/pkg/shallot_audio.wasm"),
             ),
-    );
-    const idx = existsSync(join(shipped, "examples/AGENTS.md"))
-        ? readFileSync(join(shipped, "examples/AGENTS.md"), "utf8")
-        : "";
-    check(
-        "the shipped index carries recipes with no dangling gym/showcase tier",
-        /## Recipes/.test(idx) && !/## Gym/.test(idx) && !/## Showcase/.test(idx),
-    );
-    check(
-        "the shipped index names `shallot recipe` as the copy-out command",
-        /shallot recipe/.test(idx),
-    );
-
-    if (install.ok) {
-        console.log("shallot build (the installed CLI, manifest project)…");
-        const build = run(["bun", CLI, "build", "."], sandbox);
-        check("shallot build exits clean", build.ok, build.ok ? "" : build.out.slice(-900));
+        );
         check(
-            "no unresolved imports in the build",
-            !/Failed to resolve|does not provide an export/i.test(build.out),
+            "the schema shipped in the tarball",
+            existsSync(join(sandbox, "node_modules/@dylanebert/shallot/shallot.schema.json")),
+        );
+        // the version-matched agent context: the prepack projection must ship (engine AGENTS.md + the
+        // examples index + the recipes corpus), and the shipped index must not dangle at tiers the tarball
+        // omits (gym/showcase live in the repo only).
+        const shipped = join(sandbox, "node_modules/@dylanebert/shallot");
+        check(
+            "the engine AGENTS.md shipped in the tarball",
+            existsSync(join(shipped, "AGENTS.md")),
+        );
+        check(
+            "the 0.9 migration guide shipped in the tarball",
+            existsSync(join(shipped, "MIGRATION.md")),
+        );
+        check(
+            "the recipes corpus shipped in the tarball (prepack projection)",
+            existsSync(join(shipped, "examples/AGENTS.md")) &&
+                existsSync(join(shipped, "examples/recipes/build-a-scene/src/build.ts")) &&
+                existsSync(join(shipped, "examples/recipes/save-and-restore/shallot.json")),
+        );
+        check(
+            "a shipped recipe carries its package.json (the copy-out project surface)",
+            existsSync(join(shipped, "examples/recipes/build-a-scene/package.json")),
+        );
+        check(
+            "no monorepo-only plumbing leaked into a shipped recipe (tsconfig / node_modules)",
+            !existsSync(join(shipped, "examples/recipes/build-a-scene/tsconfig.json")) &&
+                !existsSync(join(shipped, "examples/recipes/build-a-scene/node_modules")),
+        );
+        // repo test files import across the monorepo root (scripts/, examples/gym), paths that dangle
+        // in a consumer install — the `files` surface must exclude every *.test.ts, bin included.
+        const leakedTests = [...new Bun.Glob("**/*.test.ts").scanSync({ cwd: shipped })];
+        check(
+            "no test files shipped in the tarball (files surface excludes *.test.ts)",
+            leakedTests.length === 0,
+            leakedTests.slice(0, 5).join(", "),
+        );
+        // the dynamics-smoke plugins are CI scaffolding — stripped from the shipped corpus (file + manifest
+        // entry) so a copied-out physics recipe carries no `./src/smoke` reference that would fail to build.
+        check(
+            "the shipped physics recipe dropped its smoke plugin (file + manifest entry)",
+            !existsSync(join(shipped, "examples/recipes/joints/src/smoke.ts")) &&
+                !/smoke/.test(
+                    readFileSync(join(shipped, "examples/recipes/joints/shallot.json"), "utf8"),
+                ),
+        );
+        const idx = existsSync(join(shipped, "examples/AGENTS.md"))
+            ? readFileSync(join(shipped, "examples/AGENTS.md"), "utf8")
+            : "";
+        check(
+            "the shipped index carries recipes with no dangling gym/showcase tier",
+            /## Recipes/.test(idx) && !/## Gym/.test(idx) && !/## Showcase/.test(idx),
+        );
+        check(
+            "the shipped index names `shallot recipe` as the copy-out command",
+            /shallot recipe/.test(idx),
         );
 
-        const dist = join(sandbox, "dist");
-        check("dist/index.html produced", existsSync(join(dist, "index.html")));
-        const assets = existsSync(join(dist, "assets")) ? readdirSync(join(dist, "assets")) : [];
-        check(
-            "the audio wasm bundled into dist",
-            assets.some((f) => f.endsWith(".wasm")),
-            assets.join(", ") || "(no assets dir)",
-        );
-
-        // rust/window ships in the tarball (package.json `files` includes `rust/window` minus
-        // `target/`), so `shallot build --target <os>` from an installed package compiles the crate
-        // lazily via cargo. A real native build is a multi-minute cargo/CEF arm — gated out of the
-        // default suite (suite-speed budgets). Here we assert the crate is present and
-        // resolvable in the installed layout; the premise builds (spec gates 4+5) run it for real.
-        check(
-            "the rust/window crate ships in the installed package (lazy native-build source)",
-            existsSync(join(shipped, "rust/window/Cargo.toml")) &&
-                existsSync(join(shipped, "rust/window/Cargo.lock")),
-        );
-
-        // the crate-present check above says the file crossed the pack/install boundary; it says nothing
-        // about the CLI's behavior when it hasn't. `requireRustCrate` runs before cargo is spawned, so
-        // hiding the crate exercises the whole diagnostic path — resolution, message, non-zero exit —
-        // for the price of a rename, with no toolchain involved.
-        console.log("shallot build --target linux with the crate hidden (ENOENT guard fires)…");
-        const crate = join(shipped, "rust/window");
-        const hidden = `${crate}.hidden`;
-        renameSync(crate, hidden);
-        const guarded = run(["bun", CLI, "build", ".", "--target", "linux"], sandbox);
-        renameSync(hidden, crate);
-        check(
-            "a missing crate fails with the corrupt-install diagnostic, not a raw ENOENT from cargo",
-            !guarded.ok &&
-                /corrupt install/.test(guarded.out) &&
-                !/ENOENT|No such file or directory/.test(guarded.out),
-            guarded.out.slice(-900),
-        );
-        check("the hidden crate is restored", existsSync(join(crate, "Cargo.toml")));
-
-        tgslFlow(sandbox, dist);
-
-        // the dev server: live resolution + asset serving over vite (a different path than the build
-        // bundle — it's where the cross-repo fs.allow / wasm-serving lives).
-        console.log("shallot dev (boot + resolve + serve the wasm)…");
-        const port = 5191;
-        const dev = Bun.spawn(["bun", CLI, "dev", ".", "--port", String(port)], {
-            cwd: sandbox,
-            stdout: "pipe",
-            stderr: "pipe",
-        });
-        const dec = new TextDecoder();
-        let devLog = "";
-        const pump = (stream: ReadableStream<Uint8Array>) =>
-            (async () => {
-                const reader = stream.getReader();
-                for (;;) {
-                    const { done, value } = await reader.read();
-                    if (done) break;
-                    if (value) devLog += dec.decode(value);
-                }
-            })();
-        const drain = pump(dev.stdout);
-        const drainErr = pump(dev.stderr);
-        try {
-            // Wait on the server's own ready signal, not a wall clock: `dev.ts` calls
-            // `server.printUrls()` immediately after `server.listen()` resolves, so the banner is the
-            // moment the socket is up. A fixed HTTP-poll deadline conflated "still starting" with
-            // "never coming" and flaked 2 runs in 5. The child exiting ends the wait too — a crashed
-            // dev server has nothing to wait out. `printUrls` colors its output, so strip SGR first.
-            const banner = new RegExp(`Local:\\s+\\S*http://localhost:${port}/`);
-            const listening = await waitFor(
-                async () => banner.test(strip(devLog)) || dev.exitCode !== null,
-                90000,
-            );
-            // Once listening, a request that can't be served in a second is a real failure, not slow boot.
-            const up =
-                listening &&
-                dev.exitCode === null &&
-                (await waitFor(async () => {
-                    try {
-                        // localhost, not 127.0.0.1 — vite binds the family localhost resolves to
-                        // (IPv6-only on macOS), and it's the host the banner advertises
-                        return (await fetch(`http://localhost:${port}/`)).ok;
-                    } catch {
-                        return false;
-                    }
-                }, 5000));
+        if (install.ok) {
+            console.log("shallot build (the installed CLI, manifest project)…");
+            const build = run(["bun", CLI, "build", "."], sandbox);
+            check("shallot build exits clean", build.ok, build.ok ? "" : build.out.slice(-900));
             check(
-                "shallot dev boots a server",
-                up,
-                up
-                    ? ""
-                    : `${dev.exitCode !== null ? `dev exited ${dev.exitCode}; ` : listening ? "banner printed, no response; " : "no ready banner; "}${devLog.slice(-400)}`,
+                "no unresolved imports in the build",
+                !/Failed to resolve|does not provide an export/i.test(build.out),
             );
-            if (up) {
-                const mod = await fetch(`http://localhost:${port}/@id/__x00__virtual:project`).then(
-                    (r) => r.text(),
+
+            const dist = join(sandbox, "dist");
+            check("dist/index.html produced", existsSync(join(dist, "index.html")));
+            const assets = existsSync(join(dist, "assets"))
+                ? readdirSync(join(dist, "assets"))
+                : [];
+            check(
+                "the audio wasm bundled into dist",
+                assets.some((f) => f.endsWith(".wasm")),
+                assets.join(", ") || "(no assets dir)",
+            );
+
+            // rust/window ships in the tarball (package.json `files` includes `rust/window` minus
+            // `target/`), so `shallot build --target <os>` from an installed package compiles the crate
+            // lazily via cargo. A real native build is a multi-minute cargo/CEF arm — gated out of the
+            // default suite (suite-speed budgets). Here we assert the crate is present and
+            // resolvable in the installed layout; the premise builds (spec gates 4+5) run it for real.
+            check(
+                "the rust/window crate ships in the installed package (lazy native-build source)",
+                existsSync(join(shipped, "rust/window/Cargo.toml")) &&
+                    existsSync(join(shipped, "rust/window/Cargo.lock")),
+            );
+
+            // the crate-present check above says the file crossed the pack/install boundary; it says nothing
+            // about the CLI's behavior when it hasn't. `requireRustCrate` runs before cargo is spawned, so
+            // hiding the crate exercises the whole diagnostic path — resolution, message, non-zero exit —
+            // for the price of a rename, with no toolchain involved.
+            console.log("shallot build --target linux with the crate hidden (ENOENT guard fires)…");
+            const crate = join(shipped, "rust/window");
+            const hidden = `${crate}.hidden`;
+            renameSync(crate, hidden);
+            const guarded = run(["bun", CLI, "build", ".", "--target", "linux"], sandbox);
+            renameSync(hidden, crate);
+            check(
+                "a missing crate fails with the corrupt-install diagnostic, not a raw ENOENT from cargo",
+                !guarded.ok &&
+                    /corrupt install/.test(guarded.out) &&
+                    !/ENOENT|No such file or directory/.test(guarded.out),
+                guarded.out.slice(-900),
+            );
+            check("the hidden crate is restored", existsSync(join(crate, "Cargo.toml")));
+
+            tgslFlow(sandbox, dist);
+
+            // the dev server: live resolution + asset serving over vite (a different path than the build
+            // bundle — it's where the cross-repo fs.allow / wasm-serving lives).
+            console.log("shallot dev (boot + resolve + serve the wasm)…");
+            const port = 5191;
+            const dev = Bun.spawn(["bun", CLI, "dev", ".", "--port", String(port)], {
+                cwd: sandbox,
+                stdout: "pipe",
+                stderr: "pipe",
+            });
+            const dec = new TextDecoder();
+            let devLog = "";
+            const pump = (stream: ReadableStream<Uint8Array>) =>
+                (async () => {
+                    const reader = stream.getReader();
+                    for (;;) {
+                        const { done, value } = await reader.read();
+                        if (done) break;
+                        if (value) devLog += dec.decode(value);
+                    }
+                })();
+            const drain = pump(dev.stdout);
+            const drainErr = pump(dev.stderr);
+            try {
+                // Wait on the server's own ready signal, not a wall clock: `dev.ts` calls
+                // `server.printUrls()` immediately after `server.listen()` resolves, so the banner is the
+                // moment the socket is up. A fixed HTTP-poll deadline conflated "still starting" with
+                // "never coming" and flaked 2 runs in 5. The child exiting ends the wait too — a crashed
+                // dev server has nothing to wait out. `printUrls` colors its output, so strip SGR first.
+                const banner = new RegExp(`Local:\\s+\\S*http://localhost:${port}/`);
+                const listening = await waitFor(
+                    async () => banner.test(strip(devLog)) || dev.exitCode !== null,
+                    90000,
                 );
+                // Once listening, a request that can't be served in a second is a real failure, not slow boot.
+                const up =
+                    listening &&
+                    dev.exitCode === null &&
+                    (await waitFor(async () => {
+                        try {
+                            // localhost, not 127.0.0.1 — vite binds the family localhost resolves to
+                            // (IPv6-only on macOS), and it's the host the banner advertises
+                            return (await fetch(`http://localhost:${port}/`)).ok;
+                        } catch {
+                            return false;
+                        }
+                    }, 5000));
                 check(
-                    "dev resolves the manifest (installed subpath + local + engine)",
-                    /shallot-widget-fixture/.test(mod) &&
-                        /src\/spin/.test(mod) &&
-                        !/Failed to resolve/i.test(mod),
+                    "shallot dev boots a server",
+                    up,
+                    up
+                        ? ""
+                        : `${dev.exitCode !== null ? `dev exited ${dev.exitCode}; ` : listening ? "banner printed, no response; " : "no ready banner; "}${devLog.slice(-400)}`,
                 );
-                const wasmFs = resolve(
-                    sandbox,
-                    "node_modules/@dylanebert/shallot/rust/audio/pkg/shallot_audio.wasm",
-                );
-                const res = await fetch(`http://localhost:${port}/@fs${wasmFs}`);
-                const magic = new Uint8Array(
-                    (res.ok ? await res.arrayBuffer() : new ArrayBuffer(0)).slice(0, 4),
-                );
-                // the dev arm of the TGSL contract: `shallot dev` synthesizes its own vite config, a
-                // different path than the build above, and it must transform engine source in
-                // node_modules too. Ask the server for the module the page imports and read what it
-                // serves. (It does not cover a prebundled `.vite/deps` copy — dep optimization runs on
-                // page load, which this headless boot never performs. The real-browser rung below does.)
-                const engineMod = await fetch(
-                    `http://localhost:${port}/node_modules/@dylanebert/shallot/src/engine/runtime/gpu.ts`,
-                );
-                const served = engineMod.ok ? await engineMod.text() : "";
+                if (up) {
+                    const mod = await fetch(
+                        `http://localhost:${port}/@id/__x00__virtual:project`,
+                    ).then((r) => r.text());
+                    check(
+                        "dev resolves the manifest (installed subpath + local + engine)",
+                        /shallot-widget-fixture/.test(mod) &&
+                            /src\/spin/.test(mod) &&
+                            !/Failed to resolve/i.test(mod),
+                    );
+                    const wasmFs = resolve(
+                        sandbox,
+                        "node_modules/@dylanebert/shallot/rust/audio/pkg/shallot_audio.wasm",
+                    );
+                    const res = await fetch(`http://localhost:${port}/@fs${wasmFs}`);
+                    const magic = new Uint8Array(
+                        (res.ok ? await res.arrayBuffer() : new ArrayBuffer(0)).slice(0, 4),
+                    );
+                    // the dev arm of the TGSL contract: `shallot dev` synthesizes its own vite config, a
+                    // different path than the build above, and it must transform engine source in
+                    // node_modules too. Ask the server for the module the page imports and read what it
+                    // serves. (It does not cover a prebundled `.vite/deps` copy — dep optimization runs on
+                    // page load, which this headless boot never performs. The real-browser rung below does.)
+                    const engineMod = await fetch(
+                        `http://localhost:${port}/node_modules/@dylanebert/shallot/src/engine/runtime/gpu.ts`,
+                    );
+                    const served = engineMod.ok ? await engineMod.text() : "";
+                    check(
+                        "dev serves engine TGSL through the transform",
+                        TRANSPILED.test(served),
+                        engineMod.ok ? "" : `HTTP ${engineMod.status}`,
+                    );
+                    check(
+                        "dev serves the audio wasm (fs.allow ok, valid magic 0061736d)",
+                        res.ok &&
+                            magic[0] === 0x00 &&
+                            magic[1] === 0x61 &&
+                            magic[2] === 0x73 &&
+                            magic[3] === 0x6d,
+                        res.ok ? "" : `HTTP ${res.status}`,
+                    );
+                }
                 check(
-                    "dev serves engine TGSL through the transform",
-                    TRANSPILED.test(served),
-                    engineMod.ok ? "" : `HTTP ${engineMod.status}`,
+                    "no dev-server errors (resolve / fs allow-list)",
+                    !/Failed to resolve|outside of Vite serving allow list/i.test(strip(devLog)),
                 );
+            } finally {
+                dev.kill();
+                await Promise.race([Promise.all([drain, drainErr]), Bun.sleep(1500)]);
+            }
+
+            // the real-device boot rung the fetch-only checks above can't be: Vite's dependency optimizer
+            // prebundles a bare `@dylanebert/shallot` import only on an actual browser page load (esbuild
+            // scans the entry HTML's script graph), never on a raw HTTP fetch of a known module path — so
+            // this sandbox (a genuine `node_modules` install off a packed tarball, same resolution shape a
+            // registry install produces — not a symlink) is booted through a real browser and its rendered
+            // pipelines are asserted, catching the 5b-2f-5 prebundle-before-transform defect the checks
+            // above structurally could not (`scripts/verify.ts`'s `verify()` is the same shipped gate
+            // `bun bench` / `bun run flows` / `bun run recipes` drive; display-gated identically, native
+            // hardware only — WSL runs it for real against the Windows host's GPU via the bridge).
+            console.log(
+                "shallot verify (a real browser boot — warms the installed engine's pipelines)…",
+            );
+            const skip = skipReason();
+            if (skip) {
+                console.log(`  · skipped (needs native hardware: ${skip})`);
+            } else {
+                const result = await verify(sandbox, ["--timeout", "30000"], true);
                 check(
-                    "dev serves the audio wasm (fs.allow ok, valid magic 0061736d)",
-                    res.ok &&
-                        magic[0] === 0x00 &&
-                        magic[1] === 0x61 &&
-                        magic[2] === 0x73 &&
-                        magic[3] === 0x6d,
-                    res.ok ? "" : `HTTP ${res.status}`,
+                    "a real browser boots the installed engine and warms its pipelines",
+                    result?.pass === true && result.booted === true && result.rendered === true,
+                    result
+                        ? JSON.stringify(result.errors ?? result.error ?? result)
+                        : "no verify result",
                 );
             }
-            check(
-                "no dev-server errors (resolve / fs allow-list)",
-                !/Failed to resolve|outside of Vite serving allow list/i.test(strip(devLog)),
-            );
-        } finally {
-            dev.kill();
-            await Promise.race([Promise.all([drain, drainErr]), Bun.sleep(1500)]);
+            await teardownBridge();
         }
 
-        // the real-device boot rung the fetch-only checks above can't be: Vite's dependency optimizer
-        // prebundles a bare `@dylanebert/shallot` import only on an actual browser page load (esbuild
-        // scans the entry HTML's script graph), never on a raw HTTP fetch of a known module path — so
-        // this sandbox (a genuine `node_modules` install off a packed tarball, same resolution shape a
-        // registry install produces — not a symlink) is booted through a real browser and its rendered
-        // pipelines are asserted, catching the 5b-2f-5 prebundle-before-transform defect the checks
-        // above structurally could not (`scripts/verify.ts`'s `verify()` is the same shipped gate
-        // `bun bench` / `bun run flows` / `bun run recipes` drive; display-gated identically, native
-        // hardware only — WSL runs it for real against the Windows host's GPU via the bridge).
-        console.log(
-            "shallot verify (a real browser boot — warms the installed engine's pipelines)…",
-        );
-        const skip = skipReason();
-        if (skip) {
-            console.log(`  · skipped (needs native hardware: ${skip})`);
-        } else {
-            const result = await verify(sandbox, ["--timeout", "30000"], true);
-            check(
-                "a real browser boots the installed engine and warms its pipelines",
-                result?.pass === true && result.booted === true && result.rendered === true,
-                result
-                    ? JSON.stringify(result.errors ?? result.error ?? result)
-                    : "no verify result",
-            );
-        }
-        await teardownBridge();
+        if (install.ok) recipeFlow(work, engineTgz, sandbox);
+
+        await ejectedFlow(work, engineTgz);
+
+        await identityBrowserFlow(work, engineTgz);
+
+        createShallotFlow(work, engineTgz);
+    } finally {
+        rmSync(work, { recursive: true, force: true });
     }
 
-    if (install.ok) recipeFlow(work, engineTgz);
-
-    await ejectedFlow(work, engineTgz);
-
-    await identityBrowserFlow(work, engineTgz);
-
-    createShallotFlow(work, engineTgz);
-} finally {
-    rmSync(work, { recursive: true, force: true });
-}
-
-if (fails.length) {
-    console.error(`\nFAIL: ${fails.length} check(s) failed: ${fails.join("; ")}`);
-    process.exit(1);
-}
-console.log("\nPASS: real-install flow clean");
+    if (fails.length) {
+        console.error(`\nFAIL: ${fails.length} check(s) failed: ${fails.join("; ")}`);
+        process.exit(1);
+    }
+    console.log("\nPASS: real-install flow clean");
+} // import.meta.main

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -51,6 +51,18 @@ export interface VerifyResult {
     /** `true` rendered structure, `false` blank, `"opt-out"` when the harness declared `noRender`
      *  (renders nothing by design — the pixel gate was skipped). */
     rendered?: boolean | "opt-out";
+    /** shader compilation artifacts, present only on failure — carries the GPU diagnostic text
+     *  (compilation errors, validation messages) the page captured. The driver surfaces this so a
+     *  red with empty `errors` still names its diagnostic rather than printing `[]`. */
+    artifacts?: ShaderArtifactSummary[];
+}
+
+/** the minimal slice of `bin/verify.ts`'s `ShaderArtifact` a driver reads for diagnostics. */
+export interface ShaderArtifactSummary {
+    label: string;
+    stage: string;
+    compilationError?: { errorClass: string; message: string };
+    messages?: Array<{ type: string; message: string; lineNum: number; linePos: number }>;
 }
 
 const isWSL = process.platform === "linux" && existsSync("/proc/sys/fs/binfmt_misc/WSLInterop");


### PR DESCRIPTION
**Problem.** The ejected-recipe boot arm in `scripts/install-test.ts` printed `JSON.stringify(green.errors ?? green.error ?? green)` as its detail. An empty `errors` array is not nullish, so a red printed `[]` — and that empty container is exactly why a red reading at 0.9.3 S4 was dismissed as a flake.

**Cause.** Two defects wearing one symptom. The detail short-circuited on the first non-nullish field rather than looking where a diagnostic could actually have landed (setup `error`, failed `verdict.checks`, shader `artifacts`); and on this failure mode nothing lands in any of them, so no printing change alone could name anything.

**Fix.** `verifyDiagnostic()` surfaces the diagnostic wherever it landed and, when none carried one, reports a *named instrument fault* carrying the failing predicate and the result's own field state — so a red is never a dead end and the empty container cannot recur. `VerifyResult` gains the `artifacts` field `bin/verify.ts` already emitted. The capture path (`attachErrorCapture`, `withGpuLog` → the `gpu.error` verdict check, `failureArtifacts`, `observeDevice` → `console.error`) was read channel by channel and drops nothing, so this mode provably emits no diagnostic rather than one the harness threw away.

**Evidence.** `bun check` green; `bun test packages/shallot` 2498 pass / 5 fail, all pre-existing `OrbitSystem`, matching the floor. Deterministic arms over synthetic results in `bin/verify.test.ts` pin each branch's content, red-witnessed: mutating the instrument-fault return reds six of them. Two full `bun run test:install` runs on native hardware (`apple / metal-3`), the live red reading:

```
✗ the documented ejected recipe boots and warms its pipelines as written — instrument fault: verify red with no
diagnostic (no page errors, no verdict checks, no shader artifacts); failed predicates: pass===true,
rendered===true; pass=false, booted=true, rendered=false, hardware=apple / metal-3, verdict=absent, memory=absent
```

The arm is nondeterministic — green in one run and red in two others on the same tree and machine — which is why the deterministic arms, not the live one, are the standing reader. Why the boot renders blank is deliberately not decided here; that verdict is the spec's next stage.
