### PR TITLE
shallot-untested-paths: S5 — bump every version site to 0.9.4 and write its changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Newest first. **Breaking:** marks a change that needs consumer action; [`packages/shallot/MIGRATION.md`](packages/shallot/MIGRATION.md) is the 0.8→0.9 port. Versions follow [semver](https://semver.org).
 
+## 0.9.4 — 2026-08-24
+
+The patch that carries the three untested-path fixes: the bare barrel now imports under Node, the release workflow can talk to its own repo, and the `verify` boot arms carry legible diagnostics and render measurements. It does not claim an ejected-recipe fix — the investigation refuted that defect's existence; the nondeterministic blank-render boot arm is carried as a known red in this release's floor.
+
+- **packaging** — the bare barrel (`@dylanebert/shallot`) no longer touches `GPUTextureUsage` at module scope: the three reads in `COLOR_LANES`'s `usage` field are deferred to first access, so importing the default entry under Node (or bun, which defines no WebGPU globals either) no longer throws `GPUTextureUsage is not defined`. This supersedes 0.9.3's note that the bare barrel is browser-only — it now imports cleanly in any JS runtime, and a `check-node-import` arm guards the barrel alongside its existing subject.
+- **release** — the release workflow's asset-attachment step sets `GH_REPO: ${{ github.repository }}`, so `gh` resolves the repo from the environment rather than a local clone the job never has. Both branches of the step (`gh release create --verify-tag` and `gh release view`) were broken by the same missing context — `gh` verifies the tag against the remote, not a checkout — so one env line restores both while keeping `--verify-tag`. A static arm in `prebuilt.test.ts` gates the shape: any job that invokes `gh` with no `actions/checkout` must set `GH_REPO`.
+- **diagnostics** — `shallot verify`'s `Result` now carries a render probe (samples taken, last centre/corner RGB, spread against its threshold, elapsed, wait outcome), and a red of either boot arm prints it from `verifyDiagnostic`'s instrument-fault branch rather than a bare `[]`. A red carrying no page diagnostic reports a named instrument fault with the failing predicate (`pass`/`booted`/`rendered`) and the result's own field values, so an empty error array can no longer dismiss a genuine red. Five deterministic arms over synthetic settle states in `bin/verify.test.ts` pin the branch content.
+- **diagnostics** — the TGSL metadata assertion that reds on the install gate is repaired at the format version: the stale `externalNames` term (a V1 field no supported version emits) is retired for a metadata-format-version assertion, so a future rename reds under its own name rather than as a mystery. The surviving `TRANSPILED` shape term is untouched.
+- **known red** — the shared `verify` boot arm reds nondeterministically as a blank render (`spread=0`, a uniform frame at a single colour, timeout after 30 s) on real Metal, in both the zero-config and ejected configurations. The render measurement above is the instrument that records it; the cause is not an ejected recipe (refuted: the zero-config boot, which carries no ejected recipe, reds the same way) and remains open.
+
 ## 0.9.3 — 2026-08-21
 
 The packaging patch: prebuilt native shells on release builds, a loading subpath that imports under Node ≥26, and an audit pass over the whole export surface.

--- a/bun.lock
+++ b/bun.lock
@@ -310,12 +310,12 @@
     },
     "packages/create-shallot": {
       "name": "create-shallot",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "bin": "./index.ts",
     },
     "packages/shallot": {
       "name": "@dylanebert/shallot",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "bin": {
         "shallot": "./bin/cli.ts",
       },

--- a/packages/create-shallot/package.json
+++ b/packages/create-shallot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-shallot",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "type": "module",
     "bin": "./index.ts",
     "files": ["index.ts"],

--- a/packages/shallot/MIGRATION.md
+++ b/packages/shallot/MIGRATION.md
@@ -1,4 +1,4 @@
-# Migrating from 0.8 to 0.9.3
+# Migrating from 0.8 to 0.9.4
 
 This port touches GPU code only: the ECS, scene, and ordinary component APIs keep their 0.8 shape. What moves is the GPU substrate. Layouts now come from TypeGPU schemas, custom shaders use TGSL, and render registries carry typed resources.
 
@@ -11,7 +11,7 @@ Already on 0.9.0 or 0.9.1? You need none of the GPU-substrate port: the TypeGPU 
 Install the engine and its TypeGPU peer at the same time. Keep TypeGPU on the 0.12 minor used by Shallot; two copies in one bundle race over the same metadata map. The TypeGPU plugin versions move with the library, never independently.
 
 ```bash
-bun add @dylanebert/shallot@^0.9.3 typegpu@~0.12.0
+bun add @dylanebert/shallot@^0.9.4 typegpu@~0.12.0
 bun add -d unplugin-typegpu@~0.12.1 eslint@^9 eslint-plugin-typegpu@~0.12.0
 bun add -d @babel/core@^7.28.6 @babel/eslint-parser@^7.28.6 @babel/plugin-syntax-typescript@^7.28.5
 ```

--- a/packages/shallot/package.json
+++ b/packages/shallot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dylanebert/shallot",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "description": "WebGPU game engine. Procedural-first, ECS, declarative scenes. In development.",
     "sideEffects": [
         "./src/standard/index.ts",

--- a/packages/shallot/rust/audio/Cargo.toml
+++ b/packages/shallot/rust/audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shallot-audio"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 
 [lib]

--- a/packages/shallot/rust/window/Cargo.lock
+++ b/packages/shallot/rust/window/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "shallot-window"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "cef",
  "image",

--- a/packages/shallot/rust/window/Cargo.toml
+++ b/packages/shallot/rust/window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shallot-window"
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
The pre-publish half of the release cycle: version sites per check-versions.ts's
own enumeration, a changelog entry naming the barrel fix, the workflow fix and
the diagnostic work, and superseding 0.9.3's now-false trailing claim that the
bare barrel is browser-only.

check-versions --release green, bun check green, packages/shallot 5 fail (the
OrbitSystem floor), test:install 78 pass / 2 fail — pnpm absent and the
nondeterministic ejected boot arm, both the standing remainder, the latter now
printing its render probe (spread=0, uniform [24,17,9], timeout at 53 samples).
