### PR TITLE
voxel-chunk-streaming: S1 pure CPU core — facesInChunk + region allocator

### DIFF
--- a/examples/showcase/voxel/src/voxel/grid.test.ts
+++ b/examples/showcase/voxel/src/voxel/grid.test.ts
@@ -9,8 +9,11 @@ import {
     coord,
     DIM,
     faces,
+    facesInChunk,
     index,
+    SLOT_COUNT,
     SLOTS,
+    set,
     solid,
     TOTAL_CELLS,
     voxelIndex,
@@ -284,5 +287,100 @@ describe("recenter", () => {
         const centred = recenter(data);
         expect(count(centred)).toBe(1);
         expect(solid(centred, 128, 128, 128)).toBe(true);
+    });
+});
+
+describe("facesInChunk — the CPU twin of the emit kernel's per-chunk emission", () => {
+    function sumChunks(data: Float32Array): number {
+        let n = 0;
+        for (let slot = 0; slot < SLOT_COUNT; slot++) n += facesInChunk(data, slot);
+        return n;
+    }
+
+    test("SLOT_COUNT is the 8³ chunk grid (512 chunks)", () => {
+        expect(SLOT_COUNT).toBe(512);
+    });
+
+    test("single isolated voxel — all six faces attributed to its own chunk", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        single(data, 40, 50, 60);
+        const slot = Math.floor(index(40, 50, 60) / CHUNK_CELLS);
+        expect(facesInChunk(data, slot)).toBe(6);
+        expect(sumChunks(data)).toBe(faces(data));
+    });
+
+    test("solid chunk — the CPU twin matches faces() for that one chunk", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        solidChunk(data, 1, 1, 1);
+        const slot = (1 * SLOTS.y + 1) * SLOTS.x + 1;
+        expect(facesInChunk(data, slot)).toBe(6 * CHUNK * CHUNK);
+        expect(sumChunks(data)).toBe(faces(data));
+    });
+
+    test("differential — Σ facesInChunk over every slot equals faces() on the canonical patterns", () => {
+        const patterns: Float32Array[] = [];
+
+        const single1 = new Float32Array(TOTAL_CELLS);
+        single(single1, 0, 0, 0); // grid corner — all-OOB neighbours
+        patterns.push(single1);
+
+        const solidChunkGrid = new Float32Array(TOTAL_CELLS);
+        solidChunk(solidChunkGrid, 3, 4, 5);
+        patterns.push(solidChunkGrid);
+
+        const checkerGrid = new Float32Array(TOTAL_CELLS);
+        checker(checkerGrid, 0, 0, 0, 16, 16, 16);
+        patterns.push(checkerGrid);
+
+        const slabGrid = new Float32Array(TOTAL_CELLS);
+        slab(slabGrid, 3);
+        patterns.push(slabGrid);
+
+        const tunnelGrid = new Float32Array(TOTAL_CELLS);
+        tunnel(tunnelGrid, 10, 10, 10, 16);
+        patterns.push(tunnelGrid);
+
+        // spans multiple chunks (r=40 > CHUNK=32) — the case a chunk-local-only neighbour read gets wrong,
+        // since the seam faces straddle two chunks' data.
+        const sphereGrid = new Float32Array(TOTAL_CELLS);
+        sphere(sphereGrid, 128, 128, 128, 40);
+        patterns.push(sphereGrid);
+
+        for (const data of patterns) expect(sumChunks(data)).toBe(faces(data));
+    });
+
+    test("differential — mutating a grid across a chunk seam keeps the two counts in lockstep", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        sphere(data, 128, 128, 128, 40);
+        expect(sumChunks(data)).toBe(faces(data));
+
+        // carve a hole straddling a chunk boundary (128 sits on a CHUNK=32 seam)
+        for (let z = 125; z <= 131; z++) {
+            for (let y = 125; y <= 131; y++) {
+                for (let x = 125; x <= 131; x++) set(data, x, y, z, 0);
+            }
+        }
+        expect(sumChunks(data)).toBe(faces(data));
+
+        // re-solidify part of the carved hole, back across the same seam
+        for (let z = 126; z <= 129; z++) {
+            for (let y = 126; y <= 129; y++) {
+                for (let x = 126; x <= 129; x++) set(data, x, y, z, 1.0);
+            }
+        }
+        expect(sumChunks(data)).toBe(faces(data));
+    });
+
+    test("print-only — full-grid Σ facesInChunk (512 chunks) cost at boot", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        slab(data, 3); // the boot-generated ground slab — the canonical non-trivial boot fixture
+        const start = performance.now();
+        const total = sumChunks(data);
+        const elapsed = performance.now() - start;
+        expect(total).toBe(faces(data));
+        // print-only per spec (no wall-clock gate) — S3 reads this to judge the loading-screen budget
+        console.log(
+            `[voxel-chunk-streaming] boot facesInChunk over ${SLOT_COUNT} chunks: ${elapsed.toFixed(3)}ms`,
+        );
     });
 });

