### PR TITLE
shallot untested paths/S4

### DIFF
--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -44,6 +44,7 @@ import {
     type MemorySample,
     parseVerifyArgs,
     RESOURCE_BUFFER,
+    type RenderProbe,
     type ResourceEntry,
     type Result,
     report,
@@ -1713,7 +1714,7 @@ describe("verifyDiagnostic — the ejected boot arm's diagnostic reporter", () =
         expect(diag).toBe(
             "instrument fault: verify red with no diagnostic (no page errors, no verdict checks, no shader artifacts); " +
                 "failed predicates: pass===true, rendered===true; " +
-                "pass=false, booted=true, rendered=false, hardware=apple / metal / apple m2 / apple m2, verdict=absent, memory=absent",
+                "pass=false, booted=true, rendered=false, hardware=apple / metal / apple m2 / apple m2, verdict=absent, memory=absent, renderProbe=absent",
         );
     });
 
@@ -1824,6 +1825,254 @@ describe("verifyDiagnostic — the ejected boot arm's diagnostic reporter", () =
         // the correct version DOES report it with field state
         expect(correct).toContain("instrument fault");
         expect(correct).toContain("failed predicates");
+        // the arm discriminates: the broken and correct outputs differ
+        expect(broken).not.toBe(correct);
+    });
+});
+
+// S4: the render probe on verify's Result — the pixel evidence behind the `rendered` verdict. The
+// settle path records samples taken, the last centre/corner RGB, the spread against `structured`'s
+// threshold, the elapsed wait, and how the wait concluded; `verifyDiagnostic`'s instrument-fault branch
+// prints it so a blank-render red carries its measurement rather than printing `[]`. These arms feed
+// synthetic `VerifyResult` values carrying a `renderProbe` through the instrument-fault branch, pinning
+// that each settle state names its measurement. The two-sided vacuity reading — a red carrying no probe
+// AND no diagnostic still reports as a named instrument fault under its own name — pins that the
+// probe's absence is named, never an empty container. The red-when-broken witness (revert-the-behavior)
+// is run inline: a mutated copy of `verifyDiagnostic` with the probe-printing branch removed drops the
+// measurement, proving the arms discriminate.
+describe("verifyDiagnostic — the render probe in the instrument-fault branch", () => {
+    /** construct a minimal VerifyResult with the given overrides. */
+    const mk = (overrides: Partial<VerifyResult>): VerifyResult => ({
+        pass: false,
+        ...overrides,
+    });
+
+    /** a probe with spread just under `structured`'s threshold — the blank-render red's own reading. */
+    const underThreshold: RenderProbe = {
+        samples: 42,
+        center: [10, 10, 10],
+        corner: [14, 12, 11],
+        spread: 7, // |10-14| + |10-12| + |10-11| = 4+2+1 = 7, under 12
+        threshold: 12,
+        elapsed: 30000,
+        outcome: "timeout",
+    };
+
+    /** a probe with spread over threshold — the frame showed structure but never settled. */
+    const overThreshold: RenderProbe = {
+        samples: 60,
+        center: [200, 100, 50],
+        corner: [10, 10, 10],
+        spread: 320, // |200-10| + |100-10| + |50-10| = 190+90+40 = 320, over 12
+        threshold: 12,
+        elapsed: 30000,
+        outcome: "timeout",
+    };
+
+    /** a probe with zero samples — no canvas was ever capturable. */
+    const zeroSamples: RenderProbe = {
+        samples: 0,
+        center: null,
+        corner: null,
+        spread: null,
+        threshold: 12,
+        elapsed: 30000,
+        outcome: "timeout",
+    };
+
+    test("a blank-render red (spread under threshold) carries its probe measurement", () => {
+        const result = mk({
+            pass: false,
+            booted: true,
+            rendered: false,
+            hardware: "apple / metal / apple m2 / apple m2",
+            errors: [],
+            renderProbe: underThreshold,
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("instrument fault");
+        expect(diag).toContain("failed predicates: pass===true, rendered===true");
+        // the probe's measurement is printed
+        expect(diag).toContain("renderProbe={samples=42");
+        expect(diag).toContain("spread=7");
+        expect(diag).toContain("threshold=12");
+        expect(diag).toContain("elapsed=30000ms");
+        expect(diag).toContain("outcome=timeout");
+        // the last centre/corner RGB is printed
+        expect(diag).toContain("center=[10,10,10]");
+        expect(diag).toContain("corner=[14,12,11]");
+    });
+
+    test("a red with spread over threshold carries its probe measurement", () => {
+        const result = mk({
+            pass: false,
+            booted: true,
+            rendered: true, // structure was seen but never settled
+            hardware: "apple / metal / apple m2 / apple m2",
+            errors: [],
+            renderProbe: overThreshold,
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("instrument fault");
+        expect(diag).toContain("renderProbe={samples=60");
+        expect(diag).toContain("spread=320");
+        expect(diag).toContain("outcome=timeout");
+    });
+
+    test("a red with zero samples carries the null probe measurement", () => {
+        const result = mk({
+            pass: false,
+            booted: true,
+            rendered: false,
+            hardware: "unknown",
+            errors: [],
+            renderProbe: zeroSamples,
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("instrument fault");
+        expect(diag).toContain("renderProbe={samples=0");
+        expect(diag).toContain("center=[null]");
+        expect(diag).toContain("corner=[null]");
+        expect(diag).toContain("spread=null");
+        expect(diag).toContain("outcome=timeout");
+    });
+
+    test("a red carrying no probe and no diagnostic still reports as a named instrument fault", () => {
+        // the two-sided vacuity reading: no probe, no diagnostic — the fault is named under its own
+        // shape, never an empty container a future reader can dismiss
+        const result = mk({
+            pass: false,
+            booted: true,
+            rendered: false,
+            hardware: "apple / metal / apple m2 / apple m2",
+            errors: [],
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("instrument fault");
+        expect(diag).toContain("renderProbe=absent");
+        expect(diag).toContain("failed predicates: pass===true, rendered===true");
+        // the probe's absence is named, not silently dropped
+        expect(diag).not.toContain("renderProbe={");
+    });
+
+    test("a red with a harness-path probe (outcome=harness) carries its measurement", () => {
+        const probe: RenderProbe = {
+            samples: 3, // wait-loop + ready + post
+            center: [0, 0, 0],
+            corner: [0, 0, 0],
+            spread: 0,
+            threshold: 12,
+            elapsed: 5000,
+            outcome: "harness",
+        };
+        const result = mk({
+            pass: false,
+            booted: true,
+            rendered: false,
+            hardware: "apple / metal / apple m2 / apple m2",
+            errors: [],
+            renderProbe: probe,
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("renderProbe={samples=3");
+        expect(diag).toContain("spread=0");
+        expect(diag).toContain("outcome=harness");
+    });
+
+    test("a red with a settled probe (outcome=settled) carries its measurement", () => {
+        const probe: RenderProbe = {
+            samples: 5,
+            center: [100, 80, 60],
+            corner: [20, 20, 20],
+            spread: 180,
+            threshold: 12,
+            elapsed: 3000,
+            outcome: "settled",
+        };
+        const result = mk({
+            pass: false,
+            booted: true,
+            rendered: true, // settled but pass is still false (e.g. page errors)
+            hardware: "test-gpu",
+            errors: [],
+            renderProbe: probe,
+        });
+        const diag = verifyDiagnostic(result);
+        expect(diag).toContain("renderProbe={samples=5");
+        expect(diag).toContain("spread=180");
+        expect(diag).toContain("outcome=settled");
+    });
+
+    // RED-WHEN-BROKEN WITNESS: a mutated copy of verifyDiagnostic with the probe-printing branch
+    // removed (the `renderProbe` field state replaced with a bare `renderProbe=absent` regardless of
+    // whether a probe was carried) must drop the measurement, proving the arms discriminate the
+    // probe-printing branch. If the arms still passed with the branch broken, they would pin nothing
+    // about the probe's content.
+    test("red-when-broken: removing the probe-printing branch drops the measurement", () => {
+        // the production function, with the probe-printing branch replaced — the defect these arms
+        // exist to catch
+        function brokenVerifyDiagnostic(result: VerifyResult | null): string {
+            if (!result) return "no verify result";
+            const errors = result.errors ?? [];
+            if (errors.length > 0) return errors.join(" | ");
+            if (result.error) return result.error;
+            if (result.pass) return "pass";
+            const failedChecks = (result.verdict?.checks ?? []).filter((c) => !c.ok);
+            if (failedChecks.length > 0) return JSON.stringify(failedChecks);
+            const artifacts = result.artifacts ?? [];
+            const diagArtifacts = artifacts.filter(
+                (a: ShaderArtifactSummary) =>
+                    a.compilationError || (a.messages && a.messages.length > 0),
+            );
+            if (diagArtifacts.length > 0)
+                return JSON.stringify(
+                    diagArtifacts.map((a) => ({
+                        label: a.label,
+                        compilationError: a.compilationError,
+                        messages: a.messages,
+                    })),
+                );
+            const failed: string[] = [];
+            failed.push("pass===true");
+            if (result.booted !== true) failed.push("booted===true");
+            if (result.rendered !== true) failed.push("rendered===true");
+            const fields: string[] = [
+                `pass=${result.pass}`,
+                `booted=${result.booted ?? "undefined"}`,
+                `rendered=${result.rendered ?? "undefined"}`,
+                `hardware=${result.hardware ?? "undefined"}`,
+            ];
+            if (result.verdict) {
+                fields.push(`verdict.ok=${result.verdict.ok ?? "undefined"}`);
+                fields.push(`verdict.checks=${result.verdict.checks?.length ?? 0}`);
+            } else {
+                fields.push("verdict=absent");
+            }
+            fields.push(result.memory !== undefined ? "memory=present" : "memory=absent");
+            // THE BROKEN BRANCH: the probe-printing block is replaced with a bare absent — the
+            // measurement is silently dropped regardless of whether a probe was carried.
+            fields.push("renderProbe=absent");
+            return `instrument fault: verify red with no diagnostic (no page errors, no verdict checks, no shader artifacts); failed predicates: ${failed.join(", ")}; ${fields.join(", ")}`;
+        }
+
+        const withProbe = mk({
+            pass: false,
+            booted: true,
+            rendered: false,
+            hardware: "test-gpu",
+            errors: [],
+            renderProbe: underThreshold,
+        });
+        const broken = brokenVerifyDiagnostic(withProbe);
+        const correct = verifyDiagnostic(withProbe);
+
+        // the broken version drops the measurement — it reports absent even though a probe was carried
+        expect(broken).toContain("renderProbe=absent");
+        expect(broken).not.toContain("renderProbe={");
+        expect(broken).not.toContain("spread=7");
+        // the correct version carries the measurement
+        expect(correct).toContain("renderProbe={");
+        expect(correct).toContain("spread=7");
         // the arm discriminates: the broken and correct outputs differ
         expect(broken).not.toBe(correct);
     });

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -340,9 +340,14 @@ export interface TimingProbes {
 const spread = (a: number[], b: number[]): number =>
     Math.abs(a[0] - b[0]) + Math.abs(a[1] - b[1]) + Math.abs(a[2] - b[2]);
 
+/** the centre-vs-corner spread a frame must exceed to count as structure. One constant because the
+ *  render probe reports the spread *against* it — a second literal at the populate site would let a
+ *  tuned threshold make the probe lie about the reading it just took. */
+export const STRUCTURE_THRESHOLD = 12;
+
 /** a frame carries visible structure (not a single flat clear color) — center vs corner region contrast. */
 export function structured(center: number[], corner: number[]): boolean {
-    return spread(center, corner) > 12;
+    return spread(center, corner) > STRUCTURE_THRESHOLD;
 }
 
 /** a captured frame shows visible structure — the pixel-honest signal the harness path gates `rendered` on.
@@ -605,7 +610,7 @@ export interface RenderProbe {
     corner: number[] | null;
     /** the centre-vs-corner spread (sum of abs channel diffs) of the last sample, or null. */
     spread: number | null;
-    /** the threshold `structured` gates on (the `12` in `hasStructure`). */
+    /** the threshold `structured` gates on (`STRUCTURE_THRESHOLD`). */
     threshold: number;
     /** elapsed milliseconds from the first poll to the wait outcome. */
     elapsed: number;
@@ -1478,7 +1483,7 @@ async function drive(
         center: lastSample?.center ?? null,
         corner: lastSample?.corner ?? null,
         spread: lastSample ? spread(lastSample.center, lastSample.corner) : null,
-        threshold: 12,
+        threshold: STRUCTURE_THRESHOLD,
         elapsed: Date.now() - waitStart,
         outcome,
     };

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -585,8 +585,33 @@ export interface Result {
     memory?: MemoryStats | null;
     /** bounded generated WGSL records, present only on failure. */
     artifacts?: ShaderArtifact[];
+    /** the render probe — samples taken, last centre/corner RGB, spread against `structured`'s
+     *  threshold, elapsed wait, and how the wait concluded — so a blank-render red carries its
+     *  measurement rather than printing `[]`. Absent on a setup failure. */
+    renderProbe?: RenderProbe;
     errors: string[];
     pass: boolean;
+}
+
+/** the render probe the settle path records on its Result — the pixel evidence behind the `rendered`
+ *  verdict. Carries the frame samples the wait loop took, the last centre/corner RGB and the spread
+ *  against `structured`'s threshold, the elapsed wait, and how the wait concluded. */
+export interface RenderProbe {
+    /** frame samples the wait loop captured (non-null `sampleFrame` returns). */
+    samples: number;
+    /** last centre RGB [r,g,b] the probe measured, or null if no sample was ever taken. */
+    center: number[] | null;
+    /** last corner RGB [r,g,b] the probe measured, or null if no sample was ever taken. */
+    corner: number[] | null;
+    /** the centre-vs-corner spread (sum of abs channel diffs) of the last sample, or null. */
+    spread: number | null;
+    /** the threshold `structured` gates on (the `12` in `hasStructure`). */
+    threshold: number;
+    /** elapsed milliseconds from the first poll to the wait outcome. */
+    elapsed: number;
+    /** how the wait concluded: `harness` (window.__harness appeared), `settled` (two consecutive
+     *  structured shots below the diff epsilon), or `timeout` (the deadline expired). */
+    outcome: "harness" | "settled" | "timeout";
 }
 
 // the Playwright Page — typed loosely because playwright is an optional dep with no types at build time.
@@ -1420,13 +1445,20 @@ async function drive(
     }
 
     const deadline = Date.now() + args.timeoutMs;
+    const waitStart = Date.now();
     const st: WaitState = { booted: false, prev: null };
     let outcome: "harness" | "settled" | "timeout" = "timeout";
+    let sampleCount = 0;
+    let lastSample: FrameSample | null = null;
     for (;;) {
         const harnessDefined = (await page
             .evaluate(() => typeof window.__harness !== "undefined")
             .catch(() => false)) as boolean;
         const sample = harnessDefined ? null : await sampleFrame(page);
+        if (sample) {
+            sampleCount++;
+            lastSample = sample;
+        }
         const step = stepWait(st, harnessDefined, sample);
         if (step !== "continue") {
             outcome = step;
@@ -1435,6 +1467,21 @@ async function drive(
         if (Date.now() >= deadline) break;
         await page.waitForTimeout(500);
     }
+
+    // the render probe — the pixel evidence behind the `rendered` verdict. Carries the wait loop's
+    // samples, the last centre/corner RGB and spread against `structured`'s threshold, the elapsed
+    // wait, and how the wait concluded. The harness path updates it with the ready/post samples; the
+    // settle path carries it as-is. A blank-render red (no sample ever showed structure) is the
+    // reading this probe exists to make legible.
+    const renderProbe: RenderProbe = {
+        samples: sampleCount,
+        center: lastSample?.center ?? null,
+        corner: lastSample?.corner ?? null,
+        spread: lastSample ? spread(lastSample.center, lastSample.corner) : null,
+        threshold: 12,
+        elapsed: Date.now() - waitStart,
+        outcome,
+    };
 
     // read the adapter identity once the wait has concluded; a broken page returns "unknown", never a crash.
     base.hardware = await readHardware(page).catch(() => "unknown");
@@ -1460,7 +1507,10 @@ async function drive(
     }
 
     if (outcome === "harness")
-        return withGpuLog(page, await driveHarness(page, base, args, errors, checkpoints));
+        return withGpuLog(
+            page,
+            await driveHarness(page, base, args, errors, checkpoints, renderProbe),
+        );
 
     // no harness to wait for or run — both phases are instant, but the checkpoints stay uniform across
     // the harness and settle-only paths so a --timings reader compares the same phase list either way.
@@ -1479,6 +1529,7 @@ async function drive(
         // --memory needs a harness run() to measure across; a settle-only page has no steady state.
         ...(args.memory ? { memory: null } : {}),
         pass: settlePass(st.booted, rendered, errors.length),
+        renderProbe,
     });
 }
 
@@ -1524,8 +1575,10 @@ export async function driveHarness(
     args: VerifyArgs,
     errors: string[],
     checkpoints: Checkpoint[],
+    renderProbe?: RenderProbe,
 ): Promise<Result> {
     base.harness = true;
+    if (renderProbe) base.renderProbe = renderProbe;
     try {
         await page.waitForFunction(() => window.__harness?.ready === true, null, {
             timeout: args.timeoutMs,
@@ -1560,6 +1613,12 @@ export async function driveHarness(
     // during build then tears the scene down inside run(). A scenario that draws nothing fails on this,
     // not only on its own asserts. Reuses the settle path's compositor screenshot + structure check.
     const readySample = noRender ? null : await sampleFrame(page);
+    if (readySample && renderProbe) {
+        renderProbe.samples++;
+        renderProbe.center = readySample.center;
+        renderProbe.corner = readySample.corner;
+        renderProbe.spread = spread(readySample.center, readySample.corner);
+    }
 
     // --leak red-proof: start a known retained allocation now (harness is ready), so it runs through run()
     // and on into the post-run idle window the --memory slope is fitted over. Off (0) in every normal run.
@@ -1641,6 +1700,12 @@ export async function driveHarness(
     } else {
         await nextFrame(page);
         const postSample = await sampleFrame(page);
+        if (postSample && renderProbe) {
+            renderProbe.samples++;
+            renderProbe.center = postSample.center;
+            renderProbe.corner = postSample.corner;
+            renderProbe.spread = spread(postSample.center, postSample.corner);
+        }
         rendered = hasStructure(readySample) || hasStructure(postSample);
         const probes = (await page
             .evaluate(() => window.__harness?.pixelProbe)

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -117,6 +117,19 @@ export function verifyDiagnostic(result: VerifyResult | null): string {
         fields.push("verdict=absent");
     }
     fields.push(result.memory !== undefined ? "memory=present" : "memory=absent");
+    // the render probe — the pixel evidence behind the `rendered` verdict. A blank-render red (the
+    // reading this exists for) carries its measurement here: samples taken, the last centre/corner RGB,
+    // the spread against `structured`'s threshold, elapsed, and how the wait concluded. When no probe
+    // was captured at all (a crash before the settle path ran), the fault stays named under its own
+    // shape — never an empty container a future reader can dismiss.
+    if (result.renderProbe) {
+        const p = result.renderProbe;
+        fields.push(
+            `renderProbe={samples=${p.samples}, center=[${p.center ?? "null"}], corner=[${p.corner ?? "null"}], spread=${p.spread ?? "null"}, threshold=${p.threshold}, elapsed=${p.elapsed}ms, outcome=${p.outcome}}`,
+        );
+    } else {
+        fields.push("renderProbe=absent");
+    }
     return `instrument fault: verify red with no diagnostic (no page errors, no verdict checks, no shader artifacts); failed predicates: ${failed.join(", ")}; ${fields.join(", ")}`;
 }
 
@@ -1375,9 +1388,7 @@ if (import.meta.main) {
                 check(
                     "a real browser boots the installed engine and warms its pipelines",
                     result?.pass === true && result.booted === true && result.rendered === true,
-                    result
-                        ? JSON.stringify(result.errors ?? result.error ?? result)
-                        : "no verify result",
+                    verifyDiagnostic(result),
                 );
             }
             await teardownBridge();

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -55,6 +55,33 @@ export interface VerifyResult {
      *  (compilation errors, validation messages) the page captured. The driver surfaces this so a
      *  red with empty `errors` still names its diagnostic rather than printing `[]`. */
     artifacts?: ShaderArtifactSummary[];
+    /** the render probe — samples taken, last centre/corner RGB, spread against `structured`'s
+     *  threshold, elapsed wait, and how the wait concluded — so a blank-render red carries its
+     *  measurement rather than printing `[]`. Absent on a setup failure (a crash before the settle
+     *  path ran emits `{ pass:false, error }` with no probe). */
+    renderProbe?: RenderProbe;
+}
+
+/** the render probe `verify`'s settle path records on its Result — the pixel evidence behind the
+ *  `rendered` verdict. Carries the frame samples the wait loop took, the last centre/corner RGB and
+ *  the spread against `structured`'s threshold, the elapsed wait, and how the wait concluded — so a
+ *  blank-render red names its measurement rather than printing `[]`. */
+export interface RenderProbe {
+    /** frame samples the wait loop captured (non-null `sampleFrame` returns). */
+    samples: number;
+    /** last centre RGB [r,g,b] the probe measured, or null if no sample was ever taken. */
+    center: number[] | null;
+    /** last corner RGB [r,g,b] the probe measured, or null if no sample was ever taken. */
+    corner: number[] | null;
+    /** the centre-vs-corner spread (sum of abs channel diffs) of the last sample, or null. */
+    spread: number | null;
+    /** the threshold `structured` gates on (the `12` in `hasStructure`). */
+    threshold: number;
+    /** elapsed milliseconds from the first poll to the wait outcome. */
+    elapsed: number;
+    /** how the wait concluded: `harness` (window.__harness appeared), `settled` (two consecutive
+     *  structured shots below the diff epsilon), or `timeout` (the deadline expired). */
+    outcome: "harness" | "settled" | "timeout";
 }
 
 /** the minimal slice of `bin/verify.ts`'s `ShaderArtifact` a driver reads for diagnostics. */


### PR DESCRIPTION
- **shallot-untested-paths: s4 — render probe on verify's Result**
- **shallot-untested-paths: s4 — one threshold constant behind the probe**
