### PR TITLE
shallot gate never writes/close

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -12,7 +12,7 @@ paths:
 
 Shallot-specific testing patterns.
 
-**`bun check` is not read-only — it opens with `bun run format` (`biome check --write`).** A grep taken before it is not the state you commit: it silently renamed an authored function-local `SCREAMING_SNAKE` const to PascalCase between one stage's read and its commit, and a review round then filed biome's own autofix as a convention defect. Read the tree you intend to commit *after* `bun check`, and compare a spelling against its own scope's siblings before calling it a violation.
+**A gate verifies and never writes; `bun run format` is the only writer.** `bun check` reports and exits without touching the tree, so the state you read before it is the state you commit.
 
 ## GPU testing
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -67,7 +67,7 @@ jobs:
       - run: bun run site
 
       # Runs check-site.ts (the site membership + root-absolute gate) with
-      # SITE_OUT_REQUIRED=1. The full `bun check` suite's first step (format.ts) imports
+      # SITE_OUT_REQUIRED=1. The full `bun check` suite includes scripts/format.ts, which imports
       # the engine barrel, which transitively imports the gitignored audio wasm
       # (packages/shallot/rust/audio/pkg/shallot_audio.js) — so the full suite is red in a
       # fresh CI checkout without a Rust build step, and this workflow adds none (the

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -1052,10 +1052,7 @@ function tgslFlow(sandbox: string, dist: string) {
     // line names it. Restored, the arm greens with `expected=2`. Mutating the *expectation* is the
     // witness that matters; deleting the assertion greens for free and witnesses nothing.
     //
-    // NB the spelling: `bun check` begins with `bun run format` = `biome check --write`, so biome's
-    // naming convention rewrites a SCREAMING_SNAKE local const to PascalCase here and the gate
-    // silently reformats what you wrote. Renaming this to match the file's module-level constants
-    // is reverted by the next `bun check`.
+    // NB the spelling: `bun run format` runs `biome check --write`, whose naming convention rewrites a SCREAMING_SNAKE local const to PascalCase here.
     const ExpectedMetaVersion = 2;
     // TRANSPILED term diagnostic: bundle byte length and whether any transpiled-shape marker appears
     // at all. `body:[0,` is the TRANSPILED regex's head; `__TYPEGPU_META__` ships with the typegpu


### PR DESCRIPTION
- **shallot-gate-never-writes: close — promote the non-writing-gate rule**
- **shallot-gate-never-writes: close — drop the stale check-ordering claim in site.yml**
