### PR TITLE
audit-claim-and-roster-checks: derive the tumble scene count from a test arm

### DIFF
--- a/packages/shallot/scripts/gen-tumble-fixtures.ts
+++ b/packages/shallot/scripts/gen-tumble-fixtures.ts
@@ -5,7 +5,8 @@
 //
 // The reference is built with BOX3D_DISABLE_SIMD=ON (default overflow OFF) — the colored solver with
 // graph coloring + the wide (4-lane) convex path + serial mesh/overflow spill, which the port mirrors
-// per-lane. DISABLE_SIMD's scalar FloatW is bit-identical per lane to the SIMD build (proven 52/52), so
+// per-lane. DISABLE_SIMD's scalar FloatW is bit-identical per lane to the SIMD build (proven across
+// every scene), so
 // these fixtures pin the wide-simd wasm path too. Requires cmake and a C toolchain.
 //
 // The committed fixtures are the frozen contract (pin 29bf523 — tests/tumble/fixtures/README.md); only

--- a/packages/shallot/src/standard/tumble/engine/step.fixture.ts
+++ b/packages/shallot/src/standard/tumble/engine/step.fixture.ts
@@ -1586,83 +1586,15 @@ const stepFactories: Record<string, () => (world: World, step: number) => void> 
 };
 
 // scene name → [enableSleep, enableContinuous], matching gen.c's per-scene world flags.
-const SCENES: [string, boolean, boolean][] = [
-    ["free-fall", false, false],
-    ["sphere-drop", false, false],
-    ["box-stack", false, false],
-    ["sphere-sleep", true, false],
-    ["box-sleep", true, false],
-    ["wake-drop", true, false],
-    ["split-slide", true, false],
-    ["revolute-dd", false, false],
-    ["revolute-pendulum", false, false],
-    ["revolute-motor", false, false],
-    ["revolute-limit", false, false],
-    ["revolute-chain", true, false],
-    ["weld-dd", false, false],
-    ["parallel", false, false],
-    ["joint-contacts", false, false],
-    ["motor", false, false],
-    ["motor-spring", false, false],
-    ["distance", false, false],
-    ["distance-spring", false, false],
-    ["prismatic", false, false],
-    ["prismatic-motor", false, false],
-    ["spherical", false, false],
-    ["spherical-limits", false, false],
-    ["spherical-motor", false, false],
-    ["wheel", false, false],
-    ["wheel-spin", false, false],
-    ["wheel-steer", false, false],
-    ["ragdoll", true, false],
-    // CCD: continuous on.
-    ["ccd-drop", false, true],
-    ["ccd-bullet", false, true],
-    // mesh contacts: a box / sphere / capsule dropped onto a static grid-mesh floor.
-    ["mesh-box", false, false],
-    ["mesh-sphere", false, false],
-    ["mesh-capsule", false, false],
-    // mesh CCD: a fast box swept onto the static mesh floor (continuous on).
-    ["mesh-ccd", false, true],
-    // height fields: box / sphere / capsule dropped onto a static grid height field, then
-    // a fast box for the height-field CCD path (continuous on).
-    ["height-box", false, false],
-    ["height-sphere", false, false],
-    ["height-capsule", false, false],
-    ["height-ccd", false, true],
-    // compound contacts: a box dropped onto a static compound floor built from hull /
-    // capsule / sphere / mesh children (sleep off).
-    ["compound-hull", false, false],
-    ["compound-capsule", false, false],
-    ["compound-sphere", false, false],
-    ["compound-mesh", false, false],
-    // compound CCD: a fast box swept onto the static two-hull compound floor (continuous on).
-    ["compound-ccd", false, true],
-    // sensors: a static sensor volume that dynamic bodies fall / sweep through — the sensor
-    // must not perturb dynamics, so the body hashes match the C oracle (continuous on for the fast body).
-    ["sensor", false, true],
-    // hardening: the benchmark scenes at reduced scale — the bit-exact contract at scale
-    // (large islands, many islands, a big joint grid, kinematic contact churn, the move buffer), plus a
-    // 2000-step drift gate. Sleep off; large-world spawns spheres via its stepFactory.
-    ["bench-pyramid", false, false],
-    ["bench-many-pyramids", false, false],
-    ["bench-joint-grid", false, false],
-    ["bench-washer", false, false],
-    ["bench-large-world", false, false],
-    // Trees: cylinder stacks on a wavy mesh ground whose libm-sinf vertices are loaded from the fixture
-    // (the port cannot reproduce sinf bit-exactly); the dynamics on that fixed ground are bit-exact.
-    ["bench-trees", false, false],
-    // Junkyard: rock pile + a kinematic cylinder swept by setTargetTransform (bit-exact pusher pose).
-    ["bench-junkyard", false, false],
-    // Rain: ragdolls (14-bone articulated joint island) dropped onto a mesh ground, spawned over time.
-    ["bench-rain", false, false],
-    ["drift", false, false],
-];
+// SCENES lives in step.scenes.ts so the default-suite parity arm in step.test.ts can import it without
+// registering the heavy bit-exact fixture tests in `bun test`. The count of entries is derived by that
+// arm against the committed fixture files in tests/tumble/fixtures/.
+import { SCENES } from "./step.scenes";
 
 // The hashes are the C reference's, generated serially — and cross-thread-count determinism is what the
 // ported task machinery guarantees (within a color no two constraints share a body, the overflow color
 // and contact creation stay serial in creation order, no reduction depends on worker identity). So the
