### PR TITLE
audit scene roundtrip integrity/s1

### DIFF
--- a/packages/shallot/src/engine/scene/codec.ts
+++ b/packages/shallot/src/engine/scene/codec.ts
@@ -379,7 +379,21 @@ function parseNumber(value: string): number | null {
         if (hex.length === 3) {
             return parseInt(hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2], 16);
         }
-        return parseInt(hex, 16);
+        // CSS shorthand: #rgba expands to #rrggbbaa (each digit doubled), so #ffff →
+        // 0xffffffff, not the 16-bit parseInt("ffff", 16) = 65535
+        if (hex.length === 4) {
+            return parseInt(
+                hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2] + hex[3] + hex[3],
+                16,
+            );
+        }
+        if (hex.length === 6 || hex.length === 8) {
+            return parseInt(hex, 16);
+        }
+        // any other length is not a valid CSS hex color — return null (same as the
+        // charset rejection above) rather than a raw short int that yields a silent
+        // wrong color
+        return null;
     }
 
     if (value === "true") return 1;

--- a/packages/shallot/src/engine/scene/codec.ts
+++ b/packages/shallot/src/engine/scene/codec.ts
@@ -231,8 +231,15 @@ export function serialize(state: State, eids?: Iterable<number>): Node[] {
         }
     }
 
