### PR TITLE
shallot boot noise/s3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Newest first. **Breaking:** marks a change that needs consumer action; [`packages/shallot/MIGRATION.md`](packages/shallot/MIGRATION.md) is the 0.8→0.9 port. Versions follow [semver](https://semver.org).
 
+## 0.9.5 — 2026-08-24
+
+The warm idiom is now `initAsync()`, and the docs teach one contract.
+
+- **gpu** — the warm path stops dispatching. `precompile`'s callback returns the bound typegpu pipeline and the drain awaits its `initAsync()`; the zero-workgroup dispatch a consumer's own code used to write no longer happens, so following the documented warm idiom no longer raises Dawn's `DispatchWorkgroups with a workgroup count of 0 is unusual` warning in their own console. The drain classifies the return exhaustively: a typegpu pipeline (awaited), an array of already-unwrapped raw pipelines (skipped — the sear forcer's shape, `[]` when nothing specializes), anything else truthy (a labelled throw). `MIGRATION.md` and `AGENTS.md` teach the new return contract; the 0.9.0 line that named zero-workgroup dispatches is superseded.
+
 ## 0.9.4 — 2026-08-24
 
 Three paths no gate had ever run are now covered: the bare barrel imports under a runtime with no WebGPU globals, the release workflow can attach its own assets without a hand recovery, and a `verify` red carries the pixel measurement behind it. No consumer action, nothing breaking.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 Newest first. **Breaking:** marks a change that needs consumer action; [`packages/shallot/MIGRATION.md`](packages/shallot/MIGRATION.md) is the 0.8→0.9 port. Versions follow [semver](https://semver.org).
 
-## 0.9.5 — 2026-08-24
-
-The warm idiom is now `initAsync()`, and the docs teach one contract.
-
-- **gpu** — the warm path stops dispatching. `precompile`'s callback returns the bound typegpu pipeline and the drain awaits its `initAsync()`; the zero-workgroup dispatch a consumer's own code used to write no longer happens, so following the documented warm idiom no longer raises Dawn's `DispatchWorkgroups with a workgroup count of 0 is unusual` warning in their own console. The drain classifies the return exhaustively: a typegpu pipeline (awaited), an array of already-unwrapped raw pipelines (skipped — the sear forcer's shape, `[]` when nothing specializes), anything else truthy (a labelled throw). `MIGRATION.md` and `AGENTS.md` teach the new return contract; the 0.9.0 line that named zero-workgroup dispatches is superseded.
-
 ## 0.9.4 — 2026-08-24
 
 Three paths no gate had ever run are now covered: the bare barrel imports under a runtime with no WebGPU globals, the release workflow can attach its own assets without a hand recovery, and a `verify` red carries the pixel measurement behind it. No consumer action, nothing breaking.

--- a/packages/shallot/AGENTS.md
+++ b/packages/shallot/AGENTS.md
@@ -92,7 +92,7 @@ Author with `tgpu.fn`, `computeFn`, `vertexFn`, or `fragmentFn`; put `"use gpu"`
 
 TGSL integer division uses `idiv` from `utils/core`, never `/`; initialize integer locals with `d.u32(...)` or `d.i32(...)`. Apply `eslint-plugin-typegpu` to every `"use gpu"` file.
 
-Force pipeline creation during loading: from `warm`, queue a `precompile(label, force)` whose callback returns the bound typegpu pipeline; the drain awaits `initAsync()` on it — never dispatch.
+Force pipeline creation during loading: from `warm`, queue `precompile(label, force)`; return the bound pipeline or an array of raw ones — the drain awaits `initAsync()`, never dispatch.
 
 ### Typed surfaces
 

--- a/packages/shallot/AGENTS.md
+++ b/packages/shallot/AGENTS.md
@@ -92,7 +92,7 @@ Author with `tgpu.fn`, `computeFn`, `vertexFn`, or `fragmentFn`; put `"use gpu"`
 
 TGSL integer division uses `idiv` from `utils/core`, never `/`; initialize integer locals with `d.u32(...)` or `d.i32(...)`. Apply `eslint-plugin-typegpu` to every `"use gpu"` file.
 
