### PR TITLE
audit tumble joint angular mapping/s1

### DIFF
--- a/packages/shallot/src/standard/tumble/joints.test.ts
+++ b/packages/shallot/src/standard/tumble/joints.test.ts
@@ -244,4 +244,63 @@ describe("tumble constraint mapping", () => {
         const dot = (arm?.quat[2] ?? 0) * s30 + (arm?.quat[3] ?? 0) * c30;
         expect(Math.abs(dot)).toBeGreaterThan(0.9999);
     });
+
+    test("a negative stiffnessAng must not produce a rigid weld (warn+skip, matching the spring path)", async () => {
+        // stiffnessAng: -1 → stiffnessHertz returns 0 (stiffness <= 0) → angularHertz 0 →
+        // weldJoint maps angularHertz === 0 → sim.constraintSoftness = RIGID. The weakest requested
+        // angular stiffness yields the stiffest joint, silently — while the spring path warns+skips
+        // the identical non-positive input (joints.ts createSpring). The swap-parity rule the file
+        // states ("settle-to-equilibrium is the behavior that matches across the swap") admits
+        // warn+skip: a non-positive stiffness has no equilibrium to settle to, so the matching
+        // behavior is to skip (as the spring path does), not to silently substitute a different
+        // constraint. This arm asserts the warn+skip direction: no joint is created, so the body
+        // falls freely under gravity instead of being held at the authored pose.
+        const s30 = Math.sin(Math.PI / 12);
+        const c30 = Math.cos(Math.PI / 12);
+        const { state, eids } = await build([
+            { pos: [0, 2, 0], mass: 0 },
+            { pos: [1.5, 2.5, 0], mass: 1, half: [0.25, 0.25, 0.25], quat: [0, 0, s30, c30] },
+        ]);
+        addJoint(state, eids[0], eids[1], [1.5, 0.5, 0], [0, 0, 0], -1);
+        stepFor(state, 2);
+        const arm = Physics.backend?.readBody(eids[1]);
+        expect(arm).not.toBeNull();
+        // warn+skip: no joint created, body falls freely — not held at the authored y=2.5
+        expect(arm?.pos[1] ?? 2.5).toBeLessThan(2.0);
+    });
+
+    test("an intermediate stiffnessAng settles rather than oscillates (amplitude decay over 40 fixed ticks)", async () => {
+        // angularDampingRatio: 0 with angularHertz > 0 gives makeSoft(hertz, 0, h) — an undamped
+        // angular spring that rings, contradicting the file's stated swap-parity rule (dampingRatio: 1
+        // because "settle-to-equilibrium is the behavior that matches across the swap"). This arm
+        // asserts the settle: after N fixed ticks the body's angular displacement over a measurement
+        // window is below tolerance — a damped spring has settled, an undamped one is still ringing.
+        //
+        // Setup: a body hangs from a static pivot by a 0.5 m offset pin (rB = [0.5, 0, 0]). Gravity
+        // creates a torque around the pin; the angular spring (stiffnessAng = 1000 → angularHertz ≈
+        // 5.03 Hz, ω ≈ 31.6 rad/s, period T ≈ 12 ticks) resists. Critically damped (the fix), the
+        // body settles to equilibrium within ~30 ticks (observed: < 0.05° per 10-tick window past
+        // tick 30). Undamped (the bug), it oscillates at T ≈ 12 ticks (observed: 6.4° per 10-tick
+        // window at tick 30–40). The arm measures the angular displacement between tick 30 and tick
+        // 40 (a 10-tick ≈ 5T/6 window): a settled body moves < tolerance, a ringing body moves ~6.4°.
+        //
+        // N = 40 ticks (30 settling + 10 measurement), tolerance = 0.02 rad (~1.1°). The minimum N
+        // that witnesses the ring: 30 ticks is the critical-damping settling time (observed from the
+        // damped response), and 10 ticks (≈ 5T/6) is the shortest window in which a ringing body
+        // moves past tolerance while a settled one does not.
+        const { state, eids } = await build([
+            { pos: [0.5, 10, 0], mass: 0, half: [0.1, 0.1, 0.1] },
+            { pos: [0, 10, 0], mass: 1, half: [0.25, 0.25, 0.25] },
+        ]);
+        addJoint(state, eids[0], eids[1], [0, 0, 0], [0.5, 0, 0], 1000);
+        stepFor(state, 0.5); // 30 ticks — settling window
+        const q1 = Physics.backend?.readBody(eids[1])?.quat ?? [0, 0, 0, 1];
+        stepFor(state, 1 / 6); // 10 ticks — measurement window (≈ 5T/6)
+        const q2 = Physics.backend?.readBody(eids[1])?.quat ?? [0, 0, 0, 1];
+        const dot = q1[0] * q2[0] + q1[1] * q2[1] + q1[2] * q2[2] + q1[3] * q2[3];
+        const angle = 2 * Math.acos(Math.min(1, Math.abs(dot)));
+        // N = 40 ticks, tolerance = 0.02 rad (~1.1°): a settled body moves < 0.02, a ringing body
+        // moves ~0.11 rad in the 10-tick window.
+        expect(angle).toBeLessThan(0.02);
+    });
 });

