### PR TITLE
audit tumble late marshal constraints/s3

### DIFF
--- a/packages/shallot/src/standard/tumble/index.ts
+++ b/packages/shallot/src/standard/tumble/index.ts
@@ -119,7 +119,7 @@ const SyncSystem: System = {
         // signature change only — none of which moves here — so the constraint re-sync is pumped from this
         // loop. Set inside the walk that already runs, on ANY body-set change: normally that IS the marshal
         // transition, but a continuously spawning scene changes its body set every tick and so re-syncs every
-        // tick — a no-op walk over the live joints (each is reused, nothing created), and silent (joints.ts).
+        // tick — a no-op walk over the live joints (each is reused, nothing created), and deduped (not silenced) (joints.ts).
         let bodySetChanged = false;
         for (const eid of state.query([Body])) {
             const stamp = state.stamp(eid);
@@ -177,9 +177,10 @@ const SyncSystem: System = {
         }
         // the pump: re-run the retained authored constraint sets against the new body set, so a create that
         // returned null against a not-yet-marshaled endpoint retries now. Content-keyed, so a live joint is
-        // reused (warm impulses survive) and only the dropped def is created. The retry is silent — a def
-        // still unsatisfiable would otherwise re-warn on every body-set change, which is the `failed` ledger's
-        // never-thrash-the-frame-loop invariant above; the authored upload keeps the one warning.
+        // reused (warm impulses survive) and only the dropped def is created. The retry is deduped (not
+        // silenced): the warned-key set is cleared on authored upload, not on this re-sync — so a def
+        // that stays unsatisfiable warns once, not per body-set change (the never-thrash invariant above),
+        // while a cause that becomes evaluable only after a deferred marshal resolves still warns once.
         if (bodySetChanged) resyncConstraints(world, bodies, isDeferred);
     },
 };

--- a/packages/shallot/src/standard/tumble/joints.ts
+++ b/packages/shallot/src/standard/tumble/joints.ts
@@ -80,13 +80,16 @@ const liveJoints = new Map<string, TumbleJoint[]>();
 let retainedSprings: readonly SpringDef[] = [];
 let retainedJoints: readonly JointDef[] = [];
 // warned-key dedupe sets — keyed on `${springKey}|${cause}` / `${jointKey}|${cause}` so each diagnostic site
-// (endpoint-unavailable, hertz-zero, both-static, non-positive-stiffness) is deduped independently. Cleared on
-// an authored upload (`syncSprings`/`syncJoints`) and in `resetConstraints`. This mirrors `index.ts`'s `failed`
-// ledger: it gates the *attempt* and re-warns when the key moves — it does not mute. A boolean `quiet` that
-// silenced the retry path (S2's stopgap) hid every cause that only becomes visible after a deferred marshal
-// resolves (the both-static guard sits after `endpoints()` returns a pair, so the retry is the only path
-// that can evaluate it). Dedupe on the composite key lets the both-static warning fire once on the retry even
-// though the endpoint warning already banked the def's base key on the authored upload.
+// (endpoint-unavailable, hertz-zero, both-static, non-positive-stiffness) is deduped independently. The
+// endpoint-unavailable cause folds in the per-endpoint classification (`parts`), so a narrowed composition
+// (a deferred half marshals, leaving only the genuinely-non-`Body` half) is a DISTINCT key that re-warns
+// once — a mixed pair does not inherit the authored upload's stale key. Cleared on an authored upload
+// (`syncSprings`/`syncJoints`) and in `resetConstraints`. This mirrors `index.ts`'s `failed` ledger: it gates
+// the *attempt* and re-warns when the key moves — it does not mute. A boolean `quiet` that silenced the retry
+// path (S2's stopgap) hid every cause that only becomes visible after a deferred marshal resolves (the
+// both-static guard sits after `endpoints()` returns a pair, so the retry is the only path that can evaluate
+// it). Dedupe on the composite key lets the both-static warning fire once on the retry even though the
+// endpoint warning already banked the def's base key on the authored upload.
 const warnedSprings = new Set<string>();
 const warnedJoints = new Set<string>();
 
