### PR TITLE
shallot boot noise/s4

### DIFF
--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -1745,18 +1745,17 @@ async function nextFrame(page: Page): Promise<void> {
         .catch(() => {});
 }
 
-// write a post-run canvas PNG when --screenshot asked for one. Best-effort — a screenshot failure never fails.
-// Uses the canvas element screenshot (the proven mechanism — drawImage(webgpuCanvas) reads blank on
-// real hardware, probed 2026-07-13) rather than page.screenshot, which captures the full compositor
-// including the browser chrome and is byte-identical across a green and a red boot.
+// write a post-run PNG when --screenshot asked for one. Best-effort — a screenshot failure never fails.
+// Deliberately full-page rather than the canvas element: `scripts/flows.ts`'s ui-containment oracle samples
+// host chrome in the 64px body padding *outside* the canvas, so a canvas-clipped capture reds that gate and
+// makes the property unobservable from its own artifact (measured 2026-08-24, caught in review). A canvas
+// capture is the better render diagnostic — this one is byte-identical across a green and a red boot — but
+// it is an added mode behind its own flag, gated by `bun run flows`, never a change to this default.
 async function maybeScreenshot(page: Page, path: string | undefined): Promise<void> {
     if (!path) return;
     try {
         await nextFrame(page);
-        await page
-            .locator("canvas")
-            .first()
-            .screenshot({ path: resolve(path), timeout: 5_000 });
+        await page.screenshot({ path: resolve(path) });
     } catch {
         // a screenshot is a convenience, never a gate
     }

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -1746,11 +1746,17 @@ async function nextFrame(page: Page): Promise<void> {
 }
 
 // write a post-run canvas PNG when --screenshot asked for one. Best-effort — a screenshot failure never fails.
+// Uses the canvas element screenshot (the proven mechanism — drawImage(webgpuCanvas) reads blank on
+// real hardware, probed 2026-07-13) rather than page.screenshot, which captures the full compositor
+// including the browser chrome and is byte-identical across a green and a red boot.
 async function maybeScreenshot(page: Page, path: string | undefined): Promise<void> {
     if (!path) return;
     try {
         await nextFrame(page);
-        await page.screenshot({ path: resolve(path) });
+        await page
+            .locator("canvas")
+            .first()
+            .screenshot({ path: resolve(path), timeout: 5_000 });
     } catch {
         // a screenshot is a convenience, never a gate
     }

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -629,6 +629,9 @@ function writeIdentityZeroConfig(dir: string, engineTgz: string) {
             2,
         )}\n`,
     );
+    // deliberately left unframed (camera at the origin, inside the part) unlike the two boot fixtures:
+    // this arm reads `verdict.checks` and never `rendered`, so no pixel is asserted here. Do not copy this
+    // scene shape into an arm that does — an origin camera sees only the cleared background.
     writeFileSync(
         join(dir, "scenes", "main.scene"),
         `<scene>\n    <a ambient-light="intensity: 0.6" />\n    <a camera sear transform />\n    <a part transform color="rgba: 0.8 0.5 0.3" />\n</scene>\n`,

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -354,11 +354,11 @@ async function ejectedFlow(work: string, engineTgz: string) {
     writeFileSync(join(proj, "vite.config.ts"), `${config}\n`);
     writeFileSync(
         join(proj, "shallot.json"),
-        `${JSON.stringify({ scene: "scenes/main.scene", plugins: {} }, null, 2)}\n`,
+        `${JSON.stringify({ scene: "scenes/main.scene", plugins: { Orbit: true } }, null, 2)}\n`,
     );
     writeFileSync(
         join(proj, "scenes", "main.scene"),
-        `<scene>\n    <a ambient-light="intensity: 0.6" />\n    <a camera sear transform />\n    <a part transform color="rgba: 0.8 0.5 0.3" />\n</scene>\n`,
+        `<scene>\n    <a ambient-light="color: 0xd0dcec; intensity: 0.5" />\n    <a directional-light="direction: -0.4 -1 -0.55; color: 0xfff4e0; intensity: 1.1" />\n    <a camera sear orbit="distance: 5; yaw: 0.6; pitch: 0.25" transform />\n    <a part transform="pos: 0 0 0" color="rgba: 0.85 0.55 0.35 1" />\n</scene>\n`,
     );
     writeFileSync(
         join(proj, "index.html"),
@@ -1175,6 +1175,7 @@ if (import.meta.main) {
                 {
                     scene: "scenes/main.scene",
                     plugins: {
+                        Orbit: true, // the orbit camera the scene's `orbit` attribute drives
                         Audio: true, // an engine extra whose wasm must ship
                         Widget: "shallot-widget-fixture/widget", // an installed plugin by subpath
                         Spin: "./src/spin", // a local plugin
@@ -1186,7 +1187,7 @@ if (import.meta.main) {
         );
         writeFileSync(
             join(sandbox, "scenes", "main.scene"),
-            `<scene>\n    <a ambient-light="intensity: 0.6" />\n    <a camera sear transform />\n    <a part transform color="rgba: 0.8 0.5 0.3" />\n</scene>\n`,
+            `<scene>\n    <a ambient-light="color: 0xd0dcec; intensity: 0.5" />\n    <a directional-light="direction: -0.4 -1 -0.55; color: 0xfff4e0; intensity: 1.1" />\n    <a camera sear orbit="distance: 5; yaw: 0.6; pitch: 0.25" transform />\n    <a part transform="pos: 0 0 0" color="rgba: 0.85 0.55 0.35 1" />\n</scene>\n`,
         );
         writeFileSync(
             join(sandbox, "src", "spin.ts"),


### PR DESCRIPTION
- **shallot-boot-noise: s4 — frame fixture scenes, fix saved-frame instrument**
- **shallot-boot-noise: s4 — revert the canvas capture, mark the third unframed fixture**
