### PR TITLE
audit tumble late marshal constraints/s2

### DIFF
--- a/packages/shallot/src/standard/tumble/index.ts
+++ b/packages/shallot/src/standard/tumble/index.ts
@@ -17,7 +17,7 @@ import { Hulls } from "../physics/core";
 import { SlabPlugin } from "../slab";
 import { nlerpShortest, renderScale } from "./compose";
 import { init, type Body as TumbleBody, World as TumbleWorld } from "./engine";
-import { resetConstraints, syncJoints, syncSprings } from "./joints";
+import { resetConstraints, resyncConstraints, syncJoints, syncSprings } from "./joints";
 import { marshalBody } from "./marshal";
 
 // tumble physics — the default backend for the physics substrate (`standard/physics`), a CPU rigid-body
@@ -59,6 +59,10 @@ const kinPrev = new Map<number, [number, number, number]>();
 // they failed at, so SyncSystem retries the marshal (and re-warns) only when the eid recycles or a new hull
 // is registered, never every frame. Normally empty; the error path never thrashes the frame loop.
 const failed = new Map<number, { stamp: number; hulls: number }>();
+// the deferred-marshal discriminator handed to the constraint path: an endpoint missing from `bodies` is a
+// pending marshal (it will retry, and so will its constraint) rather than a non-`Body` reference. `endpoints`
+// is otherwise handed only `bodies`, which is why the warning used to name the wrong cause (joints.ts).
+const isDeferred = (eid: number): boolean => failed.has(eid);
 
 // render-interpolation double buffer, capacity-sized flat arrays indexed by eid (3 lanes pos, 4 lanes quat).
 // Rewritten only for a body that actually moved this fixed tick (from `getBodyEvents`), so a sleeping/static