-Force pipeline creation during loading: from `warm`, queue a zero-workgroup `precompile(label, force)`. Allocate late inputs in its callback and return the dispatched non-null bound pipeline.
+Force pipeline creation during loading: from `warm`, queue a `precompile(label, force)` whose callback returns the bound typegpu pipeline; the drain awaits `initAsync()` on it — never dispatch.
 
 ### Typed surfaces
 

--- a/packages/shallot/MIGRATION.md
+++ b/packages/shallot/MIGRATION.md
@@ -276,17 +276,16 @@ Relocatable shader text is now usually resolved lazily from the same TGSL functi
 
 ## Warm typed pipelines
 
-TypeGPU creates pipelines synchronously, and Dawn can defer the real compile to the first dispatch. Register a zero-workgroup force during `warm`:
+TypeGPU creates pipelines synchronously, and Dawn can defer the real compile to the first dispatch. Register a force during `warm` whose callback returns the bound typegpu pipeline:
 
 ```ts
 precompile("particles", () => {
     const bound = bindForWarm();
-    bound.dispatchWorkgroups(0);
     return bound;
 });
 ```
 
-The label must be unique in a build. Allocate and bind throwaway inputs inside the callback, which runs after plugin warms. Return the non-null bound pipeline after dispatching; a missing return fails instead of moving the stall to frame one. Use `options.after` when a producer publishes a resource during another warm.
+The label must be unique in a build. Allocate and bind throwaway inputs inside the callback, which runs after plugin warms. The callback returns the bound pipeline and the drain awaits its `initAsync()` — never dispatch from the callback: a zero-workgroup dispatch trips Dawn's `DispatchWorkgroups with a workgroup count of 0 is unusual` warning in your own code. A missing (nullish) return fails instead of moving the stall to frame one. The drain classifies the return exhaustively: a typegpu pipeline (awaited), an array of already-unwrapped raw pipelines (skipped — the sear forcer's shape, `[]` when nothing specializes), anything else truthy (a labelled throw). Use `options.after` when a producer publishes a resource during another warm.
 
 ## Keep raw WebGPU where it owns the boundary
 

