### PR TITLE
audit cli numeric flags/s1

### DIFF
--- a/packages/shallot/bin/bench.test.ts
+++ b/packages/shallot/bin/bench.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { parseArgs } from "../../../scripts/bench";
+
+// HOLE-RECORD ARMS — `scripts/bench.ts`'s six numeric flags (`--seed`, `--count`, `--warmup`, `--frames`,
+// `--timeout`, `--leak`) are each `parseInt`'d without validation (bench.ts:240-261), so a non-numeric
+// value silently becomes NaN and flows into the query string (`warmup=NaN`) or `--timeout NaN`. verify.ts:112's
+// own JSDoc states the policy — "a typo must not silently no-op or flow NaN" — the same repo's stated rule,
+// unapplied one file over.
+//
+// Each matcher below can distinguish a throw from a clean return — it CANNOT distinguish a NaN-rejecting
+// parse from a NaN-substituting default (both would make the arm green); that discrimination is S2's to
+// prove. S2 of this spec (audit-cli-numeric-flags) is the unit that flips these arms green.
+
+describe("parseArgs — bench.ts numeric flag validation (RED today)", () => {
+    test("--count abc throws instead of flowing NaN into the query string — RED today", () => {
+        expect(() => parseArgs(["--count", "abc"])).toThrow();
+    });
+
+    test("--seed abc throws instead of flowing NaN — RED today", () => {
+        expect(() => parseArgs(["--seed", "abc"])).toThrow();
+    });
+
+    test("--warmup abc throws instead of flowing warmup=NaN into the query string — RED today", () => {
+        expect(() => parseArgs(["--warmup", "abc"])).toThrow();
+    });
+
+    test("--frames abc throws instead of flowing NaN — RED today", () => {
+        expect(() => parseArgs(["--frames", "abc"])).toThrow();
+    });
+
+    test("--timeout abc throws instead of flowing --timeout NaN — RED today", () => {
+        expect(() => parseArgs(["--timeout", "abc"])).toThrow();
+    });
+
+    test("--leak abc throws instead of flowing NaN — RED today", () => {
+        expect(() => parseArgs(["--leak", "abc"])).toThrow();
+    });
+});

--- a/packages/shallot/bin/bench.test.ts
+++ b/packages/shallot/bin/bench.test.ts
@@ -7,9 +7,11 @@ import { parseArgs } from "../../../scripts/bench";
 // own JSDoc states the policy — "a typo must not silently no-op or flow NaN" — the same repo's stated rule,
 // unapplied one file over.
 //