-// same 52 fixtures gate the multithreaded kernel unchanged: `TUMBLE_THREADS=n bun run test:fixture:mt`,
+// same fixtures gate the multithreaded kernel unchanged: `TUMBLE_THREADS=n bun run test:fixture:mt`,
 // or `TUMBLE_THREADS=auto` to drive the default-on path — bare `init()`, which multithreads standalone.
 const RAW = process.env.TUMBLE_THREADS;
 const AUTO = RAW === "auto";

--- a/packages/shallot/src/standard/tumble/engine/step.scenes.ts
+++ b/packages/shallot/src/standard/tumble/engine/step.scenes.ts
@@ -1,0 +1,79 @@
+// The scene roster for the tumble fixture gate — scene name → [enableSleep, enableContinuous],
+// matching gen.c's per-scene world flags. Extracted from step.fixture.ts so the default-suite parity
+// arm in step.test.ts can import SCENES without importing the fixture file itself (which would register
+// the heavy bit-exact tests in the default `bun test` suite). The count of entries here is derived by
+// that arm against the committed fixture files in tests/tumble/fixtures/, so a prose restatement of the
+// number anywhere in the corpus is stale the moment a scene is added or removed.
+
+export const SCENES: [string, boolean, boolean][] = [
+    ["free-fall", false, false],
+    ["sphere-drop", false, false],
+    ["box-stack", false, false],
+    ["sphere-sleep", true, false],
+    ["box-sleep", true, false],
+    ["wake-drop", true, false],
+    ["split-slide", true, false],
+    ["revolute-dd", false, false],
+    ["revolute-pendulum", false, false],
+    ["revolute-motor", false, false],
+    ["revolute-limit", false, false],
+    ["revolute-chain", true, false],
+    ["weld-dd", false, false],
+    ["parallel", false, false],
+    ["joint-contacts", false, false],
+    ["motor", false, false],
+    ["motor-spring", false, false],
+    ["distance", false, false],
+    ["distance-spring", false, false],
+    ["prismatic", false, false],
+    ["prismatic-motor", false, false],
+    ["spherical", false, false],
+    ["spherical-limits", false, false],
+    ["spherical-motor", false, false],
+    ["wheel", false, false],
+    ["wheel-spin", false, false],
+    ["wheel-steer", false, false],
+    ["ragdoll", true, false],
+    // CCD: continuous on.
+    ["ccd-drop", false, true],
+    ["ccd-bullet", false, true],
+    // mesh contacts: a box / sphere / capsule dropped onto a static grid-mesh floor.
+    ["mesh-box", false, false],
+    ["mesh-sphere", false, false],
+    ["mesh-capsule", false, false],
+    // mesh CCD: a fast box swept onto the static mesh floor (continuous on).
+    ["mesh-ccd", false, true],
+    // height fields: box / sphere / capsule dropped onto a static grid height field, then
+    // a fast box for the height-field CCD path (continuous on).
+    ["height-box", false, false],
+    ["height-sphere", false, false],
+    ["height-capsule", false, false],
+    ["height-ccd", false, true],
+    // compound contacts: a box dropped onto a static compound floor built from hull /
+    // capsule / sphere / mesh children (sleep off).
+    ["compound-hull", false, false],
+    ["compound-capsule", false, false],
+    ["compound-sphere", false, false],
+    ["compound-mesh", false, false],
+    // compound CCD: a fast box swept onto the static two-hull compound floor (continuous on).
+    ["compound-ccd", false, true],
+    // sensors: a static sensor volume that dynamic bodies fall / sweep through — the sensor
+    // must not perturb dynamics, so the body hashes match the C oracle (continuous on for the fast body).
+    ["sensor", false, true],
+    // hardening: the benchmark scenes at reduced scale — the bit-exact contract at scale
+    // (large islands, many islands, a big joint grid, kinematic contact churn, the move buffer), plus a
+    // 2000-step drift gate. Sleep off; large-world spawns spheres via its stepFactory.
+    ["bench-pyramid", false, false],
+    ["bench-many-pyramids", false, false],
+    ["bench-joint-grid", false, false],
+    ["bench-washer", false, false],
+    ["bench-large-world", false, false],
+    // Trees: cylinder stacks on a wavy mesh ground whose libm-sinf vertices are loaded from the fixture
+    // (the port cannot reproduce sinf bit-exactly); the dynamics on that fixed ground are bit-exact.
+    ["bench-trees", false, false],
+    // Junkyard: rock pile + a kinematic cylinder swept by setTargetTransform (bit-exact pusher pose).
+    ["bench-junkyard", false, false],
+    // Rain: ragdolls (14-bone articulated joint island) dropped onto a mesh ground, spawned over time.
+    ["bench-rain", false, false],
+    ["drift", false, false],
+];

