### PR TITLE
audit cli numeric flags/s2

### DIFF
--- a/packages/shallot/bin/bench.test.ts
+++ b/packages/shallot/bin/bench.test.ts
@@ -31,4 +31,16 @@ describe("parseArgs — bench.ts numeric flag validation", () => {
     test("--leak abc throws with a message naming the flag instead of flowing NaN", () => {
         expect(() => parseArgs(["--leak", "abc"])).toThrow('invalid --leak value "abc"');
     });
+
+    test("an empty --seed value is rejected as empty, not silently coerced to 0", () => {
+        expect(() => parseArgs(["--seed", ""])).toThrow(
+            'invalid --seed value "" — must not be empty',
+        );
+    });
+
+    test("a whitespace-only --seed value is rejected, not silently coerced to 0", () => {
+        expect(() => parseArgs(["--seed", " "])).toThrow(
+            'invalid --seed value " " — must not be empty',
+        );
+    });
 });

--- a/packages/shallot/bin/bench.test.ts
+++ b/packages/shallot/bin/bench.test.ts
@@ -15,26 +15,26 @@ import { parseArgs } from "../../../scripts/bench";
 
 describe("parseArgs — bench.ts numeric flag validation (RED today)", () => {
     test("--count abc throws instead of flowing NaN into the query string — RED today", () => {
-        expect(() => parseArgs(["--count", "abc"])).toThrow();
+        expect(() => parseArgs(["--count", "abc"])).toThrow('invalid --count value "abc"');
     });
 
     test("--seed abc throws instead of flowing NaN — RED today", () => {
-        expect(() => parseArgs(["--seed", "abc"])).toThrow();
+        expect(() => parseArgs(["--seed", "abc"])).toThrow('invalid --seed value "abc"');
     });
 
     test("--warmup abc throws instead of flowing warmup=NaN into the query string — RED today", () => {
-        expect(() => parseArgs(["--warmup", "abc"])).toThrow();
+        expect(() => parseArgs(["--warmup", "abc"])).toThrow('invalid --warmup value "abc"');
     });
 
     test("--frames abc throws instead of flowing NaN — RED today", () => {
-        expect(() => parseArgs(["--frames", "abc"])).toThrow();
+        expect(() => parseArgs(["--frames", "abc"])).toThrow('invalid --frames value "abc"');
     });
 
     test("--timeout abc throws instead of flowing --timeout NaN — RED today", () => {
-        expect(() => parseArgs(["--timeout", "abc"])).toThrow();
+        expect(() => parseArgs(["--timeout", "abc"])).toThrow('invalid --timeout value "abc"');
     });
 
     test("--leak abc throws instead of flowing NaN — RED today", () => {
-        expect(() => parseArgs(["--leak", "abc"])).toThrow();
+        expect(() => parseArgs(["--leak", "abc"])).toThrow('invalid --leak value "abc"');
     });
 });

--- a/packages/shallot/bin/bench.test.ts
+++ b/packages/shallot/bin/bench.test.ts
@@ -1,40 +1,34 @@
 import { describe, expect, test } from "bun:test";
 import { parseArgs } from "../../../scripts/bench";
 
-// HOLE-RECORD ARMS — `scripts/bench.ts`'s six numeric flags (`--seed`, `--count`, `--warmup`, `--frames`,
-// `--timeout`, `--leak`) are each `parseInt`'d without validation (bench.ts:240-261), so a non-numeric
-// value silently becomes NaN and flows into the query string (`warmup=NaN`) or `--timeout NaN`. verify.ts:112's
-// own JSDoc states the policy — "a typo must not silently no-op or flow NaN" — the same repo's stated rule,
-// unapplied one file over.
-//
-// Each bare `toThrow()` below distinguishes a throw from a clean return, so a NaN-substituting default
-// leaves it red — but it CANNOT distinguish the validation throw from an unrelated one (an unknown-option
-// guard, a precondition firing first), so a message assertion is owed the moment a message exists. S2 of
-// this spec (audit-cli-numeric-flags) is the unit that flips these arms green, and it tightens each
-// `toThrow()` to name the flag in the message rather than leaving the fragment loose.
+// `scripts/bench.ts`'s six numeric flags (`--seed`, `--count`, `--warmup`, `--frames`, `--timeout`,
+// `--leak`) each reject a non-numeric value with a message naming the flag, so a typo doesn't flow NaN
+// into the query string (`warmup=NaN`) or `--timeout NaN` (the policy in verify.ts's `--port` JSDoc:
+// "a typo must not silently no-op or flow NaN"). Each message assertion distinguishes the validation
+// throw from an unrelated one (an unknown-option guard, a precondition firing first).
 
