### PR TITLE
voxel-chunk-streaming: S2 mesher rewrite — chunk table + per-chunk cursors

### DIFF
--- a/examples/showcase/voxel/src/boot.ts
+++ b/examples/showcase/voxel/src/boot.ts
@@ -4,13 +4,15 @@ import { gate } from "./gate";
 import type { Check } from "./harness";
 import { type EmitDispatchSample, emitDispatchSample } from "./perf";
 import { generate } from "./voxel/generate";
-import { syncGrid, Voxels } from "./voxel/mesher";
+import { Voxels } from "./voxel/mesher";
 
 // The voxel showcase's boot orchestration, as a plugin (a manifest project has no `main.ts` entry).
-// The mesher allocates `Voxels.grid` + `.indirect` in its first-frame setup, so the boot can only run once
+// The mesher allocates `Voxels.grid` + `.cursor` in its first-frame setup, so the boot can only run once
 // they exist: it fills the grid on the GPU (FBM terrain — the live visual), syncs the CPU mirror so the carve
-// path can march it, mounts the toolbar + keys, and installs the device gate. `mode: always` so the terrain
-// meshes in edit mode too, not just play. Idempotent per State — `setup` re-arms it each build (ecs.md
+// path can march it, mounts the toolbar + keys, and installs the device gate. The gate + perf probe both
+// mirror `Voxels.cursor` (the per-chunk atomic face count) rather than `.indirect` — the CPU-authored draw
+// record would make the gate circular (`voxel-chunk-streaming` S2). `mode: always` so the terrain meshes
+// in edit mode too, not just play. Idempotent per State — `setup` re-arms it each build (ecs.md
 // "Reload-safety"); `dispose` tears the UI down so a rebuild doesn't stack overlays.
 
 declare global {
@@ -25,7 +27,7 @@ declare global {
 const SEED = 1337;
 
 let armed = true;
-let indirect: Mirror | null = null;
+let cursorMirror: Mirror | null = null;
 let toolbar: { setTool: (t: "pointer" | "terrain") => void; dispose: () => void } | null = null;
 
 const BootSystem: System = {
@@ -36,24 +38,25 @@ const BootSystem: System = {
         armed = true; // setup runs once per State build — re-arm so a rebuild re-boots
     },
     update(state) {
-        if (!armed || !Voxels.grid || !Voxels.indirect) return;
+        if (!armed || !Voxels.grid || !Voxels.cursor) return;
         armed = false;
-        indirect = mirror(Voxels.indirect);
-        const m = indirect;
+        cursorMirror = mirror(Voxels.cursor);
+        const m = cursorMirror;
         void boot(state, m);
     },
     dispose() {
         teardownUi();
-        indirect?.dispose();
-        indirect = null;
+        cursorMirror?.dispose();
+        cursorMirror = null;
         delete window.__voxelGate;
         delete window.__voxelPerf;
     },
 };
 
 async function boot(state: State, m: Mirror): Promise<void> {
+    // generate() syncs the CPU mirror itself (`voxel-chunk-streaming` S2: the mesher's chunk allocation is
+    // CPU-exact), so there's no separate syncGrid() step to sequence here anymore.
     await generate(SEED);
-    await syncGrid();
     if (state.signal.aborted) return;
     initCarve(state, document.querySelector("canvas"), SEED);
     mountUi(state);

--- a/examples/showcase/voxel/src/carve.ts
+++ b/examples/showcase/voxel/src/carve.ts
@@ -12,7 +12,7 @@ import { segment } from "@dylanebert/shallot/extras";
 import { cursorRay, qRotate } from "@dylanebert/shallot/physics/core";
 import { brush, march } from "./voxel/edit";
 import { generate } from "./voxel/generate";
-import { commitEdit, syncGrid, Voxels } from "./voxel/mesher";
+import { commitEdit, Voxels } from "./voxel/mesher";
 
 // Realtime carving (the voxel showcase's interactive layer). A top toolbar picks the pointer (orbit) or
 // terrain (sculpt) tool (keys V / B). In the terrain tool left-drag adds, shift+drag carves, scroll resizes
@@ -83,8 +83,8 @@ const VoxelControlSystem: System = {
     update() {
         if (!Voxels.grid || seed === appliedSeed) return;
         appliedSeed = seed;
-        // re-sync the CPU mirror after the GPU regen so a carve marches/edits the new terrain, not the old.
-        void generate(seed).then(syncGrid);
+        // generate() syncs the CPU mirror itself, so the new terrain is immediately carveable.
+        void generate(seed);
     },
 };
 

--- a/examples/showcase/voxel/src/gate.ts
+++ b/examples/showcase/voxel/src/gate.ts
@@ -17,6 +17,11 @@ import { checker, recenter, single, slab, solidChunk, sphere, tunnel } from "./v
 // under-counts). (2) Generation: the generated grid is deterministic in its seed (two runs read back
 // bit-identical), its solid fraction lands in the derived band, its surface relief is real (not a flat
 // plane), the mesher stays watertight over it, and a carve → grid-write → remesh stays watertight too.
+//
+// The GPU face count is the per-chunk atomic cursor buffer (`Voxels.cursor`), summed over all 512 slots —
+// never the CPU-authored indirect record (`voxel-chunk-streaming` S2: `indexCount = pool tail × 6` is the
+// same CPU count the allocator already computed, so comparing it back to `faces()` would be circular). The
+// cursor sum is the one signal this gate reads that the emit kernel itself produced.
 
 // the six canonical patterns — each a distinct mesher code path (isolated voxel, occluded interior,
 // every-face-exposed, flat plane, inward faces, cross-chunk curve). `faces()` is the analytic expected count.
@@ -78,15 +83,19 @@ function equalGrid(a: Float32Array, b: Float32Array): boolean {
     return true;
 }
 
-// the meshed face count, read back from the indirect record's first word (the index count = faces × 6).
-function liveFaces(indirect: Mirror): number | null {
-    if (!indirect.snapshot) return null;
-    return new Uint32Array(indirect.snapshot.bytes)[0] / 6;
+// the meshed face count: every chunk's atomic cursor, summed — the GPU kernel's own claim of how many
+// faces it wrote, independent of the CPU-authored indirect record (see the module doc above).
+function liveFaces(cursor: Mirror): number | null {
+    if (!cursor.snapshot) return null;
+    const view = new Uint32Array(cursor.snapshot.bytes);
+    let sum = 0;
+    for (let i = 0; i < view.length; i++) sum += view[i];
+    return sum;
 }
 
-/** run the full mesher gate against the live device, restoring the generated terrain when done. `indirect`
- *  is a {@link Mirror} of the voxel draw record (its first word = the index count). */
-export async function gate(indirect: Mirror): Promise<Check[]> {
+/** run the full mesher gate against the live device, restoring the generated terrain when done. `cursor`
+ *  is a {@link Mirror} of the per-chunk atomic cursor buffer (`Voxels.cursor`). */
+export async function gate(cursor: Mirror): Promise<Check[]> {
     const checks: Check[] = [];
 
     // (1) mesher correctness: swap in each canonical grid, re-mesh, assert the GPU's atomic face count
@@ -95,8 +104,8 @@ export async function gate(indirect: Mirror): Promise<Check[]> {
     for (const pat of PATTERNS) {
         const grid = authorGrid(pat.name);
         uploadVoxels(grid);
-        await settle(indirect);
-        const got = liveFaces(indirect);
+        await settle(cursor);
+        const got = liveFaces(cursor);
         const want = faces(grid);
         const seam = pat.name === "sphere" ? " — watertight across chunk seams" : "";
         checks.push({
@@ -109,11 +118,11 @@ export async function gate(indirect: Mirror): Promise<Check[]> {
     // (2) generation: generate twice at one seed and read both grids back. The first drives the
     // density/relief/watertight checks; the pair drives determinism.
     await generate(GATE_SEED);
-    await settle(indirect);
+    await settle(cursor);
     const grid = await readGrid();
-    const gpuFaces = liveFaces(indirect);
+    const gpuFaces = liveFaces(cursor);
     await generate(GATE_SEED);
-    await settle(indirect);
+    await settle(cursor);
     const grid2 = await readGrid();
 
     checks.push({
@@ -154,18 +163,18 @@ export async function gate(indirect: Mirror): Promise<Check[]> {
     // settle here so the initial upload's own emit fires before the edit — otherwise the upload and the
     // edit collapse into one dirty pass and the edit path (a re-mesh over already-meshed geometry) goes
     // unexercised (`showcase-frame-floor` S3 side finding).
-    await settle(indirect);
+    await settle(cursor);
     const touched = brush(edited, DIM.x / 2, DIM.y / 2, DIM.z / 2, 12, -DENSITY);
     commitEdit(touched);
-    await settle(indirect);
+    await settle(cursor);
     checks.push({
         name: "carve-watertight",
-        pass: liveFaces(indirect) === faces(edited),
-        detail: `${liveFaces(indirect)} faces (expected ${faces(edited)}) after carving the core`,
+        pass: liveFaces(cursor) === faces(edited),
+        detail: `${liveFaces(cursor)} faces (expected ${faces(edited)}) after carving the core`,
     });
 
     // restore the generated terrain for the live view.
     await generate(GATE_SEED);
-    await settle(indirect);
+    await settle(cursor);
     return checks;
 }

--- a/examples/showcase/voxel/src/perf.ts
+++ b/examples/showcase/voxel/src/perf.ts
@@ -27,17 +27,17 @@ export interface EmitDispatchSample {
 
 /** author a lone solid voxel, carve it away, and read the dispatch scope the resulting re-mesh fires — a
  *  one-chunk edit, structurally the smallest non-trivial touch. Two dirty fires land (the author upload,
- *  then the carve); `indirect` settles after each so the read trails the fire it measures, never a stale
- *  one. */
-export async function emitDispatchSample(indirect: Mirror): Promise<EmitDispatchSample> {
+ *  then the carve); `cursor` (a {@link Mirror} of `Voxels.cursor`) settles after each so the read trails
+ *  the fire it measures, never a stale one. */
+export async function emitDispatchSample(cursor: Mirror): Promise<EmitDispatchSample> {
     const grid = new Float32Array(TOTAL_CELLS);
     single(grid, PROBE_X, PROBE_Y, PROBE_Z);
     uploadVoxels(grid);
-    await settle(indirect);
+    await settle(cursor);
 
     const touched = brush(grid, PROBE_X, PROBE_Y, PROBE_Z, PROBE_RADIUS, -1);
     commitEdit(touched);
-    await settle(indirect);
+    await settle(cursor);
 
     return { touchedChunks: touched.size, workgroups: EmitTelemetry.lastWorkgroups };
 }

--- a/examples/showcase/voxel/src/voxel/chunkpool.test.ts
+++ b/examples/showcase/voxel/src/voxel/chunkpool.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test";
+import { buildTable, type ChunkPool, createChunkPool, fullRemesh, planRemesh } from "./chunkpool";
+import {
+    CHUNK_CELLS,
+    chunkNeighbors,
+    chunkSlot,
+    faces,
+    facesInChunk,
+    SLOT_COUNT,
+    set,
+} from "./grid";
+import { checker, single, sphere } from "./patterns";
+
+const TOTAL_CELLS = SLOT_COUNT * CHUNK_CELLS;
+
+function sumLiveRegions(pool: ChunkPool): number {
+    let n = 0;
+    for (const region of pool.region) if (region) n += region.size;
+    return n;
+}
+
+describe("createChunkPool", () => {
+    test("starts with every slot empty and a zero tail", () => {
+        const pool = createChunkPool(100);
+        expect(pool.tail).toBe(0);
+        expect(pool.region.every((r) => r === null)).toBe(true);
+        expect(pool.region.length).toBe(SLOT_COUNT);
+    });
+});
+
+describe("fullRemesh", () => {
+    test("allocates every non-empty chunk exactly its facesInChunk count, packed with no gaps", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        single(data, 40, 50, 60);
+        const pool = fullRemesh(1024, data);
+
+        const slot = chunkSlot(40, 50, 60);
+        expect(pool.region[slot]).toEqual({ start: 0, size: 6 });
+        expect(pool.tail).toBe(6);
+        expect(sumLiveRegions(pool)).toBe(faces(data));
+
+        // every other slot is empty — this fixture touches exactly one chunk.
+        for (let s = 0; s < SLOT_COUNT; s++) {
+            if (s === slot) continue;
+            expect(pool.region[s]).toBeNull();
+        }
+    });
+
+    test("packs multiple non-empty chunks back-to-back in ascending slot order", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        checker(data, 0, 0, 0, 16, 16, 16); // slot 0 — 6 · 16³/2 = 12,288 faces
+        single(data, 200, 200, 200); // a later slot
+        const pool = fullRemesh(20_000, data);
+
+        const first = chunkSlot(0, 0, 0);
+        const second = chunkSlot(200, 200, 200);
+        expect(first).toBeLessThan(second);
+        const a = pool.region[first]!;
+        const b = pool.region[second]!;
+        expect(a.start).toBe(0);
+        expect(a.size).toBe(facesInChunk(data, first));
+        // packed: the second region starts exactly where the first ends, even though many empty slots
+        // sit between them in slot order.
+        expect(b.start).toBe(a.size);
+        expect(b.size).toBe(facesInChunk(data, second));
+        expect(pool.tail).toBe(a.size + b.size);
+    });
+
+    test("a grid exceeding capacity silently caps — over-budget chunks stay unallocated", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        single(data, 40, 50, 60); // 6 faces
+        const pool = fullRemesh(3, data); // smaller than the one chunk's 6 faces
+        const slot = chunkSlot(40, 50, 60);
+        expect(pool.region[slot]).toBeNull();
+        expect(pool.tail).toBe(0);
+    });
+});
+
+describe("planRemesh", () => {
+    test("allocates a newly-touched empty slot and leaves everything else alone", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        single(data, 40, 50, 60);
+        const pool = createChunkPool(1024);
+        const slot = chunkSlot(40, 50, 60);
+
+        const plan = planRemesh(pool, data, [slot]);
+        expect(plan.exhausted).toBe(false);
+        expect(plan.freed).toEqual([]);
+        expect(pool.region[slot]).toEqual({ start: 0, size: 6 });
+        expect(pool.tail).toBe(6);
+    });
+
+    test("a chunk whose face count is unchanged keeps its region (no free, no realloc)", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        single(data, 40, 50, 60);
+        const pool = createChunkPool(1024);
+        const slot = chunkSlot(40, 50, 60);
+        planRemesh(pool, data, [slot]);
+        const before = pool.region[slot];
+
+        const plan = planRemesh(pool, data, [slot]); // re-plan the same unchanged chunk
+        expect(plan.freed).toEqual([]);
+        expect(pool.region[slot]).toBe(before);
+    });
+
+    test("a grown chunk frees its old region and grants a new, larger one", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        single(data, 40, 50, 60); // 6 faces
+        const pool = createChunkPool(4096);
+        const slot = chunkSlot(40, 50, 60);
+        planRemesh(pool, data, [slot]);
+        const oldRegion = pool.region[slot]!;
+
+        // grows the same chunk's occupancy well past 6 faces (6 · 8³/2 = 1,536), still under capacity
+        checker(data, 32, 32, 32, 8, 8, 8);
+        const plan = planRemesh(pool, data, [slot]);
+        expect(plan.freed).toEqual([oldRegion]);
+        expect(plan.exhausted).toBe(false);
+        const grown = pool.region[slot]!;
+        expect(grown.size).toBe(facesInChunk(data, slot));
+        expect(grown.size).toBeGreaterThan(oldRegion.size);
+    });
+
+    test("a chunk carved to empty frees its region and stays unallocated", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        single(data, 40, 50, 60);
+        const pool = createChunkPool(1024);
+        const slot = chunkSlot(40, 50, 60);
+        planRemesh(pool, data, [slot]);
+        const region = pool.region[slot]!;
+
+        data.fill(0); // carve everything away
+        const plan = planRemesh(pool, data, [slot]);
+        expect(plan.freed).toEqual([region]);
+        expect(pool.region[slot]).toBeNull();
+    });
+
+    test("exhaustion signals without granting the resized chunk a region", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        single(data, 40, 50, 60); // 6 faces, capacity 6 leaves no room to grow
+        const pool = createChunkPool(6);
+        const slot = chunkSlot(40, 50, 60);
+        planRemesh(pool, data, [slot]);
+
+        checker(data, 32, 32, 32, 8, 8, 8); // grows past the fixed 6-face capacity
+        const plan = planRemesh(pool, data, [slot]);
+        expect(plan.exhausted).toBe(true);
+    });
+
+    test("differential — Σ live region sizes always equals faces() after any sequence of plans", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        sphere(data, 128, 128, 128, 40);
+        const pool = fullRemesh(1 << 20, data);
+        expect(sumLiveRegions(pool)).toBe(faces(data));
+
+        // carve a hole straddling a chunk seam (mirrors grid.test.ts's mutation fixture) and re-plan the
+        // touched+halo set the same way `mesher.ts`'s `commitEdit` would (`chunkNeighbors` is its halo
+        // primitive).
+        const touched = new Set<number>();
+        for (let z = 125; z <= 131; z++) {
+            for (let y = 125; y <= 131; y++) {
+                for (let x = 125; x <= 131; x++) {
+                    touched.add(chunkSlot(x, y, z));
+                    set(data, x, y, z, 0);
+                }
+            }
+        }
+        const affected = new Set<number>();
+        for (const slot of touched) {
+            affected.add(slot);
+            for (const neighbor of chunkNeighbors(slot)) affected.add(neighbor);
+        }
+        const plan = planRemesh(pool, data, [...affected]);
+        expect(plan.exhausted).toBe(false);
+        expect(sumLiveRegions(pool)).toBe(faces(data));
+    });
+});
+
+describe("buildTable", () => {
+    test("encodes (start, capacity) per slot, zero for an unallocated chunk", () => {
+        const data = new Float32Array(TOTAL_CELLS);
+        single(data, 40, 50, 60);
+        const pool = fullRemesh(1024, data);
+        const slot = chunkSlot(40, 50, 60);
+
+        const table = buildTable(pool);
+        expect(table.length).toBe(SLOT_COUNT * 2);
+        expect(table[slot * 2]).toBe(0);
+        expect(table[slot * 2 + 1]).toBe(6);
+
+        const other = (slot + 1) % SLOT_COUNT;
+        expect(table[other * 2]).toBe(0);
+        expect(table[other * 2 + 1]).toBe(0);
+    });
+});

--- a/examples/showcase/voxel/src/voxel/chunkpool.ts
+++ b/examples/showcase/voxel/src/voxel/chunkpool.ts
@@ -1,0 +1,99 @@
+// The chunk-aware allocation glue over `RegionAllocator` (`voxel-chunk-streaming` S2): pure, device-free,
+// CPU-exact per-chunk sizing against `facesInChunk`. `RegionAllocator` itself stays generic (S1) — this
+// module is the one place that knows a "region" means one chunk's exact face-pool slice.
+//
+// Two entry points. `fullRemesh` builds a fresh pool from scratch, allocating every non-empty chunk in
+// ascending slot order into an empty allocator — first-fit against one contiguous free block packs them
+// back-to-back with no gaps, so the pool's high-water mark (`tail`) is exact and no freed region is ever
+// orphaned (there's nothing to free). `planRemesh` resizes only the chunks the caller names (a touched+halo
+// set), freeing and reallocating a chunk whose count changed and leaving one alone whose count didn't
+// (its geometry can still differ — a face flips at a shared seam without changing the count — but the
+// caller re-emits it regardless; only the *region* is stable). Exhaustion during `planRemesh` (no free
+// region big enough) signals the caller to fall back to `fullRemesh` over the whole grid — `pool` is left
+// as whatever partial mutation happened, which is fine because the caller discards it wholesale on that
+// signal (`mesher.ts`'s `remeshFull` builds a brand new pool, never repairs this one).
+
+import { facesInChunk, SLOT_COUNT } from "./grid";
+import { type Region, RegionAllocator } from "./pool";
+
+export interface ChunkPool {
+    readonly allocator: RegionAllocator;
+    /** the live region for each chunk slot, `null` where the chunk currently has no exposed faces. */
+    readonly region: (Region | null)[];
+    /** high-water mark of allocated pool space — the single indirect draw covers `[0, tail)`. */
+    tail: number;
+}
+
+export function createChunkPool(capacity: number): ChunkPool {
+    return {
+        allocator: new RegionAllocator(capacity),
+        region: new Array(SLOT_COUNT).fill(null),
+        tail: 0,
+    };
+}
+
+export interface RemeshPlan {
+    /** regions released during this plan (freed outright, or replaced by a differently-sized region) —
+     *  the caller zero-fills their index range so a stale face doesn't render as a hole reopens elsewhere
+     *  in the pool. Empty when {@link exhausted}. */
+    readonly freed: readonly Region[];
+    /** no free region fit a resized chunk — `pool` reflects a partial, discardable attempt; the caller
+     *  falls back to {@link fullRemesh} over the whole grid rather than repairing this one. */
+    readonly exhausted: boolean;
+}
+
+/** resize exactly the chunks in `slots` (already touched+halo-expanded by the caller) against their
+ *  current {@link facesInChunk} count, mutating `pool` in place. */
+export function planRemesh(
+    pool: ChunkPool,
+    data: Float32Array,
+    slots: readonly number[],
+): RemeshPlan {
+    const freed: Region[] = [];
+    for (const slot of slots) {
+        const size = facesInChunk(data, slot);
+        const existing = pool.region[slot];
+        if (existing && existing.size === size) continue; // same footprint — caller still re-emits it
+        if (existing) {
+            pool.allocator.free(existing.start);
+            pool.region[slot] = null;
+            freed.push(existing);
+        }
+        if (size === 0) continue; // now empty — no region needed
+        const granted = pool.allocator.alloc(size);
+        if (!granted) return { freed, exhausted: true };
+        pool.region[slot] = granted;
+        pool.tail = Math.max(pool.tail, granted.start + granted.size);
+    }
+    return { freed, exhausted: false };
+}
+
+/** rebuild the whole pool from `data`: every one of the 512 chunks, in ascending slot order, into a fresh
+ *  empty allocator. First-fit against one contiguous free block can only fail to grant a slot when the
+ *  grid's total exposed-face count exceeds `capacity` — the same overflow the emit kernel's own per-chunk
+ *  capacity guard already clips, so a failed grant here is silently skipped (capacity 0, matching the
+ *  guard) rather than treated as a second exhaustion signal. */
+export function fullRemesh(capacity: number, data: Float32Array): ChunkPool {
+    const pool = createChunkPool(capacity);
+    for (let slot = 0; slot < SLOT_COUNT; slot++) {
+        const size = facesInChunk(data, slot);
+        if (size === 0) continue;
+        const granted = pool.allocator.alloc(size);
+        if (!granted) continue;
+        pool.region[slot] = granted;
+        pool.tail = granted.start + granted.size; // ascending, gap-free allocation ⇒ monotonic tail
+    }
+    return pool;
+}
+
+/** the GPU chunk-table payload: `vec2<u32>` per slot (`region.start`, `region.size`), zero for an
+ *  unallocated (empty) chunk — the kernel's exact-capacity guard reads `size` as the write bound. */
+export function buildTable(pool: ChunkPool): Uint32Array {
+    const out = new Uint32Array(SLOT_COUNT * 2);
+    for (let slot = 0; slot < SLOT_COUNT; slot++) {
+        const region = pool.region[slot];
+        out[slot * 2] = region ? region.start : 0;
+        out[slot * 2 + 1] = region ? region.size : 0;
+    }
+    return out;
+}

--- a/examples/showcase/voxel/src/voxel/generate.ts
+++ b/examples/showcase/voxel/src/voxel/generate.ts
@@ -20,7 +20,7 @@ import tgpu, { type StorageFlag, type TgpuBuffer } from "typegpu";
 import * as d from "typegpu/data";
 import * as std from "typegpu/std";
 import { DENSITY, DIM, GridData, voxelIndex } from "./grid";
-import { Voxels } from "./mesher";
+import { syncGrid, Voxels } from "./mesher";
 import { fbm2, GROUND_LEVEL, HFREQ, makePermutation, noiseLayout, PermData, RELIEF } from "./noise";
 
 export { solidFractionBand } from "./noise";
@@ -161,13 +161,19 @@ const runDensity = createDensityRunner<
     },
 });
 
-/** fill `Voxels.grid` from the heightmap density for `seed`, then dirty it so the mesher re-meshes. The
- *  pipeline compiles once (baked constants); each call rebuilds the per-seed permutation table. Runs on
- *  its own encoder + submit (decoupled from the frame loop). */
+/** fill `Voxels.grid` from the heightmap density for `seed`, sync the CPU mirror, then dirty it so the
+ *  mesher re-meshes. The pipeline compiles once (baked constants); each call rebuilds the per-seed
+ *  permutation table. Runs on its own encoder + submit (decoupled from the frame loop). The sync
+ *  (`syncGrid`, a 64 MiB GPU→CPU readback) is part of this call's own contract, not an optional follow-up
+ *  — the mesher's chunk allocation is CPU-exact (`facesInChunk`), so a remesh dispatched against a
+ *  GPU-only grid has nothing to size chunks from and defers indefinitely (`mesher.ts`'s
+ *  `VoxelEmitSystem`). Every caller (boot, reseed, the correctness gate) gets a remeshable grid for free;
+ *  `voxel-chunk-streaming` S3 measures whether this cost needs a GPU-count fallback. */
 export async function generate(seed: number): Promise<void> {
     if (!Voxels.grid) throw new Error("voxel: generate before the grid buffer exists");
     const { device, root } = Compute;
     await runDensity({ root, device, grid: Voxels.grid }, seed);
+    await syncGrid();
     Voxels.dirty = true;
 }
 

--- a/examples/showcase/voxel/src/voxel/grid.test.ts
+++ b/examples/showcase/voxel/src/voxel/grid.test.ts
@@ -6,6 +6,7 @@ import {
     BYTES,
     CHUNK,
     CHUNK_CELLS,
+    chunkNeighbors,
     coord,
     DIM,
     faces,
@@ -369,6 +370,37 @@ describe("facesInChunk — the CPU twin of the emit kernel's per-chunk emission"
             }
         }
         expect(sumChunks(data)).toBe(faces(data));
+    });
+
+    test("chunkNeighbors — an interior slot has all 6 face-adjacent neighbours, none itself", () => {
+        const slot = (4 * SLOTS.y + 4) * SLOTS.x + 4; // (4,4,4) — interior of the 8³ chunk grid
+        const neighbors = chunkNeighbors(slot);
+        expect(neighbors.length).toBe(6);
+        expect(new Set(neighbors).size).toBe(6);
+        expect(neighbors).not.toContain(slot);
+        const expected = [
+            (4 * SLOTS.y + 4) * SLOTS.x + 5,
+            (4 * SLOTS.y + 4) * SLOTS.x + 3,
+            (4 * SLOTS.y + 5) * SLOTS.x + 4,
+            (4 * SLOTS.y + 3) * SLOTS.x + 4,
+            (5 * SLOTS.y + 4) * SLOTS.x + 4,
+            (3 * SLOTS.y + 4) * SLOTS.x + 4,
+        ];
+        expect(new Set(neighbors)).toEqual(new Set(expected));
+    });
+
+    test("chunkNeighbors — a corner slot is bounds-clipped to exactly 3 neighbours", () => {
+        expect(chunkNeighbors(0).length).toBe(3); // (0,0,0)
+        const last = SLOT_COUNT - 1; // (SLOTS.x-1, SLOTS.y-1, SLOTS.z-1)
+        expect(chunkNeighbors(last).length).toBe(3);
+    });
+
+    test("chunkNeighbors is symmetric: a neighbour of A always lists A back", () => {
+        for (const slot of [0, 1, SLOT_COUNT - 1, (4 * SLOTS.y + 4) * SLOTS.x + 4]) {
+            for (const neighbor of chunkNeighbors(slot)) {
+                expect(chunkNeighbors(neighbor)).toContain(slot);
+            }
+        }
     });
 
     test("print-only — full-grid Σ facesInChunk (512 chunks) cost at boot", () => {

--- a/examples/showcase/voxel/src/voxel/grid.ts
+++ b/examples/showcase/voxel/src/voxel/grid.ts
@@ -160,6 +160,30 @@ export function faces(data: Float32Array): number {
  * a chunk boundary is not a data boundary. `Σ facesInChunk(data, slot)` over every slot equals
  * {@link faces}; this is what lets S2 allocate each touched chunk's region exactly, no worst-case pad.
  */
+/**
+ * the up-to-6 face-adjacent chunk slots of `slot`, bounds-clipped to the 8³ chunk grid — the halo a
+ * touched chunk's edit can also affect: a face straddling the shared boundary can flip on either side
+ * even when the neighbour's own occupancy is untouched (`facesInChunk`'s cross-chunk read), so a scoped
+ * remesh re-emits the halo too, not just the chunk that changed. `slot` itself is never included.
+ */
+export function chunkNeighbors(slot: number): number[] {
+    const sx = slot % SLOTS.x;
+    const sy = Math.floor(slot / SLOTS.x) % SLOTS.y;
+    const sz = Math.floor(slot / (SLOTS.x * SLOTS.y));
+    const out: number[] = [];
+    const push = (nx: number, ny: number, nz: number): void => {
+        if (nx < 0 || ny < 0 || nz < 0 || nx >= SLOTS.x || ny >= SLOTS.y || nz >= SLOTS.z) return;
+        out.push((nz * SLOTS.y + ny) * SLOTS.x + nx);
+    };
+    push(sx + 1, sy, sz);
+    push(sx - 1, sy, sz);
+    push(sx, sy + 1, sz);
+    push(sx, sy - 1, sz);
+    push(sx, sy, sz + 1);
+    push(sx, sy, sz - 1);
+    return out;
+}
+
 export function facesInChunk(data: Float32Array, slot: number): number {
     const [ox, oy, oz] = coord(slot * CHUNK_CELLS);
     let n = 0;

--- a/examples/showcase/voxel/src/voxel/mesher.test.ts
+++ b/examples/showcase/voxel/src/voxel/mesher.test.ts
@@ -171,7 +171,7 @@ describe("voxel mesher emit kernel", () => {
         integerDiscipline(kernel);
         noDivision(kernel);
         const hash = createHash("sha256").update(flat(kernel)).digest("hex");
-        expect(hash).toBe("8fafc6a71ad0f3207505d88378368364ff636adaa20f21c5936c29fcfc417fe8");
+        expect(hash).toBe("c963b82275d9ad70ff459fc465d3025a533cbec995c1641a7f8e667b7938e368");
         const mutated = flat(kernel).replace(
             "indices[(base + 0u)] = (v0 + 0u);",
             "indices[(base + 0u)] = (v0 + 1u);",

--- a/examples/showcase/voxel/src/voxel/mesher.ts
+++ b/examples/showcase/voxel/src/voxel/mesher.ts
@@ -25,18 +25,27 @@ import {
     registerSurface,
     surfaceLayout,
 } from "@dylanebert/shallot/sear/core";
-import {
-    encodePos,
-    encodeUv,
-    idiv,
-    MeshQuant,
-    octEncodeNormal,
-} from "@dylanebert/shallot/utils/core";
+import { encodePos, encodeUv, MeshQuant, octEncodeNormal } from "@dylanebert/shallot/utils/core";
 import type { TgpuBindGroup } from "typegpu";
 import tgpu, { writeToArrayBuffer } from "typegpu";
 import * as d from "typegpu/data";
 import * as std from "typegpu/std";
-import { BINDING_FLOOR, BYTES, CHUNK_CELLS, DIM, GridData, ISO, VOXEL, voxelIndex } from "./grid";
+import { buildTable, type ChunkPool, createChunkPool, fullRemesh, planRemesh } from "./chunkpool";
+import {
+    BINDING_FLOOR,
+    BYTES,
+    CHUNK,
+    CHUNK_CELLS,
+    chunkNeighbors,
+    coord,
+    DIM,
+    GridData,
+    ISO,
+    SLOT_COUNT,
+    VOXEL,
+    voxelIndex,
+} from "./grid";
+import type { Region } from "./pool";
 
 const VERTS_PER_QUAD = 4;
 const INDICES_PER_QUAD = 6;
@@ -62,11 +71,13 @@ const GRID_QUANT = new Float32Array([
     0,
     0,
 ]);
-export const DISPATCH = {
-    x: Math.ceil(DIM.x / WG),
-    y: Math.ceil(DIM.y / WG),
-    z: Math.ceil(DIM.z / WG),
-};
+// one chunk's own emit-kernel dispatch volume in workgroups per axis (CHUNK=32, WG=4 → 8); the dispatch
+// grid for N chunks is (WG_PER_CHUNK, WG_PER_CHUNK, WG_PER_CHUNK·N) — each chunk gets its own CHUNK-deep
+// slab of the z axis, and `global_invocation_id.z` decomposes into (chunk index, local z) via shift/mask
+// (LOG2_CHUNK below), never division (`noDivision`, `mesher.test.ts`).
+const WG_PER_CHUNK = CHUNK / WG;
+const LOG2_CHUNK = Math.log2(CHUNK);
+const FULL_SLOTS: readonly number[] = Array.from({ length: SLOT_COUNT }, (_, i) => i);
 
 // the 16 B main stream must fit one storage binding (the largest of the three per-face buffers), so cap
 // faces at ¾ of the portable 128 MiB floor. The canonical worst case (the full ground slab, ~134k faces)
@@ -78,21 +89,25 @@ export const MAX_FACES = Math.floor((BINDING_FLOOR * 3) / 4 / (VERTS_PER_QUAD * 
  * the one voxel world: the CPU grid (`data`, null when generated GPU-side), the GPU grid buffer (`grid` —
  * what the mesher reads and the generator writes), and the mesher's outputs. A scenario either authors
  * `data` before the first frame (the way a scene declares entities) and the mesher uploads + meshes it, or
- * leaves it null and fills `grid` directly on the GPU; either way it exposes `indirect` — the draw record
- * whose first word is the index count, mirrored to read the atomic face count back. {@link uploadVoxels}
- * rewrites the grid and re-meshes (the assert's per-pattern swap; Phase 5's carve will write through it too).
+ * leaves it null and fills `grid` directly on the GPU; either way it exposes `indirect` — the CPU-authored
+ * draw record (`indexCount = pool tail × 6`, `mesher.ts`'s `writeIndirect`) — and `cursor`, the per-chunk
+ * atomic face count the correctness gate reads back (never `indirect`, which would be circular: it's the
+ * same CPU count restated). {@link uploadVoxels} rewrites the grid and re-meshes; {@link commitEdit} does
+ * the same over a touched chunk subset (Phase 5's carve).
  */
 export const Voxels = {
     data: null as Float32Array | null,
     grid: null as GPUBuffer | null,
     indirect: null as GPUBuffer | null,
+    cursor: null as GPUBuffer | null,
     dirty: false,
 };
 
-/** read-only observability for the perf gate (`showcase-frame-floor` S2): the workgroup count issued by
- *  the most recent emit dispatch, set only by {@link VoxelEmitSystem} — no production code reads it, so it
- *  changes no behavior. `test/perf.spec.ts` (via `src/perf.ts`) gates dispatch scope against touched-chunk
- *  volume; today it's always the full-grid `DISPATCH` product, regardless of what fired the re-mesh. */
+/** read-only observability for the perf gate (`showcase-frame-floor` S2, discharged by
+ *  `voxel-chunk-streaming` S2): the workgroup count issued by the most recent emit dispatch, set only by
+ *  {@link VoxelEmitSystem} — no production code reads it, so it changes no behavior. `test/perf.spec.ts`
+ *  (via `src/perf.ts`) gates dispatch scope against touched-chunk volume: `WG_PER_CHUNK³ × N` for the `N`
+ *  chunks in that fire's dispatch list, never the full grid. */
 export const EmitTelemetry = { lastWorkgroups: 0 };
 
 const gpu = {
@@ -101,16 +116,30 @@ const gpu = {
     position: null as GPUBuffer | null,
     quant: null as GPUBuffer | null,
     indices: null as GPUBuffer | null,
+    chunkList: null as GPUBuffer | null,
+    chunkTable: null as GPUBuffer | null,
+    chunkCursor: null as GPUBuffer | null,
     pipeline: null as ReturnType<typeof Compute.root.createComputePipeline> | null,
     bindGroup: null as TgpuBindGroup<typeof mesherLayout.entries> | null,
 };
+
+// the CPU-side allocation state (S2): the region allocator + per-chunk regions over the face pool
+// (`chunkpool.ts`), and the chunk-slot list the next `VoxelEmitSystem` fire owes — `null` means "a full
+// remesh is owed once `Voxels.data` exists" (covers `generate()`'s GPU-only dirty, deferred until
+// `syncGrid` populates the CPU mirror — `voxel-chunk-streaming` S3 firms up that ordering); a populated
+// array is the scoped touched+halo list `commitEdit` (or a full remesh) already resolved — count, alloc,
+// and the chunk-table upload are already done by the time `VoxelEmitSystem` reads it.
+let pool: ChunkPool | null = null;
+let pendingSlots: readonly number[] | null = null;
 
 let warmEpoch = 0;
 
 const VoxelVertices = d.arrayOf(d.vec4u, MAX_FACES * VERTS_PER_QUAD);
 const VoxelPosition = d.arrayOf(d.vec2u, MAX_FACES * VERTS_PER_QUAD);
 const VoxelIndices = d.arrayOf(d.u32, MAX_FACES * INDICES_PER_QUAD);
-const VoxelAtomicIndirect = d.arrayOf(d.atomic(d.u32), 1);
+const ChunkList = d.arrayOf(d.vec4u, SLOT_COUNT);
+const ChunkTable = d.arrayOf(d.vec2u, SLOT_COUNT);
+const ChunkCursor = d.arrayOf(d.atomic(d.u32), SLOT_COUNT);
 
 type WarmOwner<Buffer, MeshEntry extends { name: string }, DrawEntry extends { name: string }> = {
     readonly buffers: Buffer[];
@@ -225,12 +254,54 @@ type VoxelWarmOwner = WarmOwner<GPUBuffer, Mesh, Draw> & { readonly state: State
 let activeOwner: VoxelWarmOwner | null = null;
 const stateOwners = new WeakMap<State, VoxelWarmOwner>();
 
-/** rewrite the grid and mark it dirty so the next frame re-meshes. No-op before the mesher's buffers
- *  exist (first-frame setup uploads `Voxels.data` itself). */
+/** the GPU chunk-table + indirect-record side of a full remesh: rebuild `pool` from scratch against
+ *  `data` ({@link fullRemesh}) and push the table + CPU-authored draw record. Doesn't touch `pendingSlots`
+ *  or `Voxels.dirty` — callers own when the next {@link VoxelEmitSystem} fire should pick it up. */
+function remeshFull(data: Float32Array): void {
+    pool = fullRemesh(MAX_FACES, data);
+    uploadChunkTable();
+    writeIndirect();
+}
+
+function uploadChunkTable(): void {
+    if (!gpu.chunkTable || !pool) return;
+    Compute.device.queue.writeBuffer(gpu.chunkTable, 0, buildTable(pool));
+}
+
+/** the CPU-authored draw record (`indexCount = pool.tail × 6`) — never a GPU atomic, so the correctness
+ *  gate's per-chunk cursor readback stays an independent signal against it, not a restatement. */
+function writeIndirect(): void {
+    if (!Voxels.indirect || !pool) return;
+    const buf = new ArrayBuffer(d.sizeOf(DrawIndexedIndirect));
+    writeToArrayBuffer(buf, DrawIndexedIndirect, {
+        indexCount: pool.tail * INDICES_PER_QUAD,
+        instanceCount: 1,
+        firstIndex: 0,
+        baseVertex: 0,
+        firstInstance: 0,
+    });
+    Compute.device.queue.writeBuffer(Voxels.indirect, 0, buf);
+}
+
+/** degenerate-fill a freed region's indices (all zero → a zero-area triangle, culled at primitive
+ *  assembly) so a later chunk's un-shrunk draw range doesn't render a stale face over the hole. */
+function zeroIndices(region: Region): void {
+    if (!gpu.indices) return;
+    Compute.device.queue.writeBuffer(
+        gpu.indices,
+        region.start * INDICES_PER_QUAD * 4,
+        new Uint32Array(region.size * INDICES_PER_QUAD),
+    );
+}
+
+/** rewrite the grid and mark it dirty so the next frame re-meshes every chunk. No-op before the mesher's
+ *  buffers exist (first-frame setup uploads `Voxels.data` itself). */
 export function uploadVoxels(data: Float32Array): void {
     Voxels.data = data;
-    if (!gpu.voxels) return;
+    if (!gpu.voxels || !pool) return;
     Compute.device.queue.writeBuffer(gpu.voxels, 0, data as Float32Array<ArrayBuffer>);
+    remeshFull(data);
+    pendingSlots = FULL_SLOTS;
     Voxels.dirty = true;
 }
 
@@ -263,19 +334,46 @@ export async function syncGrid(): Promise<void> {
     Voxels.data = await readGrid();
 }
 
-/** push the edited chunk slices from the CPU mirror to the GPU grid and dirty so the next frame re-meshes.
- *  Chunk-major makes each chunk one contiguous range, so a carve uploads only the slots it touched — not the
- *  whole 64 MiB. {@link Voxels.data} is authoritative; this commits a {@link brush}'s changes. */
+/** the touched set plus its face-adjacent halo (deduplicated) — a face straddling a chunk seam can flip on
+ *  the untouched side too (`chunkNeighbors`'s doc), so the halo re-emits even where its own region is
+ *  unchanged. */
+function touchedAndHalo(touched: Iterable<number>): number[] {
+    const affected = new Set<number>();
+    for (const slot of touched) {
+        affected.add(slot);
+        for (const neighbor of chunkNeighbors(slot)) affected.add(neighbor);
+    }
+    return [...affected];
+}
+
+/** push the edited chunk slices from the CPU mirror to the GPU grid, drive count → alloc → free-list
+ *  zero-fill → table upload over the touched+halo set, and mark the next frame's dispatch to that scoped
+ *  list. Chunk-major makes each voxel slice one contiguous range, so a carve uploads only the slots it
+ *  touched — not the whole 64 MiB. {@link Voxels.data} is authoritative; this commits a {@link brush}'s
+ *  changes. Allocator exhaustion falls back to a full remesh over the whole grid (always correct, rare). */
 export function commitEdit(chunks: Iterable<number>): void {
-    if (!gpu.voxels || !Voxels.data) return;
+    if (!gpu.voxels || !Voxels.data || !pool) return;
     const data = Voxels.data as Float32Array<ArrayBuffer>;
-    let any = false;
+    const touched = new Set<number>();
     for (const slot of chunks) {
         const start = slot * CHUNK_CELLS;
         Compute.device.queue.writeBuffer(gpu.voxels, start * 4, data, start, CHUNK_CELLS);
-        any = true;
+        touched.add(slot);
     }
-    if (any) Voxels.dirty = true;
+    if (touched.size === 0) return;
+
+    const affected = touchedAndHalo(touched);
+    const plan = planRemesh(pool, data, affected);
+    if (plan.exhausted) {
+        remeshFull(data);
+        pendingSlots = FULL_SLOTS;
+    } else {
+        for (const region of plan.freed) zeroIndices(region);
+        uploadChunkTable();
+        writeIndirect();
+        pendingSlots = affected;
+    }
+    Voxels.dirty = true;
 }
 
 // posU.w carries a per-vertex material slot (read as `uv.x` in the fs) for the Phase-3 palette — one block
@@ -305,8 +403,10 @@ const mesherLayout = tgpu.bindGroupLayout({
     voxels: { storage: GridData, access: "readonly" },
     vertices: { storage: VoxelVertices, access: "mutable" },
     indices: { storage: VoxelIndices, access: "mutable" },
-    indirect: { storage: VoxelAtomicIndirect, access: "mutable" },
     position: { storage: VoxelPosition, access: "mutable" },
+    chunkList: { storage: ChunkList, access: "readonly" },
+    chunkTable: { storage: ChunkTable, access: "readonly" },
+    chunkCursor: { storage: ChunkCursor, access: "mutable" },
 });
 
 const gridQuant: d.Infer<typeof MeshQuant> = {
@@ -322,29 +422,40 @@ const emitKernel = tgpu
     })((input) => {
         "use gpu";
         const gid = input.gid;
-        if (gid.x >= d.u32(DIM.x) || gid.y >= d.u32(DIM.y) || gid.z >= d.u32(DIM.z)) return;
-        if (mesherLayout.$.voxels[voxelIndex(gid.x, gid.y, gid.z)] < d.f32(ISO)) return;
+        // the dispatch grid is (WG_PER_CHUNK, WG_PER_CHUNK, WG_PER_CHUNK·N): `gid.x`/`gid.y` are already
+        // chunk-local (dispatched only over one chunk's extent), and `gid.z` decomposes into (chunk index
+        // into the dispatch's chunk list, local z within the chunk) by shift/mask — CHUNK is a power of
+        // two, so this is exact and division-free (`noDivision`, `mesher.test.ts`).
+        const chunkIdx = gid.z >> d.u32(LOG2_CHUNK);
+        const lz = gid.z & d.u32(CHUNK - 1);
+        const entry = mesherLayout.$.chunkList[chunkIdx];
+        const slot = entry.w;
+        const ix = entry.x + gid.x;
+        const iy = entry.y + gid.y;
+        const iz = entry.z + lz;
 
-        const ix = gid.x;
-        const iy = gid.y;
-        const iz = gid.z;
-        const x0 = (d.f32(gid.x) - d.f32(HALF_X)) * d.f32(VOXEL);
-        const y0 = (d.f32(gid.y) - d.f32(HALF_Y)) * d.f32(VOXEL);
-        const z0 = (d.f32(gid.z) - d.f32(HALF_Z)) * d.f32(VOXEL);
+        if (mesherLayout.$.voxels[voxelIndex(ix, iy, iz)] < d.f32(ISO)) return;
+
+        const x0 = (d.f32(ix) - d.f32(HALF_X)) * d.f32(VOXEL);
+        const y0 = (d.f32(iy) - d.f32(HALF_Y)) * d.f32(VOXEL);
+        const z0 = (d.f32(iz) - d.f32(HALF_Z)) * d.f32(VOXEL);
         const x1 = x0 + d.f32(VOXEL);
         const y1 = y0 + d.f32(VOXEL);
         const z1 = z0 + d.f32(VOXEL);
         const blockU = d.f32(1);
         const uvw = encodeUv(d.vec2f(blockU, d.f32(0)), gridQuant);
+        const table = mesherLayout.$.chunkTable[slot];
+        const capacity = table.y;
 
         if (
             ix + d.u32(1) >= d.u32(DIM.x) ||
             mesherLayout.$.voxels[voxelIndex(ix + d.u32(1), iy, iz)] < d.f32(ISO)
         ) {
-            const base = std.atomicAdd(mesherLayout.$.indirect[0], d.u32(INDICES_PER_QUAD));
-            const fi = idiv(base, d.u32(INDICES_PER_QUAD));
-            if (fi < d.u32(MAX_FACES)) {
-                const v0 = fi * d.u32(VERTS_PER_QUAD);
+            const local = std.atomicAdd(mesherLayout.$.chunkCursor[slot], d.u32(1));
+            if (local < capacity) {
+                const faceIdx = table.x + local;
+                const v0 = faceIdx * d.u32(VERTS_PER_QUAD);
+                const base = faceIdx * d.u32(INDICES_PER_QUAD);
                 const octN = octEncodeNormal(d.vec3f(1, 0, 0));
                 const m0 = encodePos(d.vec3f(x1, y0, z0), d.u32(0), gridQuant);
                 const m1 = encodePos(d.vec3f(x1, y1, z0), d.u32(0), gridQuant);
@@ -370,10 +481,11 @@ const emitKernel = tgpu
             ix === d.u32(0) ||
             mesherLayout.$.voxels[voxelIndex(ix - d.u32(1), iy, iz)] < d.f32(ISO)
         ) {
-            const base = std.atomicAdd(mesherLayout.$.indirect[0], d.u32(INDICES_PER_QUAD));
-            const fi = idiv(base, d.u32(INDICES_PER_QUAD));
-            if (fi < d.u32(MAX_FACES)) {
-                const v0 = fi * d.u32(VERTS_PER_QUAD);
+            const local = std.atomicAdd(mesherLayout.$.chunkCursor[slot], d.u32(1));
+            if (local < capacity) {
+                const faceIdx = table.x + local;
+                const v0 = faceIdx * d.u32(VERTS_PER_QUAD);
+                const base = faceIdx * d.u32(INDICES_PER_QUAD);
                 const octN = octEncodeNormal(d.vec3f(-1, 0, 0));
                 const m0 = encodePos(d.vec3f(x0, y0, z0), d.u32(0), gridQuant);
                 const m1 = encodePos(d.vec3f(x0, y0, z1), d.u32(0), gridQuant);
@@ -399,10 +511,11 @@ const emitKernel = tgpu
             iy + d.u32(1) >= d.u32(DIM.y) ||
             mesherLayout.$.voxels[voxelIndex(ix, iy + d.u32(1), iz)] < d.f32(ISO)
         ) {
-            const base = std.atomicAdd(mesherLayout.$.indirect[0], d.u32(INDICES_PER_QUAD));
-            const fi = idiv(base, d.u32(INDICES_PER_QUAD));
-            if (fi < d.u32(MAX_FACES)) {
-                const v0 = fi * d.u32(VERTS_PER_QUAD);
+            const local = std.atomicAdd(mesherLayout.$.chunkCursor[slot], d.u32(1));
+            if (local < capacity) {
+                const faceIdx = table.x + local;
+                const v0 = faceIdx * d.u32(VERTS_PER_QUAD);
+                const base = faceIdx * d.u32(INDICES_PER_QUAD);
                 const octN = octEncodeNormal(d.vec3f(0, 1, 0));
                 const m0 = encodePos(d.vec3f(x0, y1, z0), d.u32(0), gridQuant);
                 const m1 = encodePos(d.vec3f(x0, y1, z1), d.u32(0), gridQuant);
@@ -428,10 +541,11 @@ const emitKernel = tgpu
             iy === d.u32(0) ||
             mesherLayout.$.voxels[voxelIndex(ix, iy - d.u32(1), iz)] < d.f32(ISO)
         ) {
-            const base = std.atomicAdd(mesherLayout.$.indirect[0], d.u32(INDICES_PER_QUAD));
-            const fi = idiv(base, d.u32(INDICES_PER_QUAD));
-            if (fi < d.u32(MAX_FACES)) {
-                const v0 = fi * d.u32(VERTS_PER_QUAD);
+            const local = std.atomicAdd(mesherLayout.$.chunkCursor[slot], d.u32(1));
+            if (local < capacity) {
+                const faceIdx = table.x + local;
+                const v0 = faceIdx * d.u32(VERTS_PER_QUAD);
+                const base = faceIdx * d.u32(INDICES_PER_QUAD);
                 const octN = octEncodeNormal(d.vec3f(0, -1, 0));
                 const m0 = encodePos(d.vec3f(x0, y0, z0), d.u32(0), gridQuant);
                 const m1 = encodePos(d.vec3f(x1, y0, z0), d.u32(0), gridQuant);
@@ -457,10 +571,11 @@ const emitKernel = tgpu
             iz + d.u32(1) >= d.u32(DIM.z) ||
             mesherLayout.$.voxels[voxelIndex(ix, iy, iz + d.u32(1))] < d.f32(ISO)
         ) {
-            const base = std.atomicAdd(mesherLayout.$.indirect[0], d.u32(INDICES_PER_QUAD));
-            const fi = idiv(base, d.u32(INDICES_PER_QUAD));
-            if (fi < d.u32(MAX_FACES)) {
-                const v0 = fi * d.u32(VERTS_PER_QUAD);
+            const local = std.atomicAdd(mesherLayout.$.chunkCursor[slot], d.u32(1));
+            if (local < capacity) {
+                const faceIdx = table.x + local;
+                const v0 = faceIdx * d.u32(VERTS_PER_QUAD);
+                const base = faceIdx * d.u32(INDICES_PER_QUAD);
                 const octN = octEncodeNormal(d.vec3f(0, 0, 1));
                 const m0 = encodePos(d.vec3f(x0, y0, z1), d.u32(0), gridQuant);
                 const m1 = encodePos(d.vec3f(x1, y0, z1), d.u32(0), gridQuant);
@@ -486,10 +601,11 @@ const emitKernel = tgpu
             iz === d.u32(0) ||
             mesherLayout.$.voxels[voxelIndex(ix, iy, iz - d.u32(1))] < d.f32(ISO)
         ) {
-            const base = std.atomicAdd(mesherLayout.$.indirect[0], d.u32(INDICES_PER_QUAD));
-            const fi = idiv(base, d.u32(INDICES_PER_QUAD));
-            if (fi < d.u32(MAX_FACES)) {
-                const v0 = fi * d.u32(VERTS_PER_QUAD);
+            const local = std.atomicAdd(mesherLayout.$.chunkCursor[slot], d.u32(1));
+            if (local < capacity) {
+                const faceIdx = table.x + local;
+                const v0 = faceIdx * d.u32(VERTS_PER_QUAD);
+                const base = faceIdx * d.u32(INDICES_PER_QUAD);
                 const octN = octEncodeNormal(d.vec3f(0, 0, -1));
                 const m0 = encodePos(d.vec3f(x0, y0, z0), d.u32(0), gridQuant);
                 const m1 = encodePos(d.vec3f(x0, y1, z0), d.u32(0), gridQuant);
@@ -520,14 +636,35 @@ export function emitWgsl(): string {
     });
 }
 
-const INDIRECT_INIT = new ArrayBuffer(d.sizeOf(DrawIndexedIndirect));
-writeToArrayBuffer(INDIRECT_INIT, DrawIndexedIndirect, {
-    indexCount: 0,
-    instanceCount: 1,
-    firstIndex: 0,
-    baseVertex: 0,
-    firstInstance: 0,
-});
+const ZERO_CURSOR = new Uint32Array(1);
+
+/** zero the atomic cursor for every slot in `slots` — never the whole buffer, so a scoped dispatch leaves
+ *  an untouched chunk's last-known face count intact for the correctness gate's summed readback. A full
+ *  remesh's slot list is exactly `[0, SLOT_COUNT)`, contiguous, so that case is one write instead of 512. */
+function resetCursors(slots: readonly number[]): void {
+    if (!gpu.chunkCursor) return;
+    if (slots.length === SLOT_COUNT) {
+        Compute.device.queue.writeBuffer(gpu.chunkCursor, 0, new Uint32Array(SLOT_COUNT));
+        return;
+    }
+    for (const slot of slots)
+        Compute.device.queue.writeBuffer(gpu.chunkCursor, slot * 4, ZERO_CURSOR);
+}
+
+/** the chunk-list payload for one dispatch: `vec4<u32>(originX, originY, originZ, slot)` per entry, in
+ *  dispatch order — the emit kernel reads chunk origin from this list (never recomputes it from `slot`). */
+function buildChunkList(slots: readonly number[]): Uint32Array {
+    const out = new Uint32Array(slots.length * 4);
+    for (let i = 0; i < slots.length; i++) {
+        const slot = slots[i];
+        const [ox, oy, oz] = coord(slot * CHUNK_CELLS);
+        out[i * 4] = ox;
+        out[i * 4 + 1] = oy;
+        out[i * 4 + 2] = oz;
+        out[i * 4 + 3] = slot;
+    }
+    return out;
+}
 
 export const VoxelEmitSystem: System = {
     name: "voxel-emit",
@@ -541,8 +678,20 @@ export const VoxelEmitSystem: System = {
     before: [PrepassSystem],
     setup() {},
     update() {
-        if (!Voxels.dirty || !gpu.pipeline || !gpu.bindGroup || !Render.encoder) return;
-        Compute.device.queue.writeBuffer(Voxels.indirect!, 0, INDIRECT_INIT);
+        if (!Voxels.dirty || !gpu.pipeline || !gpu.bindGroup || !Render.encoder || !pool) return;
+        let slots = pendingSlots;
+        if (!slots) {
+            // an implicit full remesh (generate()'s GPU-only dirty, or the first-frame publish before any
+            // scenario authored data): needs the CPU mirror to size chunks, so it waits — `Voxels.dirty`
+            // stays true — until `syncGrid` (or an authored `uploadVoxels`) populates `Voxels.data`.
+            if (!Voxels.data) return;
+            remeshFull(Voxels.data);
+            slots = FULL_SLOTS;
+        }
+        pendingSlots = null;
+
+        resetCursors(slots);
+        Compute.device.queue.writeBuffer(gpu.chunkList!, 0, buildChunkList(slots));
         const pass = Render.encoder.beginComputePass({
             label: "voxel-emit",
             timestampWrites: Compute.span?.("voxel:emit"),
@@ -550,8 +699,8 @@ export const VoxelEmitSystem: System = {
         gpu.pipeline
             .with(gpu.bindGroup)
             .with(pass)
-            .dispatchWorkgroups(DISPATCH.x, DISPATCH.y, DISPATCH.z);
-        EmitTelemetry.lastWorkgroups = DISPATCH.x * DISPATCH.y * DISPATCH.z;
+            .dispatchWorkgroups(WG_PER_CHUNK, WG_PER_CHUNK, WG_PER_CHUNK * slots.length);
+        EmitTelemetry.lastWorkgroups = WG_PER_CHUNK * WG_PER_CHUNK * WG_PER_CHUNK * slots.length;
         pass.end();
         Voxels.dirty = false;
     },
@@ -564,6 +713,9 @@ type VoxelRawBuffers = {
     readonly quant: GPUBuffer;
     readonly indices: GPUBuffer;
     readonly indirect: GPUBuffer;
+    readonly chunkList: GPUBuffer;
+    readonly chunkTable: GPUBuffer;
+    readonly chunkCursor: GPUBuffer;
 };
 
 function allocateVoxelBuffers(
@@ -600,19 +752,47 @@ function allocateVoxelBuffers(
     device.queue.writeBuffer(quant, 0, GRID_QUANT as Float32Array<ArrayBuffer>);
     const indices = allocate({
         label: "voxel-indices",
+        // COPY_DST: `zeroIndices` degenerate-fills a freed region directly (the emit kernel only ever
+        // writes the live regions it's dispatched for), so a shrunk/freed chunk's stale indices need a
+        // CPU-side write path too.
         size: maxIndices * 4,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.INDEX,
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.INDEX | GPUBufferUsage.COPY_DST,
     });
     const indirect = allocate({
         label: "voxel-indirect",
+        // the CPU-authored draw record only — never a GPU atomic target (S2), so no STORAGE binding is
+        // read/written by the kernel; COPY_DST is what `writeIndirect` targets.
         size: 20,
-        usage:
-            GPUBufferUsage.STORAGE |
-            GPUBufferUsage.INDIRECT |
-            GPUBufferUsage.COPY_DST |
-            GPUBufferUsage.COPY_SRC,
+        usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
     });
-    return { voxels, vertices, position, quant, indices, indirect };
+    const chunkList = allocate({
+        label: "voxel-chunk-list",
+        size: SLOT_COUNT * 16, // vec4<u32> per slot (origin.xyz, slot)
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    const chunkTable = allocate({
+        label: "voxel-chunk-table",
+        size: SLOT_COUNT * 8, // vec2<u32> per slot (region start, capacity)
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    const chunkCursor = allocate({
+        label: "voxel-chunk-cursor",
+        // COPY_SRC: the correctness gate mirrors this buffer (`Voxels.cursor`) for its GPU-side face-count
+        // readback — never `.indirect`, which would be circular (`voxel-chunk-streaming` S2).
+        size: SLOT_COUNT * 4, // atomic<u32> per slot
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+    });
+    return {
+        voxels,
+        vertices,
+        position,
+        quant,
+        indices,
+        indirect,
+        chunkList,
+        chunkTable,
+        chunkCursor,
+    };
 }
 
 function wrapVoxelBuffers(raw: VoxelRawBuffers) {
@@ -625,18 +805,22 @@ function wrapVoxelBuffers(raw: VoxelRawBuffers) {
         .createBuffer(VoxelIndices, raw.indices)
         .$usage("storage", "index");
     const typedVoxels = Compute.root.createBuffer(GridData, raw.voxels).$usage("storage");
-    const typedAtomicIndirect = Compute.root
-        .createBuffer(VoxelAtomicIndirect, raw.indirect)
-        .$usage("storage");
     const typedIndirect = Compute.root
         .createBuffer(DrawIndexedIndirect, raw.indirect)
-        .$usage("storage", "indirect");
+        .$usage("indirect");
+    const typedChunkList = Compute.root.createBuffer(ChunkList, raw.chunkList).$usage("storage");
+    const typedChunkTable = Compute.root.createBuffer(ChunkTable, raw.chunkTable).$usage("storage");
+    const typedChunkCursor = Compute.root
+        .createBuffer(ChunkCursor, raw.chunkCursor)
+        .$usage("storage");
     const bindGroup = Compute.root.createBindGroup(mesherLayout, {
         voxels: typedVoxels,
         vertices: typedVertices,
         indices: typedIndices,
-        indirect: typedAtomicIndirect,
         position: typedPosition,
+        chunkList: typedChunkList,
+        chunkTable: typedChunkTable,
+        chunkCursor: typedChunkCursor,
     });
     return { typedVertices, typedPosition, typedQuant, typedIndices, typedIndirect, bindGroup };
 }
@@ -656,11 +840,17 @@ function clearVoxelWarmOwner(owner: VoxelWarmOwner): void {
             gpu.position = null;
             gpu.quant = null;
             gpu.indices = null;
+            gpu.chunkList = null;
+            gpu.chunkTable = null;
+            gpu.chunkCursor = null;
             gpu.pipeline = null;
             gpu.bindGroup = null;
             Voxels.grid = null;
             Voxels.indirect = null;
+            Voxels.cursor = null;
             Voxels.dirty = false;
+            pool = null;
+            pendingSlots = null;
         },
     });
     if (stateOwners.get(owner.state) === owner) stateOwners.delete(owner.state);
@@ -751,10 +941,23 @@ const voxelWarmLifecycle = createWarmLifecycle<
         gpu.position = prepared.raw.position;
         gpu.quant = prepared.raw.quant;
         gpu.indices = prepared.raw.indices;
+        gpu.chunkList = prepared.raw.chunkList;
+        gpu.chunkTable = prepared.raw.chunkTable;
+        gpu.chunkCursor = prepared.raw.chunkCursor;
         gpu.pipeline = prepared.pipeline;
         gpu.bindGroup = prepared.wrapped.bindGroup;
         Voxels.grid = prepared.raw.voxels;
         Voxels.indirect = prepared.raw.indirect;
+        Voxels.cursor = prepared.raw.chunkCursor;
+        pool = createChunkPool(MAX_FACES);
+        // a scenario that authored `Voxels.data` before setup (the pattern-swap / assert path) already has
+        // what a full remesh needs — alloc it now instead of waiting a frame; the GPU-generated path (no
+        // authored data yet) leaves `pendingSlots` at its default (`null` = full, pending `Voxels.data`),
+        // which `VoxelEmitSystem` resolves once `generate()` + `syncGrid` populate it.
+        if (Voxels.data) {
+            remeshFull(Voxels.data);
+            pendingSlots = FULL_SLOTS;
+        }
         Voxels.dirty = true;
     },
 });

--- a/examples/showcase/voxel/test/perf.spec.ts
+++ b/examples/showcase/voxel/test/perf.spec.ts
@@ -26,17 +26,12 @@ import { adapterName, SOFTWARE } from "./gpu-adapter";
 // dispatch is always 262144", exactly the mechanism S1 named. The correctness gate (`test/voxel.spec.ts`)
 // and the project's 51 unit tests stay green against the same tree.
 //
-// S3 (reshaped, answered fork 2026-08-24): the minimal dispatch-scope fix is refuted, not shipped —
-// `VoxelEmitSystem` resets the shared atomic-append buffers on every fire, so a full-grid re-dispatch is
-// what keeps the draw buffer complete; scoping the dispatch to the touched region alone drops all geometry
-// outside it (measured ~97.6% face loss, 393,216 → 9,222 faces, on a 1-chunk edit). A correct reduction
-// needs per-chunk buffer regions/compaction — Phase-4 streaming machinery this unit's Out of scope excludes.
-// The assertion below is therefore `test.fail()`-annotated: expected-red on trunk, by design, until the
-// successor unit lands. Trunk must not close carrying an unannotated red gate, so this stays the honest
-// form rather than a deletion — the bound derivation, the witnessed-red record above, and the ungated
-// occupancy reading all stay live and unchanged. Successor: per-chunk streaming, its own `(scope first)`
-// roadmap item, which inherits this gate (bound already derived, red already witnessed) as its pre-minted
-// floor — the fix ships there, not here.
+// Discharged by `voxel-chunk-streaming` S2: the earlier `showcase-frame-floor` S3 fork found the minimal
+// dispatch-scope fix refuted (a full-grid re-dispatch was load-bearing for the shared atomic-append
+// buffers' completeness) and left this assertion `test.fail()`-annotated — expected-red on trunk until a
+// per-chunk buffer-region/compaction rewrite landed. That rewrite is `voxel-chunk-streaming` S2 (chunk
+// table + per-chunk cursors + a CPU-exact allocator), so the annotation comes off here: the bound
+// derivation and the witnessed-red record above stay live as the fixture this diff discharges.
 
 import { CHUNK } from "../src/voxel/grid";
 import { WG } from "../src/voxel/mesher";
@@ -48,13 +43,6 @@ const FORCE_FIRES = 20; // 5× S1's ungated sample count, cheap at one chunk per
 test("structural — emit dispatch scope tracks touched-chunk volume, not the full grid", async ({
     page,
 }) => {
-    // expected-red on trunk (docblock above) — S3 descoped the fix; the successor per-chunk-streaming
-    // unit discharges this annotation when it ships the correct reduction.
-    test.fail(
-        true,
-        "showcase-frame-floor S3: dispatch-scope fix refuted, ships in per-chunk streaming",
-    );
-
     const errors: string[] = [];
     page.on("pageerror", (e) => errors.push(String(e)));
 


### PR DESCRIPTION
Chunk-table + per-chunk-cursor GPU buffers; the emit kernel takes chunk
origin from a CPU-built chunk list and writes at table[chunk] +
atomicAdd(cursor[chunk], 1) under an exact-capacity guard.
VoxelEmitSystem dispatches only the touched+halo chunk list and resets
only those cursors. commitEdit/uploadVoxels drive count -> alloc (S1's
facesInChunk + RegionAllocator, via the new chunkpool.ts glue) ->
free-list zero-fill -> table upload; allocator exhaustion falls back to
a full remesh. The CPU authors the DrawIndexedIndirect record
(indexCount = pool tail x 6); the correctness gate's GPU face count
moves to the per-chunk cursor readback (summed), never the
CPU-authored record, so it stays an independent signal. Full remesh
(boot, reseed, pattern swap) routes through the same path with all 512
chunks listed; generate() now syncs the CPU mirror itself since the
allocator needs it before it can size a remesh.

Discharges test/perf.spec.ts's test.fail annotation: the structural
dispatch-scope floor (<=3,584 workgroups for a 1-chunk edit) now gates.
