### PR TITLE
shallot demo site/s7

### DIFF
--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -3,25 +3,28 @@ import { dirname, resolve, sep } from "node:path";
 import { Glob } from "bun";
 import { ROSTER } from "../site/roster";
 
-// `bun run scripts/check-site.ts` — the site membership gate, wired into `bun check`. Five clauses:
+// `bun run scripts/check-site.ts` — the site membership gate, wired into `bun check`. Four clauses:
 //
-//   1. roster set-equals the showcase dirs on disk — a demo that ships without a roster entry (or
-//      vice versa) reds here. This class already has a live defect: `examples/showcase/roads/`
-//      existed since the roads unit shipped and appeared in no index — exactly what this reds on.
-//   2. every entry's dir has a manifest — a showcase dir without `shallot.json` (or, for an
+//   1. every entry's dir has a manifest — a showcase dir without `shallot.json` (or, for an
 //      ejected project, `index.html`) is not a buildable demo.
-//   3. the ejected manifest names the release version — the in-repo `package.json` pins
+//   2. the ejected manifest names the release version — the in-repo `package.json` pins
 //      `@dylanebert/shallot` as `workspace:*`; the build script rewrites it to the release version
 //      from `packages/shallot/package.json`. This clause verifies the in-repo form is `workspace:*`
 //      and that the release version is a real semver (not `workspace:*`), so the ejection would
 //      produce a published-consumer pin, not a workspace alias that can't resolve outside the repo.
-//   4. no import escapes a demo's own directory — an ejected demo importing anything outside its
+//   3. no import escapes a demo's own directory — an ejected demo importing anything outside its
 //      own dir would break, since only the demo's dir is copied to the scratch tree. A relative
 //      import that climbs out is the failure mode; package imports (`@dylanebert/shallot`,
 //      `typegpu`) resolve through node_modules and are fine.
-//   5. no generated path is root-absolute — the site must work at any base path (GitHub Pages
+//   4. no generated path is root-absolute — the site must work at any base path (GitHub Pages
 //      serves at `/shallot/`, a dry-run artifact at root, a local out dir at `file://`). Scans
 //      `out/site/` if it exists; skips with a note if not (the build hasn't run yet).
+//
+// The roster is derived from `examples/showcase/` by enumeration (site/roster.ts), so set membership
+// is by construction — a roster-equals-disk clause would compare code against itself, the
+// self-referential shape the spec names. The live defect that clause existed to catch
+// (`examples/showcase/roads/` indexed nowhere) is caught earlier by derivation, since an unindexed
+// dir is not a state the build can represent.
 
 const root = resolve(import.meta.dir, "..");
 const showcaseDir = resolve(root, "examples/showcase");
@@ -32,35 +35,7 @@ function fail(msg: string): never {
     process.exit(1);
 }
 