-describe("parseArgs — bench.ts numeric flag validation (RED today)", () => {
-    test("--count abc throws instead of flowing NaN into the query string — RED today", () => {
+describe("parseArgs — bench.ts numeric flag validation", () => {
+    test("--count abc throws with a message naming the flag instead of flowing NaN into the query string", () => {
         expect(() => parseArgs(["--count", "abc"])).toThrow('invalid --count value "abc"');
     });
 
-    test("--seed abc throws instead of flowing NaN — RED today", () => {
+    test("--seed abc throws with a message naming the flag instead of flowing NaN", () => {
         expect(() => parseArgs(["--seed", "abc"])).toThrow('invalid --seed value "abc"');
     });
 
-    test("--warmup abc throws instead of flowing warmup=NaN into the query string — RED today", () => {
+    test("--warmup abc throws with a message naming the flag instead of flowing warmup=NaN into the query string", () => {
         expect(() => parseArgs(["--warmup", "abc"])).toThrow('invalid --warmup value "abc"');
     });
 
-    test("--frames abc throws instead of flowing NaN — RED today", () => {
+    test("--frames abc throws with a message naming the flag instead of flowing NaN", () => {
         expect(() => parseArgs(["--frames", "abc"])).toThrow('invalid --frames value "abc"');
     });
 
-    test("--timeout abc throws instead of flowing --timeout NaN — RED today", () => {
+    test("--timeout abc throws with a message naming the flag instead of flowing --timeout NaN", () => {
         expect(() => parseArgs(["--timeout", "abc"])).toThrow('invalid --timeout value "abc"');
     });
 
-    test("--leak abc throws instead of flowing NaN — RED today", () => {
+    test("--leak abc throws with a message naming the flag instead of flowing NaN", () => {
         expect(() => parseArgs(["--leak", "abc"])).toThrow('invalid --leak value "abc"');
     });
 });

--- a/packages/shallot/bin/cli.test.ts
+++ b/packages/shallot/bin/cli.test.ts
@@ -58,14 +58,10 @@ describe("parseCliArgs", () => {
         expect(() => parseCliArgs(["dev", "--nope"])).toThrow("unknown option: --nope");
     });
 
-    // HOLE-RECORD ARM — `--port abc` should throw (verify.ts:112's own JSDoc states the policy: "a typo
-    // must not silently no-op or flow NaN"), but cli.ts:83 `parseInt`'s `--port` with no validation, so
-    // `--port abc` silently becomes NaN and flows to devConfig's port (dev.ts:65) into vite. The bare
-    // `toThrow()` distinguishes a throw from a clean return, so a NaN-substituting default leaves it red —
-    // but it CANNOT tell the validation throw from an unrelated one (the `unknown option` guard four lines
-    // up throws too), so S2 tightens it to assert the message, as that sibling arm already does. S2 of this
-    // spec (audit-cli-numeric-flags) is the unit that flips this arm green.
-    test("--port abc throws instead of flowing NaN to vite — RED today (cli.ts:83 parseInt, no validation)", () => {
+    // `--port abc` throws with a message naming the flag, so a typo doesn't flow NaN into vite's port
+    // (the policy in verify.ts's `--port` JSDoc: "a typo must not silently no-op or flow NaN"). The
+    // message assertion distinguishes this validation throw from the `unknown option` guard above.
+    test("--port abc throws with a message naming the flag instead of flowing NaN to vite", () => {
         expect(() => parseCliArgs(["dev", "--port", "abc"])).toThrow('invalid --port value "abc"');
     });
 });

--- a/packages/shallot/bin/cli.test.ts
+++ b/packages/shallot/bin/cli.test.ts
@@ -64,4 +64,28 @@ describe("parseCliArgs", () => {
     test("--port abc throws with a message naming the flag instead of flowing NaN to vite", () => {
         expect(() => parseCliArgs(["dev", "--port", "abc"])).toThrow('invalid --port value "abc"');
     });
+
+    test("an empty --port value is rejected as empty, not silently coerced to 0", () => {
+        expect(() => parseCliArgs(["dev", "--port="])).toThrow(
+            'invalid --port value "" — must not be empty',
+        );
+    });
+
+    test("a whitespace-only --port value is rejected, not silently coerced to 0", () => {
+        expect(() => parseCliArgs(["dev", "--port", " "])).toThrow(
+            'invalid --port value " " — must not be empty',
+        );
+    });
+
+    test("--port 8080abc is rejected as non-numeric, not truncated to 8080", () => {
+        expect(() => parseCliArgs(["dev", "--port", "8080abc"])).toThrow(
+            'invalid --port value "8080abc"',
+        );
+    });
+
+    test("--port 8080.5 is rejected as a non-integer, not passed to vite as a float", () => {
+        expect(() => parseCliArgs(["dev", "--port", "8080.5"])).toThrow(
+            'invalid --port value "8080.5" — expected an integer',
+        );
+    });
 });

--- a/packages/shallot/bin/cli.test.ts
+++ b/packages/shallot/bin/cli.test.ts
@@ -66,6 +66,6 @@ describe("parseCliArgs", () => {
     // up throws too), so S2 tightens it to assert the message, as that sibling arm already does. S2 of this
     // spec (audit-cli-numeric-flags) is the unit that flips this arm green.
     test("--port abc throws instead of flowing NaN to vite — RED today (cli.ts:83 parseInt, no validation)", () => {
-        expect(() => parseCliArgs(["dev", "--port", "abc"])).toThrow();
+        expect(() => parseCliArgs(["dev", "--port", "abc"])).toThrow('invalid --port value "abc"');
     });
 });

--- a/packages/shallot/bin/cli.ts
+++ b/packages/shallot/bin/cli.ts
@@ -72,9 +72,15 @@ export function parseCliArgs(raw: string[]): CliArgs {
     let help = false;
 
     const num = (flag: string, v: string): number => {
+        if (v.trim() === "") {
+            throw new Error(`invalid ${flag} value "${v}" — must not be empty`);
+        }
         const n = Number(v);
         if (!Number.isFinite(n) || n <= 0) {
             throw new Error(`invalid ${flag} value "${v}" — expected a positive number`);
+        }
+        if (!Number.isInteger(n)) {
+            throw new Error(`invalid ${flag} value "${v}" — expected an integer`);
         }
         return n;
     };

--- a/packages/shallot/bin/cli.ts
+++ b/packages/shallot/bin/cli.ts
@@ -71,6 +71,14 @@ export function parseCliArgs(raw: string[]): CliArgs {
     let strictPort = false;
     let help = false;
 
+    const num = (flag: string, v: string): number => {
+        const n = Number(v);
+        if (!Number.isFinite(n) || n <= 0) {
+            throw new Error(`invalid ${flag} value "${v}" — expected a positive number`);
+        }
+        return n;
+    };
+
     for (let i = 0; i < raw.length; i++) {
         if (raw[i] === "--target" && raw[i + 1]) {
             target = raw[i + 1];
@@ -80,10 +88,10 @@ export function parseCliArgs(raw: string[]): CliArgs {
         } else if (raw[i] === "--portable") {
             portable = true;
         } else if (raw[i] === "--port" && raw[i + 1]) {
-            port = parseInt(raw[i + 1]);
+            port = num("--port", raw[i + 1]);
             i++;
         } else if (raw[i]?.startsWith("--port=")) {
-            port = parseInt(raw[i].split("=")[1]);
+            port = num("--port", raw[i].split("=")[1]);
         } else if (raw[i] === "--strict-port") {
             strictPort = true;
         } else if (raw[i] === "--help" || raw[i] === "-h") {

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -138,6 +138,24 @@ describe("parseVerifyArgs", () => {
         expect(() => parseVerifyArgs(["--timeout=-5"])).toThrow('invalid --timeout value "-5"');
     });
 
+    test("an empty --port value is rejected as empty, not silently coerced to 0", () => {
+        expect(() => parseVerifyArgs(["--port="])).toThrow(
+            'invalid --port value "" — must not be empty',
+        );
+    });
+
+    test("a whitespace-only --port value is rejected, not silently coerced to 0", () => {
+        expect(() => parseVerifyArgs(["--port", " "])).toThrow(
+            'invalid --port value " " — must not be empty',
+        );
+    });
+
+    test("--port 8080abc is rejected as non-numeric, not truncated to 8080", () => {
+        expect(() => parseVerifyArgs(["--port", "8080abc"])).toThrow(
+            'invalid --port value "8080abc"',
+        );
+    });
+
     test("--memory and --alloc are separate flags, default false", () => {
         const a = parseVerifyArgs([]);
         expect(a.memory).toBe(false);
@@ -168,6 +186,18 @@ describe("parseVerifyArgs", () => {
     test("--leak 0 is accepted as off (leak === 0, not rejected)", () => {
         expect(() => parseVerifyArgs(["--leak", "0"])).not.toThrow();
         expect(parseVerifyArgs(["--leak", "0"]).leak).toBe(0);
+    });
+
+    test("an empty --leak value is rejected as empty, not silently coerced to 0", () => {
+        expect(() => parseVerifyArgs(["--leak="])).toThrow(
+            'invalid --leak value "" — must not be empty',
+        );
+    });
+
+    test("a whitespace-only --leak value is rejected, not silently coerced to 0", () => {
+        expect(() => parseVerifyArgs(["--leak", " "])).toThrow(
+            'invalid --leak value " " — must not be empty',
+        );
     });
 
     test("--timings defaults off, flips on", () => {

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -161,15 +161,11 @@ describe("parseVerifyArgs", () => {
         expect(() => parseVerifyArgs(["--leak=122880"])).toThrow("--leak requires --memory");
     });
 
-    // HOLE-RECORD ARM — `--leak 0` should be accepted as "off" (verify.ts:94 JSDoc: "0 = off",
-    // line 130 defaults `leak: 0`, line 172 branches on `args.leak > 0 && !args.memory`), but `num()`
-    // (verify.ts:117) rejects `n <= 0` so `--leak 0` throws. `.not.toThrow()` sees only the absence of a
-    // throw: it CANNOT see the parsed *value*, so an S2 that stops throwing while parsing `0` to anything
-    // else greens it — which is why the sibling arm above pins `parseVerifyArgs([]).leak === 0` and why S2
-    // owes `parseVerifyArgs(["--leak", "0"]).leak === 0` here. S2 of this spec (audit-cli-numeric-flags) is
-    // the unit that flips this arm green, and its first act in this file is deleting the status-quo pin at
-    // the `--leak defaults to 0 (off)` arm above, which asserts the very throw this arm forbids.
-    test("--leak 0 is accepted as off, not rejected by num() — RED today (verify.ts:94 says 0 = off)", () => {
+    // `--leak 0` is accepted as off: `numNonNeg` allows zero (the `--leak` JSDoc: "0 = off"), and the
+    // `--leak requires --memory` guard branches on `args.leak > 0`, so 0 never trips it. The sibling arm
+    // above pins `parseVerifyArgs([]).leak === 0`; this one pins `parseVerifyArgs(["--leak", "0"]).leak
+    // === 0` so a parser that substitutes a nonzero value for 0 can't pass both.
+    test("--leak 0 is accepted as off (leak === 0, not rejected)", () => {
         expect(() => parseVerifyArgs(["--leak", "0"])).not.toThrow();
         expect(parseVerifyArgs(["--leak", "0"]).leak).toBe(0);
     });

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -154,7 +154,6 @@ describe("parseVerifyArgs", () => {
         expect(parseVerifyArgs([]).leak).toBe(0);
         expect(parseVerifyArgs(["--leak", "122880", "--memory"]).leak).toBe(122880);
         expect(parseVerifyArgs(["--leak=122880", "--memory"]).leak).toBe(122880);
-        expect(() => parseVerifyArgs(["--leak", "0"])).toThrow("expected a positive number");
     });
 
     test("--leak without --memory is a parse error (nothing samples the injected allocation)", () => {
@@ -172,6 +171,7 @@ describe("parseVerifyArgs", () => {
     // the `--leak defaults to 0 (off)` arm above, which asserts the very throw this arm forbids.
     test("--leak 0 is accepted as off, not rejected by num() — RED today (verify.ts:94 says 0 = off)", () => {
         expect(() => parseVerifyArgs(["--leak", "0"])).not.toThrow();
+        expect(parseVerifyArgs(["--leak", "0"]).leak).toBe(0);
     });
 
     test("--timings defaults off, flips on", () => {

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -113,6 +113,9 @@ export interface VerifyArgs {
  */
 export function parseVerifyArgs(raw: string[]): VerifyArgs {
     const num = (flag: string, v: string): number => {
+        if (v.trim() === "") {
+            throw new Error(`invalid ${flag} value "${v}" — must not be empty`);
+        }
         const n = Number(v);
         if (!Number.isFinite(n) || n <= 0) {
             throw new Error(`invalid ${flag} value "${v}" — expected a positive number`);
@@ -120,6 +123,9 @@ export function parseVerifyArgs(raw: string[]): VerifyArgs {
         return n;
     };
     const numNonNeg = (flag: string, v: string): number => {
+        if (v.trim() === "") {
+            throw new Error(`invalid ${flag} value "${v}" — must not be empty`);
+        }
         const n = Number(v);
         if (!Number.isFinite(n) || n < 0) {
             throw new Error(`invalid ${flag} value "${v}" — expected a non-negative number`);

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -119,6 +119,13 @@ export function parseVerifyArgs(raw: string[]): VerifyArgs {
         }
         return n;
     };
+    const numNonNeg = (flag: string, v: string): number => {
+        const n = Number(v);
+        if (!Number.isFinite(n) || n < 0) {
+            throw new Error(`invalid ${flag} value "${v}" — expected a non-negative number`);
+        }
+        return n;
+    };
     const args: VerifyArgs = {
         dir: ".",
         dist: false,
@@ -140,8 +147,9 @@ export function parseVerifyArgs(raw: string[]): VerifyArgs {
         else if (a === "--memory") args.memory = true;
         else if (a === "--alloc") args.alloc = true;
         else if (a === "--timings") args.timings = true;
-        else if (a === "--leak" && raw[i + 1]) args.leak = num("--leak", raw[++i]);
-        else if (a?.startsWith("--leak=")) args.leak = num("--leak", a.slice("--leak=".length));
+        else if (a === "--leak" && raw[i + 1]) args.leak = numNonNeg("--leak", raw[++i]);
+        else if (a?.startsWith("--leak="))
+            args.leak = numNonNeg("--leak", a.slice("--leak=".length));
         else if (a === "--help" || a === "-h") args.help = true;
         else if (a === "--screenshot" && raw[i + 1]) args.screenshot = raw[++i];
         else if (a === "--connect" && raw[i + 1]) args.connect = raw[++i];

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -229,6 +229,9 @@ export function parseArgs(argv: string[]): Args {
         return argv[i + 1];
     };
     const num = (flag: string, v: string): number => {
+        if (v.trim() === "") {
+            throw new Error(`invalid ${flag} value "${v}" — must not be empty`);
+        }
         const n = Number(v);
         if (!Number.isFinite(n)) {
             throw new Error(`invalid ${flag} value "${v}" — expected a number`);

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -228,6 +228,13 @@ export function parseArgs(argv: string[]): Args {
         if (i + 1 >= argv.length) throw new Error(`--${name} requires a value`);
         return argv[i + 1];
     };
+    const num = (flag: string, v: string): number => {
+        const n = Number(v);
+        if (!Number.isFinite(n)) {
+            throw new Error(`invalid ${flag} value "${v}" — expected a number`);
+        }
+        return n;
+    };
     for (let i = 0; i < argv.length; i++) {
         const arg = argv[i];
         if (!arg.startsWith("--")) continue; // passthrough was Playwright-runner-specific; verify has none
@@ -237,19 +244,19 @@ export function parseArgs(argv: string[]): Args {
                 out.scenario = take(name, i++);
                 break;
             case "seed":
-                out.seed = parseInt(take(name, i++), 10);
+                out.seed = num(`--${name}`, take(name, i++));
                 break;
             case "count":
-                out.count = parseInt(take(name, i++), 10);
+                out.count = num(`--${name}`, take(name, i++));
                 break;
             case "warmup":
-                out.warmup = parseInt(take(name, i++), 10);
+                out.warmup = num(`--${name}`, take(name, i++));
                 break;
             case "frames":
-                out.frames = parseInt(take(name, i++), 10);
+                out.frames = num(`--${name}`, take(name, i++));
                 break;
             case "timeout":
-                out.timeoutMs = parseInt(take(name, i++), 10);
+                out.timeoutMs = num(`--${name}`, take(name, i++));
                 break;
             case "param":
                 out.params.push(take(name, i++));
@@ -258,7 +265,7 @@ export function parseArgs(argv: string[]): Args {
                 out.screenshot = take(name, i++);
                 break;
             case "leak":
-                out.leak = parseInt(take(name, i++), 10);
+                out.leak = num(`--${name}`, take(name, i++));
                 break;
             case "list":
                 out.list = true;


### PR DESCRIPTION
- **audit-cli-numeric-flags: s2**
- **audit-cli-numeric-flags: s2 arm descriptions state the invariant, not the history**
- **audit-cli-numeric-flags: s2 reject empty and non-integer flag values loudly**
