### PR TITLE
shallot boot noise/s1

### DIFF
--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -940,12 +940,16 @@ describe("precompile", () => {
             events.push("pop");
             return null;
         };
-        device.queue.onSubmittedWorkDone = async () => {
-            events.push("fence");
-        };
         try {
             await requestGPU(device);
-            precompile("forward", () => events.push("force"));
+            precompile("forward", () => {
+                events.push("force");
+                return {
+                    initAsync: async () => {
+                        events.push("fence");
+                    },
+                };
+            });
             await precompileAll();
             expect(events).toEqual(["push:validation", "force", "fence", "pop"]);
         } finally {

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -962,12 +962,42 @@ describe("precompile", () => {
         try {
             await requestGPU(fakeDevice());
             const order: string[] = [];
-            precompile("first", () => order.push("first"));
-            precompile("dependent-a", () => order.push("dependent-a"), { after: ["publish"] });
-            precompile("independent", () => order.push("independent"));
-            precompile("dependent-b", () => order.push("dependent-b"), { after: ["publish"] });
-            precompile("publish", () => order.push("publish"));
-            precompile("optional", () => order.push("optional"), { after: ["missing"] });
+            precompile("first", () => {
+                order.push("first");
+                return [];
+            });
+            precompile(
+                "dependent-a",
+                () => {
+                    order.push("dependent-a");
+                    return [];
+                },
+                { after: ["publish"] },
+            );
+            precompile("independent", () => {
+                order.push("independent");
+                return [];
+            });
+            precompile(
+                "dependent-b",
+                () => {
+                    order.push("dependent-b");
+                    return [];
+                },
+                { after: ["publish"] },
+            );
+            precompile("publish", () => {
+                order.push("publish");
+                return [];
+            });
+            precompile(
+                "optional",
+                () => {
+                    order.push("optional");
+                    return [];
+                },
+                { after: ["missing"] },
+            );
 
             await precompileAll();
             expect(order).toEqual([
@@ -1015,16 +1045,25 @@ describe("precompile", () => {
         // a build began: that, and only that, re-opens the queue
         await requestGPU(fakeDevice());
         const order: string[] = [];
-        precompile("a", () => order.push("a"));
-        precompile("b", () => order.push("b"));
-        // nothing runs during warm — a dispatch here could hit a bind group whose dependency another
+        precompile("a", () => {
+            order.push("a");
+            return [];
+        });
+        precompile("b", () => {
+            order.push("b");
+            return [];
+        });
+        // nothing runs during warm — a forcer here could bind against a group whose dependency another
         // plugin's warm hasn't published yet
         expect(order).toEqual([]);
 
         precompile("broken", () => {
             throw new Error("createComputePipeline failed");
         });
-        precompile("c", () => order.push("c"));
+        precompile("c", () => {
+            order.push("c");
+            return [];
+        });
 
         // the throw names the pipeline, so a build failure points at the kernel, not at `build`
         await expect(precompileAll()).rejects.toThrow(/precompile "broken" failed/);
@@ -1037,7 +1076,10 @@ describe("precompile", () => {
 
         // past the drain a lazily-built pipeline compiles on arrival: late beats silently dropped,
         // which would surface as a multi-second first-frame stall with nothing pointing at it
-        await precompile("late", () => order.push("late"));
+        await precompile("late", () => {
+            order.push("late");
+            return [];
+        });
         expect(order).toEqual(["a", "b", "c", "late"]);
         await expect(
             precompile("late-broken", () => {
@@ -1045,11 +1087,24 @@ describe("precompile", () => {
             }),
         ).rejects.toThrow(/precompile "late-broken" failed/);
 
-        // a forcer that binds nothing dispatches nothing, so its pipeline silently falls through to the
-        // first frame — the multi-second stall the queue exists to prevent. The drain refuses it
+        // a forcer that binds nothing has no pipeline to init, so its compile silently falls through to
+        // the first frame — the multi-second stall the queue exists to prevent. The drain refuses it
         await expect(precompile("unbound", () => null)).rejects.toThrow(
             /precompile "unbound" bound nothing/,
         );
         Object.assign(Compute, saved);
+    });
+
+    test("a forcer returning a truthy non-pipeline, non-array value throws with its label", async () => {
+        const saved = { ...Compute };
+        try {
+            await requestGPU(fakeDevice());
+            precompile("wrong-shape", () => 42);
+            await expect(precompileAll()).rejects.toThrow(
+                /precompile "wrong-shape" returned a value that is neither a pipeline with initAsync nor an array of raw pipelines/,
+            );
+        } finally {
+            Object.assign(Compute, saved);
+        }
     });
 });

--- a/packages/shallot/src/engine/runtime/gpu.ts
+++ b/packages/shallot/src/engine/runtime/gpu.ts
@@ -918,10 +918,18 @@ async function compileValidated(forcer: Forcer): Promise<void> {
     const start = now();
     await validateGpu(Compute.device, forcer.label, async () => {
         const pipeline = compile(forcer);
-        // the sear variant thunk returns an array of already-unwrapped raw pipelines that need
-        // nothing — initAsync is only on typegpu pipelines (compute / render / guarded)
+        // the drain classifies a forcer's return exhaustively:
+        // (a) a typegpu pipeline (compute / render / guarded) exposes initAsync → await it
         if (typeof (pipeline as { initAsync?: unknown }).initAsync === "function") {
             await (pipeline as { initAsync(): Promise<void> }).initAsync();
+        } else if (Array.isArray(pipeline)) {
+            // (b) the sear variant (standard/sear/forward.ts) returns an array of already-unwrapped
+            // raw pipelines — skip, deliberately: initAsync is only on typegpu pipelines
+        } else {
+            // (c) anything else truthy is a forcer that returned the wrong shape — name the site
+            throw new Error(
+                `precompile "${forcer.label}" returned a value that is neither a pipeline with initAsync nor an array of raw pipelines`,
+            );
         }
     });
     // validation always fences what precompile claims; only attribution stays profiler-owned

--- a/packages/shallot/src/engine/runtime/gpu.ts
+++ b/packages/shallot/src/engine/runtime/gpu.ts
@@ -768,19 +768,20 @@ let _draining = false;
 let _drained = false;
 let _latePrecompile = Promise.resolve();
 
-function compile({ label, force }: Forcer): void {
+function compile({ label, force }: Forcer): unknown {
     let forced: unknown;
     try {
         forced = force();
     } catch (cause) {
         throw new Error(`precompile "${label}" failed — its pipeline did not compile`, { cause });
     }
-    // a forcer that binds nothing dispatches nothing, so the compile silently falls through to the
-    // first frame — the exact stall the queue exists to prevent, and invisible without this
+    // a forcer that binds nothing has no pipeline to init, so the compile silently falls through to
+    // the first frame — the exact stall the queue exists to prevent, and invisible without this
     if (!forced)
         throw new Error(
             `precompile "${label}" bound nothing — its pipeline would compile on the first frame instead`,
         );
+    return forced;
 }
 
 /**
@@ -916,8 +917,12 @@ export async function precompileAll(): Promise<void> {
 async function compileValidated(forcer: Forcer): Promise<void> {
     const start = now();
     await validateGpu(Compute.device, forcer.label, async () => {
-        compile(forcer);
-        await Compute.device.queue.onSubmittedWorkDone();
+        const pipeline = compile(forcer);
+        // the sear variant thunk returns an array of already-unwrapped raw pipelines that need
+        // nothing — initAsync is only on typegpu pipelines (compute / render / guarded)
+        if (typeof (pipeline as { initAsync?: unknown }).initAsync === "function") {
+            await (pipeline as { initAsync(): Promise<void> }).initAsync();
+        }
     });
     // validation always fences what precompile claims; only attribution stays profiler-owned
     Compute.precompiled?.(forcer.label, start, now());

--- a/packages/shallot/src/extras/outline/index.ts
+++ b/packages/shallot/src/extras/outline/index.ts
@@ -445,13 +445,13 @@ function prepareOutline(): void {
 }
 
 /**
- * force the two typed pipelines to compile under the loading screen. typegpu has no async pipeline creation,
- * so Dawn defers the real compile to the first dispatch — and the outline's passes run every frame a
+ * force the two typed pipelines to compile under the loading screen. typegpu creates pipelines
+ * synchronously, so Dawn defers the real compile — and the outline's passes run every frame a
  * highlight exists, which would put that stall on whichever frame the first hover lands. Their real bind
  * groups need per-camera targets that don't exist until a view attaches, so each forcer allocates its own
- * 1×1 stand-ins, binds, and does zero work. The stand-ins are destroyed right after, like glaze's: the
- * dispatch/draw is already submitted and ran no invocation, and a destroyed resource's allocation stays alive
- * until the submission it was recorded into completes. Waiting on `onSubmittedWorkDone` instead would leak
+ * 1×1 stand-ins and binds. The stand-ins are destroyed right after, like glaze's: the drain awaits
+ * `initAsync` on the bound pipeline, and a destroyed resource's allocation stays alive until the
+ * submission it was recorded into completes. Waiting on `onSubmittedWorkDone` instead would leak
  * all four whenever the device is torn down before the promise settles.
  */
 function forceCompile(): void {

--- a/packages/shallot/src/extras/outline/index.ts
+++ b/packages/shallot/src/extras/outline/index.ts
@@ -449,10 +449,9 @@ function prepareOutline(): void {
  * synchronously, so Dawn defers the real compile — and the outline's passes run every frame a
  * highlight exists, which would put that stall on whichever frame the first hover lands. Their real bind
  * groups need per-camera targets that don't exist until a view attaches, so each forcer allocates its own
- * 1×1 stand-ins and binds. The stand-ins are destroyed right after, like glaze's: the drain awaits
- * `initAsync` on the bound pipeline, and a destroyed resource's allocation stays alive until the
- * submission it was recorded into completes. Waiting on `onSubmittedWorkDone` instead would leak
- * all four whenever the device is torn down before the promise settles.
+ * 1×1 stand-ins and binds. Destroying them before the drain is safe because `initAsync` only compiles
+ * the pipeline — it records and submits nothing, so compilation never reads the bind groups the
+ * stand-ins were bound into.
  */
 function forceCompile(): void {
     const stand = (format: GPUTextureFormat, usage: number) =>

--- a/packages/shallot/src/extras/outline/index.ts
+++ b/packages/shallot/src/extras/outline/index.ts
@@ -470,10 +470,10 @@ function forceCompile(): void {
             seed: src.createView(),
             step: _gpu.steps[0],
         });
-        _gpu.jfa!.with(group).withColorAttachment({ view: dst.createView() }).draw(0);
+        const bound = _gpu.jfa!.with(group).withColorAttachment({ view: dst.createView() });
         src.destroy();
         dst.destroy();
-        return _gpu.jfa;
+        return bound;
     });
 
     precompile("outline-composite", () => {
@@ -487,12 +487,12 @@ function forceCompile(): void {
             attr: attr.createView(),
             output: out.createView(),
         });
-        _gpu.composite!.with(group).dispatchWorkgroups(0);
+        const bound = _gpu.composite!.with(group);
         scene.destroy();
         seed.destroy();
         attr.destroy();
         out.destroy();
-        return _gpu.composite;
+        return bound;
     });
 
     // the mask buffers (position/indices/transforms/maskEids/maskAttrs/meshQuant) are storage bindings, not
@@ -522,12 +522,10 @@ function forceCompile(): void {
             maskAttrs: attrs,
             meshQuant: quant,
         });
-        _gpu.maskPlain!.with(group)
-            .withColorAttachment({
-                seed: { view: seed.createView() },
-                attr: { view: attr.createView() },
-            })
-            .draw(0);
+        const bound = _gpu.maskPlain!.with(group).withColorAttachment({
+            seed: { view: seed.createView() },
+            attr: { view: attr.createView() },
+        });
         position.destroy();
         indices.destroy();
         transformsBuf.destroy();
@@ -536,7 +534,7 @@ function forceCompile(): void {
         quant.destroy();
         seed.destroy();
         attr.destroy();
-        return _gpu.maskPlain;
+        return bound;
     });
 
     precompile("outline-mask-occlude", () => {
@@ -559,12 +557,10 @@ function forceCompile(): void {
             meshQuant: quant,
             sceneDepth: depth.createView(),
         });
-        _gpu.maskOcclude!.with(group)
-            .withColorAttachment({
-                seed: { view: seed.createView() },
-                attr: { view: attr.createView() },
-            })
-            .draw(0);
+        const bound = _gpu.maskOcclude!.with(group).withColorAttachment({
+            seed: { view: seed.createView() },
+            attr: { view: attr.createView() },
+        });
         position.destroy();
         indices.destroy();
         transformsBuf.destroy();
@@ -574,7 +570,7 @@ function forceCompile(): void {
         seed.destroy();
         attr.destroy();
         depth.destroy();
-        return _gpu.maskOcclude;
+        return bound;
     });
 }
 

--- a/packages/shallot/src/standard/avbd/step.test.ts
+++ b/packages/shallot/src/standard/avbd/step.test.ts
@@ -488,7 +488,6 @@ describe("per-instance precompile labels", () => {
                 ...stub(),
                 queue: {
                     writeBuffer() {},
-                    onSubmittedWorkDone: () => lateFence ?? Promise.resolve(),
                 },
                 pushErrorScope() {},
                 popErrorScope: async () => null,
@@ -557,11 +556,6 @@ describe("per-instance precompile labels", () => {
                 ...base,
                 queue: {
                     writeBuffer() {},
-                    onSubmittedWorkDone() {
-                        if (!physicsAllocated) return Promise.resolve();
-                        physicsFences++;
-                        return physicsFences === 1 ? firstFence : restFence;
-                    },
                 },
                 pushErrorScope() {},
                 popErrorScope: async () => null,

--- a/packages/shallot/src/standard/avbd/step.test.ts
+++ b/packages/shallot/src/standard/avbd/step.test.ts
@@ -501,12 +501,7 @@ describe("per-instance precompile labels", () => {
                 with() {
                     return this;
                 },
-                dispatchWorkgroups() {
-                    return this;
-                },
-                dispatchWorkgroupsIndirect() {
-                    return this;
-                },
+                initAsync: () => lateFence ?? Promise.resolve(),
             };
             Object.assign(Compute, {
                 root: {
@@ -584,8 +579,10 @@ describe("per-instance precompile labels", () => {
                 with() {
                     return this;
                 },
-                dispatchWorkgroups() {
-                    return this;
+                initAsync() {
+                    if (!physicsAllocated) return Promise.resolve();
+                    physicsFences++;
+                    return physicsFences === 1 ? firstFence : restFence;
                 },
             };
             Object.assign(Compute, {

--- a/packages/shallot/src/standard/avbd/step.ts
+++ b/packages/shallot/src/standard/avbd/step.ts
@@ -4467,9 +4467,9 @@ export class PhysicsStep {
             .with(roRo.layout, this._sharedBG.roRo);
         // a typed pipeline is created synchronously, so Dawn defers its shader compile to the first
         // dispatch — a first-frame hitch where the raw passes' `createComputePipelineAsync` compiled at
-        // build. Force it at warm with a 0-workgroup dispatch, the shipped drain. Both groups are
-        // already bound here, so the drain's bound-nothing guard is inert — a forcer that allocates its
-        // own buffers must return the *dispatch* for that guard to fire.
+        // build. The drain awaits `initAsync` to force the compile under the loading screen. Both groups
+        // are already bound here, so the drain's bound-nothing guard is inert — a forcer that allocates
+        // its own buffers must return the bound pipeline for that guard to fire.
         register(`${this._scope}-aabb`, () => {
             return this._aabbPipe;
         });

--- a/packages/shallot/src/standard/avbd/step.ts
+++ b/packages/shallot/src/standard/avbd/step.ts
@@ -4471,7 +4471,6 @@ export class PhysicsStep {
         // already bound here, so the drain's bound-nothing guard is inert — a forcer that allocates its
         // own buffers must return the *dispatch* for that guard to fire.
         register(`${this._scope}-aabb`, () => {
-            this._aabbPipe.dispatchWorkgroups(0);
             return this._aabbPipe;
         });
         this._broadphasePipe = root
@@ -4487,7 +4486,6 @@ export class PhysicsStep {
             )
             .with(roRo.layout, this._sharedBG.roRo);
         register(`${this._scope}-broadphase`, () => {
-            this._broadphasePipe.dispatchWorkgroups(0);
             return this._broadphasePipe;
         });
         this._broadphaseSmallPipe = root
@@ -4503,14 +4501,12 @@ export class PhysicsStep {
             )
             .with(roRo.layout, this._sharedBG.roRo);
         register(`${this._scope}-broadphase-small`, () => {
-            this._broadphaseSmallPipe.dispatchWorkgroups(0);
             return this._broadphaseSmallPipe;
         });
         this._collidePipes = this._makeCollidePipes();
         for (const [i, label] of ["box", "rounded", "hull", "rounded-poly"].entries()) {
             register(`${this._scope}-collide-${label}`, () => {
                 const pipe = this._collidePipes[i];
-                pipe.dispatchWorkgroups(0);
                 return pipe;
             });
         }
@@ -4520,7 +4516,6 @@ export class PhysicsStep {
             .with(root.createBindGroup(inertialLayout, { eids: this.eids }))
             .with(rwRw.layout, this._sharedBG.rwRw);
         register(`${this._scope}-inertial`, () => {
-            this._inertialPipe.dispatchWorkgroups(0);
             return this._inertialPipe;
         });
         this._velocityPipe = root
@@ -4529,7 +4524,6 @@ export class PhysicsStep {
             .with(root.createBindGroup(velocityLayout, { eids: this.eids }))
             .with(rwRw.layout, this._sharedBG.rwRw);
         register(`${this._scope}-velocity`, () => {
-            this._velocityPipe.dispatchWorkgroups(0);
             return this._velocityPipe;
         });
         this._csrCountPipe = root
@@ -4538,7 +4532,6 @@ export class PhysicsStep {
             .with(root.createBindGroup(csrCountLayout, { csr: this.csr, eids: this.eids }))
             .with(roRo.layout, this._sharedBG.roRo);
         register(`${this._scope}-csr-count`, () => {
-            this._csrCountPipe.dispatchWorkgroups(0);
             return this._csrCountPipe;
         });
         this._csrScatterPipe = root
@@ -4553,7 +4546,6 @@ export class PhysicsStep {
             )
             .with(roRo.layout, this._sharedBG.roRo);
         register(`${this._scope}-csr-scatter`, () => {
-            this._csrScatterPipe.dispatchWorkgroups(0);
             return this._csrScatterPipe;
         });
         this._colorIdxBufs = [];
@@ -4583,7 +4575,6 @@ export class PhysicsStep {
         );
         register(`${this._scope}-commit`, () => {
             const pipe = this._commitColorPipes[0];
-            pipe.dispatchWorkgroups(0);
             return pipe;
         });
         this._dualPipe = root
@@ -4592,7 +4583,6 @@ export class PhysicsStep {
             .with(root.createBindGroup(dualLayout, { eids: this.eids }))
             .with(roRw.layout, this._sharedBG.roRw);
         register(`${this._scope}-dual`, () => {
-            this._dualPipe.dispatchWorkgroups(0);
             return this._dualPipe;
         });
         this._csrScanBG = device.createBindGroup({
@@ -4611,31 +4601,24 @@ export class PhysicsStep {
         // forcer, matching setHulls' growth policy for the collide pipes.
         register(`${this._scope}-primal`, () => {
             const pipe = this._primalColorPipes[0];
-            pipe.dispatchWorkgroups(0);
             return pipe;
         });
         register(`${this._scope}-solve-lds`, () => {
-            this._solveLdsPipe.dispatchWorkgroups(0);
             return this._solveLdsPipe;
         });
         register(`${this._scope}-coloring`, () => {
-            this._coloringPipe.dispatchWorkgroups(0);
             return this._coloringPipe;
         });
         register(`${this._scope}-repair`, () => {
-            this._repairPipe.dispatchWorkgroups(0);
             return this._repairPipe;
         });
         register(`${this._scope}-csr-color-small`, () => {
-            this._csrColorSmallPipe.dispatchWorkgroups(0);
             return this._csrColorSmallPipe;
         });
         register(`${this._scope}-joint-init`, () => {
-            this._jointInitPipe.dispatchWorkgroups(0);
             return this._jointInitPipe;
         });
         register(`${this._scope}-joint-dual`, () => {
-            this._jointDualPipe.dispatchWorkgroups(0);
             return this._jointDualPipe;
         });
     }
@@ -5761,7 +5744,6 @@ export class PhysicsStep {
             .with(roRo.layout, this._sharedBG.roRo);
         if (!this._composeCompiled) {
             const preparation = precompile(`${this._scope}-compose`, () => {
-                pipe.dispatchWorkgroups(0);
                 return pipe;
             }).then(() => {
                 this._composeCompiled = true;

--- a/packages/shallot/src/standard/bvh/bounds.ts
+++ b/packages/shallot/src/standard/bvh/bounds.ts
@@ -341,7 +341,6 @@ export async function createSceneBounds(
         ["finalize", finalizeBound],
     ] as const) {
         await precompile(`${scope}-${label}`, () => {
-            bound.dispatchWorkgroups(0);
             return bound;
         });
     }

--- a/packages/shallot/src/standard/bvh/build.ts
+++ b/packages/shallot/src/standard/bvh/build.ts
@@ -691,7 +691,6 @@ export async function createBuild(
         ["sweep", sweepAB],
     ] as const) {
         await precompile(`${scope}-${label}`, () => {
-            bound.dispatchWorkgroups(0);
             return bound;
         });
     }

--- a/packages/shallot/src/standard/bvh/morton.ts
+++ b/packages/shallot/src/standard/bvh/morton.ts
@@ -219,7 +219,6 @@ export async function createMorton(
         );
     // per-instance label — an app can build more than one BVH, and the queue rejects a duplicate label
     await precompile(precompileScope("morton"), () => {
-        bound.dispatchWorkgroups(0);
         return bound;
     });
 

--- a/packages/shallot/src/standard/bvh/sort-lds.ts
+++ b/packages/shallot/src/standard/bvh/sort-lds.ts
@@ -398,7 +398,6 @@ export async function createRadixSortLds(
         ["reorder", reorderBound[0]],
     ] as const) {
         await precompile(`${scope}-${label}`, () => {
-            bound.dispatchWorkgroups(0);
             return bound;
         });
     }

--- a/packages/shallot/src/standard/bvh/sort.test.ts
+++ b/packages/shallot/src/standard/bvh/sort.test.ts
@@ -270,9 +270,9 @@ describe("per-instance precompile labels", () => {
             with() {
                 return this;
             },
-            dispatchWorkgroups() {
+            initAsync() {
                 events.push("force");
-                return this;
+                return fence;
             },
         };
         try {
@@ -293,10 +293,10 @@ describe("per-instance precompile labels", () => {
             await Promise.resolve();
             await Promise.resolve();
             expect(resolved).toBe(false);
-            expect(events).toEqual(["push", "force", "fence"]);
+            expect(events).toEqual(["push", "force"]);
             release();
             await creating;
-            expect(events).toEqual(["push", "force", "fence", "pop"]);
+            expect(events).toEqual(["push", "force", "pop"]);
         } finally {
             Object.assign(Compute, saved);
         }

--- a/packages/shallot/src/standard/bvh/sort.test.ts
+++ b/packages/shallot/src/standard/bvh/sort.test.ts
@@ -251,10 +251,6 @@ describe("per-instance precompile labels", () => {
             limits: {},
             queue: {
                 writeBuffer() {},
-                onSubmittedWorkDone() {
-                    events.push("fence");
-                    return fence;
-                },
             },
             createBuffer: (d: GPUBufferDescriptor) => ({ ...d, destroy() {} }),
             pushErrorScope: () => events.push("push"),

--- a/packages/shallot/src/standard/bvh/sort.ts
+++ b/packages/shallot/src/standard/bvh/sort.ts
@@ -811,7 +811,6 @@ export async function createRadixSort(
         ...(prepare ? ([["prepare", prepare.bound]] as const) : []),
     ] as const) {
         await precompile(`${scope}-${label}`, () => {
-            bound.dispatchWorkgroups(0);
             return bound;
         });
     }

--- a/packages/shallot/src/standard/fog/index.ts
+++ b/packages/shallot/src/standard/fog/index.ts
@@ -272,8 +272,6 @@ export const FogPlugin: Plugin = {
                 fog: _fog.buffer!,
             });
             const bound = _fog.pipeline!.with(group0).with(fogLights());
-            bound.dispatchWorkgroups(0);
-            // the dispatch is already submitted and ran no invocation, so the throwaways are dead here
             src.destroy();
             depth.destroy();
             dst.destroy();

--- a/packages/shallot/src/standard/fog/index.ts
+++ b/packages/shallot/src/standard/fog/index.ts
@@ -240,7 +240,7 @@ export const FogPlugin: Plugin = {
         _lights = null;
         _views.clear();
 
-        // typegpu has no async pipeline creation, so Dawn defers the real compile to first dispatch — and
+        // typegpu creates pipelines synchronously, so Dawn defers the real compile — and
         // the march runs every frame `Fog` + `Depth` are both present, so an unfired compile would land the
         // stall on whichever frame that is. Group 1's real resources (the light/shadow service) exist by the
         // time this runs (deferred past every plugin's `warm`); group 0 is genuinely per-camera,

--- a/packages/shallot/src/standard/glaze/index.ts
+++ b/packages/shallot/src/standard/glaze/index.ts
@@ -216,8 +216,6 @@ export const GlazePlugin: Plugin = {
                     output: dst.createView(),
                 }),
             );
-            bound.dispatchWorkgroups(0);
-            // the dispatch is already submitted and ran no invocation, so the throwaways are dead here
             src.destroy();
             dst.destroy();
             return bound;

--- a/packages/shallot/src/standard/glaze/index.ts
+++ b/packages/shallot/src/standard/glaze/index.ts
@@ -192,8 +192,8 @@ export const GlazePlugin: Plugin = {
         _composite = composite(format);
         const { layout, pipeline } = _composite;
 
-        // typegpu pipelines are created synchronously and Dawn defers the real shader compile to the first
-        // dispatch, so without this the composite compiles inside frame 1 — glaze runs every frame, so that
+        // typegpu pipelines are created synchronously and Dawn defers the real shader compile, so without
+        // this the composite compiles inside frame 1 — glaze runs every frame, so that
         // is the whole first-frame stall. The real bind needs the per-frame swapchain view, which does not
         // exist at warm, so the forcer binds 1×1 throwaways of the same formats
         precompile("glaze", () => {

--- a/packages/shallot/src/standard/part/part.ts
+++ b/packages/shallot/src/standard/part/part.ts
@@ -471,17 +471,14 @@ export function warmPart(state: State): void {
     precompile("shallot-part-count", () => {
         syncBuffers();
         const bound = bindCount();
-        bound?.dispatchWorkgroups(0);
         return bound;
     });
     precompile("shallot-part-scan", () => {
         const bound = bindScan();
-        bound?.dispatchWorkgroups(0);
         return bound;
     });
     precompile("shallot-part-scatter", () => {
         const bound = bindScatter();
-        bound?.dispatchWorkgroups(0);
         return bound;
     });
 }

--- a/packages/shallot/src/standard/part/part.ts
+++ b/packages/shallot/src/standard/part/part.ts
@@ -466,7 +466,7 @@ export function warmPart(state: State): void {
     // both the allocation and the bind are deferred into the forcers, not done here. The drain runs
     // after every plugin's warm has resolved (warm hooks run under `Promise.all`), which is the first
     // moment `Meshes` is flushed and `membership` / `transforms` / `cullVolumes` are published — so
-    // `syncBuffers` can size the pack's buffers there, and the dispatch that forces the compile has
+    // `syncBuffers` can size the pack's buffers there, and the pipeline that forces the compile has
     // something to bind. One forcer per pipeline, so each gets its own row in the compile table
     precompile("shallot-part-count", () => {
         syncBuffers();

--- a/packages/shallot/src/standard/render/cluster.ts
+++ b/packages/shallot/src/standard/render/cluster.ts
@@ -376,7 +376,6 @@ export function warmClusters(): void {
     // has resolved (warm hooks run under `Promise.all`), the first moment every input buffer is up
     precompile("shallot-cluster-aabbs", () => {
         const bound = bindGrid();
-        bound.dispatchWorkgroups(0);
         return bound;
     });
 }
@@ -844,12 +843,10 @@ export function warmLightCull(state: State): void {
     _cullPipe = root.createComputePipeline({ compute: cullKernel }).$name("shallot-light-cull");
     precompile("shallot-light-compact", () => {
         const bound = bindCompact();
-        bound.dispatchWorkgroups(0);
         return bound;
     });
     precompile("shallot-light-cull", () => {
         const bound = bindCull();
-        bound.dispatchWorkgroups(0);
         return bound;
     });
 }

--- a/packages/shallot/src/standard/render/cluster.ts
+++ b/packages/shallot/src/standard/render/cluster.ts
@@ -372,7 +372,7 @@ export function warmClusters(): void {
     Compute.typed.set("clusterAabbs", _typedAabbs);
 
     _pipe = root.createComputePipeline({ compute: gridKernel }).$name("shallot-cluster-aabbs");
-    // the bind, not just the dispatch, is deferred into the forcer: it runs after every plugin's warm
+    // the bind is deferred into the forcer: it runs after every plugin's warm
     // has resolved (warm hooks run under `Promise.all`), the first moment every input buffer is up
     precompile("shallot-cluster-aabbs", () => {
         const bound = bindGrid();

--- a/packages/shallot/src/standard/sear/pipelines.test.ts
+++ b/packages/shallot/src/standard/sear/pipelines.test.ts
@@ -743,7 +743,7 @@ test("Sear warms Part-published specializing variants; post-build variants stay 
         precompile("shallot-part-count", () => {
             events.push("part");
             publishPartDraws(buffer, surfaces.size, surfaces.size * meshes.size, registries);
-            return true;
+            return [];
         });
         await precompileAll();
 

--- a/packages/shallot/src/standard/slab/index.ts
+++ b/packages/shallot/src/standard/slab/index.ts
@@ -384,7 +384,6 @@ export class Slab {
             forced.add(key);
             const bound = s._bound;
             precompile(`slab-scatter-${key}`, () => {
-                bound.dispatchWorkgroups(0);
                 return bound;
             });
         }

--- a/packages/shallot/src/standard/slab/index.ts
+++ b/packages/shallot/src/standard/slab/index.ts
@@ -374,7 +374,7 @@ export class Slab {
 
     /** allocate the canonical buffer + scatter bind group for every live slab, then queue one forced
      *  compile per element type — typegpu creates pipelines synchronously and Dawn defers the real
-     *  compile to the first dispatch, so without this the first frame pays it */
+     *  compile, so without this the first frame pays it */
     static prepareAll(): void {
         for (const s of Slab._all) if (s.gpuSupported) s.prepare();
         const forced = new Set<string>();

--- a/packages/shallot/src/standard/transforms/index.ts
+++ b/packages/shallot/src/standard/transforms/index.ts
@@ -175,7 +175,7 @@ export const TransformsPlugin: Plugin = {
 
     warm() {
         if (!_composePipeline) return;
-        // the bind, not just the dispatch, is deferred into the forcer: the drain runs after every
+        // the bind is deferred into the forcer: the drain runs after every
         // plugin's warm has resolved, which is the first moment the buffers this reads are all up
         precompile("shallot-transforms-compose", () => {
             const bound = bind();

--- a/packages/shallot/src/standard/transforms/index.ts
+++ b/packages/shallot/src/standard/transforms/index.ts
@@ -179,7 +179,6 @@ export const TransformsPlugin: Plugin = {
         // plugin's warm has resolved, which is the first moment the buffers this reads are all up
         precompile("shallot-transforms-compose", () => {
             const bound = bind();
-            bound?.dispatchWorkgroups(0);
             return bound;
         });
     },


### PR DESCRIPTION
- **shallot-boot-noise: warm path awaits initAsync instead of zero-count dispatch**
- **shallot-boot-noise: classify drain return, drop dead mocks, fix stale comments**
- **shallot-boot-noise: fix stale drain comment in outline forcer**
