### PR TITLE
audit tumble engine bitexact literals/s1b

### DIFF
--- a/packages/shallot/tests/check-tumble-fp.test.ts
+++ b/packages/shallot/tests/check-tumble-fp.test.ts
@@ -2,6 +2,11 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+
+// The CLI script path — used by the F2 arm that spawns the script and reads its exit code,
+// the same pattern as `format-gate.test.ts` / `test-cap.test.ts`.
+const SCRIPT = resolve(import.meta.dir, "../../../scripts/check-tumble-fp.ts");
+
 // A meta-test over repo-root tooling, same placement pattern as check-scripts.test.ts /
 // check-exports.test.ts — `scripts/check-tumble-fp.ts` stays at `scripts/`, beside its siblings;
 // only the test moves, so it rides the default `bun test` sweep instead of running by hand.
@@ -71,6 +76,26 @@ describe("splitTopLevel", () => {
             "Math.PI",
             "rowFrequency",
         ]);
+    });
+
+    // B1 fix: an identifier ending in `e`/`E` before a `+`/`-` is NOT an exponent suffix.
+    // The discriminator is what precedes the `e`/`E` — a digit or `.` — not the `e`/`E` alone.
+    // Without this fix, `distance + 0.1` collapses into one token and `0.1` is silently missed.
+    test("does not treat an identifier ending in 'e' before '+' as an exponent suffix", () => {
+        expect(splitTopLevel("distance + 0.1")).toEqual(["distance", "0.1"]);
+    });
+
+    test("does not treat an identifier ending in 'E' before '-' as an exponent suffix", () => {
+        expect(splitTopLevel("value - 0.3")).toEqual(["value", "0.3"]);
+    });
+
+    // The leg the B1 fix could break: real exponent-literal shapes must still parse as one token.
+    test("still treats a real exponent suffix with '+' as a single token", () => {
+        expect(splitTopLevel("1e+5 * a")).toEqual(["1e+5", "a"]);
+    });
+
+    test("still treats a real exponent suffix with '-' as a single token", () => {
+        expect(splitTopLevel("1.5E-3 * a")).toEqual(["1.5E-3", "a"]);
     });
 });
 
@@ -167,6 +192,20 @@ describe("TRIG_ALLOWLIST — exactly two entries", () => {
         expect(TRIG_ALLOWLIST).toHaveLength(2);
         const totalLines = TRIG_ALLOWLIST.reduce((n, e) => n + e.lines.length, 0);
         expect(totalLines).toBe(4);
+    });
+
+    // F3: the allowlist's deviation labels are ungated — renaming `deviation: "createWaveMesh"`
+    // to `"wrong"` stayed green. Assert each entry's `file` and `deviation` content so a rename
+    // or mislabel reds. Entry granularity is (file, documented deviation), so the asserted
+    // entry count stays 2.
+    test("entry 0 is (engine/mesh.ts, createWaveMesh)", () => {
+        expect(TRIG_ALLOWLIST[0].file).toBe("engine/mesh.ts");
+        expect(TRIG_ALLOWLIST[0].deviation).toBe("createWaveMesh");
+    });
+
+    test("entry 1 is (engine/heightfield.ts, createWave)", () => {
+        expect(TRIG_ALLOWLIST[1].file).toBe("engine/heightfield.ts");
+        expect(TRIG_ALLOWLIST[1].deviation).toBe("createWave");
     });
 });
 
@@ -353,6 +392,147 @@ describe("sweepLiterals — red-first proof on a fixture tree (S1 carried forwar
     });
 });
 
