### PR TITLE
audit claim and roster checks/s1

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -160,7 +160,7 @@ Prefer the smallest applicable observation ladder: (a) CPU-callable TGSL or stru
 
 Three limits worth naming before reading `DEFAULT_CHECKS` as full coverage. `isTgpuFn` excludes compute/vertex/fragment entry points, and `src` exports none today — that arm is unexercised, and the day one is exported it leaves the population silently. `noDivision`, the stronger check for index-only arithmetic, stays inert corpus-wide until a kernel opts in via its registry row's `also` — `DEFAULT_CHECKS` excludes it deliberately, or every legitimate float division would red. And `callsSymbol` alone proves only call-position syntax; `importsSymbol` closes most of that residual (the exemption clause above), leaving the wrong-module import arm open, and together they prove a call happened, not that its result is asserted against a reference.
 
-## `.test.ts` vs `.oracle.ts` vs `.lab.ts` vs `.tier.ts`
+## `.test.ts` vs `.oracle.ts` vs `.probes.ts` vs `.tier.ts` vs `.lab.ts`
 
 The suffix is the tier — bun only auto-discovers `.test.`/`.spec.`, so a different suffix opts a file out of the default `bun test` while staying runnable via a `./`-prefixed path.
 

--- a/packages/shallot/tests/cli-coverage.test.ts
+++ b/packages/shallot/tests/cli-coverage.test.ts
@@ -9,6 +9,7 @@ import {
     cliTestFiles,
     globToRegExp,
 } from "./cli-coverage";
+import { TEST_TIER_SUFFIXES } from "./test-tiers";
 
 // fixture-only red-proofs (a check is evidence only if you've seen it fail): each of these
 // was run against a broken registry first — see the spec's Live log / commit for the real-file mutations
