### PR TITLE
voxel chunk streaming/s3

### DIFF
--- a/examples/showcase/voxel/src/boot.ts
+++ b/examples/showcase/voxel/src/boot.ts
@@ -11,7 +11,7 @@ import { Voxels } from "./voxel/mesher";
 // they exist: it fills the grid on the GPU (FBM terrain — the live visual), syncs the CPU mirror so the carve
 // path can march it, mounts the toolbar + keys, and installs the device gate. The gate + perf probe both
 // mirror `Voxels.cursor` (the per-chunk atomic face count) rather than `.indirect` — the CPU-authored draw
-// record would make the gate circular (`voxel-chunk-streaming` S2). `mode: always` so the terrain meshes
+// record would make the gate circular. `mode: always` so the terrain meshes
 // in edit mode too, not just play. Idempotent per State — `setup` re-arms it each build (ecs.md
 // "Reload-safety"); `dispose` tears the UI down so a rebuild doesn't stack overlays.
 
@@ -19,7 +19,7 @@ declare global {
     interface Window {
         // the device gate, driven by the project's own Playwright on a real GPU (test/voxel.spec.ts).
         __voxelGate?: () => Promise<Check[]>;
-        // the structural perf probe (`showcase-frame-floor` S2), driven by test/perf.spec.ts.
+        // the structural perf probe, driven by test/perf.spec.ts.
         __voxelPerf?: () => Promise<EmitDispatchSample>;
     }
 }