+// B1 — the exponent-suffix discriminator, armed at the sweep level. The old predicate treated
+// any `e`/`E` before a `+`/`-` as a numeric exponent suffix, including when that `e`/`E` was the
+// last character of an identifier (`distance`, `value`). The `+`/`-` was then not a split point,
+// the whole expression collapsed into one non-literal token, and a bare non-exact literal at
+// the top level was silently missed — no finding, and no unparsed report either. The fix
+// discriminates by what precedes the `e`/`E` (a digit or `.`), and these arms prove it at the
+// composition-adjacent entry (`sweepLiterals` over a fixture root), not merely at the leaf.
+describe("sweepLiterals — B1: identifier ending in e/E before +/- is not an exponent suffix", () => {
+    // Red: `distance` ends in `e`, `+` must be a split point, `0.1` is a bare non-exact literal.
+    // Mutation: revert the B1 fix in `splitTopLevelTokens` (drop the `j > start && /[0-9.]/.test`
+    // guard) → `distance + 0.1` collapses into one token, `0.1` is invisible, this reds.
+    test("flags f32(distance + 0.1) — identifier ends in 'e' before '+'", async () => {
+        const root = fixture({
+            "fake/distance.ts": "export const bad = f32(distance + 0.1);\n",
+        });
+        const findings = await sweepLiterals(root);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].kind).toBe("literal");
+        if (findings[0].kind === "literal") {
+            expect(findings[0].literals).toEqual(["0.1"]);
+        }
+    });
+
+    // Red: `value` ends in `e`, `-` must be a split point, `0.3` is a bare non-exact literal.
+    // Mutation: same revert → `value - 0.3` collapses, `0.3` invisible, this reds.
+    test("flags f32(value - 0.3) — identifier ends in 'e' before '-'", async () => {
+        const root = fixture({
+            "fake/value.ts": "export const bad = f32(value - 0.3);\n",
+        });
+        const findings = await sweepLiterals(root);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].kind).toBe("literal");
+        if (findings[0].kind === "literal") {
+            expect(findings[0].literals).toEqual(["0.3"]);
+        }
+    });
+
+    // The leg the B1 fix could break: a real exponent literal with `+` must still parse as one
+    // token. `1e+5` is exactly representable in f32, so `f32(1e+5 * a)` stays silent.
+    // Mutation: over-broaden the fix (treat all `e`/`E` as non-exponent) → `1e+5` splits into
+    // `1e` and `5`, `1e` is not a numeric literal, the split is wrong, this reds.
+    test("does not flag f32(1e+5 * a) — real exponent suffix with '+' stays one token", async () => {
+        const root = fixture({
+            "fake/exponent-plus.ts": "export const ok = f32(1e+5 * a);\n",
+        });
+        const findings = await sweepLiterals(root);
+        expect(findings).toHaveLength(0);
+    });
+
+    // The leg the B1 fix could break: a real exponent literal with `-` must still parse as one
+    // token. `1.5E-3` is non-exact in f32, so `f32(1.5E-3 * a)` IS a finding — but the literal
+    // must be a single token `1.5E-3`, not split into `1.5E` and `3` by the fix.
+    // Mutation: over-broaden the fix (treat all `e`/`E` as non-exponent) → `1.5E-3` splits into
+    // `1.5E` and `3`, the literal list changes, this reds.
+    test("flags f32(1.5E-3 * a) as a single exponent literal, not a split", async () => {
+        const root = fixture({
+            "fake/exponent-minus.ts": "export const ok = f32(1.5E-3 * a);\n",
+        });
+        const findings = await sweepLiterals(root);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].kind).toBe("literal");
+        if (findings[0].kind === "literal") {
+            expect(findings[0].literals).toEqual(["1.5E-3"]);
+        }
+    });
+});
+
+// F1 — the structural legs (template awareness, comment awareness, quote awareness, nested
+// call-argument traversal) are armed only at the leaf (direct calls to `maskLiterals` /
+// `splitTopLevel`). The real-corpus floor arm runs `sweep(REAL_ROOT)` and asserts 11 findings,
+// but none of the 11 depends on those legs — so deleting any leg reds only the leaf arms, never
+// the composition. This arm gives the composition its own synthetic fixture root carrying a shape
+// per leg, driven through the same `sweep`/`sweepLiterals`/`sweepUnparsed` entry the real run
+// uses, asserting content and cardinality — not just a count.
+describe("sweep — F1: composition fixture exercising every structural leg", () => {
+    // One small tree carrying a shape per leg:
+    //   - a literal inside a template interpolation (template awareness)
+    //   - a literal inside a string that must stay silent (quote awareness)
+    //   - a literal inside a comment that must stay silent (comment awareness)
+    //   - a literal nested in a call argument (call-argument traversal)
+    //   - an undecomposable region that must be reported (fail-loud)
+    const compositionFixture: Record<string, string> = {
+        // Template interpolation: `f32(0.1 * mass)` inside `${...}` is real code, must be found.
+        // Mutation: delete template-literal handling in `maskLiterals` (mask the interpolation
+        // expression too) → this finding disappears, the assertion reds.
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: test fixture intentionally contains template syntax
+        "engine/template.ts": "const msg = `result ${f32(0.1 * mass)}`;\n",
+        // String content: `f32(0.1 * mass)` inside a string literal is NOT code, must stay silent.
+        // Mutation: stop masking string content in `maskLiterals` (preserve it as code) → this
+        // becomes a spurious finding, the assertion reds.
+        "engine/string.ts": 'const s = "f32(0.1 * mass)";\n',
+        // Comment content: `f32(0.1 * mass)` inside a comment is NOT code, must stay silent.
+        // Mutation: stop masking line comments in `maskLiterals` → this becomes a spurious
+        // finding, the assertion reds.
+        "engine/comment.ts": "// f32(0.1 * mass) is bad\nexport const ok = f32(f32(0.1) * mass);\n",
+        // Nested call argument: `0.1` inside `Math.sqrt(...)`'s argument list, not at the top
+        // level of the outer split. Must be found by recursive traversal.
+        // Mutation: delete the recursion into parenthesized groups in `collectOffendingLiterals`
+        // → `0.1` is invisible, this finding disappears, the assertion reds.
+        "engine/nested-call.ts": "export const bad = f32(Math.sqrt(0.1 * a));\n",
+        // Undecomposable region: an unterminated string. Must be reported as unparsed, not
+        // silently swallowed.
+        // Mutation: delete the unterminated-string report in `maskLiterals` → the unparsed
+        // finding disappears, the assertion reds.
+        "engine/undecomposable.ts":
+            'const s = "unterminated string\nconst bad = f32(0.1 * mass);\n',
+    };
+
+    test("sweepLiterals finds the template-interpolation literal and the nested-call literal", async () => {
+        const root = fixture(compositionFixture);
+        const findings = await sweepLiterals(root);
+        // Two literal findings: one from the template interpolation, one from the nested call.
+        expect(findings).toHaveLength(2);
+        const files = findings.map((f) => f.file).sort();
+        expect(files).toEqual(["engine/nested-call.ts", "engine/template.ts"]);
+        // The string and comment fixtures must NOT appear — they are masked.
+        const allFiles = findings.map((f) => f.file);
+        expect(allFiles).not.toContain("engine/string.ts");
+        expect(allFiles).not.toContain("engine/comment.ts");
+    });
+
+    test("sweepUnparsed reports the undecomposable region", async () => {
+        const root = fixture(compositionFixture);
+        const findings = await sweepUnparsed(root);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].kind).toBe("unparsed");
+        expect(findings[0].file).toBe("engine/undecomposable.ts");
+    });
+
+    test("sweep over the composition fixture exercises every leg through the real entry point", async () => {
+        const root = fixture(compositionFixture);
+        const findings = await sweep(root);
+        // 2 literal findings + 1 unparsed = 3 total. No trig findings.
+        expect(findings).toHaveLength(3);
+        const literalCount = findings.filter((f) => f.kind === "literal").length;
+        const unparsedCount = findings.filter((f) => f.kind === "unparsed").length;
+        expect(literalCount).toBe(2);
+        expect(unparsedCount).toBe(1);
+    });
+});
+
 describe("sweepTrig — the allowlist arm", () => {
     test("a synthetic Math.sin site outside the allowlist reds", async () => {
         const root = fixture({
@@ -495,5 +675,32 @@ describe("sweep — the real engine tree, pinned floor", () => {
     test("the unparsed arm is clean against the real tree — no undecomposable regions", async () => {
         const findings = await sweepUnparsed(REAL_ROOT);
         expect(findings).toHaveLength(0);
+    });
+});
+
+// F2 — the "exits non-zero" claim is prose nothing gates. The script's docblock and help text
+// claim a loud inconclusive exits non-zero; every arm calls `sweep*` directly and none reads the
+// CLI's exit status. This arm spawns the CLI (`Bun.spawnSync`, same pattern as `format-gate.test.ts`)
+// and reads the exit code — both directions: non-zero when there are findings (the real tree),
+// and zero on a synthetic clean root pointed at via `--root`.
+describe("CLI exit code — F2: the loud inconclusive exits non-zero", () => {
+    test("exits non-zero when the sweep finds violations (the real engine tree)", () => {
+        const proc = Bun.spawnSync(["bun", SCRIPT, "--root", REAL_ROOT], {
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        expect(proc.exitCode).not.toBe(0);
+        expect(proc.exitCode).toBe(1);
+    });
+
+    test("exits zero on a synthetic clean root pointed at via --root", () => {
+        const root = fixture({
+            "engine/clean.ts": "export const ok = f32(f32(0.1) * mass);\n",
+        });
+        const proc = Bun.spawnSync(["bun", SCRIPT, "--root", root], {
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        expect(proc.exitCode).toBe(0);
     });
 });

--- a/packages/shallot/tests/check-tumble-fp.test.ts
+++ b/packages/shallot/tests/check-tumble-fp.test.ts
@@ -6,11 +6,13 @@ import { join, resolve } from "node:path";
 // check-exports.test.ts — `scripts/check-tumble-fp.ts` stays at `scripts/`, beside its siblings;
 // only the test moves, so it rides the default `bun test` sweep instead of running by hand.
 import {
+    maskLiterals,
     splitTopLevel,
     stripComments,
     sweep,
     sweepLiterals,
     sweepTrig,
+    sweepUnparsed,
     TRIG_ALLOWLIST,
 } from "../../../scripts/check-tumble-fp";
 
@@ -72,15 +74,91 @@ describe("splitTopLevel", () => {
     });
 });
 
-describe("stripComments", () => {
-    test("blanks a line comment but preserves the newline", () => {
-        const out = stripComments("const x = 1; // f32(0.1 * mass)\nconst y = 2;");
-        expect(out).toBe("const x = 1; \nconst y = 2;");
+// `maskLiterals` is the S1b rebuild of the S1 `stripComments`. It masks string and comment
+// content (→ spaces, newlines preserved) so a `)` or `{` inside a string never confuses the
+// depth counters in `findCalls` / `splitTopLevelTokens`, and it handles template-literal
+// interpolations (`${...}`) by preserving the interpolation expression as real code while masking
+// the template text. Any construct it cannot close is reported as an `UnparsedSite`.
+describe("maskLiterals", () => {
+    test("masks a line comment, preserving the newline", () => {
+        const { masked } = maskLiterals("const x = 1; // f32(0.1 * mass)\nconst y = 2;");
+        expect(masked).not.toContain("f32(0.1 * mass)");
+        expect(masked).toContain("\n");
+        expect(masked).toContain("const y = 2;");
     });
 
-    test("preserves string literals containing comment-like text", () => {
+    test("masks string content so comment-like text inside strings is invisible", () => {
+        const { masked } = maskLiterals('const s = "// not a comment";');
+        expect(masked).not.toContain("// not a comment");
+        expect(masked).toContain("const s = ");
+        expect(masked).toContain(";");
+    });
+
+    test("masks template-literal text but preserves interpolation expressions", () => {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: test fixture intentionally contains template syntax
+        const { masked } = maskLiterals("const msg = `hello ${f32(0.1 * mass)}`;");
+        // The template text "hello " is masked, but the interpolation expression is preserved.
+        expect(masked).toContain("f32(0.1 * mass)");
+        expect(masked).not.toContain("hello");
+    });
+
+    test("masks nested template literals inside interpolations", () => {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: test fixture intentionally contains template syntax
+        const { masked } = maskLiterals("const msg = `outer ${`inner ${f32(0.1)}`}`;");
+        expect(masked).toContain("f32(0.1)");
+        expect(masked).not.toContain("outer");
+        expect(masked).not.toContain("inner");
+    });
+
+    test("reports an unterminated string literal as an unparsed site", () => {
+        const { unparsed } = maskLiterals('const s = "unterminated');
+        expect(unparsed).toHaveLength(1);
+        expect(unparsed[0].reason).toBe("unterminated string literal");
+    });
+
+    test("reports an unterminated template literal as an unparsed site", () => {
+        const { unparsed } = maskLiterals("const msg = `unterminated");
+        expect(unparsed).toHaveLength(1);
+        expect(unparsed[0].reason).toBe("unterminated template literal");
+    });
+
+    test("reports an unterminated block comment as an unparsed site", () => {
+        const { unparsed } = maskLiterals("/* unterminated");
+        expect(unparsed).toHaveLength(1);
+        expect(unparsed[0].reason).toBe("unterminated block comment");
+    });
+
+    test("reports a template literal with an unbalanced interpolation brace as an unparsed site", () => {
+        // `${ {a: 1}` — the `}` closes the object literal but there is no closing `}` for the
+        // interpolation itself. The backtick after `}` starts a nested template (we are still
+        // inside the interpolation), which consumes the rest of the file. The template is
+        // reported as unterminated — not silently swallowed.
+        const { unparsed } = maskLiterals(
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: test fixture intentionally contains template syntax
+            "const msg = `hello ${ {a: 1}`;\nconst bad = f32(0.1 * mass);\n",
+        );
+        expect(unparsed).toHaveLength(1);
+        expect(unparsed[0].reason).toBe("unterminated template literal");
+    });
+});
+
+// `stripComments` is a backward-compatible wrapper around `maskLiterals` — the masked text only,
+// without the unparsed-site list. The S1 tests checked that comment content is removed and string
+// content is preserved; the S1b rebuild masks string content too (so a `)` inside a string never
+// confuses the depth counters), so the string test now checks masking rather than preservation.
+describe("stripComments", () => {
+    test("masks a line comment but preserves the newline", () => {
+        const out = stripComments("const x = 1; // f32(0.1 * mass)\nconst y = 2;");
+        expect(out).not.toContain("f32(0.1 * mass)");
+        expect(out).toContain("\n");
+        expect(out).toContain("const y = 2;");
+    });
+
+    test("masks string content so comment-like text inside strings is invisible", () => {
         const out = stripComments('const s = "// not a comment";');
-        expect(out).toBe('const s = "// not a comment";');
+        expect(out).not.toContain("// not a comment");
+        expect(out).toContain("const s = ");
+        expect(out).toContain(";");
     });
 });
 
@@ -92,7 +170,83 @@ describe("TRIG_ALLOWLIST — exactly two entries", () => {
     });
 });
 
-describe("sweepLiterals — red-first proof on a fixture tree", () => {
+// S1b demonstrated members — the three shapes the rebuilt predicate must catch, each with a real
+// f32 divergence measured by the S1 review pass. Each arm selects its subject (a literal finding
+// or an unparsed finding) out of a corpus, so cardinality is asserted in the same breath as
+// content.
+describe("sweepLiterals — S1b demonstrated members (structural traversal)", () => {
+    // Member 1: a non-exact literal inside a sanctioned call argument. The old predicate only
+    // inspected the top-level split's own operands, so `0.1` hiding inside `Math.sqrt(...)`'s
+    // argument list was invisible. The rebuilt predicate recurses into every parenthesized group
+    // (call-argument parens included), so `0.1` is found. The matcher distinguishes this from a
+    // bare `f32(0.1 * a)` (same literal, no call wrapper) and from a properly wrapped
+    // `f32(Math.sqrt(f32(0.1) * a))` (nested f32 call skipped by the recursion).
+    test("flags a non-exact literal inside a sanctioned call argument: f32(Math.sqrt(0.1 * a))", async () => {
+        const root = fixture({
+            "fake/call-arg.ts": "export const bad = f32(Math.sqrt(0.1 * a));\n",
+        });
+        const findings = await sweepLiterals(root);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].kind).toBe("literal");
+        if (findings[0].kind === "literal") {
+            expect(findings[0].literals).toEqual(["0.1"]);
+        }
+    });
+
+    // Control for member 1: the same shape but the literal is properly pre-wrapped in a nested
+    // f32() call. The recursion skips nested f32() calls (findCalls handles them separately), so
+    // this stays silent — a control green at both ends.
+    test("does not flag a properly pre-wrapped literal inside a call argument", async () => {
+        const root = fixture({
+            "fake/wrapped-call-arg.ts": "export const good = f32(Math.sqrt(f32(0.1) * a));\n",
+        });
+        const findings = await sweepLiterals(root);
+        expect(findings).toHaveLength(0);
+    });
+
+    // Member 2: a whole-level literal-only chain of 2+ ops. `f32(1 - 1/3)` has 3 literals and 2
+    // operators (`-` and `/`). The intermediate `1/3 = 0.333…` is non-exact and is not rounded
+    // to f32 before the subtraction, exactly the double-rounding gap rule 1a names. The old
+    // predicate's `reduceLiteralCluster` was single-pass left-to-right (`(1-1)/3 = 0`, which IS
+    // exact in f32), silently hiding the divergence. The rebuilt evaluator is two-pass
+    // (precedence-aware), so `1 - 1/3 = 0.666…` is correctly non-exact. The matcher distinguishes
+    // this from a bare `f32(1 / 3)` (1 operator, double-rounding theorem covers it, stays silent).
+    test("flags a whole-level literal-only chain of 2+ ops: f32(1 - 1/3)", async () => {
+        const root = fixture({
+            "fake/chain.ts": "export const bad = f32(1 - 1/3);\n",
+        });
+        const findings = await sweepLiterals(root);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].kind).toBe("literal");
+        if (findings[0].kind === "literal") {
+            expect(findings[0].literals).toEqual(["1", "1", "3"]);
+        }
+    });
+
+    // Control for member 2: a bare fraction of individually-exact literals with no further fused
+    // operator — `f32(1 / 3)`. This is exactly the correct place to round it (the double-rounding
+    // theorem covers a two-operand op whose operands are already f32-valued), so it stays silent.
+    // The matcher distinguishes this from `f32(1 - 1/3)` (2+ ops, intermediate not rounded).
+    test("does not flag a bare fraction of exact literals: f32(1 / 3)", async () => {
+        const root = fixture({
+            "fake/bare-fraction.ts": "export const ok = f32(1 / 3);\n",
+        });
+        const findings = await sweepLiterals(root);
+        expect(findings).toHaveLength(0);
+    });
+
+    // Control for member 2: a whole-level chain of 2+ ops where all literals and all intermediates
+    // are exactly representable — `f32(2 * 3 + 1)` = 7, exact. Must stay silent.
+    test("does not flag a whole-level chain whose result is exactly representable", async () => {
+        const root = fixture({
+            "fake/exact-chain.ts": "export const ok = f32(2 * 3 + 1);\n",
+        });
+        const findings = await sweepLiterals(root);
+        expect(findings).toHaveLength(0);
+    });
+});
+
+describe("sweepLiterals — red-first proof on a fixture tree (S1 carried forward)", () => {
     test("flags a bare non-exact literal inside an f32(...) arithmetic wrap", async () => {
         const root = fixture({
             "fake/unwrapped.ts": "export const bad = f32(0.1 * mass);\n",
@@ -160,10 +314,6 @@ describe("sweepLiterals — red-first proof on a fixture tree", () => {
         expect(findings).toHaveLength(0);
     });
 
-    // Rule 1a's own named example: a non-exact fraction built from individually-exact literals
-    // (`1`, `3`), fused with a further operator in the same wrap. Neither `1` nor `3` alone fails
-    // the old per-operand exactness check, so a predicate that only tests each split operand's own
-    // value misses this shape entirely.
     test("flags a non-exact fraction of exact literals fused with a further operator", async () => {
         const root = fixture({
             "fake/fraction.ts": "export const bad = f32(1 / 3 * mass);\n",
@@ -175,8 +325,6 @@ describe("sweepLiterals — red-first proof on a fixture tree", () => {
         }
     });
 
-    // Two-sided control: the same shape, but the fraction (1/4 = 0.25) is exactly representable —
-    // must stay silent.
     test("does not flag an exact fraction fused with a further operator", async () => {
         const root = fixture({
             "fake/fraction.ts": "export const ok = f32(1 / 4 * mass);\n",
@@ -185,20 +333,6 @@ describe("sweepLiterals — red-first proof on a fixture tree", () => {
         expect(findings).toHaveLength(0);
     });
 
-    // A bare fraction of individually-exact literals, with nothing further fused in the same wrap,
-    // is exactly the correct place to round it (the double-rounding theorem covers a two-operand op
-    // whose operands are already f32-valued) — must stay silent, unlike the fused case above.
-    test("does not flag a bare fraction of exact literals with no further fused operator", async () => {
-        const root = fixture({
-            "fake/fraction.ts": "export const ok = f32(1 / 3);\n",
-        });
-        const findings = await sweepLiterals(root);
-        expect(findings).toHaveLength(0);
-    });
-
-    // A literal nested one paren-level deeper than the f32(...) call's own top level — the old
-    // predicate only inspected the top-level split's own operands, so a literal hiding inside a
-    // parenthesized sub-expression at that level was invisible.
     test("flags a non-exact literal nested one paren-level deeper than the wrap's top level", async () => {
         const root = fixture({
             "fake/nested.ts": "export const bad = f32((0.4 * mass) + 1);\n",
@@ -210,8 +344,6 @@ describe("sweepLiterals — red-first proof on a fixture tree", () => {
         }
     });
 
-    // Two-sided control: the same nested shape, but the nested literal (0.5) is exact — must stay
-    // silent.
     test("does not flag an exact literal nested one paren-level deeper than the wrap's top level", async () => {
         const root = fixture({
             "fake/nested.ts": "export const ok = f32((0.5 * mass) + 1);\n",
@@ -252,6 +384,77 @@ describe("sweepTrig — the allowlist arm", () => {
     });
 });
 
+// S1b fail-loud invariant: any `f32(` region the lexer cannot fully decompose, or a depth counter
+// that does not return to zero, is reported as an unparsed site and exits non-zero. The arm
+// selects unparsed findings out of the sweep corpus, so cardinality is asserted.
+describe("sweepUnparsed — the fail-loud arm", () => {
+    // Member 3: a template literal carrying an unbalanced brace. The S1 hand-rolled tokenizer
+    // silently swallowed the rest of the file and returned zero findings in a net — the worst
+    // failure shape for a standing check. The rebuilt lexer reports it as an unparsed site.
+    test("a template literal carrying an unbalanced brace is reported, not silently swallowed", async () => {
+        const root = fixture({
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: test fixture intentionally contains template syntax
+            "fake/template.ts": "const msg = `hello ${ {a: 1}`;\nconst bad = f32(0.1 * mass);\n",
+        });
+        const findings = await sweepUnparsed(root);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].kind).toBe("unparsed");
+        expect(findings[0].file).toBe("fake/template.ts");
+    });
+
+    // A deliberately undecomposable region — an unterminated string — is reported rather than
+    // skipped. The matcher distinguishes "reported as unparsed" from "silently returns zero
+    // findings": the sweep exits non-zero with at least one `unparsed` finding.
+    test("a deliberately undecomposable region is reported rather than skipped", async () => {
+        const root = fixture({
+            "fake/undecomposable.ts":
+                'const s = "unterminated string\nconst bad = f32(0.1 * mass);\n',
+        });
+        const findings = await sweepUnparsed(root);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].kind).toBe("unparsed");
+    });
+
+    // An unbalanced f32() call (depth counter does not return to zero) is reported as an unparsed
+    // site. The matcher distinguishes this from a balanced call with a real finding.
+    test("an unbalanced f32() call is reported as an unparsed site", async () => {
+        const root = fixture({
+            "fake/unbalanced.ts": "export const bad = f32(0.1 * mass;\n",
+        });
+        const findings = await sweepUnparsed(root);
+        expect(findings).toHaveLength(1);
+        expect(findings[0].kind).toBe("unparsed");
+        if (findings[0].kind === "unparsed") {
+            expect(findings[0].reason).toBe("unbalanced parens in f32() call");
+        }
+    });
+
+    // Control: a clean file with no unparsable constructs produces zero unparsed findings.
+    test("a clean file produces zero unparsed findings", async () => {
+        const root = fixture({
+            "fake/clean.ts": "export const ok = f32(f32(0.1) * mass);\n",
+        });
+        const findings = await sweepUnparsed(root);
+        expect(findings).toHaveLength(0);
+    });
+});
+
+// The full sweep over a template-literal-with-unbalanced-brace fixture must NOT return zero
+// findings — the S1 tokenizer's worst failure shape was returning zero findings in a net. The
+// rebuilt sweep reports the unparsed site, so the net is non-zero.
+describe("sweep — template literal with unbalanced brace is not zero findings in a net", () => {
+    test("the sweep returns non-zero findings (the unparsed site), not zero", async () => {
+        const root = fixture({
+            // biome-ignore lint/suspicious/noTemplateCurlyInString: test fixture intentionally contains template syntax
+            "fake/template.ts": "const msg = `hello ${ {a: 1}`;\nconst bad = f32(0.1 * mass);\n",
+        });
+        const findings = await sweep(root);
+        expect(findings.length).toBeGreaterThan(0);
+        const unparsed = findings.filter((f) => f.kind === "unparsed");
+        expect(unparsed).toHaveLength(1);
+    });
+});
+
 describe("sweep — the real engine tree, pinned floor", () => {
     test("measures exactly 11 live findings against the current tumble engine source", async () => {
         const findings = await sweep(REAL_ROOT);
@@ -286,6 +489,11 @@ describe("sweep — the real engine tree, pinned floor", () => {
 
     test("the trig arm is clean against the real tree — only the two allowlisted deviations exist", async () => {
         const findings = await sweepTrig(REAL_ROOT);
+        expect(findings).toHaveLength(0);
+    });
+
+    test("the unparsed arm is clean against the real tree — no undecomposable regions", async () => {
+        const findings = await sweepUnparsed(REAL_ROOT);
         expect(findings).toHaveLength(0);
     });
 });

--- a/packages/shallot/tests/check-tumble-fp.test.ts
+++ b/packages/shallot/tests/check-tumble-fp.test.ts
@@ -682,7 +682,10 @@ describe("sweep — the real engine tree, pinned floor", () => {
 // claim a loud inconclusive exits non-zero; every arm calls `sweep*` directly and none reads the
 // CLI's exit status. This arm spawns the CLI (`Bun.spawnSync`, same pattern as `format-gate.test.ts`)
 // and reads the exit code — both directions: non-zero when there are findings (the real tree),
-// and zero on a synthetic clean root pointed at via `--root`.
+// and zero on a synthetic clean root pointed at via `--root`. The clean-root direction also reads
+// the CLI's stdout as a launch witness: an empty root exits 0 too, so `exitCode === 0` alone cannot
+// tell "swept the fixture and found nothing" from "swept no files at all" — the stdout assertion
+// discriminates a launch that never happened (a glob scanning nothing) from a real clean sweep.
 describe("CLI exit code — F2: the loud inconclusive exits non-zero", () => {
     test("exits non-zero when the sweep finds violations (the real engine tree)", () => {
         const proc = Bun.spawnSync(["bun", SCRIPT, "--root", REAL_ROOT], {
@@ -702,5 +705,9 @@ describe("CLI exit code — F2: the loud inconclusive exits non-zero", () => {
             stderr: "pipe",
         });
         expect(proc.exitCode).toBe(0);
+        // Launch witness: an empty root also exits 0, so the exit code alone can't distinguish a
+        // real clean sweep from a launch that never happened. The clean-sweep report on stdout is
+        // what proves the CLI actually swept the fixture and found nothing.
+        expect(proc.stdout.toString()).toContain("0 findings");
     });
 });

--- a/scripts/check-tumble-fp.ts
+++ b/scripts/check-tumble-fp.ts
@@ -310,7 +310,8 @@ type Token = { text: string; opBefore: "+" | "-" | "*" | "/" | null };
 // Split `expr` into its top-level (paren/bracket/brace depth 0) operands, each paired with the
 // operator that split it off the previous one. A leading `+`/`-`, or one immediately after another
 // operator/open-paren/comma, is a unary sign (part of the operand, not a split point); an `e`/`E`-
-// adjacent `+`/`-` is an exponent suffix, never a split point either. Box3D's own
+// adjacent `+`/`-` is an exponent suffix, never a split point either, but only when the `e`/`E`
+// is preceded by a digit or `.` (see the inline comment at the discriminator below). Box3D's own
 // `-ffp-contract=off` + this port's "one op per f32 wrap" convention means most calls carry
 // exactly one top-level operator, but a chain (`2.0 * Math.PI * f`) splits into every operand so
 // each is checked independently.
@@ -338,6 +339,9 @@ function splitTopLevelTokens(expr: string): Token[] {
                 (prevChar === "e" || prevChar === "E") &&
                 j > start &&
                 /[0-9.]/.test(expr[j - 1]);
+            // Boundary: only the single char before the `e`/`E` is inspected, so an identifier ending
+            // in digit-then-`e` (e.g. `base2e + 0.1`) would still collapse — currently unreachable in
+            // this corpus (no such identifier precedes a `+`/`-` inside an f32 wrap). Not widened here.
             const isUnary = prevChar === "" || "+-*/(,".includes(prevChar);
             if (isExponent || isUnary) continue;
             tokens.push({ text: expr.slice(start, i).trim(), opBefore: pendingOp });

--- a/scripts/check-tumble-fp.ts
+++ b/scripts/check-tumble-fp.ts
@@ -7,10 +7,19 @@ import { TEST_TIER_SUFFIXES } from "../packages/shallot/tests/test-tiers";
 // `f32(f32(0.4) * mass)`, never `f32(0.4 * mass)` — JS `0.4` is an f64 operand until rounded,
 // and it multiplies/adds differently than C's `f`-suffixed `0.4f` for some right-hand values.
 // This sweeps every `f32(...)` call under the tumble engine source for that exact shape: a
-// bare (unwrapped) literal, at the call's own top level, whose `Math.fround` differs from
-// itself. It carries a second, independent arm: every `Math.sin`/`Math.cos`/`Math.atan2` call
-// site outside the two documented trig deviations (below) is also a finding — rule 1's "port
-// Box3D's own portable trig, never JS transcendentals" clause.
+// bare (unwrapped) literal, anywhere in the call's argument tree, whose `Math.fround` differs
+// from itself. It carries a second, independent arm: every `Math.sin`/`Math.cos`/`Math.atan2`
+// call site outside the two documented trig deviations (below) is also a finding — rule 1's
+// "port Box3D's own portable trig, never JS transcendentals" clause.
+//
+// **S1b — structural safety.** The predicate's soundness no longer rests on per-sample
+// demonstration. The sweep lexes once with quote / template-literal / comment awareness
+// (`maskLiterals`), then traverses *every* nested position exhaustively — call-argument parens
+// included, not just bare paren groups (`collectOffendingLiterals` recurses into any
+// parenthesized group that is not itself a nested `f32(...)` call, which `findCalls` handles
+// separately). Any `f32(` region the lexer cannot fully decompose, or a depth counter that does
+// not return to zero, is *reported as an unparsed site* and exits non-zero. Safety rests on
+// exhaustiveness over the region set plus a loud inconclusive — never on a sample.
 //
 // `bun run scripts/check-tumble-fp.ts` is EXPECTED to exit 1 at S1 (audit-tumble-engine-
 // bitexact-literals) — the check is built and pinned red before the three live divergences
@@ -35,6 +44,13 @@ export type Finding =
           line: number;
           expression: string;
           fn: string;
+      }
+    | {
+          kind: "unparsed";
+          file: string;
+          line: number;
+          reason: string;
+          snippet: string;
       };
 
 // The two documented trig deviations (tumble.md "One documented trig deviation" +
@@ -62,68 +78,237 @@ function isExactF32(n: number): boolean {
     return Math.fround(n) === n;
 }
 
-// Same shape as check-exports.ts's `stripComments` (block comments blanked but newline-
-// preserving, so line numbers stay correct; string literals copied through untouched) — a
-// documentation comment quoting the anti-pattern (`f32(0.4 * mass)`) as a bad example must
-// never read as a real finding.
-export function stripComments(content: string): string {
-    let result = "";
+function lineOf(text: string, pos: number): number {
+    let line = 1;
+    for (let i = 0; i < pos && i < text.length; i++) {
+        if (text[i] === "\n") line++;
+    }
+    return line;
+}
+
+// ---------------------------------------------------------------------------
+// Lexer: mask strings, comments, and template-literal text (preserve interpolations)
+// ---------------------------------------------------------------------------
+
+// A region the lexer could not fully decompose — an unterminated string, template literal, or
+// block comment, or an unbalanced template interpolation. The sweep reports these as `unparsed`
+// findings and exits non-zero, so safety rests on exhaustiveness plus a loud inconclusive.
+export type UnparsedSite = { line: number; reason: string; snippet: string };
+
+// Single-pass lexer producing a "masked" copy of the text where:
+//   - line-comment and block-comment content → spaces (newlines preserved, so line numbers stay
+//     correct);
+//   - single- and double-quoted string content → spaces (quote delimiters → spaces too, so a `)`
+//     inside a string never confuses the paren depth counter in `findCalls`);
+//   - template-literal text portions → spaces (backtick delimiters → spaces);
+//   - template-literal interpolation expressions (`${...}`) → **preserved as real code**, so a
+//     `f32(...)` inside an interpolation IS found by `findCalls` (it is a real call);
+//   - everything else → preserved verbatim.
+//
+// Any construct the lexer cannot close (unterminated string, unterminated template, unterminated
+// block comment, unbalanced interpolation brace) is recorded as an `UnparsedSite` rather than
+// silently swallowing the rest of the file — the worst failure shape for a standing check, which
+// the S1 hand-rolled tokenizer exhibited on a template literal carrying an unbalanced brace.
+export function maskLiterals(content: string): { masked: string; unparsed: UnparsedSite[] } {
+    const unparsed: UnparsedSite[] = [];
+    const out: string[] = [];
     let i = 0;
     const len = content.length;
 
-    while (i < len) {
-        if (content[i] === '"' || content[i] === "'" || content[i] === "`") {
-            const quote = content[i];
-            result += content[i];
+    // Mask a single- or double-quoted string. Returns true if the closing quote was found.
+    function maskString(quote: string): boolean {
+        out.push(" "); // opening quote → space
+        i++;
+        while (i < len) {
+            if (content[i] === "\\" && i + 1 < len) {
+                out.push(content[i + 1] === "\n" ? "\n" : " ", " ");
+                i += 2;
+                continue;
+            }
+            if (content[i] === quote) {
+                out.push(" "); // closing quote → space
+                i++;
+                return true;
+            }
+            out.push(content[i] === "\n" ? "\n" : " ");
             i++;
-            while (i < len) {
-                if (content[i] === "\\" && i + 1 < len) {
-                    result += content[i] + content[i + 1];
-                    i += 2;
-                    continue;
-                }
-                result += content[i];
-                if (content[i] === quote) {
+        }
+        return false;
+    }
+
+    // Mask a template literal. Text portions and backtick delimiters → spaces; `${...}`
+    // interpolation expressions are preserved as real code (the `${` and closing `}` → spaces,
+    // but the expression between them is output verbatim). Returns true if the closing backtick
+    // was found. Handles nested templates, strings, and comments inside interpolations. An
+    // unbalanced interpolation brace (depth never returns to 0) makes the template unterminated.
+    function maskTemplate(): boolean {
+        out.push(" "); // opening backtick → space
+        i++;
+        while (i < len) {
+            if (content[i] === "\\" && i + 1 < len) {
+                out.push(content[i + 1] === "\n" ? "\n" : " ", " ");
+                i += 2;
+                continue;
+            }
+            if (content[i] === "`") {
+                out.push(" "); // closing backtick → space
+                i++;
+                return true;
+            }
+            if (content[i] === "$" && i + 1 < len && content[i + 1] === "{") {
+                out.push(" ", " "); // ${ → spaces
+                i += 2;
+                // Interpolation body: track brace depth, handle nested constructs.
+                let depth = 1;
+                while (i < len && depth > 0) {
+                    if (content[i] === "/" && i + 1 < len && content[i + 1] === "/") {
+                        while (i < len && content[i] !== "\n") {
+                            out.push(" ");
+                            i++;
+                        }
+                        continue;
+                    }
+                    if (content[i] === "/" && i + 1 < len && content[i + 1] === "*") {
+                        out.push(" ", " ");
+                        i += 2;
+                        while (i < len) {
+                            if (content[i] === "*" && i + 1 < len && content[i + 1] === "/") {
+                                out.push(" ", " ");
+                                i += 2;
+                                break;
+                            }
+                            out.push(content[i] === "\n" ? "\n" : " ");
+                            i++;
+                        }
+                        continue;
+                    }
+                    if (content[i] === '"' || content[i] === "'") {
+                        maskString(content[i]);
+                        continue;
+                    }
+                    if (content[i] === "`") {
+                        maskTemplate(); // nested template — return value unchecked (outer reports)
+                        continue;
+                    }
+                    if (content[i] === "{") {
+                        depth++;
+                        out.push("{");
+                        i++;
+                        continue;
+                    }
+                    if (content[i] === "}") {
+                        depth--;
+                        if (depth === 0) {
+                            out.push(" "); // closing } of interpolation → space
+                            i++;
+                            break;
+                        }
+                        out.push("}");
+                        i++;
+                        continue;
+                    }
+                    out.push(content[i]);
                     i++;
-                    break;
                 }
+                if (depth > 0) return false; // unbalanced interpolation → unterminated template
+                continue;
+            }
+            // Template text content → mask
+            out.push(content[i] === "\n" ? "\n" : " ");
+            i++;
+        }
+        return false; // unterminated template
+    }
+
+    while (i < len) {
+        const c = content[i];
+
+        // Line comment
+        if (c === "/" && i + 1 < len && content[i + 1] === "/") {
+            while (i < len && content[i] !== "\n") {
+                out.push(" ");
                 i++;
             }
             continue;
         }
 
-        if (content[i] === "/" && i + 1 < len && content[i + 1] === "/") {
+        // Block comment
+        if (c === "/" && i + 1 < len && content[i + 1] === "*") {
+            const start = i;
+            out.push(" ", " ");
             i += 2;
-            while (i < len && content[i] !== "\n") i++;
-            continue;
-        }
-
-        if (content[i] === "/" && i + 1 < len && content[i + 1] === "*") {
-            i += 2;
+            let closed = false;
             while (i < len) {
                 if (content[i] === "*" && i + 1 < len && content[i + 1] === "/") {
+                    out.push(" ", " ");
                     i += 2;
+                    closed = true;
                     break;
                 }
-                if (content[i] === "\n") result += "\n";
+                out.push(content[i] === "\n" ? "\n" : " ");
                 i++;
+            }
+            if (!closed) {
+                unparsed.push({
+                    line: lineOf(content, start),
+                    reason: "unterminated block comment",
+                    snippet: content.slice(start, Math.min(start + 40, len)).trim(),
+                });
             }
             continue;
         }
 
-        result += content[i];
+        // Single/double-quoted string
+        if (c === '"' || c === "'") {
+            const start = i;
+            if (!maskString(c)) {
+                unparsed.push({
+                    line: lineOf(content, start),
+                    reason: "unterminated string literal",
+                    snippet: content.slice(start, Math.min(start + 40, len)).trim(),
+                });
+            }
+            continue;
+        }
+
+        // Template literal
+        if (c === "`") {
+            const start = i;
+            if (!maskTemplate()) {
+                unparsed.push({
+                    line: lineOf(content, start),
+                    reason: "unterminated template literal",
+                    snippet: content.slice(start, Math.min(start + 40, len)).trim(),
+                });
+            }
+            continue;
+        }
+
+        out.push(c);
         i++;
     }
 
-    return result;
+    return { masked: out.join(""), unparsed };
 }
 
-// A top-level (paren/bracket depth 0) operand, paired with the operator immediately preceding it
-// (`null` for the first operand in the expression).
+// Backward-compatible wrapper: returns just the masked text. Replaces the S1 `stripComments`
+// (which preserved string content and did not handle template-literal interpolations). String
+// and comment content is now masked so a `)` or `{` inside a string never confuses the depth
+// counters in `findCalls` / `splitTopLevelTokens`.
+export function stripComments(content: string): string {
+    return maskLiterals(content).masked;
+}
+
+// ---------------------------------------------------------------------------
+// Token splitting
+// ---------------------------------------------------------------------------
+
+// A top-level (paren/bracket/brace depth 0) operand, paired with the operator immediately
+// preceding it (`null` for the first operand in the expression).
 type Token = { text: string; opBefore: "+" | "-" | "*" | "/" | null };
 
-// Split `expr` into its top-level (paren/bracket depth 0) operands, each paired with the operator
-// that split it off the previous one. A leading `+`/`-`, or one immediately after another
+// Split `expr` into its top-level (paren/bracket/brace depth 0) operands, each paired with the
+// operator that split it off the previous one. A leading `+`/`-`, or one immediately after another
 // operator/open-paren/comma, is a unary sign (part of the operand, not a split point); an `e`/`E`-
 // adjacent `+`/`-` is an exponent suffix, never a split point either. Box3D's own
 // `-ffp-contract=off` + this port's "one op per f32 wrap" convention means most calls carry
@@ -162,65 +347,82 @@ export function splitTopLevel(expr: string): string[] {
     return splitTopLevelTokens(expr).map((t) => t.text);
 }
 
+// Split a call's argument list on top-level commas (depth 0, tracking parens/brackets/braces),
+// so each argument is recursed into independently by `collectOffendingLiterals`.
+function splitArgs(args: string): string[] {
+    const parts: string[] = [];
+    let depth = 0;
+    let start = 0;
+    for (let i = 0; i < args.length; i++) {
+        const c = args[i];
+        if (c === "(" || c === "[" || c === "{") depth++;
+        else if (c === ")" || c === "]" || c === "}") depth--;
+        else if (c === "," && depth === 0) {
+            parts.push(args.slice(start, i).trim());
+            start = i + 1;
+        }
+    }
+    const last = args.slice(start).trim();
+    if (last.length > 0) parts.push(last);
+    return parts;
+}
+
+// ---------------------------------------------------------------------------
+// Literal analysis
+// ---------------------------------------------------------------------------
+
 // A bare numeric-literal token — the exact shape rule 1a cares about. A wrapped operand
 // (`f32(0.4)`) or an identifier/member/call expression never matches this, so "bare" falls out
 // of the regex itself rather than needing a separate wrapped-vs-bare check.
 const NUMERIC_LITERAL = /^-?(?:\d+\.?\d*|\.\d+)(?:[eE][-+]?\d+)?$/;
 
-// True iff `s` is one balanced parenthesized group spanning its entire length (`(...)`, with the
-// opening paren's match landing on the final character) — an operand one paren-level deeper than
-// its enclosing top-level split, e.g. the `(0.4 * mass)` operand of `(0.4 * mass) + 1`.
-function isFullyParenWrapped(s: string): boolean {
-    if (s[0] !== "(") return false;
-    let depth = 0;
-    for (let i = 0; i < s.length; i++) {
-        if (s[i] === "(") depth++;
-        else if (s[i] === ")") {
-            depth--;
-            if (depth === 0) return i === s.length - 1;
-        }
-    }
-    return false;
-}
-
 // Left-to-right reduction of a maximal run of adjacent bare-literal top-level tokens (a "literal
 // cluster", e.g. the `1`, `3` of `1 / 3 * mass`), using the operators `splitTopLevelTokens`
-// recorded between them. Sound for the equal-precedence chains rule 1a's "one op per f32 wrap"
-// convention actually produces (a run of `*`/`/`, or a run of `+`/`-`) — not a general expression
-// evaluator, and never needs to be one under that convention.
+// recorded between them. **Two-pass** (first `*`/`/`, then `+`/`-`) to respect JS operator
+// precedence — `1 - 1/3` must evaluate to `0.666…` (not `(1-1)/3 = 0`), and the old single-pass
+// left-to-right evaluator silently returned `0`, which IS exactly representable in f32, hiding
+// the divergence. Sound for the chains rule 1a's "one op per f32 wrap" convention actually
+// produces — not a general expression evaluator, and never needs to be one under that convention.
 function reduceLiteralCluster(cluster: Token[]): number {
-    let value = Number(cluster[0].text);
+    // Pass 1: fold * and / left-to-right into the preceding value.
+    const pass1: { value: number; op: "+" | "-" | null }[] = [
+        { value: Number(cluster[0].text), op: null },
+    ];
     for (let k = 1; k < cluster.length; k++) {
         const rhs = Number(cluster[k].text);
-        switch (cluster[k].opBefore) {
-            case "+":
-                value += rhs;
-                break;
-            case "-":
-                value -= rhs;
-                break;
-            case "*":
-                value *= rhs;
-                break;
-            case "/":
-                value /= rhs;
-                break;
+        const op = cluster[k].opBefore;
+        if (op === "*" || op === "/") {
+            const prev = pass1[pass1.length - 1];
+            prev.value = op === "*" ? prev.value * rhs : prev.value / rhs;
+        } else {
+            pass1.push({ value: rhs, op });
         }
     }
-    return value;
+    // Pass 2: fold + and - left-to-right.
+    let result = pass1[0].value;
+    for (let k = 1; k < pass1.length; k++) {
+        result = pass1[k].op === "+" ? result + pass1[k].value : result - pass1[k].value;
+    }
+    return result;
 }
 
-// Every bare literal (recursively, through fully-parenthesized nested operands) that contributes
-// to a non-exact f32 value somewhere inside `expr` — the argument of an `f32(...)` call, or a
-// paren-wrapped operand nested one or more levels inside it.
+// Every bare literal (recursively, through *every* nested position — call-argument parens
+// included, not just bare paren groups) that contributes to a non-exact f32 value somewhere inside
+// `expr` — the argument of an `f32(...)` call, or any operand nested one or more levels inside it.
 //
-// Two shapes, both real misses of a naive "is this one split-off operand a bare non-exact
+// Three shapes, all real misses of a naive "is this one split-off operand a bare non-exact
 // literal" check:
 //
-//   1. A non-exact literal one paren-level deeper than the enclosing split (`f32((0.4 * mass) +
+//   1. A non-exact literal inside a *call argument* (`f32(Math.sqrt(0.1 * a))` — `0.1` never
+//      appears as a top-level operand of the outer split, only inside `Math.sqrt(...)`'s
+//      argument list). Handled by recursing into any parenthesized group that is not itself a
+//      nested `f32(...)` call (which `findCalls` handles separately, so a properly pre-wrapped
+//      `f32(f32(0.4) * mass)` does not double-count).
+//   2. A non-exact literal one paren-level deeper than the enclosing split (`f32((0.4 * mass) +
 //      1)` — `0.4` never appears as a top-level operand of the outer split, only inside the
-//      parenthesized one). Handled by recursing into every fully-paren-wrapped operand.
-//   2. A non-exact *fraction* built from individually-exact literals, then fused with a further
+//      parenthesized sub-expression). Handled by the same recursion — a bare `(…)` group is just
+//      a call argument with no callee.
+//   3. A non-exact *fraction* built from individually-exact literals, then fused with a further
 //      operator in the same wrap (`f32(1 / 3 * mass)` — neither `1` nor `3` is individually
 //      non-exact, but `1 / 3` is, and unlike a bare `f32(1 / 3)` — correct by the double-rounding
 //      theorem, since both operands are already f32-valued — fusing it with `* mass` inside the
@@ -228,9 +430,10 @@ function reduceLiteralCluster(cluster: Token[]): number {
 //      multiply, exactly the double-rounding gap rule 1a names for a bare non-exact literal).
 //      Handled by clustering adjacent bare-literal tokens and evaluating the cluster's own value
 //      whenever the cluster is a strict subset of the level's tokens (i.e. it IS fused with
-//      something else at that level) — a cluster spanning the whole level needs no such check,
-//      because a lone literal (sub-)expression reaching `f32(...)` with no further fused operator
-//      is exactly the correct place to round it.
+//      something else at that level). A cluster spanning the whole level with 2+ operators
+//      (3+ literals) is checked on the same principle: the first op's intermediate isn't rounded
+//      before the second. A cluster spanning the whole level with exactly 1 operator (2 literals)
+//      is the double-rounding theorem's covered case and stays silent.
 function collectOffendingLiterals(expr: string): string[] {
     const tokens = splitTopLevelTokens(expr);
     const offending: string[] = [];
@@ -241,7 +444,9 @@ function collectOffendingLiterals(expr: string): string[] {
         const individuallyNonExact = cluster.some((t) => !isExactF32(Number(t.text)));
         const isWholeLevel = cluster.length === tokens.length;
         const combinedNonExact =
-            cluster.length >= 2 && !isWholeLevel && !isExactF32(reduceLiteralCluster(cluster));
+            cluster.length >= 2 &&
+            !isExactF32(reduceLiteralCluster(cluster)) &&
+            (!isWholeLevel || cluster.length >= 3);
         if (individuallyNonExact || combinedNonExact) {
             offending.push(...cluster.map((t) => t.text));
         }
@@ -254,18 +459,47 @@ function collectOffendingLiterals(expr: string): string[] {
             continue;
         }
         flushCluster();
-        if (isFullyParenWrapped(tok.text)) {
-            offending.push(...collectOffendingLiterals(tok.text.slice(1, -1)));
+        // Recurse into any parenthesized group — call-argument parens included, not just bare
+        // paren groups. A nested f32() call is skipped (findCalls handles it separately, so a
+        // properly pre-wrapped literal does not double-count).
+        const openParen = tok.text.indexOf("(");
+        if (openParen >= 0) {
+            const beforeParen = tok.text.slice(0, openParen).trim();
+            if (beforeParen === "f32") continue;
+            // Find the matching close paren for the first open paren.
+            let depth = 0;
+            let closeParen = -1;
+            for (let j = openParen; j < tok.text.length; j++) {
+                if (tok.text[j] === "(") depth++;
+                else if (tok.text[j] === ")") {
+                    depth--;
+                    if (depth === 0) {
+                        closeParen = j;
+                        break;
+                    }
+                }
+            }
+            if (closeParen < 0) continue;
+            const argContent = tok.text.slice(openParen + 1, closeParen);
+            for (const arg of splitArgs(argContent)) {
+                offending.push(...collectOffendingLiterals(arg));
+            }
         }
     }
     flushCluster();
     return offending;
 }
 
-type Call = { start: number; argStart: number; argEnd: number };
+// ---------------------------------------------------------------------------
+// Call finding
+// ---------------------------------------------------------------------------
+
+type Call = { start: number; argStart: number; argEnd: number; balanced: boolean };
 
 // Every call to `name(` in `text` (not preceded by an identifier char, so `isF32(` doesn't
-// match `f32(`), paired with the byte offsets of its balanced-paren argument span.
+// match `f32(`), paired with the byte offsets of its balanced-paren argument span. A call whose
+// parens don't balance (depth never returns to zero before end of text) is marked `balanced:
+// false` so `sweepUnparsed` can report it as an unparsed site and `sweepLiterals` can skip it.
 function findCalls(text: string, name: string): Call[] {
     const calls: Call[] = [];
     const marker = `${name}(`;
@@ -283,41 +517,51 @@ function findCalls(text: string, name: string): Call[] {
             if (text[i] === "(") depth++;
             else if (text[i] === ")") depth--;
         }
-        calls.push({ start: idx, argStart, argEnd: i - 1 });
+        calls.push({ start: idx, argStart, argEnd: i - 1, balanced: depth === 0 });
         idx = argStart;
     }
     return calls;
 }
 
-function lineOf(text: string, pos: number): number {
-    let line = 1;
-    for (let i = 0; i < pos && i < text.length; i++) {
-        if (text[i] === "\n") line++;
-    }
-    return line;
-}
+// ---------------------------------------------------------------------------
+// Source file generator
+// ---------------------------------------------------------------------------
 
-async function* sourceFiles(root: string): AsyncGenerator<{ rel: string; text: string }> {
+async function* sourceFiles(
+    root: string,
+): AsyncGenerator<{ rel: string; text: string; unparsed: UnparsedSite[] }> {
     const glob = new Glob("**/*.ts");
     for await (const rel of glob.scan({ cwd: root })) {
         if (isTestFile(rel)) continue;
         const full = join(root, rel);
-        yield { rel, text: stripComments(await Bun.file(full).text()) };
+        const content = await Bun.file(full).text();
+        const { masked, unparsed } = maskLiterals(content);
+        yield { rel, text: masked, unparsed };
     }
 }
+
+// ---------------------------------------------------------------------------
+// Sweep arms
+// ---------------------------------------------------------------------------
 
 // The literal arm: one finding per `f32(...)` call whose argument carries at least one bare
 // non-exact literal contributing to its value — a "site" is the call, not the literal
 // (kToleranceSquared's `f32(0.05 * 0.05)` is one site with two offending literals, matching the
-// spec's "11 sites"). `collectOffendingLiterals` handles both a literal nested one paren-level
-// deeper than the call's own top level, and a non-exact fraction/cluster of individually-exact
-// literals fused with a further operator in the same wrap.
+// spec's "11 sites"). `collectOffendingLiterals` handles a literal inside a call argument, a
+// literal nested one paren-level deeper, and a non-exact fraction/cluster of individually-exact
+// literals fused with a further operator — including a whole-level 2+ op chain (`f32(1 - 1/3)`).
 export async function sweepLiterals(root: string): Promise<Finding[]> {
     const findings: Finding[] = [];
     for await (const { rel, text } of sourceFiles(root)) {
         for (const call of findCalls(text, "f32")) {
+            if (!call.balanced) continue; // reported by sweepUnparsed
             const arg = text.slice(call.argStart, call.argEnd);
-            if (splitTopLevel(arg).length < 2) continue; // no top-level binary op — a bare fround, not this class
+            // Skip a bare fround — a single numeric literal with no operator (`f32(0.1)`). This
+            // is the correct way to round a literal, not a finding. But do NOT skip a single
+            // non-literal operand (`f32(Math.sqrt(0.1 * a))`) — it may carry a non-exact literal
+            // inside a call argument that the recursion must reach.
+            const tokens = splitTopLevel(arg);
+            if (tokens.length === 1 && NUMERIC_LITERAL.test(tokens[0].trim())) continue;
             const literals = collectOffendingLiterals(arg);
             if (literals.length === 0) continue;
             findings.push({
@@ -338,6 +582,7 @@ export async function sweepTrig(root: string): Promise<Finding[]> {
     for await (const { rel, text } of sourceFiles(root)) {
         for (const fn of ["Math.sin", "Math.cos", "Math.atan2"]) {
             for (const call of findCalls(text, fn)) {
+                if (!call.balanced) continue;
                 const line = lineOf(text, call.start);
                 const allowed = TRIG_ALLOWLIST.some(
                     (a) => a.file === rel && a.lines.includes(line),
@@ -357,9 +602,44 @@ export async function sweepTrig(root: string): Promise<Finding[]> {
     return findings;
 }
 
+// The unparsed arm: any region the lexer could not fully decompose — an unterminated string,
+// template literal, or block comment from `maskLiterals`, or an `f32(` call whose parens don't
+// balance. Safety rests on exhaustiveness over the region set plus a loud inconclusive: the sweep
+// exits non-zero rather than silently swallowing the rest of the file and returning zero findings.
+export async function sweepUnparsed(root: string): Promise<Finding[]> {
+    const findings: Finding[] = [];
+    for await (const { rel, text, unparsed } of sourceFiles(root)) {
+        for (const u of unparsed) {
+            findings.push({
+                kind: "unparsed",
+                file: rel,
+                line: u.line,
+                reason: u.reason,
+                snippet: u.snippet,
+            });
+        }
+        for (const call of findCalls(text, "f32")) {
+            if (!call.balanced) {
+                findings.push({
+                    kind: "unparsed",
+                    file: rel,
+                    line: lineOf(text, call.start),
+                    reason: "unbalanced parens in f32() call",
+                    snippet: text.slice(call.start, Math.min(call.start + 40, text.length)).trim(),
+                });
+            }
+        }
+    }
+    return findings;
+}
+
 export async function sweep(root: string): Promise<Finding[]> {
-    const [literals, trig] = await Promise.all([sweepLiterals(root), sweepTrig(root)]);
-    return [...literals, ...trig].sort((a, b) =>
+    const [literals, trig, unparsed] = await Promise.all([
+        sweepLiterals(root),
+        sweepTrig(root),
+        sweepUnparsed(root),
+    ]);
+    return [...literals, ...trig, ...unparsed].sort((a, b) =>
         a.file === b.file ? a.line - b.line : a.file < b.file ? -1 : 1,
     );
 }
@@ -375,20 +655,24 @@ if (import.meta.main) {
     const findings = await sweep(root);
 
     if (findings.length > 0) {
-        console.error(`✗ ${findings.length} bit-exact-literal finding(s):\n`);
+        console.error(`✗ ${findings.length} finding(s):\n`);
         for (const f of findings) {
             if (f.kind === "literal") {
                 console.error(
                     `  ${f.file}:${f.line}  ${f.expression}  (bare non-exact literal: ${f.literals.join(", ")})`,
                 );
-            } else {
+            } else if (f.kind === "trig") {
                 console.error(`  ${f.file}:${f.line}  ${f.expression}  (undocumented trig call)`);
+            } else {
+                console.error(`  ${f.file}:${f.line}  UNPARSED: ${f.reason}  ${f.snippet}`);
             }
         }
         console.error(
             "\nRule 1a: fround a non-exact literal before it enters f32 arithmetic —\n" +
                 "f32(f32(0.4) * mass), never f32(0.4 * mass). A Math.sin/cos/atan2 call outside the\n" +
                 "two documented trig deviations must port Box3D's own portable trig instead.\n" +
+                "An unparsed site is a region the lexer could not fully decompose — safety rests\n" +
+                "on exhaustiveness over the region set plus a loud inconclusive, never a sample.\n" +
                 '(.claude/rules/tumble.md § "The contract: bit-exact f32 parity")',
         );
         process.exit(1);

--- a/scripts/check-tumble-fp.ts
+++ b/scripts/check-tumble-fp.ts
@@ -329,7 +329,15 @@ function splitTopLevelTokens(expr: string): Token[] {
             let j = i - 1;
             while (j >= start && /\s/.test(expr[j])) j--;
             const prevChar = j >= start ? expr[j] : "";
-            const isExponent = (c === "+" || c === "-") && (prevChar === "e" || prevChar === "E");
+            // Discriminate a real exponent suffix (`1e+5`, `1.5E-3`) from an identifier ending
+            // in `e`/`E` (`distance + 0.1`) by what precedes the `e`/`E` — a digit or `.` —
+            // rather than by the `e`/`E` alone. Without this, `f32(distance + 0.1)` collapses
+            // into one non-literal token and the bare `0.1` is silently missed.
+            const isExponent =
+                (c === "+" || c === "-") &&
+                (prevChar === "e" || prevChar === "E") &&
+                j > start &&
+                /[0-9.]/.test(expr[j - 1]);
             const isUnary = prevChar === "" || "+-*/(,".includes(prevChar);
             if (isExponent || isUnary) continue;
             tokens.push({ text: expr.slice(start, i).trim(), opBefore: pendingOp });


### PR DESCRIPTION
## Problem

The tumble bit-exact literal sweep landed in S1 as a hand-rolled tokenizer whose soundness was demonstrated per-sample and patched twice. `review.md`'s trigger for that shape is a structural claim instead of a sample, and the worst failure mode was live: a template literal carrying an unbalanced brace silently swallowed the rest of the expression and returned **zero findings in a net**.

## Cause

Two distinct defects behind one predicate:

1. **No structural exhaustiveness.** Nested positions were traversed selectively — bare paren groups but not call-argument parens — and a region the lexer could not decompose was skipped rather than reported, so a hole and a clean file read identically.
2. **A decomposed-but-misjudged region.** `splitTopLevelTokens` treated any `e`/`E` before a `+`/`-` as a numeric exponent suffix, including when the `e`/`E` ended an *identifier*. `f32(distance + 0.1)` collapsed into one non-literal token and the bare literal was silently missed — with no unparsed report, so the fail-loud path could not catch it either. Inherited unchanged from S1; found by the adversarial pass over this branch's first commit.

## Fix

- Lex once with quote / template-literal / comment awareness; traverse **every** nested position exhaustively, call arguments included.
- **Fail loud**: any `f32(` region that cannot be fully decomposed, or a depth counter that does not return to zero, is reported as an unparsed site and exits non-zero. Safety now rests on exhaustiveness over the region set plus a loud inconclusive.
- Discriminate a real exponent suffix from an identifier ending in `e`/`E` by requiring a digit or `.` before it. The single-character boundary (an identifier ending digit-then-`e`) is documented at the discriminator and unreachable in this corpus; deliberately not widened.
- Arms moved to the composition site: a synthetic fixture root carries one shape per structural leg and is driven through the same `sweep`/`sweepLiterals`/`sweepUnparsed` entries the real run uses, so deleting a leg reds the composition rather than only a leaf. Plus a CLI exit-code arm with a launch witness, and the trig allowlist's `file`/`deviation` content asserted at (file, documented deviation) granularity — 2 entries, 4 call lines.

No engine constant moves here and the check is **not** wired into `bun run check` — the sweep is red at 11 by design until the constants are wrapped, so wiring it now would ship a trunk whose own `check` is red.

## Evidence

| Gate | Result |
|---|---|
| `bun run scripts/check-tumble-fp.ts` | exit 1 by design, **11** findings, **0** unparsed, site list byte-identical to the recorded floor |
| `bun test ./packages/shallot/tests/check-tumble-fp.test.ts` | **59 pass / 0 fail** (26/0 at S1) |
| `bun test ./packages/shallot/src/standard/tumble/engine/step.fixture.ts` | **55 pass / 0 fail** |
| `bun run check` | exit 0, tracked tree clean |

Three demonstrated members are red with discriminating matchers and the exact-literal controls stay silent — `f32(Math.sqrt(0.1 * a))`, `f32(1 - 1/3)`, and the unbalanced-brace template (now *reported*), against bare `f32(1 / 3)` silent by rule 1's double-rounding clause. Two review rounds: the first returned the exponent blocker plus three findings, the second reviewed the repair on its premise and returned no blockers, with two-sided vacuity mutations run per arm (over-broadening `isExponent` reds 2 identifier arms and 1 composition arm).