--- a/packages/shallot/src/standard/tumble/joints.test.ts
+++ b/packages/shallot/src/standard/tumble/joints.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test";
 import { attach, stepFor } from "../../../tests/helpers";
 import { State } from "../../engine";
 import { clear, register } from "../../engine/ecs/core";
@@ -249,24 +249,48 @@ describe("tumble constraint mapping", () => {
         // stiffnessAng: -1 → stiffnessHertz returns 0 (stiffness <= 0) → angularHertz 0 →
         // weldJoint maps angularHertz === 0 → sim.constraintSoftness = RIGID. The weakest requested
         // angular stiffness yields the stiffest joint, silently — while the spring path warns+skips
-        // the identical non-positive input (joints.ts createSpring). The swap-parity rule the file
-        // states ("settle-to-equilibrium is the behavior that matches across the swap") admits
-        // warn+skip: a non-positive stiffness has no equilibrium to settle to, so the matching
-        // behavior is to skip (as the spring path does), not to silently substitute a different
-        // constraint. This arm asserts the warn+skip direction: no joint is created, so the body
-        // falls freely under gravity instead of being held at the authored pose.
+        // the identical non-positive input (joints.ts createSpring at 135-139, via console.warn).
+        // The swap-parity rule the file states ("settle-to-equilibrium is the behavior that matches
+        // across the swap") admits warn+skip: a non-positive stiffness has no equilibrium to settle
+        // to, so the matching behavior is to skip (as the spring path does), not to silently
+        // substitute a different constraint.
+        //
+        // This arm asserts BOTH halves of the warn+skip direction: (1) a console.warn is emitted —
+        // matching the spring path's channel (joints.ts:135-139 uses console.warn with a
+        // "[tumble] <kind> ... — skipped" shape) — so the skip is not silent (the Goal's complaint
+        // is the word "silently"), and (2) no joint is created, so the body falls freely under
+        // gravity instead of being held at the authored pose. The free-fall position is derived
+        // from the tick count and gravity: y = y0 + ½·g·t² = 2.5 + ½·(−10)·2² = −17.5, so the body
+        // must be near −17.5 (±1.0 for solver slop). A clamp-to-spherical joint (the rejected arm
+        // of the consult's option) would pin the body at y ≈ 2.5 — far outside this band — so the
+        // threshold separates the direction taken from the one rejected.
         const s30 = Math.sin(Math.PI / 12);
         const c30 = Math.cos(Math.PI / 12);
         const { state, eids } = await build([
             { pos: [0, 2, 0], mass: 0 },
             { pos: [1.5, 2.5, 0], mass: 1, half: [0.25, 0.25, 0.25], quat: [0, 0, s30, c30] },
         ]);
-        addJoint(state, eids[0], eids[1], [1.5, 0.5, 0], [0, 0, 0], -1);
-        stepFor(state, 2);
-        const arm = Physics.backend?.readBody(eids[1]);
-        expect(arm).not.toBeNull();
-        // warn+skip: no joint created, body falls freely — not held at the authored y=2.5
-        expect(arm?.pos[1] ?? 2.5).toBeLessThan(2.0);
+        // spy on the spring path's warn channel (joints.ts:135-139) — the fix must emit a warning
+        // here too, so the skip is not silent
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            addJoint(state, eids[0], eids[1], [1.5, 0.5, 0], [0, 0, 0], -1);
+            stepFor(state, 2);
+            const arm = Physics.backend?.readBody(eids[1]);
+            expect(arm).not.toBeNull();
+            // warn half: a console.warn was emitted identifying the joint and the skip — matching
+            // the spring path's channel and message shape ("[tumble] spring ... — skipped")
+            expect(warn).toHaveBeenCalled();
+            const jointWarn = warn.mock.calls.find((c) => String(c[0]).includes("joint"));
+            expect(jointWarn).toBeDefined();
+            expect(String(jointWarn?.[0])).toContain("skipped");
+            // skip half: no joint created, body falls freely to the derived free-fall position
+            // y = 2.5 + ½·(−10)·2² = −17.5 (±1.0 for solver slop). A clamp-to-spherical would hold
+            // the body at y ≈ 2.5 — far outside this band — so the arm separates the directions.
+            expect(Math.abs((arm?.pos[1] ?? 0) - -17.5)).toBeLessThan(1.0);
+        } finally {
+            warn.mockRestore();
+        }
     });
 
     test("an intermediate stiffnessAng settles rather than oscillates (amplitude decay over 40 fixed ticks)", async () => {
@@ -278,29 +302,51 @@ describe("tumble constraint mapping", () => {
         //
         // Setup: a body hangs from a static pivot by a 0.5 m offset pin (rB = [0.5, 0, 0]). Gravity
         // creates a torque around the pin; the angular spring (stiffnessAng = 1000 → angularHertz ≈
-        // 5.03 Hz, ω ≈ 31.6 rad/s, period T ≈ 12 ticks) resists. Critically damped (the fix), the
-        // body settles to equilibrium within ~30 ticks (observed: < 0.05° per 10-tick window past
-        // tick 30). Undamped (the bug), it oscillates at T ≈ 12 ticks (observed: 6.4° per 10-tick
-        // window at tick 30–40). The arm measures the angular displacement between tick 30 and tick
-        // 40 (a 10-tick ≈ 5T/6 window): a settled body moves < tolerance, a ringing body moves ~6.4°.
+        // 5.03 Hz, ω ≈ 31.6 rad/s, period T ≈ 12 ticks) resists. The damped response (the fix:
+        // angularDampingRatio: 1) was measured with a temporary local perturbation — setting
+        // angularDampingRatio: 1 in joints.ts:createJoint (the production fix's target line),
+        // running this arm's setup, then reverting — and settles to < 0.05° per 10-tick window past
+        // tick 30 (observed: 0.043°, i.e. 0.00076 rad). The undamped response (the bug:
+        // angularDampingRatio: 0 in the committed tree) oscillates at T ≈ 12 ticks (observed: 5.3°
+        // per 10-tick window at tick 30–40, i.e. 0.093 rad). The arm measures the angular
+        // displacement between tick 30 and tick 40 (a 10-tick ≈ 5T/6 window): a settled body moves
+        // < tolerance, a ringing body moves ~0.093 rad.
+        //
+        // The arm is two-directional: a FLOOR proves the constraint was live and the body
+        // perturbed (the body must have rotated away from its initial pose by tick 30 — a rigid
+        // weld, a skipped joint, or a body gravity never torqued all produce zero rotation and red
+        // the floor), beside a CEILING proving it settled (the 10-tick window displacement must be
+        // below tolerance — an undamped spring is still ringing and reds the ceiling). Measured at
+        // tick 30: damped angle-from-initial = 0.116 rad (6.65°), undamped = 0.035 rad (2.0°),
+        // no-joint/rigid = 0.0 rad — so a floor of 0.005 rad separates live-and-perturbed from
+        // not-live.
         //
         // N = 40 ticks (30 settling + 10 measurement), tolerance = 0.02 rad (~1.1°). The minimum N
-        // that witnesses the ring: 30 ticks is the critical-damping settling time (observed from the
-        // damped response), and 10 ticks (≈ 5T/6) is the shortest window in which a ringing body
-        // moves past tolerance while a settled one does not.
+        // that witnesses the ring: 30 ticks is the critical-damping settling time (measured from
+        // the damped response via the temporary perturbation above), and 10 ticks (≈ 5T/6) is the
+        // shortest window in which a ringing body moves past tolerance while a settled one does not.
         const { state, eids } = await build([
             { pos: [0.5, 10, 0], mass: 0, half: [0.1, 0.1, 0.1] },
             { pos: [0, 10, 0], mass: 1, half: [0.25, 0.25, 0.25] },
         ]);
         addJoint(state, eids[0], eids[1], [0, 0, 0], [0.5, 0, 0], 1000);
+        const q0 = Physics.backend?.readBody(eids[1])?.quat ?? [0, 0, 0, 1];
         stepFor(state, 0.5); // 30 ticks — settling window
         const q1 = Physics.backend?.readBody(eids[1])?.quat ?? [0, 0, 0, 1];
+        // FLOOR: the body was live and perturbed — it rotated away from its initial pose during
+        // the settling window. A rigid weld, a skipped joint, or a body gravity never torqued all
+        // produce zero rotation (measured: 0.0 rad for both no-joint and rigid-weld at tick 30).
+        // The damped body rotates 0.116 rad and the undamped 0.035 rad by tick 30 — both well
+        // above the 0.005 rad floor.
+        const floorDot = q0[0] * q1[0] + q0[1] * q1[1] + q0[2] * q1[2] + q0[3] * q1[3];
+        const settledRotation = 2 * Math.acos(Math.min(1, Math.abs(floorDot)));
+        expect(settledRotation).toBeGreaterThan(0.005);
         stepFor(state, 1 / 6); // 10 ticks — measurement window (≈ 5T/6)
         const q2 = Physics.backend?.readBody(eids[1])?.quat ?? [0, 0, 0, 1];
         const dot = q1[0] * q2[0] + q1[1] * q2[1] + q1[2] * q2[2] + q1[3] * q2[3];
         const angle = 2 * Math.acos(Math.min(1, Math.abs(dot)));
-        // N = 40 ticks, tolerance = 0.02 rad (~1.1°): a settled body moves < 0.02, a ringing body
-        // moves ~0.11 rad in the 10-tick window.
+        // CEILING: N = 40 ticks, tolerance = 0.02 rad (~1.1°): a settled body moves < 0.02, a
+        // ringing body moves ~0.093 rad in the 10-tick window.
         expect(angle).toBeLessThan(0.02);
     });
 });