--- a/packages/shallot/src/standard/tumble/engine/step.test.ts
+++ b/packages/shallot/src/standard/tumble/engine/step.test.ts
@@ -4,6 +4,8 @@
 // transitions (islands + sleeping). Sleep is left on (the default) where the test exercises it.
 
 import { expect, test } from "bun:test";
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
 import { NULL_INDEX } from "./array";
 import { AwakeContact, type Contact, ContactFlags } from "./contact";
 import { SetType } from "./core";
@@ -17,6 +19,7 @@ import {
     makeBoxHull,
     World,
 } from "./index";
+import { SCENES } from "./step.scenes";
 import { ShapeType } from "./types";
 import type { WorldState } from "./world";
 
@@ -553,4 +556,15 @@ test("a capsule child on a compound floor supports a box (non-f32 radius)", () =
     const y = b.getPosition().y;
     expect(y).toBeGreaterThan(1.2);
     expect(y).toBeLessThan(1.4);
+});
+
+// Derives the scene count: SCENES (the fixture roster in step.scenes.ts, imported by step.fixture.ts)
+// must equal the number of committed fixture files under tests/tumble/fixtures/. The directory holds
+// one `*.json` per scene plus a README.md; the scan excludes README.md and any non-fixture file (only
+// `*.json` entries are counted), so the arm is the single source of truth for the count — a prose
+// restatement elsewhere in the corpus is stale the moment a scene is added or removed.
+test("SCENES length equals the committed fixture file count", () => {
+    const fixturesDir = resolve(import.meta.dir, "../../../../tests/tumble/fixtures");
+    const fixtureFiles = readdirSync(fixturesDir).filter((name) => name.endsWith(".json"));
+    expect(SCENES.length).toBe(fixtureFiles.length);
 });


### PR DESCRIPTION
Extract SCENES from step.fixture.ts into step.scenes.ts so step.test.ts can
import it without registering the heavy bit-exact fixture tests in the default
suite. Add a parity arm asserting SCENES.length equals the count of committed
*.json fixture files under tests/tumble/fixtures/ (README.md and non-fixture
files excluded), making the count a derivation rather than a prose number.

Fix the two stale '52' prose claimants the derivation now owns:
- step.fixture.ts: 'the same 52 fixtures' -> 'the same fixtures'
- gen-tumble-fixtures.ts: 'proven 52/52' -> 'proven across every scene'

README.md (53) and tumble.md (53) already read correct — left unchanged.