-// Each matcher below can distinguish a throw from a clean return — it CANNOT distinguish a NaN-rejecting
-// parse from a NaN-substituting default (both would make the arm green); that discrimination is S2's to
-// prove. S2 of this spec (audit-cli-numeric-flags) is the unit that flips these arms green.
+// Each bare `toThrow()` below distinguishes a throw from a clean return, so a NaN-substituting default
+// leaves it red — but it CANNOT distinguish the validation throw from an unrelated one (an unknown-option
+// guard, a precondition firing first), so a message assertion is owed the moment a message exists. S2 of
+// this spec (audit-cli-numeric-flags) is the unit that flips these arms green, and it tightens each
+// `toThrow()` to name the flag in the message rather than leaving the fragment loose.
 
 describe("parseArgs — bench.ts numeric flag validation (RED today)", () => {
     test("--count abc throws instead of flowing NaN into the query string — RED today", () => {

--- a/packages/shallot/bin/cli.test.ts
+++ b/packages/shallot/bin/cli.test.ts
@@ -60,10 +60,11 @@ describe("parseCliArgs", () => {
 
     // HOLE-RECORD ARM — `--port abc` should throw (verify.ts:112's own JSDoc states the policy: "a typo
     // must not silently no-op or flow NaN"), but cli.ts:83 `parseInt`'s `--port` with no validation, so
-    // `--port abc` silently becomes NaN and flows to devConfig's port (dev.ts:65) into vite. This matcher
-    // can distinguish a throw from a clean return — it CANNOT distinguish a NaN-rejecting parse from a
-    // NaN-substituting default (both would make this green); that discrimination is S2's to prove. S2 of
-    // this spec (audit-cli-numeric-flags) is the unit that flips this arm green.
+    // `--port abc` silently becomes NaN and flows to devConfig's port (dev.ts:65) into vite. The bare
+    // `toThrow()` distinguishes a throw from a clean return, so a NaN-substituting default leaves it red —
+    // but it CANNOT tell the validation throw from an unrelated one (the `unknown option` guard four lines
+    // up throws too), so S2 tightens it to assert the message, as that sibling arm already does. S2 of this
+    // spec (audit-cli-numeric-flags) is the unit that flips this arm green.
     test("--port abc throws instead of flowing NaN to vite — RED today (cli.ts:83 parseInt, no validation)", () => {
         expect(() => parseCliArgs(["dev", "--port", "abc"])).toThrow();
     });

--- a/packages/shallot/bin/cli.test.ts
+++ b/packages/shallot/bin/cli.test.ts
@@ -57,4 +57,14 @@ describe("parseCliArgs", () => {
     test("an unrecognized -flag throws rather than silently falling through to usage", () => {
         expect(() => parseCliArgs(["dev", "--nope"])).toThrow("unknown option: --nope");
     });
+
+    // HOLE-RECORD ARM — `--port abc` should throw (verify.ts:112's own JSDoc states the policy: "a typo
+    // must not silently no-op or flow NaN"), but cli.ts:83 `parseInt`'s `--port` with no validation, so
+    // `--port abc` silently becomes NaN and flows to devConfig's port (dev.ts:65) into vite. This matcher
+    // can distinguish a throw from a clean return — it CANNOT distinguish a NaN-rejecting parse from a
+    // NaN-substituting default (both would make this green); that discrimination is S2's to prove. S2 of
+    // this spec (audit-cli-numeric-flags) is the unit that flips this arm green.
+    test("--port abc throws instead of flowing NaN to vite — RED today (cli.ts:83 parseInt, no validation)", () => {
+        expect(() => parseCliArgs(["dev", "--port", "abc"])).toThrow();
+    });
 });

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -162,6 +162,16 @@ describe("parseVerifyArgs", () => {
         expect(() => parseVerifyArgs(["--leak=122880"])).toThrow("--leak requires --memory");
     });
 
+    // HOLE-RECORD ARM — `--leak 0` should be accepted as "off" (verify.ts:94 JSDoc: "0 = off",
+    // line 130 defaults `leak: 0`, line 172 branches on `args.leak > 0 && !args.memory`), but `num()`
+    // (verify.ts:117) rejects `n <= 0` so `--leak 0` throws. This matcher can distinguish a throw from
+    // a clean return — it CANNOT distinguish a zero-allowing `num()` variant from `--leak` moving off
+    // `num()` entirely (both make this green); that discrimination is S2's to prove. S2 of this spec
+    // (audit-cli-numeric-flags) is the unit that flips this arm green.
+    test("--leak 0 is accepted as off, not rejected by num() — RED today (verify.ts:94 says 0 = off)", () => {
+        expect(() => parseVerifyArgs(["--leak", "0"])).not.toThrow();
+    });
+
     test("--timings defaults off, flips on", () => {
         expect(parseVerifyArgs([]).timings).toBe(false);
         expect(parseVerifyArgs(["--timings"]).timings).toBe(true);

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -164,10 +164,12 @@ describe("parseVerifyArgs", () => {
 
     // HOLE-RECORD ARM — `--leak 0` should be accepted as "off" (verify.ts:94 JSDoc: "0 = off",
     // line 130 defaults `leak: 0`, line 172 branches on `args.leak > 0 && !args.memory`), but `num()`
-    // (verify.ts:117) rejects `n <= 0` so `--leak 0` throws. This matcher can distinguish a throw from
-    // a clean return — it CANNOT distinguish a zero-allowing `num()` variant from `--leak` moving off
-    // `num()` entirely (both make this green); that discrimination is S2's to prove. S2 of this spec
-    // (audit-cli-numeric-flags) is the unit that flips this arm green.
+    // (verify.ts:117) rejects `n <= 0` so `--leak 0` throws. `.not.toThrow()` sees only the absence of a
+    // throw: it CANNOT see the parsed *value*, so an S2 that stops throwing while parsing `0` to anything
+    // else greens it — which is why the sibling arm above pins `parseVerifyArgs([]).leak === 0` and why S2
+    // owes `parseVerifyArgs(["--leak", "0"]).leak === 0` here. S2 of this spec (audit-cli-numeric-flags) is
+    // the unit that flips this arm green, and its first act in this file is deleting the status-quo pin at
+    // the `--leak defaults to 0 (off)` arm above, which asserts the very throw this arm forbids.
     test("--leak 0 is accepted as off, not rejected by num() — RED today (verify.ts:94 says 0 = off)", () => {
         expect(() => parseVerifyArgs(["--leak", "0"])).not.toThrow();
     });

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -209,7 +209,7 @@ export function partitionSweep(
     return { batch, isolate };
 }
 
-function parseArgs(argv: string[]): Args {
+export function parseArgs(argv: string[]): Args {
     if (argv.includes("--help") || argv.includes("-h")) {
         help();
         process.exit(0);


### PR DESCRIPTION
- **audit-cli-numeric-flags: s1 arms**
- **audit-cli-numeric-flags: correct the arms' discrimination claims**
