### PR TITLE
audit wgsl body helper vacuity/s1

### DIFF
--- a/packages/shallot/tests/wgsl.test.ts
+++ b/packages/shallot/tests/wgsl.test.ts
@@ -14,17 +14,26 @@ describe("body", () => {
      * A signature present in the source but with no `{` after it: `body()` must throw from
      * the no-brace guard, not return a slice. The `toThrow("no opening brace after signature")`
      * matcher pins the guard's site specifically — the loop-end throw emits a different message
-     * (`unterminated body for …`), so a regression that drops the guard and lets the loop
-     * rescan reds this arm on the message, not just on "threw something." Before the guard,
+     * (`unterminated body for …`), so the two causes are distinguishable in a failure. Note what
+     * each regression reds on: dropping the guard entirely reds this arm on *no throw at all*
+     * (the loop returns a slice, below), while a guard that threw the loop-end message instead
+     * is the one the message match catches. Before the guard,
      * `src.indexOf("{", start)` was `-1`, so the loop started at `i = -1` (where `src[-1]` is
      * `undefined`, matching neither branch), then rescanned from index 0 — finding the `{`
      * *before* the signature and returning `src.slice(start, i + 1)` where `i + 1 < start`,
      * i.e. an **empty string** — instead of throwing. An empty slice satisfies every
-     * `not.toMatch` in `noIntegerDivision`, so a discipline gate fed this helper would pass by
-     * extracting nothing. Latent, not historical: `body()` has no caller today (`standards.ts`
-     * imports the four discipline helpers, not this one), which is the spec's "zero current
-     * instances" — the guard exists so the first caller the TypeGPU port adds cannot inherit a
-     * silent green.
+     * `not.toMatch` in `noIntegerDivision`, so a discipline gate fed that slice passes by
+     * extracting nothing — and that composition is live, not hypothetical:
+     * `noIntegerDivision(body(…))` and its siblings are 23 invocations in 6 files, of the 20 that
+     * import this helper (`sear/pipelines.test.ts`, `extras/outline`, `extras/sky`,
+     * `showcase/roads`) — counts are invocations and files, re-derive with
+     * `grep -rn 'Division(body(\|Discipline(body(' --include=*.ts --exclude=wgsl.test.ts`. The
+     * exclusion is load-bearing: without it this docblock is in the population it counts — the
+     * pattern appears twice above (the prose example and the command itself), so the unexcluded
+     * reading comes back two too high, and both wrong numbers were written here before the
+     * exclusion caught them. The spec's "zero current instances" is about the *defect*, not the
+     * callers: every signature passed today has a brace after it, so no caller reaches the bad
+     * path — the guard is what keeps that a property of the inputs rather than a coincidence.
      */
     test("a signature present but brace-less must throw", () => {
         const src = "{ x } fn baz() no body here";
@@ -35,8 +44,10 @@ describe("body", () => {
      * A normal signature with a balanced body in a realistic multi-function module: `body()`
      * must return the full slice from the targeted signature through its matching close brace.
      * Every production caller passes a whole emitted WGSL module and slices one function out of
-     * the middle, so the signature sits after a struct and a preceding function (`start > 0`
-     * always), with a trailing function after — the equality on the returned slice can
+     * the middle, so `start > 0` always, the preceding content typically binding declarations
+     * rather than a struct. This fixture reproduces the *position* with a struct and a
+     * preceding function before the target and a
+     * trailing one after — the equality on the returned slice can
      * distinguish that the slice is the body of the *targeted* function (a guard that found
      * the wrong `{` — from preceding content — and returned a different function's body would
      * red), but it cannot see *why* `body()` found the right brace, only that the slice

--- a/packages/shallot/tests/wgsl.test.ts
+++ b/packages/shallot/tests/wgsl.test.ts
@@ -11,29 +11,46 @@ import { body } from "./wgsl";
 
 describe("body", () => {
     /**
-     * A signature present in the source but with no `{` after it: `body()` must throw
-     * `unterminated body`, not return a slice. Before the guard, `src.indexOf("{", start)` was
-     * `-1`, so the loop started at `i = -1` (where `src[-1]` is `undefined`, matching neither
-     * branch), then rescanned from index 0 — finding the `{` *before* the signature and returning
-     * `src.slice(start, i + 1)` where `i + 1 < start`, i.e. an **empty string** — instead of
-     * throwing. An empty slice satisfies every `not.toMatch` in `noIntegerDivision`, so a
-     * discipline gate passed by extracting nothing.
+     * A signature present in the source but with no `{` after it: `body()` must throw from
+     * the no-brace guard, not return a slice. The `toThrow("no opening brace after signature")`
+     * matcher pins the guard's site specifically — the loop-end throw emits a different message
+     * (`unterminated body for …`), so a regression that drops the guard and lets the loop
+     * rescan reds this arm on the message, not just on "threw something." Before the guard,
+     * `src.indexOf("{", start)` was `-1`, so the loop started at `i = -1` (where `src[-1]` is
+     * `undefined`, matching neither branch), then rescanned from index 0 — finding the `{`
+     * *before* the signature and returning `src.slice(start, i + 1)` where `i + 1 < start`,
+     * i.e. an **empty string** — instead of throwing. An empty slice satisfies every
+     * `not.toMatch` in `noIntegerDivision`, so a discipline gate passed by extracting nothing.
      */
     test("a signature present but brace-less must throw", () => {
         const src = "{ x } fn baz() no body here";
-        expect(() => body(src, "fn baz()")).toThrow("unterminated body");
+        expect(() => body(src, "fn baz()")).toThrow("no opening brace after signature");
     });
 
     /**
-     * A normal signature with a balanced body: `body()` must return the full slice from the
-     * signature through the matching close brace. Before the guard this arm was green (the
-     * defect only affected the brace-less path), and it stays green after — so it pins that the
-     * guard's condition is exactly "no brace after the signature" and not something broader that
-     * would throw on valid input. An input that reds this arm is one where a `{` follows the
-     * signature but the guard throws anyway.
+     * A normal signature with a balanced body in a realistic multi-function module: `body()`
+     * must return the full slice from the targeted signature through its matching close brace.
+     * Every production caller passes a whole emitted WGSL module and slices one function out of
+     * the middle, so the signature sits after a struct and a preceding function (`start > 0`
+     * always), with a trailing function after — the equality on the returned slice can
+     * distinguish that the slice is the body of the *targeted* function (a guard that found
+     * the wrong `{` — from preceding content — and returned a different function's body would
+     * red), but it cannot see *why* `body()` found the right brace, only that the slice
+     * matches. The position (`start > 0`) is one of the things the fixture buys: at
+     * `start = 0` a guard that searched from the start of the string instead of from the
+     * signature cannot be caught (the wrong brace and the right brace are the same), but
+     * once `start > 0` a preceding `{` sits before the signature, so the wrong-brace class
+     * reds where it stayed green at index 0. Before the guard this arm was green (the defect
+     * only affected the brace-less path), and it stays green after — so it pins that the
+     * guard does not throw on valid input.
      */
     test("a normal signature returns the balanced slice", () => {
-        const src = "fn baz() { return 0; }";
-        expect(body(src, "fn baz()")).toBe("fn baz() { return 0; }");
+        const src = [
+            "struct Vertex { pos: vec3<f32>, }",
+            "fn other() -> vec3<f32> { return vec3<f32>(0.0, 0.0, 0.0); }",
+            "fn baz() -> i32 { return 0; }",
+            "fn after() -> u32 { return 1u; }",
+        ].join("\n");
+        expect(body(src, "fn baz()")).toBe("fn baz() -> i32 { return 0; }");
     });
 });

--- a/packages/shallot/tests/wgsl.test.ts
+++ b/packages/shallot/tests/wgsl.test.ts
@@ -20,7 +20,11 @@ describe("body", () => {
      * `undefined`, matching neither branch), then rescanned from index 0 — finding the `{`
      * *before* the signature and returning `src.slice(start, i + 1)` where `i + 1 < start`,
      * i.e. an **empty string** — instead of throwing. An empty slice satisfies every
-     * `not.toMatch` in `noIntegerDivision`, so a discipline gate passed by extracting nothing.
+     * `not.toMatch` in `noIntegerDivision`, so a discipline gate fed this helper would pass by
+     * extracting nothing. Latent, not historical: `body()` has no caller today (`standards.ts`
+     * imports the four discipline helpers, not this one), which is the spec's "zero current
+     * instances" — the guard exists so the first caller the TypeGPU port adds cannot inherit a
+     * silent green.
      */
     test("a signature present but brace-less must throw", () => {
         const src = "{ x } fn baz() no body here";

--- a/packages/shallot/tests/wgsl.test.ts
+++ b/packages/shallot/tests/wgsl.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Arms for {@link body} — the brace-matched extraction helper in `wgsl.ts`. Two arms, per the spec's
+ * Validation: one that a signature present but brace-less must throw (the defect: `body()` started
+ * brace matching at `src.indexOf("{", start)`, which is `-1` when no brace follows the signature, so
+ * the loop rescanned from index 0 and returned an arbitrary — possibly empty — slice instead of
+ * reaching its own `unterminated body` throw), and one that a normal signature returns the balanced
+ * slice (so the guard cannot be satisfied by making `body()` throw more often than it should).
+ */
+import { describe, expect, test } from "bun:test";
+import { body } from "./wgsl";
+
+describe("body", () => {
+    /**
+     * A signature present in the source but with no `{` after it: `body()` must throw
+     * `unterminated body`, not return a slice. Before the guard, `src.indexOf("{", start)` was
+     * `-1`, so the loop started at `i = -1` (where `src[-1]` is `undefined`, matching neither
+     * branch), then rescanned from index 0 — finding the `{` *before* the signature and returning
+     * `src.slice(start, i + 1)` where `i + 1 < start`, i.e. an **empty string** — instead of
+     * throwing. An empty slice satisfies every `not.toMatch` in `noIntegerDivision`, so a
+     * discipline gate passed by extracting nothing.
+     */
+    test("a signature present but brace-less must throw", () => {
+        const src = "{ x } fn baz() no body here";
+        expect(() => body(src, "fn baz()")).toThrow("unterminated body");
+    });
+
+    /**
+     * A normal signature with a balanced body: `body()` must return the full slice from the
+     * signature through the matching close brace. Before the guard this arm was green (the
+     * defect only affected the brace-less path), and it stays green after — so it pins that the
+     * guard's condition is exactly "no brace after the signature" and not something broader that
+     * would throw on valid input. An input that reds this arm is one where a `{` follows the
+     * signature but the guard throws anyway.
+     */
+    test("a normal signature returns the balanced slice", () => {
+        const src = "fn baz() { return 0; }";
+        expect(body(src, "fn baz()")).toBe("fn baz() { return 0; }");
+    });
+});

--- a/packages/shallot/tests/wgsl.ts
+++ b/packages/shallot/tests/wgsl.ts
@@ -8,8 +8,10 @@ import { expect } from "bun:test";
 export function body(src: string, signature: string): string {
     const start = src.indexOf(signature);
     expect(start).toBeGreaterThanOrEqual(0);
+    const openBrace = src.indexOf("{", start);
+    if (openBrace < 0) throw new Error(`unterminated body for ${signature}`);
     let depth = 0;
-    for (let i = src.indexOf("{", start); i < src.length; i++) {
+    for (let i = openBrace; i < src.length; i++) {
         if (src[i] === "{") depth++;
         else if (src[i] === "}" && --depth === 0) return src.slice(start, i + 1);
     }

--- a/packages/shallot/tests/wgsl.ts
+++ b/packages/shallot/tests/wgsl.ts
@@ -9,7 +9,7 @@ export function body(src: string, signature: string): string {
     const start = src.indexOf(signature);
     expect(start).toBeGreaterThanOrEqual(0);
     const openBrace = src.indexOf("{", start);
-    if (openBrace < 0) throw new Error(`unterminated body for ${signature}`);
+    if (openBrace < 0) throw new Error(`no opening brace after signature: ${signature}`);
     let depth = 0;
     for (let i = openBrace; i < src.length; i++) {
         if (src[i] === "{") depth++;


### PR DESCRIPTION
- **audit-wgsl-body-helper-vacuity: guard body() against brace-less signatures returning an arbitrary slice**
- **audit-wgsl-body-helper-vacuity: repair arm-two fixture, guard message, and docblock claims**
- **audit-wgsl-body-helper-vacuity: name the vacuity path latent, not historical**
- **audit-wgsl-body-helper-vacuity: correct the docblocks' caller claims and counts**