@@ -141,7 +144,9 @@ export function syncSet<D>(
 // The diagnostic is deduped (not silenced): `warned` is the per-cause key set cleared on authored upload, so
 // the authored upload's warning fires once and the retry's re-warn is suppressed only for the SAME cause —
 // a deferred endpoint that resolves into a both-static pair warns the both-static cause on the retry because
-// that composite key was never banked.
+// that composite key was never banked. The endpoint key itself folds in `parts`, so a narrowed composition
+// (a deferred half marshals, leaving fewer missing endpoints) is a distinct key that re-warns once — the
+// authored upload's broader warning does not swallow the retry's corrected, narrower diagnostic.
 function endpoints(
     bodies: ReadonlyMap<number, TumbleBody>,
     a: number,
@@ -163,7 +168,7 @@ function endpoints(
         if (!tb) parts.push(cause("b", b));
         warnOnce(
             warned,
-            `${key}|endpoint`,
+            `${key}|endpoint|${parts.join(";")}`,
             `[tumble] ${kind} endpoint unavailable — ${parts.join("; ")}`,
         );
         return null;

--- a/packages/shallot/src/standard/tumble/joints.ts
+++ b/packages/shallot/src/standard/tumble/joints.ts
@@ -79,6 +79,22 @@ const liveJoints = new Map<string, TumbleJoint[]>();
 // calls back into `joints.ts` between signature changes, so the retained set + the re-invoke are both needed.
 let retainedSprings: readonly SpringDef[] = [];
 let retainedJoints: readonly JointDef[] = [];
+// warned-key dedupe sets — keyed on `${springKey}|${cause}` / `${jointKey}|${cause}` so each diagnostic site
+// (endpoint-unavailable, hertz-zero, both-static, non-positive-stiffness) is deduped independently. Cleared on
+// an authored upload (`syncSprings`/`syncJoints`) and in `resetConstraints`. This mirrors `index.ts`'s `failed`
+// ledger: it gates the *attempt* and re-warns when the key moves — it does not mute. A boolean `quiet` that
+// silenced the retry path (S2's stopgap) hid every cause that only becomes visible after a deferred marshal
+// resolves (the both-static guard sits after `endpoints()` returns a pair, so the retry is the only path
+// that can evaluate it). Dedupe on the composite key lets the both-static warning fire once on the retry even
+// though the endpoint warning already banked the def's base key on the authored upload.
+const warnedSprings = new Set<string>();
+const warnedJoints = new Set<string>();
+
+const warnOnce = (warned: Set<string>, key: string, message: string): void => {
+    if (warned.has(key)) return;
+    console.warn(message);
+    warned.add(key);
+};
 
 // exported as a test seam only (joints.test.ts pins the diff semantics with stub joints); not on any barrel
 export function syncSet<D>(
@@ -122,29 +138,30 @@ export function syncSet<D>(
 // pass a predicate over it so the deferred case reads as deferred-and-will-retry, not a permanent skip.
 // EACH missing endpoint is classified on its own cause: a mixed pair (one truly non-`Body`, one deferred)
 // names both, so neither half inherits the other's cause — the misdirection this discriminator exists to end.
-// `quiet` silences the diagnostic for a retry pass (`resyncConstraints`): the authored upload owns the one
-// warning, and a retry that re-warned would fire on every body-set change (index.ts's never-thrash invariant).
+// The diagnostic is deduped (not silenced): `warned` is the per-cause key set cleared on authored upload, so
+// the authored upload's warning fires once and the retry's re-warn is suppressed only for the SAME cause —
+// a deferred endpoint that resolves into a both-static pair warns the both-static cause on the retry because
+// that composite key was never banked.
 function endpoints(
     bodies: ReadonlyMap<number, TumbleBody>,
     a: number,
     b: number,
     kind: string,
     isDeferred: (eid: number) => boolean,
-    quiet: boolean,
+    warned: Set<string>,
+    key: string,
 ): [TumbleBody, TumbleBody] | null {
     const ta = bodies.get(a);
     const tb = bodies.get(b);
     if (!ta || !tb) {
-        if (!quiet) {
-            const cause = (label: string, eid: number): string =>
-                isDeferred(eid)
-                    ? `${label}: ${eid} is a deferred body (marshal pending, will retry)`
-                    : `${label}: ${eid} is not a Body (skipped)`;
-            const parts: string[] = [];
-            if (!ta) parts.push(cause("a", a));
-            if (!tb) parts.push(cause("b", b));
-            console.warn(`[tumble] ${kind} endpoint unavailable — ${parts.join("; ")}`);
-        }
+        const cause = (label: string, eid: number): string =>
+            isDeferred(eid)
+                ? `${label}: ${eid} is a deferred body (marshal pending, will retry)`
+                : `${label}: ${eid} is not a Body (skipped)`;
+        const parts: string[] = [];
+        if (!ta) parts.push(cause("a", a));
+        if (!tb) parts.push(cause("b", b));
+        warnOnce(warned, `${key}|endpoint`, `[tumble] ${kind} endpoint unavailable — ${parts.join("; ")}`);
         return null;
     }
     return [ta, tb];
@@ -155,16 +172,18 @@ function createSpring(
     bodies: ReadonlyMap<number, TumbleBody>,
     def: SpringDef,
     isDeferred: (eid: number) => boolean,
-    quiet: boolean,
+    warned: Set<string>,
 ): TumbleJoint | null {
-    const pair = endpoints(bodies, def.a, def.b, "spring", isDeferred, quiet);
+    const key = springKey(def);
+    const pair = endpoints(bodies, def.a, def.b, "spring", isDeferred, warned, key);
     if (!pair) return null;
     const hertz = stiffnessHertz(def.stiffness, dynMass(pair[0]), dynMass(pair[1]));
     if (hertz === 0) {
-        if (!quiet)
-            console.warn(
-                `[tumble] spring (a: ${def.a}, b: ${def.b}) has no dynamic endpoint or non-positive stiffness — skipped`,
-            );
+        warnOnce(
+            warned,
+            `${key}|hertz`,
+            `[tumble] spring (a: ${def.a}, b: ${def.b}) has no dynamic endpoint or non-positive stiffness — skipped`,
+        );
         return null;
     }
     return world.createDistanceJoint(pair[0], pair[1], {
@@ -186,18 +205,20 @@ function createJoint(
     bodies: ReadonlyMap<number, TumbleBody>,
     def: JointDef,
     isDeferred: (eid: number) => boolean,
-    quiet: boolean,
+    warned: Set<string>,
 ): TumbleJoint | null {
-    const pair = endpoints(bodies, def.a, def.b, "joint", isDeferred, quiet);
+    const key = jointKey(def);
+    const pair = endpoints(bodies, def.a, def.b, "joint", isDeferred, warned, key);
     if (!pair) return null;
     const [ta, tb] = pair;
     const mA = dynMass(ta);
     const mB = dynMass(tb);
     if (mA <= 0 && mB <= 0) {
-        if (!quiet)
-            console.warn(
-                `[tumble] joint (a: ${def.a}, b: ${def.b}) has no dynamic endpoint — unsatisfiable, skipped (the both-static guard)`,
-            );
+        warnOnce(
+            warned,
+            `${key}|both-static`,
+            `[tumble] joint (a: ${def.a}, b: ${def.b}) has no dynamic endpoint — unsatisfiable, skipped (the both-static guard)`,
+        );
         return null;
     }
     if (def.stiffnessAng === 0) {
@@ -207,10 +228,11 @@ function createJoint(
         });
     }
     if (def.stiffnessAng < 0) {
-        if (!quiet)
-            console.warn(
-                `[tumble] joint (a: ${def.a}, b: ${def.b}) has non-positive angular stiffness — skipped`,
-            );
+        warnOnce(
+            warned,
+            `${key}|stiffness`,
+            `[tumble] joint (a: ${def.a}, b: ${def.b}) has non-positive angular stiffness — skipped`,
+        );
         return null;
     }
     // angularHertz 0 is box3d's RIGID angular constraint; an intermediate stiffnessAng maps to a soft
@@ -230,7 +252,7 @@ function createJoint(
     });
 }
 
-/** reconcile the authored spring set against the live tumble joints: unchanged defs keep their joint (warm-started impulses survive), changed/new defs create, leftovers destroy. Retains the def set for `resyncConstraints`. */
+/** reconcile the authored spring set against the live tumble joints: unchanged defs keep their joint (warm-started impulses survive), changed/new defs create, leftovers destroy. Retains the def set for `resyncConstraints` and clears the warned-key set so the authored upload's diagnostics fire fresh. */
 export function syncSprings(
     world: TumbleWorld,
     bodies: ReadonlyMap<number, TumbleBody>,
@@ -238,10 +260,11 @@ export function syncSprings(
     isDeferred: (eid: number) => boolean,
 ): void {
     retainedSprings = defs;
-    syncSet(liveSprings, defs, springKey, (d) => createSpring(world, bodies, d, isDeferred, false));
+    warnedSprings.clear();
+    syncSet(liveSprings, defs, springKey, (d) => createSpring(world, bodies, d, isDeferred, warnedSprings));
 }
 
-/** reconcile the authored joint set against the live tumble joints — the `syncSprings` twin over the Spherical/Weld mapping. Retains the def set for `resyncConstraints`. */
+/** reconcile the authored joint set against the live tumble joints — the `syncSprings` twin over the Spherical/Weld mapping. Retains the def set for `resyncConstraints` and clears the warned-key set so the authored upload's diagnostics fire fresh. */
 export function syncJoints(
     world: TumbleWorld,
     bodies: ReadonlyMap<number, TumbleBody>,
@@ -249,7 +272,8 @@ export function syncJoints(
     isDeferred: (eid: number) => boolean,
 ): void {
     retainedJoints = defs;
-    syncSet(liveJoints, defs, jointKey, (d) => createJoint(world, bodies, d, isDeferred, false));
+    warnedJoints.clear();
+    syncSet(liveJoints, defs, jointKey, (d) => createJoint(world, bodies, d, isDeferred, warnedJoints));
 }
 
 /** re-invoke `syncJoints`/`syncSprings` over the retained def sets — the pump half of the late-marshal fix.
@@ -258,8 +282,10 @@ export function syncJoints(
  *  a no-op walk over the live joints (each `isValid()` handle is reused, nothing is created or destroyed).
  *  `syncSet` needs no new diff semantics: an unchanged def whose live joint `isValid()` is reused (warm-started
  *  impulses survive), a dropped def's `create` retries, leftovers destroy — the semantics `joints.test.ts`
- *  already pins. The retry passes `quiet`: a still-unsatisfiable def must not re-warn per body-set change, so
- *  the diagnostic stays the authored upload's one warning (index.ts's never-thrash-the-frame-loop invariant). */
+ *  already pins. The retry's diagnostics are deduped (not silenced): the warned-key set is NOT cleared here, so
+ *  a warning that already fired for a given cause on the authored upload is suppressed on the retry — but a
+ *  cause that only becomes visible after the marshal resolves (the both-static guard) fires once, because its
+ *  composite key was never banked (index.ts's never-thrash-the-frame-loop invariant). */
 export function resyncConstraints(
     world: TumbleWorld,
     bodies: ReadonlyMap<number, TumbleBody>,
@@ -267,11 +293,11 @@ export function resyncConstraints(
 ): void {
     if (retainedSprings.length > 0)
         syncSet(liveSprings, retainedSprings, springKey, (d) =>
-            createSpring(world, bodies, d, isDeferred, true),
+            createSpring(world, bodies, d, isDeferred, warnedSprings),
         );
     if (retainedJoints.length > 0)
         syncSet(liveJoints, retainedJoints, jointKey, (d) =>
-            createJoint(world, bodies, d, isDeferred, true),
+            createJoint(world, bodies, d, isDeferred, warnedJoints),
         );
 }
 
@@ -281,4 +307,6 @@ export function resetConstraints(): void {
     liveJoints.clear();
     retainedSprings = [];
     retainedJoints = [];
+    warnedSprings.clear();
+    warnedJoints.clear();
 }

--- a/packages/shallot/src/standard/tumble/joints.ts
+++ b/packages/shallot/src/standard/tumble/joints.ts
@@ -161,7 +161,11 @@ function endpoints(
         const parts: string[] = [];
         if (!ta) parts.push(cause("a", a));
         if (!tb) parts.push(cause("b", b));
-        warnOnce(warned, `${key}|endpoint`, `[tumble] ${kind} endpoint unavailable — ${parts.join("; ")}`);
+        warnOnce(
+            warned,
+            `${key}|endpoint`,
+            `[tumble] ${kind} endpoint unavailable — ${parts.join("; ")}`,
+        );
         return null;
     }
     return [ta, tb];
@@ -261,7 +265,9 @@ export function syncSprings(
 ): void {
     retainedSprings = defs;
     warnedSprings.clear();
-    syncSet(liveSprings, defs, springKey, (d) => createSpring(world, bodies, d, isDeferred, warnedSprings));
+    syncSet(liveSprings, defs, springKey, (d) =>
+        createSpring(world, bodies, d, isDeferred, warnedSprings),
+    );
 }
 
 /** reconcile the authored joint set against the live tumble joints — the `syncSprings` twin over the Spherical/Weld mapping. Retains the def set for `resyncConstraints` and clears the warned-key set so the authored upload's diagnostics fire fresh. */
@@ -273,7 +279,9 @@ export function syncJoints(
 ): void {
     retainedJoints = defs;
     warnedJoints.clear();
-    syncSet(liveJoints, defs, jointKey, (d) => createJoint(world, bodies, d, isDeferred, warnedJoints));
+    syncSet(liveJoints, defs, jointKey, (d) =>
+        createJoint(world, bodies, d, isDeferred, warnedJoints),
+    );
 }
 
 /** re-invoke `syncJoints`/`syncSprings` over the retained def sets — the pump half of the late-marshal fix.

--- a/packages/shallot/src/standard/tumble/lifecycle.test.ts
+++ b/packages/shallot/src/standard/tumble/lifecycle.test.ts
@@ -301,4 +301,134 @@ describe("TumblePlugin late-marshal constraints", () => {
             warn.mockRestore();
         }
     });
+
+    // The deferred-then-unsatisfiable class: a def whose endpoint was deferred at authored time resolves
+    // into a both-static pair on retry. The authored upload's `endpoints()` warning names "deferred, will
+    // retry" (not "unsatisfiable"), and the both-static guard sits AFTER `endpoints()` returns a pair — so
+    // the retry is the only path that can evaluate it. Under `quiet` (S2's fix), the retry was silenced, so
+    // the both-static warning was permanently unreachable: count 0. Under dedupe (S3's fix), the both-static
+    // warning fires exactly once (deduped on the composite key `jointKey|both-static`, which is distinct
+    // from the `jointKey|endpoint` the authored upload banked). Pre-fix witnessed red: count 0 (Expected 1,
+    // Received 0). Green: count 1. Under the wrong narrowing (un-quieting the three guards), the count grows
+    // past 1 — the pump fires on every body-set change (one spawn per tick), and the both-static warning
+    // re-fires each tick with no dedupe.
+    test("a deferred-then-both-static joint warns exactly once naming the unsatisfiable cause", async () => {
+        state = await buildTumble();
+
+        const anchor = state.create();
+        state.add(anchor, Body);
+        Body.shape.set(anchor, ShapeKind.Box);
+        Body.halfExtents.set(anchor, 0.5, 0.5, 0.5, 0);
+        Body.pos.set(anchor, 0, 5, 0, 0);
+        Body.mass.set(anchor, 0);
+
+        const bob = state.create();
+        state.add(bob, Body);
+        Body.shape.set(bob, ShapeKind.Hull);
+        Body.halfExtents.set(bob, 1, 1, 1, reserveLateHullId());
+        Body.pos.set(bob, 0, 4, 0, 0);
+        Body.mass.set(bob, 0); // mass-0: both-static when it marshals
+
+        const j = state.create();
+        state.add(j, Joint);
+        Joint.a.set(j, anchor);
+        Joint.b.set(j, bob);
+        Joint.rA.set(j, 0, -1, 0, 0);
+        Joint.rB.set(j, 0, 0, 0, 0);
+        Joint.stiffnessAng.set(j, 0);
+
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        const unsatisfiableWarnings = (): number =>
+            warn.mock.calls.filter((c) => String(c[0]).includes("unsatisfiable")).length;
+
+        const spawn = (i: number): void => {
+            const eid = state.create();
+            state.add(eid, Body);
+            Body.shape.set(eid, ShapeKind.Sphere);
+            Body.halfExtents.set(eid, 0, 0, 0, 0.5);
+            Body.pos.set(eid, i * 2, 10, 0, 0);
+            Body.mass.set(eid, 1);
+        };
+
+        try {
+            // tick 0: bob's marshal fails (hull not registered), endpoints warns "deferred"
+            state.step(Time.FIXED_DT);
+            // hull arrives — bob will marshal on the next tick
+            registerLateHull();
+            // 30 ticks with one spawn per tick: the pump fires every tick
+            for (let i = 0; i < 30; i++) {
+                spawn(i);
+                state.step(Time.FIXED_DT);
+            }
+            // exactly one warning naming the unsatisfiable cause (the both-static guard),
+            // not zero (quiet) and not growing (wrong narrowing / un-quieting)
+            expect(unsatisfiableWarnings()).toBe(1);
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // The pump's own safety claim: `resyncConstraints` asserts "a no-op walk over the live joints — each
+    // `isValid()` handle is reused, nothing is created or destroyed". Nothing gated this claim before — the
+    // shipped warning-count arm reads no handle identity and no pose, so a future desync between `jointKey`
+    // and the def content `syncSet` diffs on would silently destroy and recreate every constraint per tick
+    // under churn (dropping warm-started impulses, symptom: mushy chains in busy scenes) with a green suite
+    // throughout. This arm pins it: spy `createSphericalJoint`, settle a pin, then spawn one body per tick
+    // for 30 ticks (the pump fires every tick). The create count must stay exactly 1 (the initial create)
+    // and the bob's pose must stay within epsilon of settled. Green at the pre-fix state (the pump already
+    // reuses handles correctly) — this is a pinning arm, not a bug-reproducing arm. The create-count half
+    // is load-bearing: without it, the pose half alone can't detect a destroy+recreate that preserves the
+    // rest pose.
+    test("the pump reuses live joint handles across churn — create count is 1, pose holds", async () => {
+        state = await buildTumble();
+
+        const anchor = state.create();
+        state.add(anchor, Body);
+        Body.shape.set(anchor, ShapeKind.Box);
+        Body.halfExtents.set(anchor, 0.5, 0.5, 0.5, 0);
+        Body.pos.set(anchor, 0, 5, 0, 0);
+        Body.mass.set(anchor, 0);
+
+        const bob = state.create();
+        state.add(bob, Body);
+        Body.shape.set(bob, ShapeKind.Sphere);
+        Body.halfExtents.set(bob, 0, 0, 0, 0.5);
+        Body.pos.set(bob, 0, 4, 0, 0);
+        Body.mass.set(bob, 1);
+
+        const j = state.create();
+        state.add(j, Joint);
+        Joint.a.set(j, anchor);
+        Joint.b.set(j, bob);
+        Joint.rA.set(j, 0, -1, 0, 0);
+        Joint.rB.set(j, 0, 0, 0, 0);
+        Joint.stiffnessAng.set(j, 0);
+
+        const createSpy = spyOn(Tumble.world!, "createSphericalJoint");
+        try {
+            // settle the pin
+            for (let i = 0; i < 60; i++) state.step(Time.FIXED_DT);
+            expect(createSpy).toHaveBeenCalledTimes(1);
+            const settledY = Physics.backend!.readBody(bob)!.pos[1];
+
+            // churn: one body per tick for 30 ticks — the pump fires every tick
+            const spawn = (i: number): void => {
+                const eid = state.create();
+                state.add(eid, Body);
+                Body.shape.set(eid, ShapeKind.Sphere);
+                Body.halfExtents.set(eid, 0, 0, 0, 0.5);
+                Body.pos.set(eid, i * 2, 10, 0, 0);
+                Body.mass.set(eid, 1);
+            };
+            for (let i = 0; i < 30; i++) {
+                spawn(i);
+                state.step(Time.FIXED_DT);
+            }
+            expect(createSpy).toHaveBeenCalledTimes(1);
+            const liveY = Physics.backend!.readBody(bob)!.pos[1];
+            expect(Math.abs(liveY - settledY)).toBeLessThan(0.01);
+        } finally {
+            createSpy.mockRestore();
+        }
+    });
 });

--- a/packages/shallot/src/standard/tumble/lifecycle.test.ts
+++ b/packages/shallot/src/standard/tumble/lifecycle.test.ts
@@ -248,6 +248,92 @@ describe("TumblePlugin late-marshal constraints", () => {
         }
     });
 
+    // The narrowing arm: a mixed pair where `a` is genuinely non-`Body` and `b` is a deferred `Body`.
+    // On the authored upload, `endpoints()` warns naming both causes (a: not a Body; b: deferred). When `b`
+    // marshals and the pump re-runs, `endpoints()` still returns null (`a` is still missing) and should warn
+    // with the NARROWED cause naming only `a` — but under the old key (`${key}|endpoint`, ignoring `parts`)
+    // the key was already banked, so the corrected diagnostic was swallowed. Folding `parts` into the key
+    // makes a changed composition a distinct key, so the narrowed warning re-warns once.
+    //
+    // Pre-fix witnessed red: afterTen.length = 1 (Expected 2, Received 1) — the second (narrowed) warning
+    // was swallowed by the stale `${key}|endpoint` key banked on the authored upload. The final count after
+    // 30 churn ticks was also 1, so the narrowing was never observed.
+    // Green: afterTen.length = 2, final count = 2 — the narrowed warning fires once, then stays put.
+    //
+    // If the key were keyed TOO finely (e.g. on something that changes every tick), afterTen.length would
+    // grow past 2 and the final count would exceed afterTen.length — the never-thrash invariant breaks.
+    // This arm catches that direction: the final-count-equals-afterTen assertion reds on per-tick growth.
+    // The existing never-thrash arm ("a permanently unsatisfiable constraint warns once") catches the same
+    // direction for the static (non-narrowing) case; this arm catches it for the narrowing case.
+    test("a mixed pair re-warns with the narrowed cause once the deferred half marshals", async () => {
+        state = await buildTumble();
+
+        const notABody = state.create(); // no Body component: permanently unsatisfiable
+        const bob = state.create();
+        state.add(bob, Body);
+        Body.shape.set(bob, ShapeKind.Hull);
+        Body.halfExtents.set(bob, 1, 1, 1, reserveLateHullId());
+        Body.pos.set(bob, 0, 4, 0, 0);
+        Body.mass.set(bob, 1);
+
+        const j = state.create();
+        state.add(j, Joint);
+        Joint.a.set(j, notABody);
+        Joint.b.set(j, bob);
+        Joint.rA.set(j, 0, 0, 0, 0);
+        Joint.rB.set(j, 0, 0, 0, 0);
+        Joint.stiffnessAng.set(j, 0);
+
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        const endpointWarnings = (): string[] =>
+            warn.mock.calls
+                .map((c) => String(c[0]))
+                .filter((m) => m.includes("joint endpoint unavailable"));
+
+        const spawn = (i: number): void => {
+            const eid = state.create();
+            state.add(eid, Body);
+            Body.shape.set(eid, ShapeKind.Sphere);
+            Body.halfExtents.set(eid, 0, 0, 0, 0.5);
+            Body.pos.set(eid, i * 2, 10, 0, 0);
+            Body.mass.set(eid, 1);
+        };
+
+        try {
+            // tick 0: authored upload — both endpoints missing, mixed causes
+            state.step(Time.FIXED_DT);
+            const firstWarnings = endpointWarnings();
+            expect(firstWarnings.length).toBe(1);
+            expect(firstWarnings[0]).toContain(`a: ${notABody} is not a Body`);
+            expect(firstWarnings[0]).toContain(`b: ${bob} is a deferred body`);
+
+            // hull arrives — bob marshals on the next tick
+            registerLateHull();
+
+            // churn: one spawn per tick fires the pump every tick
+            for (let i = 0; i < 10; i++) {
+                spawn(i);
+                state.step(Time.FIXED_DT);
+            }
+            // the narrowed warning fires once, naming only the surviving cause (a's non-Body),
+            // NOT b's deferred cause — b marshaled, so b is no longer missing
+            const afterTen = endpointWarnings();
+            expect(afterTen.length).toBe(2);
+            expect(afterTen[1]).toContain(`a: ${notABody} is not a Body`);
+            expect(afterTen[1]).not.toContain("deferred");
+            expect(afterTen[1]).not.toContain(`b: ${bob}`);
+
+            // count stays put across remaining churn — no thrash
+            for (let i = 10; i < 30; i++) {
+                spawn(i);
+                state.step(Time.FIXED_DT);
+            }
+            expect(endpointWarnings().length).toBe(afterTen.length);
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
     // The pump fires on ANY body-set change, so a continuously spawning scene re-syncs every tick. A retry
     // that re-warned would emit one warning per tick forever, breaking the same never-thrash-the-frame-loop
     // invariant the marshal `failed` ledger holds (index.ts). Counted across ticks, because no per-tick arm


### PR DESCRIPTION
- **audit-tumble-late-marshal-constraints: s3**
- **audit-tumble-late-marshal-constraints: s3 comment claims**
- **audit-tumble-late-marshal-constraints: s3 biome format**
- **audit-tumble-late-marshal-constraints: s3 dedupe key granularity**