--- a/packages/shallot/src/engine/runtime/gpu.ts
+++ b/packages/shallot/src/engine/runtime/gpu.ts
@@ -170,9 +170,9 @@ export interface Compute {
      * optional pipeline-compile timing hook installed by `ProfilePlugin`, mirroring {@link span} /
      * {@link indirect}. typegpu pipelines are sync-created (`root.unwrap` calls the synchronous
      * `create*Pipeline`), and Dawn defers the real shader compile to the forced {@link precompile}
-     * dispatch — so timing the creation call would report a number that reads like a compile time and
-     * isn't one. {@link precompileAll} instead measures each forcer's dispatch through its own
-     * completion fence and reports it here. The validation drain always waits for that fence; a `?.`
+     * drain — so timing the creation call would report a number that reads like a compile time and
+     * isn't one. {@link precompileAll} instead measures each forcer's `initAsync()` await through its
+     * own completion fence and reports it here. The validation drain always waits for that fence; a `?.`
      * no-op without the plugin means only timing attribution is conditional.
      */
     precompiled?: (label: string, start: number, end: number) => void;
@@ -785,25 +785,28 @@ function compile({ label, force }: Forcer): unknown {
 }
 
 /**
- * force a pipeline to compile before the first frame. typegpu has no async pipeline creation —
- * unwrapping a pipeline calls the synchronous `create*Pipeline`, and Dawn defers the real compile to
- * the first dispatch (measured ~3 s of first-frame drain at engine scale). A pipeline owner registers a
- * 0-workgroup dispatch from its `warm`; `build` drains the queue once every plugin has warmed, so the
- * compile is paid under the loading screen. Registered *after* that drain (a lazily-built pipeline, a
- * post-warm producer), the dispatch starts immediately and the returned promise must be awaited — late
- * is better than silently dropped, but it still owes the same validation and completion fence.
+ * force a pipeline to compile before the first frame. A typegpu pipeline is created synchronously
+ * (`root.unwrap` calls the synchronous `create*Pipeline`), and Dawn can defer the real compile to the
+ * first dispatch (measured ~3 s of first-frame drain at engine scale). A pipeline owner registers its
+ * bound pipeline from `warm`; `build` drains the queue once every plugin has warmed, awaiting
+ * `initAsync()` on each returned pipeline, so the compile is paid under the loading screen. Registered
+ * *after* that drain (a lazily-built pipeline, a post-warm producer), the drain runs on arrival and the
+ * returned promise must be awaited — late is better than silently dropped, but it still owes the same
+ * validation and completion fence.
  *
- * `force` **returns what it dispatched**: the drain throws on a nullish return, because a forcer whose
- * buffers aren't up yet no-ops and hands the compile back to frame one without a word. Allocate inside
- * the thunk if the buffers are late — the drain runs after every plugin's warm, which is the point.
- * `label` names the pipeline in either failure and must be unique within the build. `options.after`
- * names other queued labels that must drain first. Unknown labels are ignored because the plugin that
- * owns a predecessor may be absent.
+ * `force` **returns the bound pipeline** — never dispatch from the callback: a zero-workgroup dispatch
+ * trips Dawn's `DispatchWorkgroups with a workgroup count of 0 is unusual` warning in your own code. The
+ * drain classifies the return exhaustively: a typegpu pipeline (compute / render / guarded) is awaited
+ * via its `initAsync`; an array of already-unwrapped raw pipelines is skipped (the sear forcer's
+ * legitimate shape, `[]` when nothing specializes); anything else truthy is a labelled throw. A nullish
+ * return also throws, because a forcer whose buffers aren't up yet no-ops and hands the compile back to
+ * frame one without a word. Allocate inside the thunk if the buffers are late — the drain runs after
+ * every plugin's warm, which is the point. `label` names the pipeline in either failure and must be
+ * unique within the build. `options.after` names other queued labels that must drain first. Unknown
+ * labels are ignored because the plugin that owns a predecessor may be absent.
  * @example
  * precompile("narrowphase", () => {
- *     const bound = bind();
- *     bound?.dispatchWorkgroups(0);
- *     return bound;
+ *     return bind();
  * }, {
  *     after: ["publish-inputs"],
  * });
@@ -846,10 +849,7 @@ const _precompileScopes = new Map<string, number>();
  * orders against.
  * @example
  * const scope = precompileScope("radix"); // "radix", then "radix-2", …
- * precompile(`${scope}-init`, () => {
- *     initBound.dispatchWorkgroups(0);
- *     return initBound;
- * });
+ * precompile(`${scope}-init`, () => initBound);
  */
 export function precompileScope(prefix: string): string {
     const n = (_precompileScopes.get(prefix) ?? 0) + 1;

--- a/packages/shallot/src/engine/runtime/gpu.ts
+++ b/packages/shallot/src/engine/runtime/gpu.ts
@@ -172,7 +172,9 @@ export interface Compute {
      * `create*Pipeline`), and Dawn defers the real shader compile to the forced {@link precompile}
      * drain — so timing the creation call would report a number that reads like a compile time and
      * isn't one. {@link precompileAll} instead measures each forcer's `initAsync()` await through its
-     * own completion fence and reports it here. The validation drain always waits for that fence; a `?.`
+     * own completion fence and reports it here — a forcer returning an array of already-unwrapped raw
+     * pipelines awaits nothing, so its reported span is the skip. The validation drain always waits
+     * for that fence; a `?.`
      * no-op without the plugin means only timing attribution is conditional.
      */
     precompiled?: (label: string, start: number, end: number) => void;


### PR DESCRIPTION
- **shallot-boot-noise: s3 docs teach the initAsync warm contract**
- **shallot-boot-noise: s3 drops the changelog entry to S5's bump**
- **shallot-boot-noise: s3 review — docs name the array return shape**
