### PR TITLE
showcase-frame-floor: route voxel's Playwright gate through the WSL real-GPU bridge

### DIFF
--- a/examples/showcase/voxel/playwright.config.ts
+++ b/examples/showcase/voxel/playwright.config.ts
@@ -1,14 +1,24 @@
+import { existsSync, readFileSync } from "node:fs";
 import { defineConfig } from "@playwright/test";
+import { ENDPOINT_FILE } from "./playwright.global-setup";
 
 // The voxel showcase's own browser driver — bring-your-own, as a real user would. shallot exports no
 // Playwright harness (bun ships `bun test` and tells you to bring Playwright); the reusable part is the
 // gate logic in `src/gate.ts`, written against the published surface. The web server is `shallot dev` (the
 // standalone runtime, no editor), so the gate runs against the same path a user opens. This is full device
 // testing: it needs a capable WebGPU GPU. In WSL the only adapter is software (llvmpipe), which fails
-// shallot's device floor, so the gate is display-gated there — the same posture `bun run flows` takes.
+// shallot's device floor — `playwright.global-setup.ts` routes the run through `scripts/wsl-bridge.ts`'s
+// host-GPU bridge there, so this reads `connectOptions` back from what it found (a worker process re-imports
+// this file fresh, after global setup has already written it). Off WSL, and when the bridge's own
+// prerequisites are absent, no endpoint file exists and this falls through to the local/native launch below
+// — same as it always has, display-gated by the adapter-name skip in `test/voxel.spec.ts`.
 
 const PORT = 3100;
 const URL = `http://localhost:${PORT}`;
+
+const endpoint = existsSync(ENDPOINT_FILE)
+    ? (JSON.parse(readFileSync(ENDPOINT_FILE, "utf8")) as { wsEndpoint: string })
+    : null;
 
 export default defineConfig({
     testDir: "./test",
@@ -16,6 +26,7 @@ export default defineConfig({
     workers: 1,
     reporter: [["list"]],
     timeout: 120_000,
+    globalSetup: "./playwright.global-setup.ts",
     webServer: {
         // standalone `shallot dev` over this project's manifest — `bunx` resolves the installed CLI. A cold
         // first vite build can run past 60s in CI; the warm cache serves in ~1s.
@@ -34,5 +45,6 @@ export default defineConfig({
                 "--enable-dawn-features=allow_unsafe_apis",
             ],
         },
+        ...(endpoint ? { connectOptions: { wsEndpoint: endpoint.wsEndpoint } } : {}),
     },
 });

--- a/examples/showcase/voxel/playwright.global-setup.ts
+++ b/examples/showcase/voxel/playwright.global-setup.ts
@@ -1,0 +1,114 @@
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Routes this project's gate through `scripts/wsl-bridge.ts` when on WSL, so it drives the Windows host's
+// real GPU instead of falling to the software adapter (the driver's own adapter-name skip). Identical
+// shape to `examples/showcase/roads/playwright.global-setup.ts` — see that file's header for the three
+// platform facts (blocked WSL→host TCP, bun's Playwright client hanging on connect, exact-version match)
+// that force it. `scripts/wsl-bridge-connect.ts` is the one bun subprocess this process spawns and holds
+// open for the run's duration.
+//
+// `playwright.config.ts` can't read the discovered endpoint directly — it's resolved *after* config load,
+// and a worker process re-imports the config fresh rather than sharing this process's memory. The endpoint
+// file is the handoff Playwright's own docs name for this shape: globalSetup runs once in the root process
+// before any worker spawns, writes what it found, and each worker's later re-import reads it back.
+const REPO_ROOT = resolve(import.meta.dirname, "../../..");
+const BRIDGE_CONNECT = resolve(REPO_ROOT, "scripts/wsl-bridge-connect.ts");
+export const ENDPOINT_FILE = resolve(
+    import.meta.dirname,
+    "node_modules/.cache/voxel-bridge-endpoint.json",
+);
+
+const isWSL = process.platform === "linux" && existsSync("/proc/sys/fs/binfmt_misc/WSLInterop");
+
+/** scan stdout lines for the connect script's one handshake line — never assume first or last, since the
+ *  host launcher's own inherited output can land on either side of it (mirrors `scripts/verify.ts`'s
+ *  `extractResult` scan-don't-assume idiom). */
+function waitForHandshake(
+    child: ReturnType<typeof spawn>,
+    timeoutMs: number,
+): Promise<{ skip: string } | { connectUrl: string }> {
+    return new Promise((resolve, reject) => {
+        let buf = "";
+        const timer = setTimeout(
+            () => reject(new Error("bridge connect: no handshake within timeout")),
+            timeoutMs,
+        );
+        const onData = (chunk: Buffer) => {
+            buf += chunk.toString("utf8");
+            for (const line of buf.split("\n")) {
+                const m = line.match(/^BRIDGE_ENDPOINT (.+)$/);
+                if (m) {
+                    clearTimeout(timer);
+                    child.stdout?.off("data", onData);
+                    try {
+                        resolve(JSON.parse(m[1]));
+                    } catch (e) {
+                        reject(new Error(`bridge connect: malformed handshake payload: ${e}`));
+                    }
+                    return;
+                }
+            }
+        };
+        child.stdout?.on("data", onData);
+        child.on("error", (e) => {
+            clearTimeout(timer);
+            reject(e);
+        });
+        child.on("exit", (code) => {
+            if (code !== 0) {
+                clearTimeout(timer);
+                reject(new Error(`bridge connect exited ${code} before a handshake`));
+            }
+        });
+    });
+}
+
+export default async function globalSetup(): Promise<(() => Promise<void>) | void> {
+    rmSync(ENDPOINT_FILE, { force: true });
+    if (!isWSL) return;
+
+    const child = spawn("bun", [BRIDGE_CONNECT], {
+        cwd: REPO_ROOT,
+        stdio: ["pipe", "pipe", "inherit"],
+    });
+
+    let handshake: { skip: string } | { connectUrl: string };
+    try {
+        // provisioning (host `bun install` + `playwright install chromium` on drift) plus the launcher's own
+        // 90 s deadline (`wsl-bridge.ts`) — generous enough for a cold host cache, still bounded.
+        handshake = await waitForHandshake(child, 150_000);
+    } catch (e) {
+        child.stdin?.end();
+        console.log(
+            `voxel gate: bridge unavailable (${e instanceof Error ? e.message : e}), falling back to local adapter`,
+        );
+        return;
+    }
+
+    if ("skip" in handshake) {
+        console.log(
+            `voxel gate: bridge unavailable (${handshake.skip}), falling back to local adapter`,
+        );
+        child.stdin?.end();
+        return;
+    }
+
+    try {
+        mkdirSync(resolve(ENDPOINT_FILE, ".."), { recursive: true });
+        writeFileSync(ENDPOINT_FILE, JSON.stringify({ wsEndpoint: handshake.connectUrl }));
+    } catch (e) {
+        child.stdin?.end();
+        console.log(
+            `voxel gate: bridge unavailable (couldn't write the endpoint handoff: ${e instanceof Error ? e.message : e}), falling back to local adapter`,
+        );
+        return;
+    }
+
+    return async () => {
+        child.stdin?.end();
+        await new Promise<void>((res) => child.on("exit", () => res()));
+        rmSync(ENDPOINT_FILE, { force: true });
+    };
+}


### PR DESCRIPTION
Mirrors roads' playwright.global-setup.ts pattern — under WSL, a locally
launched Chromium only offers SwiftShader, which the voxel showcase's own
device-floor skip then reads as no real adapter. Needed to reproduce and
attribute the reported carve-drag lag on this seat at all (S1).