@@ -164,12 +165,12 @@ describe("globToRegExp", () => {
 });
 
 describe("cliPopulation suffix exclusion", () => {
-    test("excludes all four test-tier suffixes testing.md names, not just .test.ts", async () => {
+    test("excludes all five test-tier suffixes the shared roster names, not just .test.ts", async () => {
         const root = resolve(import.meta.dir, "../../.."); // packages/shallot/tests -> repo root
         const population = await cliPopulation(root);
         expect(population).not.toContain("packages/shallot/bin/verify.probes.ts");
         for (const path of population) {
-            expect(path).not.toMatch(/\.(test|oracle|probes|lab)\.ts$/);
+            expect(path).not.toMatch(TEST_TIER_SUFFIXES);
         }
     });
 });

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -69,7 +69,7 @@ export function globToRegExp(glob: string): RegExp {
  *  row; it's the instrument, not the thing measured. Excluding only `.test.ts` would leave
  *  `verify.probes.ts` in the population as if it were untested production code, when it is itself the
  *  by-path browser gate for two constants `verify.test.ts` already sentinels — and omitting `.tier`
- *  would demand a `*.tier.ts` a coverage row as production code. `scripts/check-docs.ts` asserts this
+ *  would demand a `*.tier.ts` coverage row as production code. `scripts/check-docs.ts` asserts this
  *  constant against `testing.md`'s own enumeration. */
 export { TEST_TIER_SUFFIX_NAMES, TEST_TIER_SUFFIXES };
 

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -12,6 +12,7 @@
 // otherwise have held: what's covered and by what, plus what isn't and who closes it.
 
 import { posix, resolve } from "node:path";
+import { TEST_TIER_SUFFIX_NAMES, TEST_TIER_SUFFIXES } from "./test-tiers";
 
 /** the four tiers of truth a row may claim, per the spec's Locked decision. */
 export type Arm = "unit" | "tier" | "extract" | "gap";
@@ -63,12 +64,14 @@ export function globToRegExp(glob: string): RegExp {
     return new RegExp(`^${pattern}$`);
 }
 
-/** the four test-tier suffixes `testing.md` names (`.test.ts`, `.oracle.ts`, `.probes.ts`, `.lab.ts`) —
- *  a test file, at whatever tier, is not itself a population member needing a row; it's the instrument,
- *  not the thing measured. Excluding only `.test.ts` would leave `verify.probes.ts` in the population as
- *  if it were untested production code, when it is itself the by-path browser gate for two constants
- *  `verify.test.ts` already sentinels. */
-export const TEST_TIER_SUFFIXES = /\.(test|oracle|probes|lab)\.ts$/;
+/** the test-tier suffix roster — re-exported from the shared `test-tiers.ts` constant so the tier
+ *  list lives in one place. A test file, at whatever tier, is not itself a population member needing a
+ *  row; it's the instrument, not the thing measured. Excluding only `.test.ts` would leave
+ *  `verify.probes.ts` in the population as if it were untested production code, when it is itself the
+ *  by-path browser gate for two constants `verify.test.ts` already sentinels — and omitting `.tier`
+ *  would demand a `*.tier.ts` a coverage row as production code. `scripts/check-docs.ts` asserts this
+ *  constant against `testing.md`'s own enumeration. */
+export { TEST_TIER_SUFFIX_NAMES, TEST_TIER_SUFFIXES };
 
 /** walks the real filesystem under `root` (the shallot repo root) and returns every path (relative to
  *  `root`, forward-slashed) matching {@link CLI_POPULATION_GLOBS}, excluding every test-tier suffix. */

--- a/packages/shallot/tests/standards.test.ts
+++ b/packages/shallot/tests/standards.test.ts
@@ -16,6 +16,7 @@ import {
     STANDARDS_REGISTRY,
     violation,
 } from "./standards";
+import { TEST_TIER_SUFFIXES } from "./test-tiers";
 
 // The real-filesystem/real-import/real-resolve seam over the pure `checkStandards` (`./standards.ts`):
 // walk `packages/shallot/src`, dynamic-import every module, duck-detect live TGSL kernels with a
@@ -25,16 +26,21 @@ import {
 
 const SRC_DIR = join(import.meta.dir, "../src");
 
-/** every `.ts` module under `src`, repo-relative path, excluding non-source suffixes (`testing.md`'s tier
- *  convention: `.test.ts` / `.fixture.ts` / `.lab.ts`) and `.d.ts` declaration files — a `.d.ts` has no
- *  runtime module body, so dynamic-importing one throws on whatever ambient global it declares
- *  (`draco_wasm_wrapper.d.ts` -> `DracoDecoderModule is not defined`), which is a false import failure,
- *  not a real one. */
+/** every `.ts` module under `src`, repo-relative path, excluding the test-tier suffixes
+ *  (`testing.md`'s tier convention, via the shared `test-tiers.ts` constant) plus `.fixture.ts`,
+ *  which is not a tier `testing.md` names — it's a test-data file (the tumble step fixture), excluded
+ *  from the kernel walk alongside the tiers, never a second hand-written tier list — and `.d.ts`
+ *  declaration files, which have no runtime module body (dynamic-importing one throws on whatever
+ *  ambient global it declares, e.g. `draco_wasm_wrapper.d.ts` -> `DracoDecoderModule is not defined`),
+ *  which is a false import failure, not a real one. */
 async function sourceModules(): Promise<string[]> {
     const out: string[] = [];
     for await (const p of new Bun.Glob("**/*.ts").scan({ cwd: SRC_DIR })) {
         if (/\.d\.ts$/.test(p)) continue;
-        if (/\.(test|fixture|lab)\.ts$/.test(p)) continue;
+        if (TEST_TIER_SUFFIXES.test(p)) continue;
+        // `.fixture.ts` is not a tier `testing.md` names — it's a test-data file, excluded from the
+        // kernel walk as roster-plus-named-extras, never a second hand-written tier list.
+        if (/\.fixture\.ts$/.test(p)) continue;
         out.push(p);
     }
     return out.sort();

--- a/packages/shallot/tests/test-tiers.ts
+++ b/packages/shallot/tests/test-tiers.ts
@@ -3,12 +3,13 @@
  *  `.tier.ts`, `.lab.ts`), which is the enumeration `testing.md` itself makes — not the section
  *  heading (which once under-named `.probes.ts`; the heading now agrees with its own body).
  *
- *  Two consumers read this constant: `cli-coverage.ts`'s `TEST_TIER_SUFFIXES` (excludes test-tier
+ *  Consumers of this constant include `cli-coverage.ts`'s `TEST_TIER_SUFFIXES` (excludes test-tier
  *  files from the CLI coverage population so a `*.tier.ts` isn't demanded a coverage row as
- *  production code) and `standards.test.ts`'s `sourceModules()` (excludes them from the TGSL kernel
- *  walk). `scripts/check-docs.ts` asserts the roster against `testing.md`'s own enumeration and that
- *  both consumers import this constant — so the roster stops being restated. A fix that leaves two
- *  hand-written lists in agreement fails that criterion. */
+ *  production code), `standards.test.ts`'s `sourceModules()` (excludes them from the TGSL kernel
+ *  walk), and `check-exports.ts`'s `isTestFile()` (excludes them from the dead-export walk).
+ *  `scripts/check-docs.ts`'s arm (c) scans every tracked file for a literal tier-suffix roster and
+ *  asserts none exists outside this constant — so the roster stops being restated. A fix that
+ *  leaves two hand-written lists in agreement fails that criterion. */
 
 /** the five test-tier suffix names `testing.md`'s tier-section bullet ledes name, in the order the
  *  bullets list them. The source of truth is the bullet ledes, not the section heading. */