-// --- clause 1: roster set-equals showcase dirs --------------------------------------------
-
-const rosterSlugs = new Set(ROSTER.map((d) => d.slug));
-const dirSlugs = new Set(
-    readdirSync(showcaseDir, { withFileTypes: true })
-        .filter((e) => e.isDirectory())
-        .map((e) => e.name),
-);
-
-const missingFromRoster = [...dirSlugs].filter((s) => !rosterSlugs.has(s));
-const missingFromDisk = [...rosterSlugs].filter((s) => !dirSlugs.has(s));
-
-if (missingFromRoster.length > 0 || missingFromDisk.length > 0) {
-    if (missingFromRoster.length > 0) {
-        console.error(`✗ showcase dir(s) not in the roster:\n`);
-        for (const s of missingFromRoster) console.error(`  ${s}`);
-    }
-    if (missingFromDisk.length > 0) {
-        console.error(`✗ roster entr(ies) with no showcase dir on disk:\n`);
-        for (const s of missingFromDisk) console.error(`  ${s}`);
-    }
-    console.error(
-        "\nThe site roster must set-equal the showcase dirs — add the demo to site/roster.ts" +
-            " or remove the dir.",
-    );
-    process.exit(1);
-}
-
-// --- clause 2: every entry's dir has a manifest -------------------------------------------
+// --- clause 1: every entry's dir has a manifest -------------------------------------------
 
 const noManifest: string[] = [];
 for (const { slug } of ROSTER) {
@@ -78,7 +53,7 @@ if (noManifest.length > 0) {
     process.exit(1);
 }
 
-// --- clause 3: the ejected manifest names the release version -----------------------------
+// --- clause 2: the ejected manifest names the release version -----------------------------
 
 const pkg = (await Bun.file(resolve(root, "packages/shallot/package.json")).json()) as {
     version: string;
@@ -114,7 +89,7 @@ if (badVersion.length > 0) {
     process.exit(1);
 }
 
-// --- clause 4: no import escapes a demo's own directory ----------------------------------
+// --- clause 3: no import escapes a demo's own directory ----------------------------------
 
 const importRe = /(?:from\s+["']|import\s+["']|import\s*\(\s*["'])([^"']+)["']/g;
 const escaped: { slug: string; file: string; line: number; spec: string }[] = [];
@@ -152,7 +127,7 @@ if (escaped.length > 0) {
     process.exit(1);
 }
 
-// --- clause 5: no generated path is root-absolute -----------------------------------------
+// --- clause 4: no generated path is root-absolute -----------------------------------------
 
 if (!existsSync(outDir)) {
     if (process.env.SITE_OUT_REQUIRED === "1") {
@@ -160,7 +135,7 @@ if (!existsSync(outDir)) {
         process.exit(1);
     }
     console.log(
-        `✓ site roster clean (${ROSTER.length} demos, set-equal to showcase dirs, ` +
+        `✓ site roster clean (${ROSTER.length} demos, ` +
             `all manifested, all workspace-pinned, no escaping imports) — ` +
             `out/site/ not built yet (run \`bun run site\`), skipping root-absolute path check`,
     );
@@ -203,6 +178,6 @@ if (rootAbsFiles.length > 0) {
 }
 
 console.log(
-    `✓ site roster clean (${ROSTER.length} demos, set-equal to showcase dirs, ` +
+    `✓ site roster clean (${ROSTER.length} demos, ` +
         `all manifested, all workspace-pinned, no escaping imports, no root-absolute paths)`,
 );

--- a/scripts/demos.ts
+++ b/scripts/demos.ts
@@ -24,8 +24,9 @@ import { skipReason, type VerifyResult, verify } from "./verify";
 // regression gates, a skip here exits nonzero — this is a release gate, and a skipped release gate
 // is not green. The green run is native hardware with every demo verified.
 //
-// The roster is the single source of truth — imported from `site/roster.ts`, never duplicated. A
-// second copy is the exact defect `check-site.ts`'s set-equality gate exists to catch. Ejection and
+// The roster is the single source of truth — imported from `site/roster.ts`, never duplicated. It is
+// derived from `examples/showcase/` by enumeration, so a second copy is impossible by construction
+// rather than caught by a gate (the set-equality clause it used to need is gone). Ejection and
 // building are not re-implemented: `bun run site` already ejects, installs, and builds every roster
 // demo into `out/site/<slug>/`. This script drives that and then verifies the built dirs.
 

--- a/site/roster.ts
+++ b/site/roster.ts
@@ -1,41 +1,32 @@
-// The site roster — the six showcase demos. This is the single source of truth for which demos
-// the site builds and serves. `check-site.ts` asserts this set equals the showcase dirs on disk,
-// so a demo that ships without a roster entry (or vice versa) reds `bun check`.
-//
-// The roster is kept separate from `examples/AGENTS.md` because the two serve different readers:
-// the roster is the build's source of truth and the thing `check-site.ts` set-gates, while
-// `examples/AGENTS.md` lines are written for agent retrieval — different readers, so these are
-// not copies to consolidate (the Locked decision). Rows carry a title, a play link, and a code
-// link — nothing else; the demos speak for themselves.
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
+
+// The site roster — derived from `examples/showcase/` by enumeration, not a hand-maintained list.
+// Each showcase dir joins the site by existing; the title is the slug with each kebab segment
+// capitalized (no override map until a slug needs one — every current slug is single-word, so the
+// rule is exact today). `check-site.ts` gates the dirs' contracts (manifest presence, workspace-form
+// shallot pin, no escaping import, no root-absolute path); set membership is by construction, so no
+// separate roster-equals-disk clause survives. This module is the single import point:
+// `build-site.ts`, `demos.ts`, and `check-site.ts` all import `ROSTER` and none of them learn about
+// the filesystem — the change is the provenance of the array, not the shape consumers see.
 
 export interface DemoEntry {
     slug: string;
     title: string;
 }
 
-export const ROSTER: DemoEntry[] = [
-    {
-        slug: "collapse",
-        title: "Collapse",
-    },
-    {
-        slug: "fountain",
-        title: "Fountain",
-    },
-    {
-        slug: "roads",
-        title: "Roads",
-    },
-    {
-        slug: "sandbox",
-        title: "Sandbox",
-    },
-    {
-        slug: "visualization",
-        title: "Visualization",
-    },
-    {
-        slug: "voxel",
-        title: "Voxel",
-    },
-];
+const repoRoot = resolve(import.meta.dir, "..");
+const showcaseDir = resolve(repoRoot, "examples/showcase");
+
+function deriveTitle(slug: string): string {
+    return slug
+        .split("-")
+        .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+        .join(" ");
+}
+
+export const ROSTER: DemoEntry[] = readdirSync(showcaseDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort()
+    .map((slug) => ({ slug, title: deriveTitle(slug) }));


### PR DESCRIPTION
- **shallot-demo-site: derive the roster from the showcase dirs**
- **shallot-demo-site: correct demos.ts's stale set-equality reference**
