### PR TITLE
audit eval infra vs task verdict/s3

### DIFF
--- a/evals/grade.ts
+++ b/evals/grade.ts
@@ -20,6 +20,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { runPlaywright } from "./harness/playwright";
+import { deriveResultKind, resultKindToPass, type ResultKind } from "./harness/result";
 import { startServer } from "./harness/server";
 import { detectDisplay, isWSL } from "./harness/wsl";
 
@@ -47,8 +48,9 @@ interface Check {
 // dependency install `sh` throws on) or a gate that produced no envelope (the audit's own
 // "gate produced no result" branch, a fired spawn backstop included) is the *harness* failing, not
 // the agent's task — INCOMPLETE, never FAIL. A graded call site's nonzero exit (typecheck, build) is
-// the opposite: the subject's own task failing, which stays a legitimate FAIL.
-type ResultKind = "PASS" | "FAIL" | "INCOMPLETE";
+// the opposite: the subject's own task failing, which stays a legitimate FAIL. The derivation itself
+// (and its ResultKind) lives in ./harness/result — a pure, import-safe module a test can call
+// directly, since this script (argv parsing, top-level await) never can be imported by one.
 interface Result {
     task: string;
     project: string;
@@ -221,13 +223,14 @@ if (!detectDisplay()) {
 }
 
 const g = result.checks.gate;
-result.kind =
-    g.ok === null
-        ? "INCOMPLETE"
-        : result.checks.typecheck.ok === true && result.checks.build.ok === true && g.ok === true
-          ? "PASS"
-          : "FAIL";
-result.pass = result.kind === "PASS" ? true : result.kind === "FAIL" ? false : null;
+// A determined typecheck or build failure outranks an unrunnable gate — see ./harness/result's
+// docblock. INCOMPLETE is reserved for a run where nothing determined the outcome.
+result.kind = deriveResultKind(
+    result.checks.typecheck.ok === true,
+    result.checks.build.ok === true,
+    g.ok,
+);
+result.pass = resultKindToPass(result.kind);
 
 if (asJson) {
     console.log(JSON.stringify(result, null, 2));

--- a/evals/grade.ts
+++ b/evals/grade.ts
@@ -43,6 +43,12 @@ interface Check {
     ok: boolean | null;
     detail?: string;
 }
+// The result kind an infrastructure failure must be distinguishable from: a staging failure (a
+// dependency install `sh` throws on) or a gate that produced no envelope (the audit's own
+// "gate produced no result" branch, a fired spawn backstop included) is the *harness* failing, not
+// the agent's task — INCOMPLETE, never FAIL. A graded call site's nonzero exit (typecheck, build) is
+// the opposite: the subject's own task failing, which stays a legitimate FAIL.
+type ResultKind = "PASS" | "FAIL" | "INCOMPLETE";
 interface Result {
     task: string;
     project: string;
@@ -62,12 +68,18 @@ interface Result {
         verifiedHonestly: boolean | null;
         notes: string | null;
     };
+    kind: ResultKind;
     pass: boolean | null;
 }
 
+// Throws on a nonzero exit rather than discarding it — a staging failure (an install `sh` runs for
+// the browser gate) must be visible to its caller as a fault, never silently continue into a run that
+// grades the agent's task on infrastructure that never finished setting up.
 function sh(cmd: string[], cwd: string): { ok: boolean; out: string } {
     const p = Bun.spawnSync(cmd, { cwd, stdout: "pipe", stderr: "pipe" });
-    return { ok: p.exitCode === 0, out: `${p.stdout.toString()}\n${p.stderr.toString()}` };
+    const out = `${p.stdout.toString()}\n${p.stderr.toString()}`;
+    if (p.exitCode !== 0) throw new Error(`${cmd.join(" ")} exited ${p.exitCode}\n${out.trim().slice(-800)}`);
+    return { ok: true, out };
 }
 
 const args = process.argv.slice(2);
@@ -98,15 +110,29 @@ const result: Result = {
         verifiedHonestly: null,
         notes: null,
     },
+    kind: "INCOMPLETE",
     pass: null,
 };
 
-// typecheck — the check the scaffold's AGENTS.md tells the agent to run
-const tc = sh(["bunx", "tsc", "--noEmit"], project);
+// typecheck — the check the scaffold's AGENTS.md tells the agent to run. A failing typecheck is the
+// subject failing, so its nonzero exit (now a throw from `sh`) is caught and graded FAIL here, never
+// laundered into INCOMPLETE.
+let tc: { ok: boolean; out: string };
+try {
+    tc = sh(["bunx", "tsc", "--noEmit"], project);
+} catch (e) {
+    tc = { ok: false, out: e instanceof Error ? e.message : String(e) };
+}
 result.checks.typecheck = { ok: tc.ok, detail: tc.ok ? undefined : tc.out.trim().slice(-600) };
 
-// build — the shipped CLI, the way an installed user ships the project
-const build = sh(["bun", CLI, "build", "."], project);
+// build — the shipped CLI, the way an installed user ships the project. Same rule: a build failure is
+// the subject failing, graded FAIL, never INCOMPLETE.
+let build: { ok: boolean; out: string };
+try {
+    build = sh(["bun", CLI, "build", "."], project);
+} catch (e) {
+    build = { ok: false, out: e instanceof Error ? e.message : String(e) };
+}
 const built = build.ok && existsSync(join(project, "dist", "index.html"));
 result.checks.build = {
     ok: built,
@@ -126,61 +152,82 @@ if (!detectDisplay()) {
     writeFileSync(join(runDir, "gate.ts"), src);
 
     // native (non-WSL) runs Playwright in-place, so install its deps there; WSL stages + installs
-    // host-side inside runPlaywright
+    // host-side inside runPlaywright. A failed install here is the harness's own dependency staging
+    // breaking, not the agent's task — caught and mapped to INCOMPLETE, never let fall through into a
+    // gate run that would grade the task on infrastructure that never finished setting up.
+    let stagingError: string | null = null;
     if (!isWSL) {
-        sh(["bun", "install"], runDir);
-        sh(["bunx", "playwright", "install", "chromium"], runDir);
+        try {
+            sh(["bun", "install"], runDir);
+            sh(["bunx", "playwright", "install", "chromium"], runDir);
+        } catch (e) {
+            stagingError = e instanceof Error ? e.message : String(e);
+        }
     }
 
-    const url = `http://localhost:${port}/`;
-    const server = await startServer(project, port, `eval-${task}`, [
-        "bun",
-        CLI,
-        "dev",
-        ".",
-        "--port",
-        String(port),
-        "--strict-port",
-    ]);
-    try {
-        const run = runPlaywright({
-            dir: runDir,
-            config: "gate.config.ts",
-            args: ["gate.ts"],
-            stage: {
-                name: `shallot-eval-gate`,
-                files: ["package.json", "gate.config.ts", "lib.ts", "gate.ts"],
-            },
-            env: () => ({ EVAL_URL: url }),
-            timeoutMs: 240_000,
-        });
-        const m = run.stdout.match(RESULT_RE);
-        if (m) {
-            const env = JSON.parse(m[1]) as GateEnvelope;
-            result.checks.gate = {
-                ok: env.ok,
-                assertions: env.assertions,
-                errors: env.errors,
-                detail: env.booted ? undefined : "project did not boot a canvas",
-            };
-            result.verification.booted = env.booted;
-            result.verification.rendered = env.rendered;
-        } else {
-            result.checks.gate = {
-                ok: false,
-                detail: `gate produced no result (exit ${run.exitCode})`,
-            };
+    if (stagingError) {
+        result.checks.gate = {
+            ok: null,
+            detail: `dependency staging failed (harness fault, not the task): ${stagingError.trim().slice(-600)}`,
+        };
+    } else {
+        const url = `http://localhost:${port}/`;
+        const server = await startServer(project, port, `eval-${task}`, [
+            "bun",
+            CLI,
+            "dev",
+            ".",
+            "--port",
+            String(port),
+            "--strict-port",
+        ]);
+        try {
+            const run = runPlaywright({
+                dir: runDir,
+                config: "gate.config.ts",
+                args: ["gate.ts"],
+                stage: {
+                    name: `shallot-eval-gate`,
+                    files: ["package.json", "gate.config.ts", "lib.ts", "gate.ts"],
+                },
+                env: () => ({ EVAL_URL: url }),
+                timeoutMs: 240_000,
+            });
+            const m = run.stdout.match(RESULT_RE);
+            if (m) {
+                const env = JSON.parse(m[1]) as GateEnvelope;
+                result.checks.gate = {
+                    ok: env.ok,
+                    assertions: env.assertions,
+                    errors: env.errors,
+                    detail: env.booted ? undefined : "project did not boot a canvas",
+                };
+                result.verification.booted = env.booted;
+                result.verification.rendered = env.rendered;
+            } else {
+                // No result envelope — the harness itself failed to produce one (a fired spawn
+                // backstop included), never the agent's task. INCOMPLETE, never FAIL.
+                result.checks.gate = {
+                    ok: null,
+                    detail: run.timedOut
+                        ? `gate produced no result (spawn backstop fired, exit ${run.exitCode})`
+                        : `gate produced no result (exit ${run.exitCode})`,
+                };
+            }
+        } finally {
+            server.kill();
         }
-    } finally {
-        server.kill();
     }
 }
 
 const g = result.checks.gate;
-result.pass =
-    g.skipped || g.ok === null
-        ? null
-        : result.checks.typecheck.ok === true && result.checks.build.ok === true && g.ok === true;
+result.kind =
+    g.ok === null
+        ? "INCOMPLETE"
+        : result.checks.typecheck.ok === true && result.checks.build.ok === true && g.ok === true
+          ? "PASS"
+          : "FAIL";
+result.pass = result.kind === "PASS" ? true : result.kind === "FAIL" ? false : null;
 
 if (asJson) {
     console.log(JSON.stringify(result, null, 2));
@@ -190,6 +237,7 @@ if (asJson) {
     console.log(`  ${mark(result.checks.typecheck.ok)} typecheck`);
     console.log(`  ${mark(result.checks.build.ok)} build`);
     if (g.skipped) console.log(`  – gate skipped (no display)`);
+    else if (g.ok === null) console.log(`  – gate incomplete${g.detail ? ` — ${g.detail}` : ""}`);
     else {
         console.log(
             `  ${mark(g.ok)} gate  (booted ${g.ok === null ? "?" : result.verification.booted}, rendered ${result.verification.rendered})`,
@@ -200,7 +248,7 @@ if (asJson) {
         if (g.errors?.length) console.log(`      errors: ${g.errors.slice(0, 3).join(" | ")}`);
     }
     const verdict =
-        result.pass === null ? "INCOMPLETE (gate did not run)" : result.pass ? "PASS" : "FAIL";
+        result.kind === "INCOMPLETE" ? "INCOMPLETE (gate did not run)" : result.kind;
     console.log(`  => ${verdict}`);
     console.log(`\n${JSON.stringify(result)}`);
 }

--- a/evals/grade.ts
+++ b/evals/grade.ts
@@ -47,8 +47,10 @@ interface Check {
 // The result kind an infrastructure failure must be distinguishable from: a staging failure (a
 // dependency install `sh` throws on) or a gate that produced no envelope (the audit's own
 // "gate produced no result" branch, a fired spawn backstop included) is the *harness* failing, not
-// the agent's task — INCOMPLETE, never FAIL. A graded call site's nonzero exit (typecheck, build) is
-// the opposite: the subject's own task failing, which stays a legitimate FAIL. The derivation itself
+// the agent's task — a determined typecheck or build failure outranks an unrunnable gate, so
+// INCOMPLETE is reserved for a run where nothing determined the outcome (see ./harness/result's
+// docblock). A graded call site's nonzero exit (typecheck, build) is the opposite: the subject's own
+// task failing, which stays a legitimate FAIL. The derivation itself
 // (and its ResultKind) lives in ./harness/result — a pure, import-safe module a test can call
 // directly, since this script (argv parsing, top-level await) never can be imported by one.
 interface Result {
@@ -155,8 +157,9 @@ if (!detectDisplay()) {
 
     // native (non-WSL) runs Playwright in-place, so install its deps there; WSL stages + installs
     // host-side inside runPlaywright. A failed install here is the harness's own dependency staging
-    // breaking, not the agent's task — caught and mapped to INCOMPLETE, never let fall through into a
-    // gate run that would grade the task on infrastructure that never finished setting up.
+    // breaking, not the agent's task — caught and mapped to INCOMPLETE (unless typecheck or build
+    // already failed, which outranks it — see ./harness/result's docblock), never let fall through
+    // into a gate run that would grade the task on infrastructure that never finished setting up.
     let stagingError: string | null = null;
     if (!isWSL) {
         try {
@@ -208,7 +211,8 @@ if (!detectDisplay()) {
                 result.verification.rendered = env.rendered;
             } else {
                 // No result envelope — the harness itself failed to produce one (a fired spawn
-                // backstop included), never the agent's task. INCOMPLETE, never FAIL.
+                // backstop included), never the agent's task. INCOMPLETE unless typecheck or build
+                // already failed, which outranks it — see ./harness/result's docblock.
                 result.checks.gate = {
                     ok: null,
                     detail: run.timedOut
@@ -240,7 +244,10 @@ if (asJson) {
     console.log(`  ${mark(result.checks.typecheck.ok)} typecheck`);
     console.log(`  ${mark(result.checks.build.ok)} build`);
     if (g.skipped) console.log(`  – gate skipped (no display)`);
-    else if (g.ok === null) console.log(`  – gate incomplete${g.detail ? ` — ${g.detail}` : ""}`);
+    else if (g.ok === null)
+        console.log(
+            `  – gate incomplete${g.detail ? ` — ${g.detail}` : ""}${result.kind === "FAIL" ? " (typecheck or build failed — verdict already FAIL)" : ""}`,
+        );
     else {
         console.log(
             `  ${mark(g.ok)} gate  (booted ${g.ok === null ? "?" : result.verification.booted}, rendered ${result.verification.rendered})`,

--- a/evals/harness/result.ts
+++ b/evals/harness/result.ts
@@ -1,0 +1,27 @@
+// Pure derivation of a graded task's result kind from its three determined inputs — typecheck ok,
+// build ok, gate ok. No side effects, no @playwright/test import: `grade.ts` is a top-level script
+// (argv parsing, top-level await) that can never be imported by an arm, so this sibling module is
+// what a test imports and calls directly instead of reading `grade.ts`'s source as an AST.
+//
+// INCOMPLETE is reserved for a run where NOTHING determined the outcome — the browser gate never ran
+// (no display, a staging failure, no envelope) and typecheck/build both held. A determined typecheck
+// or build failure outranks an unrunnable gate: it is a legitimate FAIL even when the gate never ran,
+// never laundered into "could not measure" about a task this run did measure and fail.
+export type ResultKind = "PASS" | "FAIL" | "INCOMPLETE";
+
+export function deriveResultKind(
+    typecheckOk: boolean,
+    buildOk: boolean,
+    gateOk: boolean | null,
+): ResultKind {
+    // A determined failure is decisive regardless of whether the gate ever ran.
+    if (typecheckOk === false || buildOk === false) return "FAIL";
+    // Typecheck and build both held; the gate is the only remaining input. Its null means the harness
+    // never determined an outcome for it (skipped, staging failure, no envelope) — INCOMPLETE, not FAIL.
+    if (gateOk === null) return "INCOMPLETE";
+    return gateOk ? "PASS" : "FAIL";
+}
+
+export function resultKindToPass(kind: ResultKind): boolean | null {
+    return kind === "PASS" ? true : kind === "FAIL" ? false : null;
+}

--- a/packages/shallot/tests/check-eval-gates.test.ts
+++ b/packages/shallot/tests/check-eval-gates.test.ts
@@ -32,18 +32,19 @@
 //
 // ── Pins (green pre-fix, red on fix) ──
 //
-// S2 has landed and replaced its pin (leg A, below) with the post-fix
-// assertion in this same diff — every task gate's setTimeout argument
+// S2 and S3 have both landed and replaced their pins with post-fix
+// assertions in their own diffs — every task gate's setTimeout argument
 // resolves, via its ImportSpecifier binding from harness/lib, to the same
-// single name in lib.ts's export set. The two remaining S3 arms (legs B, D)
-// are still ordinary green tests asserting the PRE-FIX structure. Each names
-// the stage that replaces it and states that the pin expires with that
-// stage: S3 replaces its pin with the post-fix assertion in the same diff. A
-// green arm that cannot read its subject fails, so the green-because-broken
-// class is eliminated by construction. The readers are parameterized by
-// `CHECK_EVAL_GATES_ROOT`; an absent or empty root reads red (every arm
-// throws or fails its population control), which is the discriminating
-// control — a byte-identical copy is not.
+// single name in lib.ts's export set (leg A); `sh`'s body now holds a
+// ThrowStatement (leg B); a try/catch wraps the staging pair together (leg
+// D); grade.ts declares a result-kind union type carrying an INCOMPLETE
+// member (leg C, transferred to S3 per Approach S1's fourth-hole verdict).
+// No pins remain green pre-fix in this file — every leg now asserts the
+// POST-FIX structure. A green arm that cannot read its subject fails, so the
+// green-because-broken class is eliminated by construction. The readers are
+// parameterized by `CHECK_EVAL_GATES_ROOT`; an absent or empty root reads red
+// (every arm throws or fails its population control), which is the
+// discriminating control — a byte-identical copy is not.
 //
 // No spelling pins: the function `sh` is located by its call structure (its
 // body wraps a `Bun.spawnSync` call), never by the literal name; call sites
@@ -400,12 +401,15 @@ describe("S2 — derived boot budget", () => {
     });
 });
 
-// S3 — staging failure maps to INCOMPLETE. Two pre-fix pins, one per leg of
-// the mechanism; S3 replaces each with the post-fix assertion in its own diff.
-describe("S3 — staging failure maps to INCOMPLETE (pre-fix pin)", () => {
-    // Leg B — pin (S3 replaces). `sh`'s body span in `evals/grade.ts` holds no
-    // `ThrowStatement`. This pin expires with S3 — S3 replaces it with the
-    // assertion that a throw exists, in the same diff.
+// S3 — staging failure maps to INCOMPLETE (landed). Legs B and D replace
+// their pre-fix pins with the post-fix assertion in this same diff; leg C
+// (transferred here from S1 per Approach S1's fourth-hole verdict) lands
+// alongside them, since S3 is the diff that creates the code leg C is about.
+describe("S3 — staging failure maps to INCOMPLETE (post-fix)", () => {
+    // Leg B — post-fix (S3 landed; replaces the pre-fix "holds no
+    // ThrowStatement" pin). `sh`'s body span in `evals/grade.ts` now holds a
+    // `ThrowStatement` — `sh` throws on a nonzero exit instead of returning
+    // `{ ok: false }` silently.
     //
     // `sh` is located by call structure — the function whose body wraps a
     // `Bun.spawnSync` call — not by the literal name. The reader collects
@@ -416,27 +420,37 @@ describe("S3 — staging failure maps to INCOMPLETE (pre-fix pin)", () => {
     // so the inline return-type annotation is not reachable from here by
     // construction.
     //
-    // Pre-fix reading (this round): the function wrapping `Bun.spawnSync` is a
-    // `FunctionDeclaration` whose body holds 0 `ThrowStatement` nodes.
-    test("sh's body span in grade.ts holds no ThrowStatement (pin; S3 replaces)", () => {
+    // Post-fix reading (this round): the function wrapping `Bun.spawnSync` is
+    // a `FunctionDeclaration` whose body holds 1 `ThrowStatement` node.
+    test("sh's body span in grade.ts holds a ThrowStatement (post-fix; S3)", () => {
         const decl = shDeclaration(gradeAst(evalRoot()));
         const body = decl.body as Node;
-        expect(collect(body, "ThrowStatement").length).toBe(0);
+        expect(collect(body, "ThrowStatement").length).toBeGreaterThan(0);
     });
 
-    // Leg D — pin (S3 replaces). No `sh()` call site sits inside a `try` with a
-    // `handler`. This pin expires with S3 — S3 replaces it with the assertion
-    // that a try/catch wraps a staging call, in the same diff.
+    // Leg D — post-fix (S3 landed; replaces the pre-fix "no call site sits in
+    // a try with a handler" pin). The two *staging* call sites (`bun
+    // install`, `bunx playwright install chromium`) are now wrapped together
+    // in one `try` with a `handler`, so the fix's structural signature is a
+    // try/catch wrapping MORE THAN ONE `sh()` call site — distinct from each
+    // *graded* call site (`tsc --noEmit`, the CLI build), which `sh` also
+    // throws on but which S3 must keep grading FAIL, so each graded call site
+    // gets its own single-call try/catch rather than sharing the staging
+    // pair's. Asserting "a try wraps 2+ call sites together" therefore pins
+    // the staging block specifically, never merely "some try wraps some call",
+    // which would already have been true the moment any one graded site grew
+    // a catch and would not discriminate the staging fix from that alone.
     //
     // `sh` is located by call structure (the reader above), and call sites are
     // resolved from that declaration's name — not hardcoded. The population
     // control asserts the call-site set is non-empty, so the arm fails if the
     // reader loses its subject.
     //
-    // Pre-fix reading (this round): 4 call sites of the function wrapping
-    // `Bun.spawnSync`, 0 inside a `TryStatement` with a `handler`; 1
-    // `TryStatement` total (handler absent, no `sh()` call in its block).
-    test("no sh() call site sits inside a try with a handler (pin; S3 replaces)", () => {
+    // Post-fix reading (this round): 4 call sites of the function wrapping
+    // `Bun.spawnSync`; 3 `TryStatement`s with a `handler` wrap at least one
+    // call site each, and exactly one of them wraps 2 call sites together
+    // (the staging pair).
+    test("a try with a handler wraps more than one sh() call site together (post-fix; S3)", () => {
         const ast = gradeAst(evalRoot());
         const decl = shDeclaration(ast);
         const calls = callSitesOf(ast, decl);
@@ -444,9 +458,58 @@ describe("S3 — staging failure maps to INCOMPLETE (pre-fix pin)", () => {
         // empty set means the reader lost its subject, not that the property
         // holds.
         expect(calls.length).toBeGreaterThan(0);
-        const wrapped = collect(ast, "TryStatement").some(
-            (t) => t.handler != null && callSitesOf(t.block as Node, decl).length > 0,
-        );
-        expect(wrapped).toBe(false);
+        const wrappedCounts = collect(ast, "TryStatement")
+            .filter((t) => t.handler != null)
+            .map((t) => callSitesOf(t.block as Node, decl).length);
+        // Population control — at least one try/catch actually wraps a real
+        // sh() call site; an all-zero list means the reader lost its subject
+        // rather than the property being false.
+        expect(wrappedCounts.some((n) => n > 0)).toBe(true);
+        expect(wrappedCounts.some((n) => n >= 2)).toBe(true);
+    });
+
+    // Leg C — post-fix (transferred to S3 per Approach S1's fourth-hole
+    // verdict, 2026-08-25). Leg C is an ABSENCE assertion over an open shape
+    // space in its retired form ("no declaration reachable from grade.ts
+    // carries an INCOMPLETE member") — held four rounds, each holed by a
+    // landing shape the prior reader did not enumerate. S3 is the diff that
+    // creates the declaration leg C is about, so this leg asserts PRESENCE of
+    // the shape this diff actually wrote: a closed readable fact, never
+    // re-widened toward the retired absence form.
+    //
+    // `grade.ts` declares `type ResultKind = "PASS" | "FAIL" | "INCOMPLETE"`
+    // — a `TSTypeAliasDeclaration` whose `typeAnnotation` is a `TSUnionType`
+    // whose members are `TSLiteralType`s over `StringLiteral`s. The reader
+    // walks every type-alias union in grade.ts's own AST and collects each
+    // string-literal member's value, so a bare string anywhere else in the
+    // file (a display string, a `console.log("INCOMPLETE")`, a comment) does
+    // not produce this node shape and cannot satisfy the assertion — only a
+    // union-type member can.
+    //
+    // Post-fix reading (this round): 1 `TSTypeAliasDeclaration` with a
+    // `TSUnionType` annotation in grade.ts, 3 `TSLiteralType` members —
+    // `"PASS"`, `"FAIL"`, `"INCOMPLETE"`.
+    test("grade.ts declares a result-kind union type carrying an INCOMPLETE member (post-fix; S3)", () => {
+        const ast = gradeAst(evalRoot());
+        const aliases = collect(ast, "TSTypeAliasDeclaration");
+        // Population control — grade.ts must declare at least one type alias,
+        // or the reader lost its subject rather than the property being false.
+        expect(aliases.length).toBeGreaterThan(0);
+
+        const literalValues: string[] = [];
+        for (const alias of aliases) {
+            const ann = alias.typeAnnotation as Node | undefined;
+            if (ann?.type !== "TSUnionType") continue;
+            for (const member of (ann.types as Node[] | undefined) ?? []) {
+                if (member.type !== "TSLiteralType") continue;
+                const literal = member.literal as Node | undefined;
+                if (literal?.type === "StringLiteral") literalValues.push(literal.value as string);
+            }
+        }
+        // Population control — at least one union-type alias with string-
+        // literal members exists; an empty list means the reader found the
+        // wrong declaration shape, not that the property is false.
+        expect(literalValues.length).toBeGreaterThan(0);
+        expect(literalValues).toContain("INCOMPLETE");
     });
 });

--- a/packages/shallot/tests/check-eval-gates.test.ts
+++ b/packages/shallot/tests/check-eval-gates.test.ts
@@ -36,10 +36,33 @@
 // assertions in their own diffs — every task gate's setTimeout argument
 // resolves, via its ImportSpecifier binding from harness/lib, to the same
 // single name in lib.ts's export set (leg A); `sh`'s body now holds a
-// ThrowStatement (leg B); a try/catch wraps the staging pair together (leg
-// D); grade.ts declares a result-kind union type carrying an INCOMPLETE
-// member (leg C, transferred to S3 per Approach S1's fourth-hole verdict).
-// No pins remain green pre-fix in this file — every leg now asserts the
+// ThrowStatement (leg B).
+//
+// Leg D repaired: a review disproved the landed "a try with a handler wraps
+// ≥2 sh() call sites together" count with two runnable mutants (false
+// positive: group the two graded sites into one try, leave both staging
+// sites unwrapped, still reads ≥2 while an install failure now throws
+// uncaught; false negative: wrap each of the four calls in its own
+// single-call try/catch, a fully correct fix that reads <2 everywhere). The
+// repair is exhaustive, never counted: every `sh()` call site sits inside a
+// try with a handler, full stop, and no argv-literal (`"install"` vs
+// `"tsc"`) discriminates a site.
+//
+// Leg C repaired: the verdict derivation (and `ResultKind`) is extracted to
+// the pure, import-safe `evals/harness/result.ts`; `grade.ts` imports both.
+// Leg C now resolves `grade.ts`'s `harness/result` import binding to a real
+// declaration in `result.ts` — never a spelling, never a filename guess —
+// admissible as a presence check only because this diff creates the file.
+//
+// `result.ts` also gets this unit's first BEHAVIORAL arm (below the S3
+// describe block): `grade.ts` is a top-level script that can never be
+// imported by a test, but its pure sibling can be, so an arm imports
+// `deriveResultKind` and calls it across the exhaustive truth table of its
+// three inputs — replacing a structural proxy with a real call, and pinning
+// Law 3 (a determined typecheck/build failure outranks an unrunnable gate:
+// INCOMPLETE only when NOTHING determined the outcome).
+//
+// No pins remain green pre-fix in this file — every leg asserts the
 // POST-FIX structure. A green arm that cannot read its subject fails, so the
 // green-because-broken class is eliminated by construction. The readers are
 // parameterized by `CHECK_EVAL_GATES_ROOT`; an absent or empty root reads red
@@ -50,7 +73,9 @@
 // body wraps a `Bun.spawnSync` call), never by the literal name; call sites
 // are resolved from that declaration's name, not hardcoded. The harness/lib
 // arm resolves each gate's `ImportSpecifier` bindings from `harness/lib`
-// against `lib.ts`'s export set, never comparing a name as a spelling.
+// against `lib.ts`'s export set, never comparing a name as a spelling — the
+// same resolution, applied to `result.ts`, is what makes leg C's repair a
+// binding check rather than a spelling one.
 //
 // `evals/harness/gate.config.ts`'s own `timeout: 90_000` is out of S1/S2
 // scope and stays hand-written by design: each gate's `test.setTimeout`
@@ -200,14 +225,16 @@ function callSitesOf(ast: Node, decl: { id: Node | undefined }): Node[] {
     });
 }
 
-// Collect `lib.ts`'s export set: every name reachable from an
+// Collect a module's export set: every name reachable from an
 // `ExportNamedDeclaration` — its `specifiers` (for `export { foo }`),
 // declarator ids (for `export const foo = …`), `FunctionDeclaration.id`
 // (for `export function foo() {}`), and type-declaration ids (for
-// `export interface Foo`, `export type Foo = …`). Resolving the gates'
-// `ImportSpecifier` bindings against this set — rather than comparing a
-// name as a spelling — is what makes the harness/lib arm free of name
-// and form pins.
+// `export interface Foo`, `export type Foo = …`). Resolving an
+// `ImportSpecifier` binding against this set — rather than comparing a
+// name as a spelling — is what makes the harness/lib arm (and the
+// harness/result arm below it) free of name and form pins. Generic over
+// its subject module: called on `lib.ts` for the harness/lib arm and on
+// `result.ts` for leg C.
 function libExportedNames(ast: Node): Set<string> {
     const names = new Set<string>();
     for (const e of collect(ast, "ExportNamedDeclaration")) {
@@ -401,10 +428,13 @@ describe("S2 — derived boot budget", () => {
     });
 });
 
-// S3 — staging failure maps to INCOMPLETE (landed). Legs B and D replace
-// their pre-fix pins with the post-fix assertion in this same diff; leg C
-// (transferred here from S1 per Approach S1's fourth-hole verdict) lands
-// alongside them, since S3 is the diff that creates the code leg C is about.
+// S3 — staging failure maps to INCOMPLETE (landed, then repaired). Leg B
+// replaced its pre-fix pin with the post-fix assertion in S3's own diff. Legs
+// D and C are this repair round's: leg D drops the count an adversarial
+// review disproved for an exhaustive assertion over every sh() call site;
+// leg C (transferred here from S1 per Approach S1's fourth-hole verdict) now
+// resolves grade.ts's import binding into the newly-extracted result.ts
+// rather than reading a union type declared in grade.ts itself.
 describe("S3 — staging failure maps to INCOMPLETE (post-fix)", () => {
     // Leg B — post-fix (S3 landed; replaces the pre-fix "holds no
     // ThrowStatement" pin). `sh`'s body span in `evals/grade.ts` now holds a
@@ -428,29 +458,36 @@ describe("S3 — staging failure maps to INCOMPLETE (post-fix)", () => {
         expect(collect(body, "ThrowStatement").length).toBeGreaterThan(0);
     });
 
-    // Leg D — post-fix (S3 landed; replaces the pre-fix "no call site sits in
-    // a try with a handler" pin). The two *staging* call sites (`bun
-    // install`, `bunx playwright install chromium`) are now wrapped together
-    // in one `try` with a `handler`, so the fix's structural signature is a
-    // try/catch wrapping MORE THAN ONE `sh()` call site — distinct from each
-    // *graded* call site (`tsc --noEmit`, the CLI build), which `sh` also
-    // throws on but which S3 must keep grading FAIL, so each graded call site
-    // gets its own single-call try/catch rather than sharing the staging
-    // pair's. Asserting "a try wraps 2+ call sites together" therefore pins
-    // the staging block specifically, never merely "some try wraps some call",
-    // which would already have been true the moment any one graded site grew
-    // a catch and would not discriminate the staging fix from that alone.
+    // Leg D — repaired (a review disproved the landed count pin with two
+    // runnable mutants). The landed form asserted "a try with a handler
+    // wraps ≥2 sh() call sites together", which is satisfiable by the wrong
+    // try: grouping the two *graded* sites (`tsc`, the build) into one
+    // shared try/catch while leaving both *staging* sites unwrapped reads
+    // ≥2 and stays green even though an install failure now throws
+    // uncaught — strictly worse than the pre-fix defect. And it is holed
+    // the other way too: wrapping each of the four `sh()` calls in its own
+    // single-call try/catch (each staging catch still routing to
+    // INCOMPLETE) is a fully correct alternative fix that reads <2
+    // everywhere and goes red.
     //
-    // `sh` is located by call structure (the reader above), and call sites are
-    // resolved from that declaration's name — not hardcoded. The population
-    // control asserts the call-site set is non-empty, so the arm fails if the
-    // reader loses its subject.
+    // The repair drops the count and goes exhaustive: EVERY `sh()` call
+    // site — not some subset, not a particular pair — must sit inside a
+    // try with a handler. Safety is exhaustiveness over the file's own
+    // call-site set (a source of truth), not a fixture list, and no argv
+    // literal (`"install"` vs `"tsc"`) discriminates a site — that would be
+    // a spelling pin the next refactor moves, the exact class this repairs.
+    //
+    // `sh` is located by call structure (the reader above), and call sites
+    // are resolved from that declaration's name — not hardcoded. A call
+    // site counts as wrapped if it is contained (by node identity, so
+    // arbitrarily nested inside the try's block still counts) in some
+    // `TryStatement` whose `handler` is non-null.
     //
     // Post-fix reading (this round): 4 call sites of the function wrapping
-    // `Bun.spawnSync`; 3 `TryStatement`s with a `handler` wrap at least one
-    // call site each, and exactly one of them wraps 2 call sites together
-    // (the staging pair).
-    test("a try with a handler wraps more than one sh() call site together (post-fix; S3)", () => {
+    // `Bun.spawnSync`; every one of the 4 sits inside a try/catch, whatever
+    // the grouping (today: 3 try/catches, one wrapping the staging pair,
+    // two wrapping one graded call site each).
+    test("every sh() call site sits inside a try with a handler (post-fix; S3)", () => {
         const ast = gradeAst(evalRoot());
         const decl = shDeclaration(ast);
         const calls = callSitesOf(ast, decl);
@@ -458,44 +495,78 @@ describe("S3 — staging failure maps to INCOMPLETE (post-fix)", () => {
         // empty set means the reader lost its subject, not that the property
         // holds.
         expect(calls.length).toBeGreaterThan(0);
-        const wrappedCounts = collect(ast, "TryStatement")
-            .filter((t) => t.handler != null)
-            .map((t) => callSitesOf(t.block as Node, decl).length);
+
+        // Every sh() call site reachable inside some try/catch's block —
+        // collected by node identity, so a call nested arbitrarily deep
+        // inside the block (an if, another call's argument) still counts,
+        // and a call outside every try/catch's block never does.
+        const wrappedCalls = new Set<Node>();
+        for (const t of collect(ast, "TryStatement")) {
+            if (t.handler == null) continue;
+            for (const call of callSitesOf(t.block as Node, decl)) wrappedCalls.add(call);
+        }
         // Population control — at least one try/catch actually wraps a real
-        // sh() call site; an all-zero list means the reader lost its subject
+        // sh() call site; an empty set means the reader lost its subject
         // rather than the property being false.
-        expect(wrappedCounts.some((n) => n > 0)).toBe(true);
-        expect(wrappedCounts.some((n) => n >= 2)).toBe(true);
+        expect(wrappedCalls.size).toBeGreaterThan(0);
+
+        for (const call of calls) {
+            expect(wrappedCalls.has(call)).toBe(true);
+        }
     });
 
-    // Leg C — post-fix (transferred to S3 per Approach S1's fourth-hole
-    // verdict, 2026-08-25). Leg C is an ABSENCE assertion over an open shape
-    // space in its retired form ("no declaration reachable from grade.ts
-    // carries an INCOMPLETE member") — held four rounds, each holed by a
-    // landing shape the prior reader did not enumerate. S3 is the diff that
-    // creates the declaration leg C is about, so this leg asserts PRESENCE of
-    // the shape this diff actually wrote: a closed readable fact, never
-    // re-widened toward the retired absence form.
+    // Leg C — repaired (Law 2). `grade.ts` no longer declares `ResultKind`
+    // itself: the verdict derivation (and its `ResultKind`) is extracted to
+    // the pure, import-safe sibling `evals/harness/result.ts`, and `grade.ts`
+    // imports both the derivation function and the type. Leg C's obligation
+    // — resolve the subject to a real declaration, never a spelling or a
+    // filename guess — now reads as: `grade.ts`'s `ImportDeclaration` from a
+    // source ending `harness/result` resolves (via the same binding-
+    // resolution the harness/lib arm uses, `libExportedNames`, applied here
+    // to `result.ts`) against a real export of that module, and that module
+    // itself declares a union type carrying an INCOMPLETE member — a
+    // presence check admissible only because this diff is the one that
+    // creates `result.ts`.
     //
-    // `grade.ts` declares `type ResultKind = "PASS" | "FAIL" | "INCOMPLETE"`
-    // — a `TSTypeAliasDeclaration` whose `typeAnnotation` is a `TSUnionType`
-    // whose members are `TSLiteralType`s over `StringLiteral`s. The reader
-    // walks every type-alias union in grade.ts's own AST and collects each
-    // string-literal member's value, so a bare string anywhere else in the
-    // file (a display string, a `console.log("INCOMPLETE")`, a comment) does
-    // not produce this node shape and cannot satisfy the assertion — only a
-    // union-type member can.
-    //
-    // Post-fix reading (this round): 1 `TSTypeAliasDeclaration` with a
-    // `TSUnionType` annotation in grade.ts, 3 `TSLiteralType` members —
-    // `"PASS"`, `"FAIL"`, `"INCOMPLETE"`.
-    test("grade.ts declares a result-kind union type carrying an INCOMPLETE member (post-fix; S3)", () => {
-        const ast = gradeAst(evalRoot());
-        const aliases = collect(ast, "TSTypeAliasDeclaration");
-        // Population control — grade.ts must declare at least one type alias,
-        // or the reader lost its subject rather than the property being false.
-        expect(aliases.length).toBeGreaterThan(0);
+    // Post-fix reading (this round): `grade.ts` imports from a source ending
+    // `harness/result`; every imported name resolves against `result.ts`'s
+    // export set; `result.ts` declares 1 `TSTypeAliasDeclaration` with a
+    // `TSUnionType` annotation, 3 `TSLiteralType` members — `"PASS"`,
+    // `"FAIL"`, `"INCOMPLETE"`.
+    test("grade.ts's harness/result import resolves to a union type carrying an INCOMPLETE member (post-fix; S3)", () => {
+        const root = evalRoot();
+        const ast = gradeAst(root);
 
+        const importedNames: string[] = [];
+        for (const imp of collect(ast, "ImportDeclaration")) {
+            const source = (imp.source as Node).value as string;
+            if (!source.endsWith("harness/result")) continue;
+            for (const spec of (imp.specifiers as Node[] | undefined) ?? []) {
+                if (spec.type !== "ImportSpecifier") continue;
+                const imported = spec.imported as Node | undefined;
+                if (imported?.type === "Identifier") importedNames.push(imported.name as string);
+                else if (imported?.type === "StringLiteral") importedNames.push(imported.value as string);
+            }
+        }
+        // Population control — grade.ts must import from harness/result, or
+        // the reader lost its subject rather than the property being false.
+        expect(importedNames.length).toBeGreaterThan(0);
+
+        const resultPath = join(root, "evals", "harness", "result.ts");
+        const resultAst = parseFile(resultPath);
+        const exportedNames = libExportedNames(resultAst);
+        // Population control — result.ts must export something.
+        expect(exportedNames.size).toBeGreaterThan(0);
+        for (const name of importedNames) {
+            expect(exportedNames.has(name)).toBe(true);
+        }
+
+        // Presence: result.ts itself declares a union type carrying the
+        // INCOMPLETE literal — never resolved by a bare string anywhere in
+        // the file (a display string, a comment) since only a
+        // `TSUnionType` member produces this node shape.
+        const aliases = collect(resultAst, "TSTypeAliasDeclaration");
+        expect(aliases.length).toBeGreaterThan(0);
         const literalValues: string[] = [];
         for (const alias of aliases) {
             const ann = alias.typeAnnotation as Node | undefined;
@@ -511,5 +582,64 @@ describe("S3 — staging failure maps to INCOMPLETE (post-fix)", () => {
         // wrong declaration shape, not that the property is false.
         expect(literalValues.length).toBeGreaterThan(0);
         expect(literalValues).toContain("INCOMPLETE");
+    });
+});
+
+// S3 repair, Law 2 & 3 — the unit's first behavioral oracle. `grade.ts` is a
+// top-level script (argv parsing, top-level await) that can never be
+// imported by an arm — every leg above reads its AST instead of running it.
+// `evals/harness/result.ts` is a pure sibling with no @playwright/test
+// import, so it CAN be imported and called directly: this arm imports it and
+// drives `deriveResultKind` across the exhaustive truth table of its three
+// determined inputs, replacing a structural proxy with a real call.
+//
+// This is also Law 3's witness: a determined typecheck or build failure
+// outranks an unrunnable gate — INCOMPLETE is reserved for a run where
+// NOTHING determined the outcome, so `deriveResultKind(false, true, null)`
+// is FAIL, never INCOMPLETE, even though the gate never ran.
+//
+// Red at the parent ref: `harness/result.ts` does not exist there, so the
+// dynamic import throws and the test fails outright — never a green arm
+// that cannot read its subject.
+describe("S3 — result kind derivation (behavioral)", () => {
+    test("deriveResultKind covers the exhaustive truth table of its three determined inputs", async () => {
+        const root = evalRoot();
+        const resultPath = join(root, "evals", "harness", "result.ts");
+        const mod = (await import(resultPath)) as {
+            deriveResultKind?: (a: boolean, b: boolean, c: boolean | null) => unknown;
+        };
+        // Population control — the module must actually export the function
+        // under test, or the reader lost its subject rather than the
+        // property being false.
+        expect(typeof mod.deriveResultKind).toBe("function");
+        const deriveResultKind = mod.deriveResultKind as (
+            a: boolean,
+            b: boolean,
+            c: boolean | null,
+        ) => unknown;
+
+        const bools = [true, false];
+        const gateVals: (boolean | null)[] = [true, false, null];
+        let cases = 0;
+        for (const typecheckOk of bools) {
+            for (const buildOk of bools) {
+                for (const gateOk of gateVals) {
+                    cases++;
+                    const expected =
+                        typecheckOk === false || buildOk === false
+                            ? "FAIL"
+                            : gateOk === null
+                              ? "INCOMPLETE"
+                              : gateOk
+                                ? "PASS"
+                                : "FAIL";
+                    expect(deriveResultKind(typecheckOk, buildOk, gateOk)).toBe(expected);
+                }
+            }
+        }
+        // Population control — the truth table actually iterated all 12
+        // combinations (2 × 2 × 3); a broken loop reads as a pass on zero
+        // cases.
+        expect(cases).toBe(12);
     });
 });


### PR DESCRIPTION
- **audit-eval-infra-vs-task-verdict: sh throws, staging failure maps to INCOMPLETE**
- **audit-eval-infra-vs-task-verdict: repair leg D to exhaustive, extract verdict derivation**
- **audit-eval-infra-vs-task-verdict: correct the comments Law 3 falsified**