@@ -54,8 +54,8 @@ const BootSystem: System = {
 };
 
 async function boot(state: State, m: Mirror): Promise<void> {
-    // generate() syncs the CPU mirror itself (`voxel-chunk-streaming` S2: the mesher's chunk allocation is
-    // CPU-exact), so there's no separate syncGrid() step to sequence here anymore.
+    // generate() syncs the CPU mirror itself (the mesher's chunk allocation is CPU-exact), so there's no
+    // separate syncGrid() step to sequence here.
     await generate(SEED);
     if (state.signal.aborted) return;
     initCarve(state, document.querySelector("canvas"), SEED);

--- a/examples/showcase/voxel/src/gate.ts
+++ b/examples/showcase/voxel/src/gate.ts
@@ -19,8 +19,8 @@ import { checker, recenter, single, slab, solidChunk, sphere, tunnel } from "./v
 // plane), the mesher stays watertight over it, and a carve → grid-write → remesh stays watertight too.
 //
 // The GPU face count is the per-chunk atomic cursor buffer (`Voxels.cursor`), summed over all 512 slots —
-// never the CPU-authored indirect record (`voxel-chunk-streaming` S2: `indexCount = pool tail × 6` is the
-// same CPU count the allocator already computed, so comparing it back to `faces()` would be circular). The
+// never the CPU-authored indirect record (`indexCount = pool tail × 6` is the same CPU count the
+// allocator already computed, so comparing it back to `faces()` would be circular). The
 // cursor sum is the one signal this gate reads that the emit kernel itself produced.
 
 // the six canonical patterns — each a distinct mesher code path (isolated voxel, occluded interior,
@@ -162,7 +162,7 @@ export async function gate(cursor: Mirror): Promise<Check[]> {
     uploadVoxels(edited);
     // settle here so the initial upload's own emit fires before the edit — otherwise the upload and the
     // edit collapse into one dirty pass and the edit path (a re-mesh over already-meshed geometry) goes
-    // unexercised (`showcase-frame-floor` S3 side finding).
+    // unexercised.
     await settle(cursor);
     const touched = brush(edited, DIM.x / 2, DIM.y / 2, DIM.z / 2, 12, -DENSITY);
     commitEdit(touched);

--- a/examples/showcase/voxel/src/perf.ts
+++ b/examples/showcase/voxel/src/perf.ts
@@ -5,7 +5,7 @@ import { TOTAL_CELLS } from "./voxel/grid";
 import { commitEdit, EmitTelemetry, uploadVoxels } from "./voxel/mesher";
 import { single } from "./voxel/patterns";
 
-// The structural perf probe (`showcase-frame-floor` S2): drives one deterministic, single-chunk carve and
+// The structural perf probe: drives one deterministic, single-chunk carve and
 // reports the emit dispatch scope it triggers — `test/perf.spec.ts` gates the reported workgroup count
 // against touched-chunk volume, never against wall-clock (Locked decision: gate form (b), not (a)). This
 // module only produces the sample; `window.__voxelPerf` (boot.ts) is the only thing Playwright drives.

--- a/examples/showcase/voxel/src/voxel/chunkpool.ts
+++ b/examples/showcase/voxel/src/voxel/chunkpool.ts
@@ -1,6 +1,6 @@
-// The chunk-aware allocation glue over `RegionAllocator` (`voxel-chunk-streaming` S2): pure, device-free,
-// CPU-exact per-chunk sizing against `facesInChunk`. `RegionAllocator` itself stays generic (S1) — this
-// module is the one place that knows a "region" means one chunk's exact face-pool slice.
+// The chunk-aware allocation glue over `RegionAllocator`: pure, device-free, CPU-exact per-chunk sizing
+// against `facesInChunk`. `RegionAllocator` itself stays generic — this module is the one place that
+// knows a "region" means one chunk's exact face-pool slice.
 //
 // Two entry points. `fullRemesh` builds a fresh pool from scratch, allocating every non-empty chunk in
 // ascending slot order into an empty allocator — first-fit against one contiguous free block packs them

--- a/examples/showcase/voxel/src/voxel/generate.ts
+++ b/examples/showcase/voxel/src/voxel/generate.ts
@@ -168,7 +168,8 @@ const runDensity = createDensityRunner<
  *  — the mesher's chunk allocation is CPU-exact (`facesInChunk`), so a remesh dispatched against a
  *  GPU-only grid has nothing to size chunks from and defers indefinitely (`mesher.ts`'s
  *  `VoxelEmitSystem`). Every caller (boot, reseed, the correctness gate) gets a remeshable grid for free;
- *  `voxel-chunk-streaming` S3 measures whether this cost needs a GPU-count fallback. */
+ *  the full 512-chunk count this readback enables runs single-threaded on the CPU (`grid.test.ts`'s
+ *  print-only boot measurement), a cost the loading-screen budget question stays open on. */
 export async function generate(seed: number): Promise<void> {
     if (!Voxels.grid) throw new Error("voxel: generate before the grid buffer exists");
     const { device, root } = Compute;

--- a/examples/showcase/voxel/src/voxel/grid.test.ts
+++ b/examples/showcase/voxel/src/voxel/grid.test.ts
@@ -410,7 +410,7 @@ describe("facesInChunk — the CPU twin of the emit kernel's per-chunk emission"
         const total = sumChunks(data);
         const elapsed = performance.now() - start;
         expect(total).toBe(faces(data));
-        // print-only per spec (no wall-clock gate) — S3 reads this to judge the loading-screen budget
+        // print-only (no wall-clock gate) — the reading a loading-screen budget decision would use
         console.log(
             `[voxel-chunk-streaming] boot facesInChunk over ${SLOT_COUNT} chunks: ${elapsed.toFixed(3)}ms`,
         );

--- a/examples/showcase/voxel/src/voxel/grid.test.ts
+++ b/examples/showcase/voxel/src/voxel/grid.test.ts
@@ -412,7 +412,7 @@ describe("facesInChunk — the CPU twin of the emit kernel's per-chunk emission"
         expect(total).toBe(faces(data));
         // print-only (no wall-clock gate) — the reading a loading-screen budget decision would use
         console.log(
-            `[voxel-chunk-streaming] boot facesInChunk over ${SLOT_COUNT} chunks: ${elapsed.toFixed(3)}ms`,
+            `[voxel:boot-count] boot facesInChunk over ${SLOT_COUNT} chunks: ${elapsed.toFixed(3)}ms`,
         );
     });
 });

--- a/examples/showcase/voxel/src/voxel/grid.ts
+++ b/examples/showcase/voxel/src/voxel/grid.ts
@@ -16,7 +16,8 @@ import * as d from "typegpu/data";
 // distance beyond this region comes from a baked/LOD tier, decoupled from the voxel buffer.
 //
 // Chunk-major: each chunk's cells occupy one contiguous range, so a chunk uploads / evicts / remeshes as
-// a single slice — what makes per-chunk streaming + dispatch a localized write. CHUNK and SLOTS are
+// a single slice — the mesher's per-chunk allocation and scoped emit dispatch (mesher.ts) both key off
+// this layout, and a carve re-uploads and re-meshes only the chunks it touched. CHUNK and SLOTS are
 // powers of two so the WGSL mirror bakes the same arithmetic as shift/mask from these constants.
 
 export const CHUNK = 32;
@@ -153,14 +154,6 @@ export function faces(data: Float32Array): number {
 }
 
 /**
- * the exact exposed-face count for one chunk (`slot`) — the CPU twin of the emit kernel's per-chunk
- * emission (`mesher.ts`'s `emitKernel`): same `>= ISO` predicate, same f32 grid data, walked over the
- * chunk's local cells but reading neighbours through {@link solidAt} so a face straddling a chunk seam
- * (the sphere/checker fixtures, any real edit) reads the *other* chunk's data, not an assumed-air edge —
- * a chunk boundary is not a data boundary. `Σ facesInChunk(data, slot)` over every slot equals
- * {@link faces}; this is what lets S2 allocate each touched chunk's region exactly, no worst-case pad.
- */
-/**
  * the up-to-6 face-adjacent chunk slots of `slot`, bounds-clipped to the 8³ chunk grid — the halo a
  * touched chunk's edit can also affect: a face straddling the shared boundary can flip on either side
  * even when the neighbour's own occupancy is untouched (`facesInChunk`'s cross-chunk read), so a scoped
@@ -184,6 +177,15 @@ export function chunkNeighbors(slot: number): number[] {
     return out;
 }
 
+/**
+ * the exact exposed-face count for one chunk (`slot`) — the CPU twin of the emit kernel's per-chunk
+ * emission (`mesher.ts`'s `emitKernel`): same `>= ISO` predicate, same f32 grid data, walked over the
+ * chunk's local cells but reading neighbours through {@link solidAt} so a face straddling a chunk seam
+ * (the sphere/checker fixtures, any real edit) reads the *other* chunk's data, not an assumed-air edge —
+ * a chunk boundary is not a data boundary. `Σ facesInChunk(data, slot)` over every slot equals
+ * {@link faces}; this is what lets the chunk-pool allocator size each touched chunk's region exactly,
+ * with no worst-case pad.
+ */
 export function facesInChunk(data: Float32Array, slot: number): number {
     const [ox, oy, oz] = coord(slot * CHUNK_CELLS);
     let n = 0;

--- a/examples/showcase/voxel/src/voxel/mesher.ts
+++ b/examples/showcase/voxel/src/voxel/mesher.ts
@@ -1,11 +1,21 @@
-// The GPU face-cull mesher (Phase 2): a compute pass walks the voxel grid and emits an exposed-face quad
-// for every solid voxel whose neighbour across that face is air, atomically appending vertices / indices
-// into producer-owned buffers and the index count into an indirect draw record. Sear rasterizes the
-// result through one `drawIndirect` — the mesh never crosses back to the CPU. The 3D promotion of
-// a 2D terrain emit: swap "cliff per non-ground
-// neighbour" for "cube face per air neighbour", in all six directions including interior (the bored
-// tunnel) and across chunk seams (the cross-chunk sphere). Single pass over a static grid — the two-pass
-// count-then-`dispatchWorkgroupsIndirect` and per-chunk draws arrive with streaming (Phase 4).
+// The GPU face-cull mesher: one compute dispatch emits an exposed-face quad for every solid voxel whose
+// neighbour across that face is air — the 3D promotion of a 2D terrain emit, "cube face per air
+// neighbour" in all six directions, including interior (the bored tunnel) and across chunk seams (the
+// cross-chunk sphere). Sear rasterizes the result through one `drawIndexedIndirect` — the mesh never
+// crosses back to the CPU.
+//
+// Chunk allocation is CPU-exact: `facesInChunk` (grid.ts) counts each chunk's exposed faces against the
+// same `>= ISO` predicate and f32 data the kernel emits from, so a first-fit free-list (`chunkpool.ts`)
+// hands every chunk an exactly-sized contiguous region in the shared face pool — no worst-case
+// reservation, no per-chunk fixed cap. A per-chunk table (region start, capacity) and a per-chunk atomic
+// cursor let the kernel write `table[slot] + atomicAdd(cursor[slot], 1)`, one dispatch over a CPU-built
+// chunk list. A freed or resized chunk's stale index range is zero-filled into a degenerate, zero-area
+// triangle (culled at primitive assembly), so the single `drawIndexedIndirect` over `[0, pool tail)`
+// survives holes without a second draw per chunk.
+//
+// Boot, reseed, and a pattern swap dispatch every chunk (`fullRemesh`); a carve dispatches only the
+// touched chunks plus their face-adjacent halo (`planRemesh`), falling back to a full remesh on allocator
+// exhaustion — always correct, rare.
 
 import { Compute, type Plugin, RenderPlugin, type State, type System } from "@dylanebert/shallot";
 import {
@@ -93,7 +103,7 @@ export const MAX_FACES = Math.floor((BINDING_FLOOR * 3) / 4 / (VERTS_PER_QUAD * 
  * draw record (`indexCount = pool tail × 6`, `mesher.ts`'s `writeIndirect`) — and `cursor`, the per-chunk
  * atomic face count the correctness gate reads back (never `indirect`, which would be circular: it's the
  * same CPU count restated). {@link uploadVoxels} rewrites the grid and re-meshes; {@link commitEdit} does
- * the same over a touched chunk subset (Phase 5's carve).
+ * the same over a touched chunk subset (the carve path).
  */
 export const Voxels = {
     data: null as Float32Array | null,
@@ -123,12 +133,13 @@ const gpu = {
     bindGroup: null as TgpuBindGroup<typeof mesherLayout.entries> | null,
 };
 
-// the CPU-side allocation state (S2): the region allocator + per-chunk regions over the face pool
+// the CPU-side allocation state: the region allocator + per-chunk regions over the face pool
 // (`chunkpool.ts`), and the chunk-slot list the next `VoxelEmitSystem` fire owes — `null` means "a full
 // remesh is owed once `Voxels.data` exists" (covers `generate()`'s GPU-only dirty, deferred until
-// `syncGrid` populates the CPU mirror — `voxel-chunk-streaming` S3 firms up that ordering); a populated
-// array is the scoped touched+halo list `commitEdit` (or a full remesh) already resolved — count, alloc,
-// and the chunk-table upload are already done by the time `VoxelEmitSystem` reads it.
+// `syncGrid` populates the CPU mirror — `generate()` runs both in sequence, so boot and reseed always
+// reach the emit system with `Voxels.data` already synced); a populated array is the scoped touched+halo
+// list `commitEdit` (or a full remesh) already resolved — count, alloc, and the chunk-table upload are
+// already done by the time `VoxelEmitSystem` reads it.
 let pool: ChunkPool | null = null;
 let pendingSlots: readonly number[] | null = null;
 

--- a/examples/showcase/voxel/src/voxel/mesher.ts
+++ b/examples/showcase/voxel/src/voxel/mesher.ts
@@ -113,11 +113,10 @@ export const Voxels = {
     dirty: false,
 };
 
-/** read-only observability for the perf gate (`showcase-frame-floor` S2, discharged by
- *  `voxel-chunk-streaming` S2): the workgroup count issued by the most recent emit dispatch, set only by
- *  {@link VoxelEmitSystem} — no production code reads it, so it changes no behavior. `test/perf.spec.ts`
- *  (via `src/perf.ts`) gates dispatch scope against touched-chunk volume: `WG_PER_CHUNK³ × N` for the `N`
- *  chunks in that fire's dispatch list, never the full grid. */
+/** read-only observability for the perf gate: the workgroup count issued by the most recent emit
+ *  dispatch, set only by {@link VoxelEmitSystem} — no production code reads it, so it changes no
+ *  behavior. `test/perf.spec.ts` (via `src/perf.ts`) gates dispatch scope against touched-chunk volume:
+ *  `WG_PER_CHUNK³ × N` for the `N` chunks in that fire's dispatch list, never the full grid. */
 export const EmitTelemetry = { lastWorkgroups: 0 };
 
 const gpu = {
@@ -771,7 +770,7 @@ function allocateVoxelBuffers(
     });
     const indirect = allocate({
         label: "voxel-indirect",
-        // the CPU-authored draw record only — never a GPU atomic target (S2), so no STORAGE binding is
+        // the CPU-authored draw record only — never a GPU atomic target, so no STORAGE binding is
         // read/written by the kernel; COPY_DST is what `writeIndirect` targets.
         size: 20,
         usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
@@ -789,7 +788,7 @@ function allocateVoxelBuffers(
     const chunkCursor = allocate({
         label: "voxel-chunk-cursor",
         // COPY_SRC: the correctness gate mirrors this buffer (`Voxels.cursor`) for its GPU-side face-count
-        // readback — never `.indirect`, which would be circular (`voxel-chunk-streaming` S2).
+        // readback — never `.indirect`, which would be circular.
         size: SLOT_COUNT * 4, // atomic<u32> per slot
         usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
     });

--- a/examples/showcase/voxel/src/voxel/pool.ts
+++ b/examples/showcase/voxel/src/voxel/pool.ts
@@ -1,10 +1,10 @@
 // A pure, device-free first-fit free-list allocator over the face-pool number line (the CPU-side half of
-// scoped remesh, `voxel-chunk-streaming` S1): each touched chunk gets an exactly-sized contiguous region of
-// `[0, capacity)`, sized by the caller's own exact face count (`facesInChunk` in `grid.ts`) — no worst-case
-// reservation. `alloc` returns null on exhaustion (no first-fit region large enough) rather than throwing;
-// S2's caller falls back to full realloc + full re-emit through the same machinery on that signal — always
-// correct, rare. Regions merge back into the free list on `free`, so churn from repeated carves doesn't
-// fragment into unusable slivers faster than it has to.
+// scoped remesh): each touched chunk gets an exactly-sized contiguous region of `[0, capacity)`, sized by
+// the caller's own exact face count (`facesInChunk` in `grid.ts`) — no worst-case reservation. `alloc`
+// returns null on exhaustion (no first-fit region large enough) rather than throwing; the caller falls
+// back to full realloc + full re-emit through the same machinery on that signal — always correct, rare.
+// Regions merge back into the free list on `free`, so churn from repeated carves doesn't fragment into
+// unusable slivers faster than it has to.
 
 export interface Region {
     readonly start: number;

--- a/examples/showcase/voxel/test/_measure.spec.ts
+++ b/examples/showcase/voxel/test/_measure.spec.ts
@@ -1,18 +1,17 @@
 import { expect, type Page, test } from "@playwright/test";
 import { adapterName, SOFTWARE } from "./gpu-adapter";
 
-// The showcase-frame-floor measurement instrument (S1's reproduction driver, rewritten and committed here
-// so S3's adversarial pass can re-run the same before/after measurement — a figure whose tooling wasn't
-// recorded is a figure, not a reproduction target, `checks.md`). Two windows, both read through
-// `window.__benchmark.measure(warmup, frames)` (ProfilePlugin's published surface): idle orbit (no input)
-// and a scripted carve drag driven by real pointer events (`page.mouse`, never `locator.fill()` — a gate
-// issuing no pointer event can't see an interaction cost, `checks.md`). Reports frame-interval
-// percentiles, the CPU/fence/gap decomposition, and the `voxel:emit` / `sear:*` GPU pass spans.
+// The showcase measurement instrument: two windows, both read through
+// `window.__benchmark.measure(warmup, frames)` (ProfilePlugin's published surface) — idle orbit (no input)
+// and a scripted carve drag driven by real pointer events (`page.mouse`, never `locator.fill()`, which
+// issues no pointer event and so can't see an interaction cost). Committed here rather than run ad hoc,
+// since a figure whose tooling isn't recorded isn't reproducible. Reports frame-interval percentiles, the
+// CPU/fence/gap decomposition, and the `voxel:emit` / `sear:*` GPU pass spans.
 //
 // Gates nothing (Locked decision: no arbitrary wall-clock band — on this seat's 240 Hz monitor the display
-// clock dominates both windows identically, S1 2026-08-24: p50/p95/p99 ≈ 4.2/4.3/4.3 ms, idle vs carve
-// indistinguishable). The only assertions here are instrument-health ones (the page raised no error, the
-// profiler actually reported passes) — never a threshold on the numbers this file prints.
+// clock dominates both windows identically: p50/p95/p99 ≈ 4.2/4.3/4.3 ms, idle vs carve indistinguishable).
+// The only assertions here are instrument-health ones (the page raised no error, the profiler actually
+// reported passes) — never a threshold on the numbers this file prints.
 
 const WARMUP = 30;
 const FRAMES = 180;

--- a/examples/showcase/voxel/test/perf.spec.ts
+++ b/examples/showcase/voxel/test/perf.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
 import { adapterName, SOFTWARE } from "./gpu-adapter";
 
-// The structural perf gate (`showcase-frame-floor` S2): a wall-clock frame-time gate is refuted for this
-// mechanism (Locked decision — the display clock dominates both the idle-orbit and carve-drag windows on
-// this seat's 240 Hz monitor, so any ratio over frame time or `fenceMs` gates the monitor, not the code).
-// The admissible form is (b): a structural gate on the named mechanism — emit dispatch scope (workgroup
-// count per emit fire) as a function of touched-chunk volume, derived below rather than fitted.
+// The structural perf gate: a wall-clock frame-time gate is refuted for this mechanism (Locked decision —
+// the display clock dominates both the idle-orbit and carve-drag windows on this seat's 240 Hz monitor, so
+// any ratio over frame time or `fenceMs` gates the monitor, not the code). The admissible form is a
+// structural gate on the named mechanism — emit dispatch scope (workgroup count per emit fire) as a
+// function of touched-chunk volume, derived below rather than fitted.
 //
 // Derivation of the bound: the emit kernel (`mesher.ts`'s `emitKernel`) decides each of a cell's six faces
 // by reading exactly one neighbour cell, one axis at a time (`ix±1`, `iy±1`, `iz±1`). A cell sitting on a
@@ -18,27 +18,26 @@ import { adapterName, SOFTWARE } from "./gpu-adapter";
 //
 // Per-fire wall-clock occupancy is printed for context, never gated: the same Locked decision that refutes
 // a frame-time gate refutes a GPU-occupancy-in-ms gate too (no arbitrary numerical band). Forced over
-// FORCE_FIRES real fires — S1's 4-sample reading gated nothing, so a quoted percentile here needs enough
-// samples to mean something.
+// FORCE_FIRES real fires — a small handful of samples gates nothing, so a quoted percentile here needs
+// enough of them to mean something.
 //
 // Witnessed red at the pre-fix ref (2026-08-24, RTX 4090 via the host bridge): exit 1 — "dispatched 262144
 // workgroups for a 1-chunk edit — expected <= 3584 (touched-chunk-scoped dispatch); the pre-fix full-grid
-// dispatch is always 262144", exactly the mechanism S1 named. The correctness gate (`test/voxel.spec.ts`)
-// and the project's 51 unit tests stay green against the same tree.
+// dispatch is always 262144", exactly the full-grid dispatch this bound replaces. The correctness gate
+// (`test/voxel.spec.ts`) and the project's 51 unit tests stay green against the same tree.
 //
-// Discharged by `voxel-chunk-streaming` S2: the earlier `showcase-frame-floor` S3 fork found the minimal
-// dispatch-scope fix refuted (a full-grid re-dispatch was load-bearing for the shared atomic-append
-// buffers' completeness) and left this assertion `test.fail()`-annotated — expected-red on trunk until a
-// per-chunk buffer-region/compaction rewrite landed. That rewrite is `voxel-chunk-streaming` S2 (chunk
-// table + per-chunk cursors + a CPU-exact allocator), so the annotation comes off here: the bound
-// derivation and the witnessed-red record above stay live as the fixture this diff discharges.
+// A naive fix that narrows the dispatch alone is refuted: the shared atomic-append buffers only stay
+// complete if every chunk in a dispatch re-emits together, so a scoped dispatch needs a per-chunk
+// buffer-region/compaction rewrite underneath it — chunk table, per-chunk cursors, a CPU-exact allocator
+// (`mesher.ts`, `chunkpool.ts`). The bound derivation and the witnessed-red record above are the fixture
+// that mechanism satisfies.
 
 import { CHUNK } from "../src/voxel/grid";
 import { WG } from "../src/voxel/mesher";
 
 const CHUNK_WORKGROUPS = (CHUNK / WG) ** 3; // one chunk's own emit-kernel dispatch volume (512)
 const HALO_CHUNKS = 7; // the touched chunk + its 6 face-adjacent neighbours (derivation above)
-const FORCE_FIRES = 20; // 5× S1's ungated sample count, cheap at one chunk per fire
+const FORCE_FIRES = 20; // enough repeated fires for a stable percentile reading, cheap at one chunk per fire
 
 test("structural — emit dispatch scope tracks touched-chunk volume, not the full grid", async ({
     page,


### PR DESCRIPTION
- **voxel-chunk-streaming: S3 boot-path verify, measurement, prose**
- **voxel-chunk-streaming: strip kex-internal citations from voxel sources**
- **voxel-chunk-streaming: rename boot-count log tag to mechanism name**