--- a/examples/showcase/voxel/src/voxel/grid.ts
+++ b/examples/showcase/voxel/src/voxel/grid.ts
@@ -27,7 +27,8 @@ export const CHUNK_CELLS = CHUNK * CHUNK * CHUNK;
 export const SLOTS = { x: 8, y: 8, z: 8 } as const;
 export const DIM = { x: SLOTS.x * CHUNK, y: SLOTS.y * CHUNK, z: SLOTS.z * CHUNK } as const;
 
-export const TOTAL_CELLS = SLOTS.x * SLOTS.y * SLOTS.z * CHUNK_CELLS;
+export const SLOT_COUNT = SLOTS.x * SLOTS.y * SLOTS.z;
+export const TOTAL_CELLS = SLOT_COUNT * CHUNK_CELLS;
 export const BYTES = TOTAL_CELLS * 4;
 export const GridData = d.arrayOf(d.f32, TOTAL_CELLS);
 
@@ -138,6 +139,36 @@ export function faces(data: Float32Array): number {
     for (let z = 0; z < DIM.z; z++) {
         for (let y = 0; y < DIM.y; y++) {
             for (let x = 0; x < DIM.x; x++) {
+                if (!solidAt(data, x, y, z)) continue;
+                if (!solidAt(data, x + 1, y, z)) n++;
+                if (!solidAt(data, x - 1, y, z)) n++;
+                if (!solidAt(data, x, y + 1, z)) n++;
+                if (!solidAt(data, x, y - 1, z)) n++;
+                if (!solidAt(data, x, y, z + 1)) n++;
+                if (!solidAt(data, x, y, z - 1)) n++;
+            }
+        }
+    }
+    return n;
+}
+
+/**
+ * the exact exposed-face count for one chunk (`slot`) — the CPU twin of the emit kernel's per-chunk
+ * emission (`mesher.ts`'s `emitKernel`): same `>= ISO` predicate, same f32 grid data, walked over the
+ * chunk's local cells but reading neighbours through {@link solidAt} so a face straddling a chunk seam
+ * (the sphere/checker fixtures, any real edit) reads the *other* chunk's data, not an assumed-air edge —
+ * a chunk boundary is not a data boundary. `Σ facesInChunk(data, slot)` over every slot equals
+ * {@link faces}; this is what lets S2 allocate each touched chunk's region exactly, no worst-case pad.
+ */
+export function facesInChunk(data: Float32Array, slot: number): number {
+    const [ox, oy, oz] = coord(slot * CHUNK_CELLS);
+    let n = 0;
+    for (let lz = 0; lz < CHUNK; lz++) {
+        const z = oz + lz;
+        for (let ly = 0; ly < CHUNK; ly++) {
+            const y = oy + ly;
+            for (let lx = 0; lx < CHUNK; lx++) {
+                const x = ox + lx;
                 if (!solidAt(data, x, y, z)) continue;
                 if (!solidAt(data, x + 1, y, z)) n++;
                 if (!solidAt(data, x - 1, y, z)) n++;

--- a/examples/showcase/voxel/src/voxel/pool.test.ts
+++ b/examples/showcase/voxel/src/voxel/pool.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { RegionAllocator } from "./pool";
+
+describe("RegionAllocator", () => {
+    test("starts as one free region spanning the whole capacity", () => {
+        const pool = new RegionAllocator(100);
+        expect(pool.regions()).toEqual([{ start: 0, size: 100 }]);
+    });
+
+    test("alloc hands back a contiguous region and shrinks the free list from the front", () => {
+        const pool = new RegionAllocator(100);
+        const a = pool.alloc(30);
+        expect(a).toEqual({ start: 0, size: 30 });
+        expect(pool.regions()).toEqual([{ start: 30, size: 70 }]);
+    });
+
+    test("an exact-size alloc consumes the whole free region, not just its size", () => {
+        const pool = new RegionAllocator(10);
+        const a = pool.alloc(10);
+        expect(a).toEqual({ start: 0, size: 10 });
+        expect(pool.regions()).toEqual([]);
+    });
+
+    test("first-fit: a later alloc lands in the first free region large enough, not the largest", () => {
+        const pool = new RegionAllocator(100);
+        const a = pool.alloc(10)!; // [0,10)
+        const b = pool.alloc(20)!; // [10,30)
+        pool.free(a.start); // free list: [0,10), [30,70)
+        const c = pool.alloc(5); // fits the smaller hole first
+        expect(c).toEqual({ start: 0, size: 5 });
+        expect(pool.regions()).toEqual([
+            { start: 5, size: 5 },
+            { start: 30, size: 70 },
+        ]);
+        expect(b).toEqual({ start: 10, size: 20 });
+    });
+
+    test("alloc returns null (exhaustion signal) when no free region is large enough", () => {
+        const pool = new RegionAllocator(10);
+        pool.alloc(6);
+        expect(pool.alloc(5)).toBeNull();
+        expect(pool.alloc(4)).toEqual({ start: 6, size: 4 });
+    });
+
+    test("free coalesces with both neighbours, restoring one contiguous region", () => {
+        const pool = new RegionAllocator(30);
+        const a = pool.alloc(10)!; // [0,10)
+        const b = pool.alloc(10)!; // [10,20)
+        const c = pool.alloc(10)!; // [20,30)
+        pool.free(a.start);
+        pool.free(c.start);
+        expect(pool.regions()).toEqual([
+            { start: 0, size: 10 },
+            { start: 20, size: 10 },
+        ]);
+        pool.free(b.start); // bridges the two, coalescing all three back into one
+        expect(pool.regions()).toEqual([{ start: 0, size: 30 }]);
+    });
+
+    test("free of an unknown start throws rather than silently corrupting the free list", () => {
+        const pool = new RegionAllocator(10);
+        expect(() => pool.free(4)).toThrow();
+    });
+
+    test("freeing the same region twice throws on the second call", () => {
+        const pool = new RegionAllocator(10);
+        const a = pool.alloc(5)!;
+        pool.free(a.start);
+        expect(() => pool.free(a.start)).toThrow();
+    });
+
+    test("alloc of a non-positive size throws", () => {
+        const pool = new RegionAllocator(10);
+        expect(() => pool.alloc(0)).toThrow();
+        expect(() => pool.alloc(-1)).toThrow();
+    });
+
+    test("repeated churn (alloc/free cycles) never grows the free list beyond one region on full release", () => {
+        const pool = new RegionAllocator(64);
+        for (let i = 0; i < 50; i++) {
+            const regions = [pool.alloc(8), pool.alloc(16), pool.alloc(4)];
+            for (const r of regions) pool.free(r!.start);
+        }
+        expect(pool.regions()).toEqual([{ start: 0, size: 64 }]);
+    });
+
+    test("a zero-capacity pool starts empty and every alloc signals exhaustion", () => {
+        const pool = new RegionAllocator(0);
+        expect(pool.regions()).toEqual([]);
+        expect(pool.alloc(1)).toBeNull();
+    });
+});

--- a/examples/showcase/voxel/src/voxel/pool.ts
+++ b/examples/showcase/voxel/src/voxel/pool.ts
@@ -1,0 +1,70 @@
+// A pure, device-free first-fit free-list allocator over the face-pool number line (the CPU-side half of
+// scoped remesh, `voxel-chunk-streaming` S1): each touched chunk gets an exactly-sized contiguous region of
+// `[0, capacity)`, sized by the caller's own exact face count (`facesInChunk` in `grid.ts`) — no worst-case
+// reservation. `alloc` returns null on exhaustion (no first-fit region large enough) rather than throwing;
+// S2's caller falls back to full realloc + full re-emit through the same machinery on that signal — always
+// correct, rare. Regions merge back into the free list on `free`, so churn from repeated carves doesn't
+// fragment into unusable slivers faster than it has to.
+
+export interface Region {
+    readonly start: number;
+    readonly size: number;
+}
+
+export class RegionAllocator {
+    private _freeList: Region[];
+    private readonly _live = new Map<number, Region>();
+
+    constructor(readonly capacity: number) {
+        this._freeList = capacity > 0 ? [{ start: 0, size: capacity }] : [];
+    }
+
+    /** the free regions, sorted by start, coalesced — read-only, for tests and diagnostics. */
+    regions(): readonly Region[] {
+        return this._freeList;
+    }
+
+    /** first-fit: the first free region large enough for `size`, split if it overshoots. Null signals
+     *  exhaustion — no single free region can satisfy the request (including full fragmentation). */
+    alloc(size: number): Region | null {
+        if (size <= 0) throw new Error("RegionAllocator: alloc size must be positive");
+        const i = this._freeList.findIndex((r) => r.size >= size);
+        if (i === -1) return null;
+        const region = this._freeList[i];
+        const granted: Region = { start: region.start, size };
+        if (region.size === size) this._freeList.splice(i, 1);
+        else this._freeList[i] = { start: region.start + size, size: region.size - size };
+        this._live.set(granted.start, granted);
+        return granted;
+    }
+
+    /** release a region previously returned by {@link alloc}, coalescing with adjacent free neighbours so
+     *  free capacity never fragments below what a later alloc could otherwise find. */
+    free(start: number): void {
+        const region = this._live.get(start);
+        if (!region) throw new Error(`RegionAllocator: free of unknown region at ${start}`);
+        this._live.delete(start);
+
+        let i = this._freeList.findIndex((r) => r.start > region.start);
+        if (i === -1) i = this._freeList.length;
+        this._freeList.splice(i, 0, region);
+
+        // coalesce with the following neighbour first — its index doesn't shift by doing so.
+        if (i + 1 < this._freeList.length) {
+            const next = this._freeList[i + 1];
+            if (region.start + region.size === next.start) {
+                this._freeList[i] = { start: region.start, size: region.size + next.size };
+                this._freeList.splice(i + 1, 1);
+            }
+        }
+        // coalesce with the preceding neighbour.
+        if (i > 0) {
+            const prev = this._freeList[i - 1];
+            const cur = this._freeList[i];
+            if (prev.start + prev.size === cur.start) {
+                this._freeList[i - 1] = { start: prev.start, size: prev.size + cur.size };
+                this._freeList.splice(i, 1);
+            }
+        }
+    }
+}


### PR DESCRIPTION
facesInChunk(data, slot) is the CPU twin of the emit kernel's per-chunk
emission (same >= ISO predicate, same f32 grid data, cross-chunk
neighbour reads via solidAt). RegionAllocator is a pure first-fit
free-list over a linear number line, alloc/free/exhaustion signal.
Differential test: Σ facesInChunk over all 512 slots == faces() on
the canonical patterns and a mutated cross-chunk-seam grid.