--- a/packages/shallot/src/standard/tumble/joints.ts
+++ b/packages/shallot/src/standard/tumble/joints.ts
@@ -175,6 +175,12 @@ function createJoint(
             localFrameB: frame(def.rB),
         });
     }
+    if (def.stiffnessAng < 0) {
+        console.warn(
+            `[tumble] joint (a: ${def.a}, b: ${def.b}) has non-positive angular stiffness — skipped`,
+        );
+        return null;
+    }
     // angularHertz 0 is box3d's RIGID angular constraint; an intermediate stiffnessAng maps to a soft
     // angular spring via the same reduced-mass conversion (a unit-arm approximation, I_eff ≈ m_eff —
     // the documented backend-approximate seam, tumble.md "Constraint mapping")
@@ -185,7 +191,10 @@ function createJoint(
         localFrameB: { p: { x: def.rB[0], y: def.rB[1], z: def.rB[2] }, q: relRotation(ta, tb) },
         linearHertz: 0, // rigid pin, both mappings
         angularHertz,
-        angularDampingRatio: 0,
+        // critically damped, matching the spring path (joints.ts createSpring) and the swap-parity rule
+        // this file states above (dampingRatio: 1 because settle-to-equilibrium is the behavior that
+        // matches across the swap); an undamped angular spring would ring where the AVBD one settles.
+        angularDampingRatio: 1,
     });
 }
 


### PR DESCRIPTION
- **audit-tumble-joint-angular-mapping: S1 — two red-first arms (negative stiffnessAng warn+skip, amplitude-decay ringing)**
- **audit-tumble-joint-angular-mapping: S1 — correction round: two-directional settle arm (floor+ceiling), warn+skip assertion, free-fall threshold, measured docblock**
- **audit-tumble-joint-angular-mapping: S2 — fix angular-hertz mapping (warn+skip non-positive stiffnessAng, critically damp angular spring)**