-    const resolveRef = (target: number): string | undefined =>
-        target > 0 && set.has(target) ? ids.get(target) : undefined;
+    const resolveRef = (target: number): string | undefined => {
+        if (target <= 0) return undefined;
+        const inSet = ids.get(target);
+        if (inSet !== undefined) return inSet;
+        // a target outside the serialized set resolves to its scene id, so a subset
+        // serialize emits `@name` rather than a raw eid that points at the wrong
+        // (recycled) entity on reload
+        return state.identity.id(target);
+    };
 
     const nodes: Node[] = [];
     for (const eid of list) {
@@ -367,6 +374,11 @@ function parseNumber(value: string): number | null {
     if (value.startsWith("#")) {
         const hex = value.slice(1);
         if (!/^[0-9a-fA-F]+$/.test(hex)) return null;
+        // CSS shorthand: #rgb expands to #rrggbb (each digit doubled), so #fff →
+        // 0xffffff, not the 12-bit parseInt("fff", 16) = 4095
+        if (hex.length === 3) {
+            return parseInt(hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2], 16);
+        }
         return parseInt(hex, 16);
     }
 

--- a/packages/shallot/src/engine/scene/roundtrip.test.ts
+++ b/packages/shallot/src/engine/scene/roundtrip.test.ts
@@ -358,6 +358,20 @@ describe("serialize identity + refs", () => {
         expect(Mark.v.get(target2)).toBe(77);
     });
 
+    // RED witnessed: serialize(state, [a]) emits "to: 2" (raw eid) instead of "to: @b"
+    // because resolveRef returns undefined for a ref target outside the serialized subset.
+    // Witnessed red: expected to contain "to: @b", received `arrow="to: 2"` — the raw eid
+    // points at the wrong (recycled) entity on reload, breaking the round-trip-by-name contract.
+    test("subset serialize emits @-ref for a target outside the serialized set", () => {
+        clear();
+        const Arrow = { to: sparse(entity) };
+        register("arrow", Arrow, { defaults: () => ({ to: 0 }) });
+        const state = new State();
+        load(parse(`<scene><a id="a" arrow="to: @b" /><a id="b" /></scene>`), state);
+        const a = state.only([Arrow as never]);
+        expect(stringify(serialize(state, [a]))).toContain("to: @b");
+    });
+
     test("captures authored entities, excludes warm-derived ones — a restore never doubles them", async () => {
         clear();
         const Tree = { kind: sparse(u32) };

--- a/packages/shallot/src/engine/scene/xml.test.ts
+++ b/packages/shallot/src/engine/scene/xml.test.ts
@@ -344,6 +344,22 @@ describe("XML", () => {
             expect(parsed.color).toBe(0xff8800);
         });
 
+        // RED witnessed: parseNumber treats #fff as parseInt("fff", 16) = 4095 (a 12-bit int)
+        // instead of expanding to the 24-bit 0xffffff or rejecting as null. Witnessed red:
+        // expected not 4095, received 4095. The spec leaves expand-vs-reject to S2's executor,
+        // so the arm asserts "never 4095" rather than pinning one of the two acceptable answers.
+        test("#rgb shorthand never silently parses as a 12-bit integer", () => {
+            const Part = { color: [] as number[] };
+            register("part", Part, { defaults: () => ({ color: 0 }) });
+            let result: number | undefined;
+            try {
+                result = parseFields("part", "color: #fff").color;
+            } catch {
+                result = undefined;
+            }
+            expect(result).not.toBe(4095);
+        });
+
         test("errors on unknown component", () => {
             expect(() => formatFields("nonexistent", { x: 1 })).toThrow("Unknown component");
         });
@@ -687,15 +703,27 @@ describe("XML", () => {
     });
 
     describe("format idempotence", () => {
+        // RED witnessed: the original fixture (three plain ids) could not construct the escape
+        // asymmetry its name claims. Replaced with a fixture carrying an escaped id ("a&amp;b").
+        // Witnessed red: expected `a&amp;amp;b` (once), received `a&amp;amp;amp;b` (twice) —
+        // escapeAttr has no parse-side inverse, so each round grows an escape layer.
         test("stringify(parse(xml)) is idempotent", () => {
             const xml = `<scene>
-    <a id="first" />
+    <a id="a&amp;b" />
     <a id="second" />
     <a id="third" />
 </scene>`;
             const once = stringify(parse(xml));
             const twice = stringify(parse(once));
             expect(twice).toBe(once);
+        });
+
+        // RED witnessed: escapeAttr escapes & → &amp; but parse never decodes &amp; back to &.
+        // Witnessed red: expected `a&amp;b`, received `a&amp;amp;b` — one round grows an escape
+        // layer, so a formatter write-back (parse → stringify) corrupts well-formed scenes.
+        test("stringify(parse(xml)) preserves escaped attribute text", () => {
+            const src = '<scene>\n    <a id="a&amp;b" />\n</scene>';
+            expect(stringify(parse(src))).toBe(src);
         });
     });
 

--- a/packages/shallot/src/engine/scene/xml.test.ts
+++ b/packages/shallot/src/engine/scene/xml.test.ts
@@ -358,13 +358,29 @@ describe("XML", () => {
         test("#rgb shorthand expands to 24-bit or is rejected, never a 12-bit integer", () => {
             const Part = { color: [] as number[] };
             register("part", Part, { defaults: () => ({ color: 0 }) });
-            let result: string | number | null | undefined;
-            try {
-                result = parseFields("part", "color: #fff").color;
-            } catch {
-                result = undefined;
-            }
-            expect(result === 0xffffff || result === null).toBe(true);
+
+            const tryColor = (attr: string): string | number | null | undefined => {
+                try {
+                    return parseFields("part", attr).color;
+                } catch {
+                    return undefined;
+                }
+            };
+
+            // length 3: #rgb → #rrggbb (expand) or rejected, never 4095
+            const r3 = tryColor("color: #fff");
+            expect(r3 === 0xffffff || r3 === null).toBe(true);
+
+            // length 4: #rgba → #rrggbbaa (expand) or rejected, never 65535
+            const r4 = tryColor("color: #ffff");
+            expect(r4 === 0xffffffff || r4 === null).toBe(true);
+
+            // lengths outside {3, 4, 6, 8} are rejected, never a raw short int
+            const r2 = tryColor("color: #ff");
+            expect(r2 === null || r2 === undefined).toBe(true);
+
+            const r5 = tryColor("color: #fffff");
+            expect(r5 === null || r5 === undefined).toBe(true);
         });
 
         test("errors on unknown component", () => {

--- a/packages/shallot/src/engine/scene/xml.test.ts
+++ b/packages/shallot/src/engine/scene/xml.test.ts
@@ -346,18 +346,25 @@ describe("XML", () => {
 
         // RED witnessed: parseNumber treats #fff as parseInt("fff", 16) = 4095 (a 12-bit int)
         // instead of expanding to the 24-bit 0xffffff or rejecting as null. Witnessed red:
-        // expected not 4095, received 4095. The spec leaves expand-vs-reject to S2's executor,
-        // so the arm asserts "never 4095" rather than pinning one of the two acceptable answers.
-        test("#rgb shorthand never silently parses as a 12-bit integer", () => {
+        // expected 0xffffff or null, received 4095.
+        //
+        // The spec leaves expand-vs-reject to S2's executor, so this asserts the *disjunction*
+        // of the two acceptable answers rather than pinning one. It is deliberately not the
+        // weaker `not.toBe(4095)`: that form is satisfied by `undefined`, a thrown-and-swallowed
+        // parse, or any garbage value, so S2 could green it without expanding or rejecting
+        // anything (`checks.md`: a criterion a shipped commit can satisfy without fixing the
+        // defect is not a criterion). The matcher below can only go green on a real fix, and it
+        // discriminates *which* fix landed without caring which one S2 picks.
+        test("#rgb shorthand expands to 24-bit or is rejected, never a 12-bit integer", () => {
             const Part = { color: [] as number[] };
             register("part", Part, { defaults: () => ({ color: 0 }) });
-            let result: number | undefined;
+            let result: string | number | null | undefined;
             try {
                 result = parseFields("part", "color: #fff").color;
             } catch {
                 result = undefined;
             }
-            expect(result).not.toBe(4095);
+            expect(result === 0xffffff || result === null).toBe(true);
         });
 
         test("errors on unknown component", () => {

--- a/packages/shallot/src/engine/scene/xml.ts
+++ b/packages/shallot/src/engine/scene/xml.ts
@@ -100,8 +100,8 @@ function parseEntity(body: string): Node {
     let m: RegExpExecArray | null;
     while ((m = ATTR_RE.exec(body)) !== null) {
         const [, name, value = ""] = m;
-        if (name === "id") id = value;
-        else attrs.push({ name, value });
+        if (name === "id") id = decodeAttr(value);
+        else attrs.push({ name, value: decodeAttr(value) });
     }
     return { id, attrs, children: [] };
 }
@@ -178,4 +178,12 @@ function escapeAttr(str: string): string {
         .replace(/"/g, "&quot;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;");
+}
+
+function decodeAttr(str: string): string {
+    return str
+        .replace(/&quot;/g, '"')
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&amp;/g, "&");
 }


### PR DESCRIPTION
- **audit-scene-roundtrip-integrity: add three red arms + strengthen idempotence fixture**
- **audit-scene-roundtrip-integrity: tighten the #rgb arm to a discriminating matcher**
- **audit-scene-roundtrip-integrity: fix subset-ref, #rgb shorthand, and escape decode**
- **audit-scene-roundtrip-integrity: close the #rgb class — expand #rgba and reject non-{3,4,6,8} hex lengths**