--- a/packages/shallot/tests/test-tiers.ts
+++ b/packages/shallot/tests/test-tiers.ts
@@ -1,0 +1,18 @@
+/** The test-tier suffix roster — one exported constant, the single place the tier list lives.
+ *  Derived from `testing.md`'s tier-section bullet ledes (`.test.ts`, `.oracle.ts`, `.probes.ts`,
+ *  `.tier.ts`, `.lab.ts`), which is the enumeration `testing.md` itself makes — not the section
+ *  heading (which once under-named `.probes.ts`; the heading now agrees with its own body).
+ *
+ *  Two consumers read this constant: `cli-coverage.ts`'s `TEST_TIER_SUFFIXES` (excludes test-tier
+ *  files from the CLI coverage population so a `*.tier.ts` isn't demanded a coverage row as
+ *  production code) and `standards.test.ts`'s `sourceModules()` (excludes them from the TGSL kernel
+ *  walk). `scripts/check-docs.ts` asserts the roster against `testing.md`'s own enumeration and that
+ *  both consumers import this constant — so the roster stops being restated. A fix that leaves two
+ *  hand-written lists in agreement fails that criterion. */
+
+/** the five test-tier suffix names `testing.md`'s tier-section bullet ledes name, in the order the
+ *  bullets list them. The source of truth is the bullet ledes, not the section heading. */
+export const TEST_TIER_SUFFIX_NAMES = ["test", "oracle", "probes", "tier", "lab"] as const;
+
+/** a RegExp matching any `.ts` file whose suffix is one of {@link TEST_TIER_SUFFIX_NAMES}. */
+export const TEST_TIER_SUFFIXES = new RegExp(`\\.(${TEST_TIER_SUFFIX_NAMES.join("|")})\\.ts$`);

--- a/scripts/check-docs.ts
+++ b/scripts/check-docs.ts
@@ -1,4 +1,3 @@
-import { readdir } from "node:fs/promises";
 import { Glob } from "bun";
 import { resolve } from "path";
 import { template } from "../packages/create-shallot/index";