@@ -110,6 +114,11 @@ const SyncSystem: System = {
     before: [ConstraintSystem, StepSystem],
     update(state: State) {
         if (!world) return;
+        // did this tick change the body set? A deferred body finally marshaling (or a body going stale) is
+        // the transition a dropped constraint waits on, and `ConstraintSystem` re-uploads on an authored
+        // signature change only — none of which moves here — so the constraint re-sync is pumped from this
+        // loop. Set inside the walk that already runs, so the re-sync fires on the transition, never per frame.
+        let bodySetChanged = false;
         for (const eid of state.query([Body])) {
             const stamp = state.stamp(eid);
             if (bodies.has(eid)) {
@@ -133,6 +142,7 @@ const SyncSystem: System = {
             failed.delete(eid);
             bodies.set(eid, tb);
             stamps.set(eid, stamp);
+            bodySetChanged = true;
             seedPose(
                 eid,
                 Body.pos.x.get(eid),
@@ -149,18 +159,24 @@ const SyncSystem: System = {
                 if (!state.has(eid, Body)) failed.delete(eid);
             }
         }
-        if (bodies.size === 0) return;
-        const stale: number[] = [];
-        for (const eid of bodies.keys()) {
-            if (!state.has(eid, Body)) stale.push(eid);
+        if (bodies.size > 0) {
+            const stale: number[] = [];
+            for (const eid of bodies.keys()) {
+                if (!state.has(eid, Body)) stale.push(eid);
+            }
+            for (const eid of stale) {
+                bodies.get(eid)?.destroy();
+                bodies.delete(eid);
+                stamps.delete(eid);
+                kinPrev.delete(eid);
+                movedThisTick.delete(eid);
+                bodySetChanged = true;
+            }
         }
-        for (const eid of stale) {
-            bodies.get(eid)?.destroy();
-            bodies.delete(eid);
-            stamps.delete(eid);
-            kinPrev.delete(eid);
-            movedThisTick.delete(eid);
-        }
+        // the pump: re-run the retained authored constraint sets against the new body set, so a create that
+        // returned null against a not-yet-marshaled endpoint retries now. Content-keyed, so a live joint is
+        // reused (warm impulses survive) and only the dropped def is created.
+        if (bodySetChanged) resyncConstraints(world, bodies, isDeferred);
     },
 };
 
@@ -244,10 +260,10 @@ const backendHandle: PhysicsBackend = {
         bodies.get(eid)?.setLinearVelocity({ x: vx, y: vy, z: vz });
     },
     setSprings(springs) {
-        if (world) syncSprings(world, bodies, springs);
+        if (world) syncSprings(world, bodies, springs, isDeferred);
     },
     setJoints(joints) {
-        if (world) syncJoints(world, bodies, joints);
+        if (world) syncJoints(world, bodies, joints, isDeferred);
     },
     get gravity() {
         return world ? world.getGravity().y : 0;

--- a/packages/shallot/src/standard/tumble/index.ts
+++ b/packages/shallot/src/standard/tumble/index.ts
@@ -117,7 +117,9 @@ const SyncSystem: System = {
         // did this tick change the body set? A deferred body finally marshaling (or a body going stale) is
         // the transition a dropped constraint waits on, and `ConstraintSystem` re-uploads on an authored
         // signature change only — none of which moves here — so the constraint re-sync is pumped from this
-        // loop. Set inside the walk that already runs, so the re-sync fires on the transition, never per frame.
+        // loop. Set inside the walk that already runs, on ANY body-set change: normally that IS the marshal
+        // transition, but a continuously spawning scene changes its body set every tick and so re-syncs every
+        // tick — a no-op walk over the live joints (each is reused, nothing created), and silent (joints.ts).
         let bodySetChanged = false;
         for (const eid of state.query([Body])) {
             const stamp = state.stamp(eid);
@@ -175,7 +177,9 @@ const SyncSystem: System = {
         }
         // the pump: re-run the retained authored constraint sets against the new body set, so a create that
         // returned null against a not-yet-marshaled endpoint retries now. Content-keyed, so a live joint is
-        // reused (warm impulses survive) and only the dropped def is created.
+        // reused (warm impulses survive) and only the dropped def is created. The retry is silent — a def
+        // still unsatisfiable would otherwise re-warn on every body-set change, which is the `failed` ledger's
+        // never-thrash-the-frame-loop invariant above; the authored upload keeps the one warning.
         if (bodySetChanged) resyncConstraints(world, bodies, isDeferred);
     },
 };

--- a/packages/shallot/src/standard/tumble/joints.ts
+++ b/packages/shallot/src/standard/tumble/joints.ts
@@ -73,6 +73,12 @@ const jointKey = (d: JointDef): string => `${d.a}|${d.b}|${d.rA}|${d.rB}|${d.sti
 // re-checked via isValid() before reuse.
 const liveSprings = new Map<string, TumbleJoint[]>();
 const liveJoints = new Map<string, TumbleJoint[]>();
+// the last authored def sets — retained so `SyncSystem` can re-invoke `syncJoints`/`syncSprings` over them
+// when a deferred body marshals (the pump half of the late-marshal fix). AVBD's `setJoints` already retains
+// the authored set (avbd/step.ts); this mirrors that contract. A ledger without a pump is inert: nothing
+// calls back into `joints.ts` between signature changes, so the retained set + the re-invoke are both needed.
+let retainedSprings: readonly SpringDef[] = [];
+let retainedJoints: readonly JointDef[] = [];
 
 // exported as a test seam only (joints.test.ts pins the diff semantics with stub joints); not on any barrel
 export function syncSet<D>(
@@ -110,16 +116,30 @@ export function syncSet<D>(
     for (const [k, v] of next) live.set(k, v);
 }
 
+// the discriminator for the deferred-marshal case: `endpoints()` is handed only the `bodies` map, so without
+// this predicate it cannot separate "not a Body" from "a Body whose marshal is pending" — which is why the
+// old warning named the wrong cause. The `failed` map (index.ts) sits beside `bodies` in the same module;
+// pass a predicate over it so the deferred case reads as deferred-and-will-retry, not a permanent skip.
 function endpoints(
     bodies: ReadonlyMap<number, TumbleBody>,
     a: number,
     b: number,
     kind: string,
+    isDeferred: (eid: number) => boolean,
 ): [TumbleBody, TumbleBody] | null {
     const ta = bodies.get(a);
     const tb = bodies.get(b);
     if (!ta || !tb) {
-        console.warn(`[tumble] ${kind} references a non-Body entity (a: ${a}, b: ${b}) — skipped`);
+        const missing = !ta ? a : b;
+        if (isDeferred(missing)) {
+            console.warn(
+                `[tumble] ${kind} references a deferred body (eid: ${missing}, pending marshal) — will retry`,
+            );
+        } else {
+            console.warn(
+                `[tumble] ${kind} references a non-Body entity (a: ${a}, b: ${b}) — skipped`,
+            );
+        }
         return null;
     }
     return [ta, tb];
@@ -129,8 +149,9 @@ function createSpring(
     world: TumbleWorld,
     bodies: ReadonlyMap<number, TumbleBody>,
     def: SpringDef,
+    isDeferred: (eid: number) => boolean,
 ): TumbleJoint | null {
-    const pair = endpoints(bodies, def.a, def.b, "spring");
+    const pair = endpoints(bodies, def.a, def.b, "spring", isDeferred);
     if (!pair) return null;
     const hertz = stiffnessHertz(def.stiffness, dynMass(pair[0]), dynMass(pair[1]));
     if (hertz === 0) {
@@ -157,8 +178,9 @@ function createJoint(
     world: TumbleWorld,
     bodies: ReadonlyMap<number, TumbleBody>,
     def: JointDef,
+    isDeferred: (eid: number) => boolean,
 ): TumbleJoint | null {
-    const pair = endpoints(bodies, def.a, def.b, "joint");
+    const pair = endpoints(bodies, def.a, def.b, "joint", isDeferred);
     if (!pair) return null;
     const [ta, tb] = pair;
     const mA = dynMass(ta);
@@ -198,26 +220,52 @@ function createJoint(
     });
 }
 
-/** reconcile the authored spring set against the live tumble joints: unchanged defs keep their joint (warm-started impulses survive), changed/new defs create, leftovers destroy. */
+/** reconcile the authored spring set against the live tumble joints: unchanged defs keep their joint (warm-started impulses survive), changed/new defs create, leftovers destroy. Retains the def set for `resyncConstraints`. */
 export function syncSprings(
     world: TumbleWorld,
     bodies: ReadonlyMap<number, TumbleBody>,
     defs: readonly SpringDef[],
+    isDeferred: (eid: number) => boolean,
 ): void {
-    syncSet(liveSprings, defs, springKey, (d) => createSpring(world, bodies, d));
+    retainedSprings = defs;
+    syncSet(liveSprings, defs, springKey, (d) => createSpring(world, bodies, d, isDeferred));
 }
 
-/** reconcile the authored joint set against the live tumble joints — the `syncSprings` twin over the Spherical/Weld mapping. */
+/** reconcile the authored joint set against the live tumble joints — the `syncSprings` twin over the Spherical/Weld mapping. Retains the def set for `resyncConstraints`. */
 export function syncJoints(
     world: TumbleWorld,
     bodies: ReadonlyMap<number, TumbleBody>,
     defs: readonly JointDef[],
+    isDeferred: (eid: number) => boolean,
 ): void {
-    syncSet(liveJoints, defs, jointKey, (d) => createJoint(world, bodies, d));
+    retainedJoints = defs;
+    syncSet(liveJoints, defs, jointKey, (d) => createJoint(world, bodies, d, isDeferred));
+}
+
+/** re-invoke `syncJoints`/`syncSprings` over the retained def sets — the pump half of the late-marshal fix.
+ *  Called by `SyncSystem` when its body set changed this tick (a deferred body marshaled or a body went
+ *  stale), so a previously-failed constraint create retries. `syncSet` needs no new diff semantics: an
+ *  unchanged def whose live joint `isValid()` is reused (warm-started impulses survive), a dropped def's
+ *  `create` retries, leftovers destroy — the semantics `joints.test.ts` already pins. */
+export function resyncConstraints(
+    world: TumbleWorld,
+    bodies: ReadonlyMap<number, TumbleBody>,
+    isDeferred: (eid: number) => boolean,
+): void {
+    if (retainedSprings.length > 0)
+        syncSet(liveSprings, retainedSprings, springKey, (d) =>
+            createSpring(world, bodies, d, isDeferred),
+        );
+    if (retainedJoints.length > 0)
+        syncSet(liveJoints, retainedJoints, jointKey, (d) =>
+            createJoint(world, bodies, d, isDeferred),
+        );
 }
 
 /** drop every tracked joint handle without destroying (the world they lived in is gone). Call beside the world teardown in `warm()`/`dispose()`. */
 export function resetConstraints(): void {
     liveSprings.clear();
     liveJoints.clear();
+    retainedSprings = [];
+    retainedJoints = [];
 }

--- a/packages/shallot/src/standard/tumble/joints.ts
+++ b/packages/shallot/src/standard/tumble/joints.ts
@@ -120,25 +120,30 @@ export function syncSet<D>(
 // this predicate it cannot separate "not a Body" from "a Body whose marshal is pending" — which is why the
 // old warning named the wrong cause. The `failed` map (index.ts) sits beside `bodies` in the same module;
 // pass a predicate over it so the deferred case reads as deferred-and-will-retry, not a permanent skip.
+// EACH missing endpoint is classified on its own cause: a mixed pair (one truly non-`Body`, one deferred)
+// names both, so neither half inherits the other's cause — the misdirection this discriminator exists to end.
+// `quiet` silences the diagnostic for a retry pass (`resyncConstraints`): the authored upload owns the one
+// warning, and a retry that re-warned would fire on every body-set change (index.ts's never-thrash invariant).
 function endpoints(
     bodies: ReadonlyMap<number, TumbleBody>,
     a: number,
     b: number,
     kind: string,
     isDeferred: (eid: number) => boolean,
+    quiet: boolean,
 ): [TumbleBody, TumbleBody] | null {
     const ta = bodies.get(a);
     const tb = bodies.get(b);
     if (!ta || !tb) {
-        const missing = !ta ? a : b;
-        if (isDeferred(missing)) {
-            console.warn(
-                `[tumble] ${kind} references a deferred body (eid: ${missing}, pending marshal) — will retry`,
-            );
-        } else {
-            console.warn(
-                `[tumble] ${kind} references a non-Body entity (a: ${a}, b: ${b}) — skipped`,
-            );
+        if (!quiet) {
+            const cause = (label: string, eid: number): string =>
+                isDeferred(eid)
+                    ? `${label}: ${eid} is a deferred body (marshal pending, will retry)`
+                    : `${label}: ${eid} is not a Body (skipped)`;
+            const parts: string[] = [];
+            if (!ta) parts.push(cause("a", a));
+            if (!tb) parts.push(cause("b", b));
+            console.warn(`[tumble] ${kind} endpoint unavailable — ${parts.join("; ")}`);
         }
         return null;
     }
@@ -150,14 +155,16 @@ function createSpring(
     bodies: ReadonlyMap<number, TumbleBody>,
     def: SpringDef,
     isDeferred: (eid: number) => boolean,
+    quiet: boolean,
 ): TumbleJoint | null {
-    const pair = endpoints(bodies, def.a, def.b, "spring", isDeferred);
+    const pair = endpoints(bodies, def.a, def.b, "spring", isDeferred, quiet);
     if (!pair) return null;
     const hertz = stiffnessHertz(def.stiffness, dynMass(pair[0]), dynMass(pair[1]));
     if (hertz === 0) {
-        console.warn(
-            `[tumble] spring (a: ${def.a}, b: ${def.b}) has no dynamic endpoint or non-positive stiffness — skipped`,
-        );
+        if (!quiet)
+            console.warn(
+                `[tumble] spring (a: ${def.a}, b: ${def.b}) has no dynamic endpoint or non-positive stiffness — skipped`,
+            );
         return null;
     }
     return world.createDistanceJoint(pair[0], pair[1], {
@@ -179,16 +186,18 @@ function createJoint(
     bodies: ReadonlyMap<number, TumbleBody>,
     def: JointDef,
     isDeferred: (eid: number) => boolean,
+    quiet: boolean,
 ): TumbleJoint | null {
-    const pair = endpoints(bodies, def.a, def.b, "joint", isDeferred);
+    const pair = endpoints(bodies, def.a, def.b, "joint", isDeferred, quiet);
     if (!pair) return null;
     const [ta, tb] = pair;
     const mA = dynMass(ta);
     const mB = dynMass(tb);
     if (mA <= 0 && mB <= 0) {
-        console.warn(
-            `[tumble] joint (a: ${def.a}, b: ${def.b}) has no dynamic endpoint — unsatisfiable, skipped (the both-static guard)`,
-        );
+        if (!quiet)
+            console.warn(
+                `[tumble] joint (a: ${def.a}, b: ${def.b}) has no dynamic endpoint — unsatisfiable, skipped (the both-static guard)`,
+            );
         return null;
     }
     if (def.stiffnessAng === 0) {
@@ -198,9 +207,10 @@ function createJoint(
         });
     }
     if (def.stiffnessAng < 0) {
-        console.warn(
-            `[tumble] joint (a: ${def.a}, b: ${def.b}) has non-positive angular stiffness — skipped`,
-        );
+        if (!quiet)
+            console.warn(
+                `[tumble] joint (a: ${def.a}, b: ${def.b}) has non-positive angular stiffness — skipped`,
+            );
         return null;
     }
     // angularHertz 0 is box3d's RIGID angular constraint; an intermediate stiffnessAng maps to a soft
@@ -228,7 +238,7 @@ export function syncSprings(
     isDeferred: (eid: number) => boolean,
 ): void {
     retainedSprings = defs;
-    syncSet(liveSprings, defs, springKey, (d) => createSpring(world, bodies, d, isDeferred));
+    syncSet(liveSprings, defs, springKey, (d) => createSpring(world, bodies, d, isDeferred, false));
 }
 
 /** reconcile the authored joint set against the live tumble joints — the `syncSprings` twin over the Spherical/Weld mapping. Retains the def set for `resyncConstraints`. */
@@ -239,14 +249,17 @@ export function syncJoints(
     isDeferred: (eid: number) => boolean,
 ): void {
     retainedJoints = defs;
-    syncSet(liveJoints, defs, jointKey, (d) => createJoint(world, bodies, d, isDeferred));
+    syncSet(liveJoints, defs, jointKey, (d) => createJoint(world, bodies, d, isDeferred, false));
 }
 
 /** re-invoke `syncJoints`/`syncSprings` over the retained def sets — the pump half of the late-marshal fix.
- *  Called by `SyncSystem` when its body set changed this tick (a deferred body marshaled or a body went
- *  stale), so a previously-failed constraint create retries. `syncSet` needs no new diff semantics: an
- *  unchanged def whose live joint `isValid()` is reused (warm-started impulses survive), a dropped def's
- *  `create` retries, leftovers destroy — the semantics `joints.test.ts` already pins. */
+ *  Called by `SyncSystem` on ANY body-set change: normally that is the deferred-marshal transition or a body
+ *  going stale, but a continuously spawning scene changes its body set every tick and so re-syncs every tick —
+ *  a no-op walk over the live joints (each `isValid()` handle is reused, nothing is created or destroyed).
+ *  `syncSet` needs no new diff semantics: an unchanged def whose live joint `isValid()` is reused (warm-started
+ *  impulses survive), a dropped def's `create` retries, leftovers destroy — the semantics `joints.test.ts`
+ *  already pins. The retry passes `quiet`: a still-unsatisfiable def must not re-warn per body-set change, so
+ *  the diagnostic stays the authored upload's one warning (index.ts's never-thrash-the-frame-loop invariant). */
 export function resyncConstraints(
     world: TumbleWorld,
     bodies: ReadonlyMap<number, TumbleBody>,
@@ -254,11 +267,11 @@ export function resyncConstraints(
 ): void {
     if (retainedSprings.length > 0)
         syncSet(liveSprings, retainedSprings, springKey, (d) =>
-            createSpring(world, bodies, d, isDeferred),
+            createSpring(world, bodies, d, isDeferred, true),
         );
     if (retainedJoints.length > 0)
         syncSet(liveJoints, retainedJoints, jointKey, (d) =>
-            createJoint(world, bodies, d, isDeferred),
+            createJoint(world, bodies, d, isDeferred, true),
         );
 }
 

--- a/packages/shallot/src/standard/tumble/lifecycle.test.ts
+++ b/packages/shallot/src/standard/tumble/lifecycle.test.ts
@@ -110,9 +110,11 @@ const registerLateHull = (): void => {
 };
 
 // the scene: a mass-0 Box anchor at y=5, a mass-1 Hull body at y=4 carrying the reserved (unregistered)
-// hull id in halfExtents.w, and a spherical pin (stiffnessAng 0) between them with rA one unit below the
-// anchor — so a live joint holds the bob at y≈4 and a dropped one free-falls it past y=0.
-function pinnedDeferredScene(state: State): { anchor: number; bob: number } {
+// hull id in halfExtents.w, and a constraint between them — a spherical pin (stiffnessAng 0) with rA one
+// unit below the anchor, or the spring twin (a stiff distance spring, anchor-to-anchor rest 1). Either way a
+// live constraint holds the bob at y≈4 and a dropped one free-falls it past y=0. Returns the bob eid, the
+// only handle an arm reads.
+function pinnedDeferredScene(state: State, kind: "joint" | "spring"): number {
     const anchor = state.create();
     state.add(anchor, Body);
     Body.shape.set(anchor, ShapeKind.Box);
@@ -127,15 +129,26 @@ function pinnedDeferredScene(state: State): { anchor: number; bob: number } {
     Body.pos.set(bob, 0, 4, 0, 0);
     Body.mass.set(bob, 1);
 
-    const j = state.create();
-    state.add(j, Joint);
-    Joint.a.set(j, anchor);
-    Joint.b.set(j, bob);
-    Joint.rA.set(j, 0, -1, 0, 0);
-    Joint.rB.set(j, 0, 0, 0, 0);
-    Joint.stiffnessAng.set(j, 0);
+    const c = state.create();
+    if (kind === "joint") {
+        state.add(c, Joint);
+        Joint.a.set(c, anchor);
+        Joint.b.set(c, bob);
+        Joint.rA.set(c, 0, -1, 0, 0);
+        Joint.rB.set(c, 0, 0, 0, 0);
+        Joint.stiffnessAng.set(c, 0);
+    } else {
+        state.add(c, Spring);
+        Spring.a.set(c, anchor);
+        Spring.b.set(c, bob);
+        Spring.rA.set(c, 0, 0, 0, 0);
+        Spring.rB.set(c, 0, 0, 0, 0);
+        // stiff enough that the static droop (mg/k ≈ 0.01 m) stays far above the free-fall the arm rejects
+        Spring.stiffness.set(c, 1000);
+        Spring.rest.set(c, 1);
+    }
 
-    return { anchor, bob };
+    return bob;
 }
 
 describe("TumblePlugin late-marshal constraints", () => {
@@ -148,7 +161,7 @@ describe("TumblePlugin late-marshal constraints", () => {
 
     test("a joint dropped against a not-yet-marshaled body is retried once it marshals", async () => {
         state = await buildTumble();
-        const { bob } = pinnedDeferredScene(state);
+        const bob = pinnedDeferredScene(state, "joint");
 
         // one tick: bob's marshal fails (its hull id has no hull), so the joint's create finds no endpoint
         state.step(Time.FIXED_DT);
@@ -164,9 +177,26 @@ describe("TumblePlugin late-marshal constraints", () => {
         expect(live?.pos[1]).toBeGreaterThan(3);
     });
 
+    // the spring half of the same pump: `createSpring` has its own early-out and its own warn, so the joint
+    // arm alone would leave `syncSprings`/`resyncConstraints`'s spring branch uncovered.
+    test("a spring dropped against a not-yet-marshaled body is retried once it marshals", async () => {
+        state = await buildTumble();
+        const bob = pinnedDeferredScene(state, "spring");
+
+        state.step(Time.FIXED_DT);
+        registerLateHull();
+        for (let i = 0; i < 60; i++) state.step(Time.FIXED_DT);
+
+        const live = Physics.backend?.readBody(bob);
+        expect(live).not.toBeNull();
+        // a live spring holds the bob one rest-length below the anchor (y≈4, minus the mg/k droop); a dropped
+        // one free-falls it well past y=0.
+        expect(live?.pos[1]).toBeGreaterThan(3);
+    });
+
     test("the skip warning names the deferred marshal, not a non-Body reference", async () => {
         state = await buildTumble();
-        pinnedDeferredScene(state);
+        pinnedDeferredScene(state, "joint");
 
         const warn = spyOn(console, "warn").mockImplementation(() => {});
         try {
@@ -177,6 +207,96 @@ describe("TumblePlugin late-marshal constraints", () => {
             expect(jointWarn).toBeDefined();
             expect(jointWarn).toContain("deferred");
             expect(jointWarn).not.toContain("non-Body entity");
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // the mixed pair: `a` is truly not a `Body`, `b` is a deferred marshal. Classifying only the first missing
+    // endpoint would name `a`'s cause and silently apply it to `b` — for the deferred half, exactly the
+    // misdirection the discriminator exists to delete. Both endpoints get their own cause.
+    test("a mixed pair names each endpoint's own cause", async () => {
+        state = await buildTumble();
+
+        const notABody = state.create(); // no Body component: permanently unsatisfiable
+        const bob = state.create();
+        state.add(bob, Body);
+        Body.shape.set(bob, ShapeKind.Hull);
+        Body.halfExtents.set(bob, 1, 1, 1, reserveLateHullId());
+        Body.pos.set(bob, 0, 4, 0, 0);
+        Body.mass.set(bob, 1);
+
+        const j = state.create();
+        state.add(j, Joint);
+        Joint.a.set(j, notABody);
+        Joint.b.set(j, bob);
+        Joint.rA.set(j, 0, 0, 0, 0);
+        Joint.rB.set(j, 0, 0, 0, 0);
+        Joint.stiffnessAng.set(j, 0);
+
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            state.step(Time.FIXED_DT);
+            const jointWarn = warn.mock.calls
+                .map((c) => String(c[0]))
+                .find((m) => m.includes("joint endpoint unavailable"));
+            expect(jointWarn).toBeDefined();
+            expect(jointWarn).toContain(`a: ${notABody} is not a Body`);
+            expect(jointWarn).toContain(`b: ${bob} is a deferred body`);
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // The pump fires on ANY body-set change, so a continuously spawning scene re-syncs every tick. A retry
+    // that re-warned would emit one warning per tick forever, breaking the same never-thrash-the-frame-loop
+    // invariant the marshal `failed` ledger holds (index.ts). Counted across ticks, because no per-tick arm
+    // can see a warning that only grows with tick count.
+    test("a permanently unsatisfiable constraint warns once, not once per body-set change", async () => {
+        state = await buildTumble();
+
+        const notABody = state.create(); // no Body: this joint can never be satisfied
+        const anchor = state.create();
+        state.add(anchor, Body);
+        Body.shape.set(anchor, ShapeKind.Box);
+        Body.halfExtents.set(anchor, 0.5, 0.5, 0.5, 0);
+        Body.pos.set(anchor, 0, 5, 0, 0);
+        Body.mass.set(anchor, 0);
+
+        const j = state.create();
+        state.add(j, Joint);
+        Joint.a.set(j, anchor);
+        Joint.b.set(j, notABody);
+        Joint.rA.set(j, 0, -1, 0, 0);
+        Joint.rB.set(j, 0, 0, 0, 0);
+        Joint.stiffnessAng.set(j, 0);
+
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        const spawn = (i: number): void => {
+            const eid = state.create();
+            state.add(eid, Body);
+            Body.shape.set(eid, ShapeKind.Sphere);
+            Body.halfExtents.set(eid, 0, 0, 0, 0.5);
+            Body.pos.set(eid, i * 2, 10, 0, 0);
+            Body.mass.set(eid, 1);
+        };
+        const jointWarnings = (): number =>
+            warn.mock.calls.filter((c) => String(c[0]).includes("joint")).length;
+
+        try {
+            // one body spawned per tick, so the body set changes (and the pump fires) on every tick
+            for (let i = 0; i < 10; i++) {
+                spawn(i);
+                state.step(Time.FIXED_DT);
+            }
+            const afterTen = jointWarnings();
+            for (let i = 10; i < 30; i++) {
+                spawn(i);
+                state.step(Time.FIXED_DT);
+            }
+            // the authored upload's one warning, and no growth with tick count
+            expect(afterTen).toBe(1);
+            expect(jointWarnings()).toBe(afterTen);
         } finally {
             warn.mockRestore();
         }

--- a/packages/shallot/src/standard/tumble/lifecycle.test.ts
+++ b/packages/shallot/src/standard/tumble/lifecycle.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test";
 import { attach } from "../../../tests/helpers";
 import { State, Time } from "../../engine";
 import { clear, register } from "../../engine/ecs/core";
@@ -12,6 +12,7 @@ import {
     Spring,
     springTraits,
 } from "../physics";
+import { Hulls } from "../physics/core";
 import { Slab } from "../slab";
 import { shutdown } from "./engine";
 import { Tumble, TumblePlugin } from "./index";
@@ -82,5 +83,102 @@ describe("TumblePlugin lifecycle", () => {
         state = await buildTumble();
         expect(Tumble.world).not.toBeNull();
         expect(() => state.step(Time.FIXED_DT)).not.toThrow();
+    });
+});
+
+// Late-marshal constraint retry: a constraint whose endpoint body hasn't marshaled yet (its hull registers
+// a tick later — the normal async-hull path) used to be dropped permanently. `createJoint` returned null
+// with no retry, and `ConstraintSystem` re-uploads on an authored-signature change only, none of which
+// moves when a deferred body finally marshals. The fix is a retained authored def set plus a `SyncSystem`
+// re-invoke pump (index.ts / joints.ts). These two arms pin both halves.
+//
+// Manufacturing a deferred hull: register a `__unit_cube__` clone under a new name, then `Hulls.delete` it
+// — `Registry.delete` frees the value and keeps the id slot, so the later re-register reuses the SAME id
+// and grows `Hulls.size`, which is the key the marshal `failed` ledger retries on.
+
+const LATE_HULL = "__late_marshal_arm__";
+
+/** reserve a hull id whose hull is not registered — a body carrying it fails to marshal until {@link registerLateHull}. */
+function reserveLateHullId(): number {
+    const id = Hulls.register({ ...Hulls.get("__unit_cube__")!, name: LATE_HULL });
+    Hulls.delete(LATE_HULL);
+    return id;
+}
+
+const registerLateHull = (): void => {
+    Hulls.register({ ...Hulls.get("__unit_cube__")!, name: LATE_HULL });
+};
+
+// the scene: a mass-0 Box anchor at y=5, a mass-1 Hull body at y=4 carrying the reserved (unregistered)
+// hull id in halfExtents.w, and a spherical pin (stiffnessAng 0) between them with rA one unit below the
+// anchor — so a live joint holds the bob at y≈4 and a dropped one free-falls it past y=0.
+function pinnedDeferredScene(state: State): { anchor: number; bob: number } {
+    const anchor = state.create();
+    state.add(anchor, Body);
+    Body.shape.set(anchor, ShapeKind.Box);
+    Body.halfExtents.set(anchor, 0.5, 0.5, 0.5, 0);
+    Body.pos.set(anchor, 0, 5, 0, 0);
+    Body.mass.set(anchor, 0);
+
+    const bob = state.create();
+    state.add(bob, Body);
+    Body.shape.set(bob, ShapeKind.Hull);
+    Body.halfExtents.set(bob, 1, 1, 1, reserveLateHullId());
+    Body.pos.set(bob, 0, 4, 0, 0);
+    Body.mass.set(bob, 1);
+
+    const j = state.create();
+    state.add(j, Joint);
+    Joint.a.set(j, anchor);
+    Joint.b.set(j, bob);
+    Joint.rA.set(j, 0, -1, 0, 0);
+    Joint.rB.set(j, 0, 0, 0, 0);
+    Joint.stiffnessAng.set(j, 0);
+
+    return { anchor, bob };
+}
+
+describe("TumblePlugin late-marshal constraints", () => {
+    let state: State;
+
+    afterEach(() => {
+        TumblePlugin.dispose?.(state);
+        Hulls.delete(LATE_HULL);
+    });
+
+    test("a joint dropped against a not-yet-marshaled body is retried once it marshals", async () => {
+        state = await buildTumble();
+        const { bob } = pinnedDeferredScene(state);
+
+        // one tick: bob's marshal fails (its hull id has no hull), so the joint's create finds no endpoint
+        state.step(Time.FIXED_DT);
+        // the hull arrives — Hulls.size grows, so the marshal ledger retries bob on the next tick
+        registerLateHull();
+        for (let i = 0; i < 60; i++) state.step(Time.FIXED_DT);
+
+        const live = Physics.backend?.readBody(bob);
+        expect(live).not.toBeNull();
+        // POSITION, not readBody's non-nullness: the body's own marshal retry already worked before this
+        // fix, so an arm keyed on readBody was green while the constraint was permanently lost. A live pin
+        // holds the bob at y≈4; the dropped joint free-fell it to ≈-1.29.
+        expect(live?.pos[1]).toBeGreaterThan(3);
+    });
+
+    test("the skip warning names the deferred marshal, not a non-Body reference", async () => {
+        state = await buildTumble();
+        pinnedDeferredScene(state);
+
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            state.step(Time.FIXED_DT);
+            const jointWarn = warn.mock.calls
+                .map((c) => String(c[0]))
+                .find((m) => m.includes("joint"));
+            expect(jointWarn).toBeDefined();
+            expect(jointWarn).toContain("deferred");
+            expect(jointWarn).not.toContain("non-Body entity");
+        } finally {
+            warn.mockRestore();
+        }
     });
 });


### PR DESCRIPTION
- **audit-tumble-late-marshal-constraints: retry a constraint whose endpoint marshals late**
- **audit-tumble-late-marshal-constraints: review fixes — the retry is silent, and both endpoints get their cause**