@@ -395,14 +394,38 @@ if (citationViolations.length > 0) {
 
 // ── Arm (b): showcase index completeness (both directions) ──────────────────────────────────────
 //
-// Every `examples/showcase/*/` dir must have an index line in `examples/AGENTS.md`, and every index
-// line must name a real dir. Both directions are reported — a stale index line is as much a defect
-// as a missing one.
+// Every `examples/showcase/*/` dir with at least one tracked file must have an index line in
+// `examples/AGENTS.md`, and every index line must name a dir with tracked content. Both directions
+// are reported — a stale index line is as much a defect as a missing one.
+//
+// The population is derived from the TRACKED set (git ls-files), not the filesystem: a dir whose
+// tracked content was deleted by a sibling lane but whose untracked dist/node_modules/test-results/
+// remain would be a false positive under a filesystem walk — the arm would flag a dir without an
+// index line that has no tracked content to index. Asking git makes the scope identical in every
+// checkout, which is the property that matters (same law as the doc scan above).
 
 const SHOWCASE_DIR = "examples/showcase";
+const showcaseTracked = Bun.spawnSync(["git", "ls-files", "-z", SHOWCASE_DIR], {
+    cwd: root,
+});
+if (!showcaseTracked.success) {
+    console.error(
+        "✗ `git ls-files` failed — the showcase arm needs a git checkout to scope its dir set.",
+    );
+    process.exit(1);
+}
 const showcaseDirs = new Set<string>();
-for (const entry of await readdir(resolve(root, SHOWCASE_DIR), { withFileTypes: true })) {
-    if (entry.isDirectory()) showcaseDirs.add(entry.name);
+for (const path of showcaseTracked.stdout.toString().split("\0").filter(Boolean)) {
+    const rel = path.slice(SHOWCASE_DIR.length + 1);
+    const parts = rel.split("/");
+    if (parts.length < 2) continue; // directly under showcase/, not a subdir (e.g. .gitkeep)
+    showcaseDirs.add(parts[0]);
+}
+if (showcaseDirs.size === 0) {
+    console.error(
+        "✗ `git ls-files examples/showcase/` matched no subdir — the showcase arm would be vacuously green.",
+    );
+    process.exit(1);
 }
 
 const agentsMd = await Bun.file(resolve(root, "examples/AGENTS.md")).text();
@@ -438,15 +461,16 @@ if (missingIndex.length > 0 || staleIndex.length > 0) {
     process.exit(1);
 }
 
-// ── Arm (c): tier-suffix roster — one constant, two consumers, asserted against testing.md ─────────
+// ── Arm (c): tier-suffix roster — one constant, derived consumers, asserted against testing.md ──────
 //
-// The test-tier suffix roster is ONE exported constant (`packages/shallot/tests/test-tiers.ts`) with
-// TWO consumers: `cli-coverage.ts`'s `TEST_TIER_SUFFIXES` and `standards.test.ts`'s `sourceModules()`
-// exclusion. This arm asserts (1) the roster matches `testing.md`'s tier-section bullet ledes — the
+// The test-tier suffix roster is ONE exported constant (`packages/shallot/tests/test-tiers.ts`).
+// This arm asserts (1) the roster matches `testing.md`'s tier-section bullet ledes — the
 // enumeration `testing.md` itself makes — (2) the section heading agrees with its own body, and
-// (3) both consumers import AND use the constant (not just a dead import beside a re-inlined
-// local regex), and no consumer still contains a literal tier-suffix regex of its own. A fix
-// that leaves two hand-written lists in agreement fails this criterion.
+// (3) no file in the repo carries a literal tier-suffix roster of its own — a line enumerating 3+
+// of the 5 suffix names as bare words with regex alternation (`|`). The consumer set is DERIVED,
+// not enumerated: the arm scans every tracked file itself, so a new file restating the roster
+// is caught without updating a hand-list. A fix that leaves two hand-written lists in agreement
+// fails this criterion.
 
 const testingMd = await Bun.file(resolve(root, ".claude/rules/testing.md")).text();
 const testingLines = testingMd.split("\n");
@@ -507,49 +531,38 @@ if (headingSuffixes.join(",") !== bulletLedeSuffixes.join(",")) {
     );
 }
 
-// assert both consumers import AND use the constant (a dead import beside a re-inlined local
-// regex would satisfy the import check alone), and that no consumer still contains a literal
-// tier-suffix regex of its own — a regex that enumerates the suffix names directly rather than
-// deriving them from the shared constant
-const ROSTER_IDENTIFIERS = ["TEST_TIER_SUFFIX_NAMES", "TEST_TIER_SUFFIXES"];
-const IMPORT_FROM_TIERS = /from\s+["']\.\/test-tiers["']/;
-// matches the full import statement (single- or multi-line) from ./test-tiers, for stripping
-const IMPORT_STATEMENT_RE = /import\s+\{[^}]*\}\s+from\s+["']\.\/test-tiers["'];?/g;
-const CONSUMERS = [
-    { file: "packages/shallot/tests/cli-coverage.ts", label: "cli-coverage.ts" },
-    { file: "packages/shallot/tests/standards.test.ts", label: "standards.test.ts" },
-];
-for (const { file, label } of CONSUMERS) {
-    const source = await Bun.file(resolve(root, file)).text();
-    if (!IMPORT_FROM_TIERS.test(source)) {
-        rosterFindings.push(
-            `${label} does not import from the shared test-tiers.ts constant — the roster is restated rather than read from one source.`,
-        );
-        continue;
-    }
-    // the imported identifier must be referenced outside its own import statement — a dead import
-    // beside a re-inlined local regex would satisfy the import check alone
-    const withoutImport = source.replace(IMPORT_STATEMENT_RE, "");
-    const usedOutsideImport = ROSTER_IDENTIFIERS.some((id) =>
-        new RegExp(`\\b${id}\\b`).test(withoutImport),
+// Derive the consumer set: scan every tracked file in the repo for a literal tier-suffix roster —
+// a line enumerating 3+ of the 5 suffix names as bare words with regex alternation (`|`). Any file
+// that carries such a roster is restating it rather than reading the shared constant; the arm finds
+// such files itself, so a new file restating the roster is caught without updating a hand-list.
+//
+// Two exclusions, stated explicitly:
+// 1. `packages/shallot/tests/test-tiers.ts` — the roster's own definition module; it MUST contain the
+//    suffix names (it is where the constant lives).
+// 2. `scripts/check-docs.ts` — this arm's own text; a self-referential gate matches its own
+//    description of what it checks (per `.claude/rules/specs.md`'s self-reference principle).
+const ROSTER_EXCLUSIONS = new Set([
+    "packages/shallot/tests/test-tiers.ts",
+    "scripts/check-docs.ts",
+]);
+const allTrackedFiles = Bun.spawnSync(["git", "ls-files", "-z"], { cwd: root });
+if (!allTrackedFiles.success) {
+    console.error(
+        "✗ `git ls-files` failed — the roster arm needs a git checkout to scope its file set.",
     );
-    if (!usedOutsideImport) {
-        rosterFindings.push(
-            `${label} imports the shared test-tiers.ts constant but never references it outside the import — a dead import beside a re-inlined local regex would stay green.`,
-        );
-    }
-    // no consumer may still contain a literal tier-suffix regex of its own — a line that enumerates
-    // 3+ of the 5 suffix names as bare words with regex alternation (`|`), rather than deriving them
-    // from the shared constant (which would only mention the identifier, not the suffix names)
-    const suffixWords = [...TEST_TIER_SUFFIX_NAMES];
-    for (const line of source.split("\n")) {
-        if (IMPORT_FROM_TIERS.test(line)) continue;
+    process.exit(1);
+}
+const suffixWords = [...TEST_TIER_SUFFIX_NAMES];
+for (const file of allTrackedFiles.stdout.toString().split("\0").filter(Boolean)) {
+    if (ROSTER_EXCLUSIONS.has(file)) continue;
+    const source = await Bun.file(resolve(root, file)).text();
+    for (const [i, line] of source.split("\n").entries()) {
         const hits = suffixWords.filter((n) => new RegExp(`\\b${n}\\b`).test(line)).length;
         if (hits >= 3 && line.includes("|")) {
             rosterFindings.push(
-                `${label} contains a literal tier-suffix regex (a line enumerating ${hits} of the 5 suffix names with regex alternation) — the roster must be derived from the shared constant, not restated.`,
+                `${file}:${i + 1} carries a literal tier-suffix roster (a line enumerating ${hits} of the 5 suffix names with regex alternation) — the roster must be derived from the shared test-tiers.ts constant, not restated.`,
             );
-            break;
+            break; // one finding per file is enough
         }
     }
 }

--- a/scripts/check-docs.ts
+++ b/scripts/check-docs.ts
@@ -309,12 +309,15 @@ if (chainOverages.length > 0) {
 // ── Arm (a): cross-citation resolution (case-insensitive) ──────────────────────────────────────
 //
 // A cross-citation is `<rule>.md "phrase"` — a rule filename followed by a double-quoted phrase —
-// naming a passage in another rule file. Each must resolve in the named file, compared
-// CASE-INSENSITIVELY: a case-sensitive first pass false-positived on avbd.md:44 citing
-// gpu.md "reuse over add", which resolves against gpu.md:40's "**Reuse over add.**". The case rule is
-// a recorded finding, not an implementation detail. The known true positive is testing.md citing
-// physics.md "the oracle is not the suspect" — that phrase lives only at avbd.md:13. Leave it RED;
-// fixing it is S3's.
+// naming a passage in another rule file, optionally continued with ` / "phrase"` for additional
+// phrases from the same rule (e.g. `render.md "Point-light shadows" / "Sun shadows"`). Each phrase
+// must resolve in the named file, compared CASE-INSENSITIVELY: a case-sensitive first pass
+// false-positived on avbd.md:44 citing gpu.md "reuse over add", which resolves against gpu.md:40's
+// "**Reuse over add.**". The case rule is a recorded finding, not an implementation detail. The known
+// true positive is testing.md citing physics.md "the oracle is not the suspect" — that phrase lives
+// only at avbd.md:13. Leave it RED; fixing it is S3's. A continuation phrase (` / "phrase"`) belongs
+// to the same rule citation, so each must be checked — not just the first: if the second phrase
+// vanished from the named rule the arm would stay green if only the first were checked.
 
 const RULE_NAMES: string[] = [];
 for await (const match of new Glob("*.md").scan({ cwd: resolve(root, ".claude/rules") })) {
@@ -331,10 +334,15 @@ async function ruleFileText(name: string): Promise<string> {
     return ruleFileCache.get(path)!;
 }
 
+// Match the full citation span: `rule.md "phrase"` plus any trailing ` / "phrase"` continuations
+// that belong to the same rule citation. The continuation group is non-capturing (a repeated
+// capture group would only keep the last match), so all phrases are extracted from the full match
+// text via PHRASE_RE.
 const CITATION_RE = new RegExp(
-    `\\b(${RULE_NAMES.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\.md "([^"]+)"`,
+    `\\b(${RULE_NAMES.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\.md "([^"]+)"(?:\\s*/\\s*"([^"]+)")*`,
     "g",
 );
+const PHRASE_RE = /"([^"]+)"/g;
 
 type CitationViolation = { file: string; line: number; rule: string; phrase: string };
 const citationViolations: CitationViolation[] = [];
@@ -343,16 +351,20 @@ let citationCount = 0;
 for (const match of docs) {
     const lines = (await Bun.file(resolve(root, match)).text()).split("\n");
     for (let i = 0; i < lines.length; i++) {
-        for (const [, rule, phrase] of lines[i].matchAll(CITATION_RE)) {
-            citationCount++;
+        for (const m of lines[i].matchAll(CITATION_RE)) {
+            const rule = m[1];
             const text = await ruleFileText(rule);
-            if (!text.includes(phrase.toLowerCase())) {
-                citationViolations.push({
-                    file: match,
-                    line: i + 1,
-                    rule,
-                    phrase,
-                });
+            // extract every quoted phrase from the full citation span (head + continuations)
+            for (const [, phrase] of m[0].matchAll(PHRASE_RE)) {
+                citationCount++;
+                if (!text.includes(phrase.toLowerCase())) {
+                    citationViolations.push({
+                        file: match,
+                        line: i + 1,
+                        rule,
+                        phrase,
+                    });
+                }
             }
         }
     }
@@ -432,8 +444,9 @@ if (missingIndex.length > 0 || staleIndex.length > 0) {
 // TWO consumers: `cli-coverage.ts`'s `TEST_TIER_SUFFIXES` and `standards.test.ts`'s `sourceModules()`
 // exclusion. This arm asserts (1) the roster matches `testing.md`'s tier-section bullet ledes — the
 // enumeration `testing.md` itself makes — (2) the section heading agrees with its own body, and
-// (3) both consumers import the constant rather than restating the list. A fix that leaves two
-// hand-written lists in agreement fails this criterion.
+// (3) both consumers import AND use the constant (not just a dead import beside a re-inlined
+// local regex), and no consumer still contains a literal tier-suffix regex of its own. A fix
+// that leaves two hand-written lists in agreement fails this criterion.
 
 const testingMd = await Bun.file(resolve(root, ".claude/rules/testing.md")).text();
 const testingLines = testingMd.split("\n");
@@ -494,17 +507,50 @@ if (headingSuffixes.join(",") !== bulletLedeSuffixes.join(",")) {
     );
 }
 
-// assert both consumers import the constant
+// assert both consumers import AND use the constant (a dead import beside a re-inlined local
+// regex would satisfy the import check alone), and that no consumer still contains a literal
+// tier-suffix regex of its own — a regex that enumerates the suffix names directly rather than
+// deriving them from the shared constant
+const ROSTER_IDENTIFIERS = ["TEST_TIER_SUFFIX_NAMES", "TEST_TIER_SUFFIXES"];
+const IMPORT_FROM_TIERS = /from\s+["']\.\/test-tiers["']/;
+// matches the full import statement (single- or multi-line) from ./test-tiers, for stripping
+const IMPORT_STATEMENT_RE = /import\s+\{[^}]*\}\s+from\s+["']\.\/test-tiers["'];?/g;
 const CONSUMERS = [
     { file: "packages/shallot/tests/cli-coverage.ts", label: "cli-coverage.ts" },
     { file: "packages/shallot/tests/standards.test.ts", label: "standards.test.ts" },
 ];
 for (const { file, label } of CONSUMERS) {
     const source = await Bun.file(resolve(root, file)).text();
-    if (!/from\s+["']\.\/test-tiers["']/.test(source)) {
+    if (!IMPORT_FROM_TIERS.test(source)) {
         rosterFindings.push(
             `${label} does not import from the shared test-tiers.ts constant — the roster is restated rather than read from one source.`,
         );
+        continue;
+    }
+    // the imported identifier must be referenced outside its own import statement — a dead import
+    // beside a re-inlined local regex would satisfy the import check alone
+    const withoutImport = source.replace(IMPORT_STATEMENT_RE, "");
+    const usedOutsideImport = ROSTER_IDENTIFIERS.some((id) =>
+        new RegExp(`\\b${id}\\b`).test(withoutImport),
+    );
+    if (!usedOutsideImport) {
+        rosterFindings.push(
+            `${label} imports the shared test-tiers.ts constant but never references it outside the import — a dead import beside a re-inlined local regex would stay green.`,
+        );
+    }
+    // no consumer may still contain a literal tier-suffix regex of its own — a line that enumerates
+    // 3+ of the 5 suffix names as bare words with regex alternation (`|`), rather than deriving them
+    // from the shared constant (which would only mention the identifier, not the suffix names)
+    const suffixWords = [...TEST_TIER_SUFFIX_NAMES];
+    for (const line of source.split("\n")) {
+        if (IMPORT_FROM_TIERS.test(line)) continue;
+        const hits = suffixWords.filter((n) => new RegExp(`\\b${n}\\b`).test(line)).length;
+        if (hits >= 3 && line.includes("|")) {
+            rosterFindings.push(
+                `${label} contains a literal tier-suffix regex (a line enumerating ${hits} of the 5 suffix names with regex alternation) — the roster must be derived from the shared constant, not restated.`,
+            );
+            break;
+        }
     }
 }
 

--- a/scripts/check-docs.ts
+++ b/scripts/check-docs.ts
@@ -1,6 +1,8 @@
+import { readdir } from "node:fs/promises";
 import { Glob } from "bun";
 import { resolve } from "path";
 import { template } from "../packages/create-shallot/index";
+import { TEST_TIER_SUFFIX_NAMES } from "../packages/shallot/tests/test-tiers";
 
 // Command docs standardize on `bunx shallot <cmd>`: bare `shallot` only resolves when the CLI is
 // globally linked, while `bunx` resolves the local install everywhere — repo and consumer project
@@ -304,8 +306,226 @@ if (chainOverages.length > 0) {
     process.exit(1);
 }
 
+// ── Arm (a): cross-citation resolution (case-insensitive) ──────────────────────────────────────
+//
+// A cross-citation is `<rule>.md "phrase"` — a rule filename followed by a double-quoted phrase —
+// naming a passage in another rule file. Each must resolve in the named file, compared
+// CASE-INSENSITIVELY: a case-sensitive first pass false-positived on avbd.md:44 citing
+// gpu.md "reuse over add", which resolves against gpu.md:40's "**Reuse over add.**". The case rule is
+// a recorded finding, not an implementation detail. The known true positive is testing.md citing
+// physics.md "the oracle is not the suspect" — that phrase lives only at avbd.md:13. Leave it RED;
+// fixing it is S3's.
+
+const RULE_NAMES: string[] = [];
+for await (const match of new Glob("*.md").scan({ cwd: resolve(root, ".claude/rules") })) {
+    RULE_NAMES.push(match.replace(/\.md$/, ""));
+}
+
+// cache rule file contents (lowercased for case-insensitive search)
+const ruleFileCache = new Map<string, string>();
+async function ruleFileText(name: string): Promise<string> {
+    const path = `.claude/rules/${name}.md`;
+    if (!ruleFileCache.has(path)) {
+        ruleFileCache.set(path, (await Bun.file(resolve(root, path)).text()).toLowerCase());
+    }
+    return ruleFileCache.get(path)!;
+}
+
+const CITATION_RE = new RegExp(
+    `\\b(${RULE_NAMES.map((n) => n.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|")})\\.md "([^"]+)"`,
+    "g",
+);
+
+type CitationViolation = { file: string; line: number; rule: string; phrase: string };
+const citationViolations: CitationViolation[] = [];
+let citationCount = 0;
+
+for (const match of docs) {
+    const lines = (await Bun.file(resolve(root, match)).text()).split("\n");
+    for (let i = 0; i < lines.length; i++) {
+        for (const [, rule, phrase] of lines[i].matchAll(CITATION_RE)) {
+            citationCount++;
+            const text = await ruleFileText(rule);
+            if (!text.includes(phrase.toLowerCase())) {
+                citationViolations.push({
+                    file: match,
+                    line: i + 1,
+                    rule,
+                    phrase,
+                });
+            }
+        }
+    }
+}
+
+if (citationCount === 0) {
+    console.error(
+        '✗ cross-citation arm matched no `<rule>.md "phrase"` citation — the arm would be vacuously green.',
+    );
+    process.exit(1);
+}
+
+if (citationViolations.length > 0) {
+    console.error(
+        `✗ ${citationViolations.length} cross-citation(s) that don't resolve in the named file (case-insensitive):\n`,
+    );
+    for (const v of citationViolations) {
+        console.error(`  ${v.file}:${v.line}: ${v.rule}.md "${v.phrase}"`);
+    }
+    console.error(
+        '\nA `<rule>.md "phrase"` cross-citation must resolve as a case-insensitive substring in the ' +
+            "named rule file. A case-sensitive comparison false-positives on phrases whose casing differs " +
+            '(e.g. gpu.md "reuse over add" resolves against "**Reuse over add.**"), so the comparison ' +
+            "is case-insensitive by design.",
+    );
+    process.exit(1);
+}
+
+// ── Arm (b): showcase index completeness (both directions) ──────────────────────────────────────
+//
+// Every `examples/showcase/*/` dir must have an index line in `examples/AGENTS.md`, and every index
+// line must name a real dir. Both directions are reported — a stale index line is as much a defect
+// as a missing one.
+
+const SHOWCASE_DIR = "examples/showcase";
+const showcaseDirs = new Set<string>();
+for (const entry of await readdir(resolve(root, SHOWCASE_DIR), { withFileTypes: true })) {
+    if (entry.isDirectory()) showcaseDirs.add(entry.name);
+}
+
+const agentsMd = await Bun.file(resolve(root, "examples/AGENTS.md")).text();
+const showcaseIndexRe = /`showcase\/([^`/]+)\//g;
+const indexedShowcases = new Set<string>();
+for (const [, name] of agentsMd.matchAll(showcaseIndexRe)) {
+    indexedShowcases.add(name);
+}
+
+const missingIndex = [...showcaseDirs].filter((d) => !indexedShowcases.has(d)).sort();
+const staleIndex = [...indexedShowcases].filter((d) => !showcaseDirs.has(d)).sort();
+
+if (missingIndex.length > 0 || staleIndex.length > 0) {
+    const parts: string[] = [];
+    if (missingIndex.length > 0) {
+        parts.push(
+            `showcase dir(s) without an index line in examples/AGENTS.md: ${missingIndex.join(", ")}`,
+        );
+    }
+    if (staleIndex.length > 0) {
+        parts.push(
+            `index line(s) in examples/AGENTS.md naming no showcase dir: ${staleIndex.join(", ")}`,
+        );
+    }
+    console.error(
+        `✗ showcase index mismatch (${parts.length} direction(s)):\n` +
+            parts.map((p) => `  ${p}`).join("\n"),
+    );
+    console.error(
+        "\nEvery `examples/showcase/*/` dir must have an index line in `examples/AGENTS.md`, and " +
+            "every index line must name a real dir. Both directions are checked.",
+    );
+    process.exit(1);
+}
+
+// ── Arm (c): tier-suffix roster — one constant, two consumers, asserted against testing.md ─────────
+//
+// The test-tier suffix roster is ONE exported constant (`packages/shallot/tests/test-tiers.ts`) with
+// TWO consumers: `cli-coverage.ts`'s `TEST_TIER_SUFFIXES` and `standards.test.ts`'s `sourceModules()`
+// exclusion. This arm asserts (1) the roster matches `testing.md`'s tier-section bullet ledes — the
+// enumeration `testing.md` itself makes — (2) the section heading agrees with its own body, and
+// (3) both consumers import the constant rather than restating the list. A fix that leaves two
+// hand-written lists in agreement fails this criterion.
+
+const testingMd = await Bun.file(resolve(root, ".claude/rules/testing.md")).text();
+const testingLines = testingMd.split("\n");
+
+// find the tier section heading (## `.test.ts` vs ...)
+let tierHeadingIdx = -1;
+for (let i = 0; i < testingLines.length; i++) {
+    if (/^## `\.test\.ts` vs /.test(testingLines[i])) {
+        tierHeadingIdx = i;
+        break;
+    }
+}
+if (tierHeadingIdx === -1) {
+    console.error(
+        "✗ tier-suffix roster arm: could not find the `## `.test.ts` vs ...` heading in testing.md.",
+    );
+    process.exit(1);
+}
+
+// collect the section's lines until the next `## ` heading
+const tierSectionLines: string[] = [];
+for (let i = tierHeadingIdx + 1; i < testingLines.length; i++) {
+    if (/^## /.test(testingLines[i])) break;
+    tierSectionLines.push(testingLines[i]);
+}
+
+// extract suffix names from bullet ledes: `- **`.suffix.ts`**`
+const bulletSuffixRe = /^- \*\*`\.(\w+)\.ts`\*\*/;
+const bulletLedeSuffixes: string[] = [];
+for (const line of tierSectionLines) {
+    const m = bulletSuffixRe.exec(line);
+    if (m) bulletLedeSuffixes.push(m[1]);
+}
+
+// extract suffix names from the heading: `` `.suffix.ts` ``
+const headingSuffixRe = /`\.(\w+)\.ts`/g;
+const headingSuffixes: string[] = [];
+for (const m of testingLines[tierHeadingIdx].matchAll(headingSuffixRe)) {
+    headingSuffixes.push(m[1]);
+}
+
+const rosterSuffixes = [...TEST_TIER_SUFFIX_NAMES];
+
+const rosterFindings: string[] = [];
+if (bulletLedeSuffixes.length === 0) {
+    rosterFindings.push(
+        "testing.md's tier section has no `- **`.suffix.ts`**` bullet ledes — the arm would be vacuously green.",
+    );
+}
+if (rosterSuffixes.join(",") !== bulletLedeSuffixes.join(",")) {
+    rosterFindings.push(
+        `the shared roster [${rosterSuffixes.join(", ")}] does not match testing.md's bullet ledes [${bulletLedeSuffixes.join(", ")}].`,
+    );
+}
+if (headingSuffixes.join(",") !== bulletLedeSuffixes.join(",")) {
+    rosterFindings.push(
+        `testing.md's tier-section heading [${headingSuffixes.join(", ")}] does not agree with its own bullet ledes [${bulletLedeSuffixes.join(", ")}].`,
+    );
+}
+
+// assert both consumers import the constant
+const CONSUMERS = [
+    { file: "packages/shallot/tests/cli-coverage.ts", label: "cli-coverage.ts" },
+    { file: "packages/shallot/tests/standards.test.ts", label: "standards.test.ts" },
+];
+for (const { file, label } of CONSUMERS) {
+    const source = await Bun.file(resolve(root, file)).text();
+    if (!/from\s+["']\.\/test-tiers["']/.test(source)) {
+        rosterFindings.push(
+            `${label} does not import from the shared test-tiers.ts constant — the roster is restated rather than read from one source.`,
+        );
+    }
+}
+
+if (rosterFindings.length > 0) {
+    console.error(`✗ tier-suffix roster arm: ${rosterFindings.length} finding(s):\n`);
+    for (const f of rosterFindings) {
+        console.error(`  ${f}`);
+    }
+    console.error(
+        "\nThe test-tier suffix roster must be one exported constant with two consumers, asserted " +
+            "against testing.md's own enumeration. A fix that leaves two hand-written lists in " +
+            "agreement fails this criterion.",
+    );
+    process.exit(1);
+}
+
 console.log(
     `✓ doc commands clean (${scanTargets.length} file(s)), ` +
         `install/scaffold/fixture pins match the manifests (${scanned} doc(s), ${fixtureMatched} fixture line(s)), ` +
-        `entry-doc chains under budget (${ENTRY_DOC_CHAINS.length} chain(s))`,
+        `entry-doc chains under budget (${ENTRY_DOC_CHAINS.length} chain(s)), ` +
+        `cross-citations resolve (${citationCount} citation(s)), ` +
+        `showcase index complete (${showcaseDirs.size} dir(s)), ` +
+        `tier roster asserted (${rosterSuffixes.length} suffix(es))`,
 );

--- a/scripts/check-exports.ts
+++ b/scripts/check-exports.ts
@@ -19,6 +19,7 @@
 import { existsSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { Glob } from "bun";
+import { TEST_TIER_SUFFIXES } from "../packages/shallot/tests/test-tiers";
 
 const PKG = "@dylanebert/shallot";
 
@@ -41,8 +42,11 @@ export type DeadExport = {
 
 // --- Helpers ----------------------------------------------------------------
 
+// `isTestFile` reads the shared `test-tiers.ts` constant rather than restating the suffix roster —
+// the tier list lives in one place, and `check-docs.ts`'s arm (c) derives any file carrying a literal
+// roster and asserts it reads the same constant.
 export function isTestFile(path: string): boolean {
-    return /\.(test|oracle|lab|probes|tier)\.ts$/.test(path);
+    return TEST_TIER_SUFFIXES.test(path);
 }
 
 export function escapeRegExp(s: string): string {


### PR DESCRIPTION
- **audit-claim-and-roster-checks: add the three enumerator arms to check-docs.ts**
- **audit-claim-and-roster-checks: repair S1 — citation continuation phrases, roster use-not-just-import, grammar fix**
- **audit-claim-and-roster-checks: repair S1 round 2 — derived roster arm, tracked showcase population**
