### PR TITLE
audit tumble engine bitexact literals/s2

### DIFF
--- a/.claude/rules/tumble.md
+++ b/.claude/rules/tumble.md
@@ -15,6 +15,7 @@ paths:
     - "scripts/tumble-interaction.ts"
     - "scripts/tumble-repro.ts"
     - "scripts/tumble-repro-driver.mjs"
+    - "scripts/probe-edge-ccd.ts"
 ---
 
 # Tumble backend

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ],
     "scripts": {
         "build": "bun run --cwd packages/shallot build",
-        "check": "tsc && biome check && eslint . --max-warnings=0 && bun run scripts/check-versions.ts && bun run scripts/check-imports.ts && bun run scripts/check-boundary.ts && bun run scripts/check-docs.ts && bun run scripts/check-pack.ts && bun run scripts/check-scripts.ts && bun run scripts/check-exports.ts && bun run scripts/check-node-import.ts && bun run scripts/check-site.ts && bun run scripts/format.ts --check",
+        "check": "tsc && biome check && eslint . --max-warnings=0 && bun run scripts/check-versions.ts && bun run scripts/check-imports.ts && bun run scripts/check-boundary.ts && bun run scripts/check-docs.ts && bun run scripts/check-pack.ts && bun run scripts/check-scripts.ts && bun run scripts/check-exports.ts && bun run scripts/check-node-import.ts && bun run scripts/check-site.ts && bun run scripts/check-tumble-fp.ts && bun run scripts/format.ts --check",
         "format": "biome check --write && bun run scripts/format.ts",
         "test": "bun test packages/shallot",
         "test:install": "bun run scripts/install-test.ts",

--- a/packages/shallot/src/standard/tumble/engine/api.ts
+++ b/packages/shallot/src/standard/tumble/engine/api.ts
@@ -1713,7 +1713,7 @@ export class RevoluteJoint extends Joint {
         const hi = f32(upper);
         const lowerAngle = lo < hi ? lo : hi;
         const upperAngle = lo > hi ? lo : hi;
-        const bound = f32(0.99 * PI);
+        const bound = f32(f32(0.99) * PI);
         const j = this.data();
         j.lowerAngle = clampf(lowerAngle, -bound, bound);
         j.upperAngle = clampf(upperAngle, -bound, bound);
@@ -2175,7 +2175,7 @@ export class SphericalJoint extends Joint {
         const hi = f32(upper);
         const lowerAngle = lo < hi ? lo : hi;
         const upperAngle = lo > hi ? lo : hi;
-        const bound = f32(0.99 * PI);
+        const bound = f32(f32(0.99) * PI);
         const j = this.data();
         j.lowerTwistAngle = clampf(lowerAngle, -bound, bound);
         j.upperTwistAngle = clampf(upperAngle, -bound, bound);

--- a/packages/shallot/src/standard/tumble/engine/core.ts
+++ b/packages/shallot/src/standard/tumble/engine/core.ts
@@ -13,20 +13,20 @@ import { f32 } from "./math";
 export const LENGTH_UNITS_PER_METER = f32(1.0);
 
 /// A small length used as a collision and constraint tolerance (B3_LINEAR_SLOP).
-export const LINEAR_SLOP = f32(0.005 * LENGTH_UNITS_PER_METER);
+export const LINEAR_SLOP = f32(f32(0.005) * LENGTH_UNITS_PER_METER);
 
 /// Shapes are extended by this amount so speculative contacts can be created before touching
 /// (B3_SPECULATIVE_DISTANCE).
 export const SPECULATIVE_DISTANCE = f32(4.0 * LINEAR_SLOP);
 
 /// Overlap queries report a hit within this slop of touching (B3_OVERLAP_SLOP).
-export const OVERLAP_SLOP = f32(0.1 * LINEAR_SLOP);
+export const OVERLAP_SLOP = f32(f32(0.1) * LINEAR_SLOP);
 
 /// Maximum points in a shape-cast proxy point cloud (B3_MAX_SHAPE_CAST_POINTS).
 export const MAX_SHAPE_CAST_POINTS = 64;
 
 /// Upper bound on the per-shape fat-AABB margin (B3_MAX_AABB_MARGIN).
-export const MAX_AABB_MARGIN = f32(0.05 * LENGTH_UNITS_PER_METER);
+export const MAX_AABB_MARGIN = f32(f32(0.05) * LENGTH_UNITS_PER_METER);
 
 /// The per-shape fat-AABB margin is this fraction of the shape extent, capped by MAX_AABB_MARGIN
 /// (B3_AABB_MARGIN_FRACTION).

--- a/packages/shallot/src/standard/tumble/engine/distance.ts
+++ b/packages/shallot/src/standard/tumble/engine/distance.ts
@@ -1151,7 +1151,7 @@ function makeSeparationFunction(
                 let axis = vec3.cross(edgeA, edgeB);
                 const lengthSquared = vec3.lengthSq(axis);
 
-                const kToleranceSquared = f32(0.05 * 0.05);
+                const kToleranceSquared = f32(f32(0.05) * f32(0.05));
                 if (lengthSquared < kToleranceSquared) {
                     fcn.type = SeparationType.Vertices;
                     fcn.witness1 = worldNormal;
@@ -1246,7 +1246,7 @@ function makeSeparationFunction(
                 let axis = vec3.cross(edgeA, edgeB);
                 const lengthSquared = vec3.lengthSq(axis);
 
-                const kToleranceSquared = f32(0.005 * 0.005);
+                const kToleranceSquared = f32(f32(0.005) * f32(0.005));
                 if (lengthSquared < kToleranceSquared) {
                     fcn.type = SeparationType.Vertices;
                     fcn.witness1 = worldNormal;

--- a/packages/shallot/src/standard/tumble/engine/geometry.ts
+++ b/packages/shallot/src/standard/tumble/engine/geometry.ts
@@ -331,7 +331,7 @@ export function rayCastCapsule(shape: Capsule, input: RayCastInput): CastOutput 
     const d = vec3.sub(c2, c1);
 
     // Fall back to sphere if the capsule is short
-    const tol = f32(0.01 * LINEAR_SLOP);
+    const tol = f32(f32(0.01) * LINEAR_SLOP);
     const lengthSquared = vec3.lengthSq(d);
     if (lengthSquared < f32(tol * tol)) {
         const sphereCenter = vec3.scale(0.5, vec3.add(shape.center1, shape.center2));

--- a/packages/shallot/src/standard/tumble/engine/hull.ts
+++ b/packages/shallot/src/standard/tumble/engine/hull.ts
@@ -1407,7 +1407,7 @@ export function makeTransformedBoxHull(
     hz: number,
     transform: Transform,
 ): HullData {
-    const minH = f32(0.2 * LINEAR_SLOP);
+    const minH = f32(f32(0.2) * LINEAR_SLOP);
     // The C API takes f32 half-extents; fround the inputs so an f64 arg (e.g. 0.2) matches b3MakeBoxHull.
     const h = vec3.max({ x: minH, y: minH, z: minH }, { x: f32(hx), y: f32(hy), z: f32(hz) });
 

--- a/packages/shallot/src/standard/tumble/engine/manifold.ts
+++ b/packages/shallot/src/standard/tumble/engine/manifold.ts
@@ -1046,7 +1046,7 @@ export function collideCapsules(
     const offset = vec3.sub(result.point2, result.point1);
     const distanceSquared = vec3.lengthSq(offset);
     const linearSlop = LINEAR_SLOP;
-    const minDistance = f32(0.01 * linearSlop);
+    const minDistance = f32(f32(0.01) * linearSlop);
 
     if (
         distanceSquared > f32(maxDistance * maxDistance) ||

--- a/packages/shallot/src/standard/tumble/engine/types.ts
+++ b/packages/shallot/src/standard/tumble/engine/types.ts
@@ -241,7 +241,7 @@ export function defaultBodyDef(): BodyDef {
         linearDamping: 0,
         angularDamping: 0,
         gravityScale: f32(1.0),
-        sleepThreshold: f32(0.05 * LENGTH_UNITS_PER_METER),
+        sleepThreshold: f32(f32(0.05) * LENGTH_UNITS_PER_METER),
         motionLocks: {
             linearX: false,
             linearY: false,

--- a/packages/shallot/tests/check-tumble-fp.test.ts
+++ b/packages/shallot/tests/check-tumble-fp.test.ts
@@ -21,13 +21,13 @@ import {
     TRIG_ALLOWLIST,
 } from "../../../scripts/check-tumble-fp";
 
-// The real tumble engine source — S1 (audit-tumble-engine-bitexact-literals) pins the check's
-// red count against this tree, so the check itself can't drift silently. The pinned floor is a
-// measurement re-read at claim (spec Validation), not a target: 11, matching the spec's recorded
-// sweep, and including the three live findings named in the spec's Locked decision
-// (core.ts:23 OVERLAP_SLOP, hull.ts:1410 minH, distance.ts:1154 kToleranceSquared) plus eight
-// sites that are equal to the C reference only by coincidence (the ratio the spec cites as the
-// reason this is a standing check, not three edits).
+// The real tumble engine source — S2 (audit-tumble-engine-bitexact-literals) wrapped all 11
+// sites the sweep flagged into rule 1a's fround-correct form, so the pinned floor is now 0.
+// The floor is a measurement re-read at claim (spec Validation), not a target: S1 recorded 11
+// (three live findings named in the spec's Locked decision — core.ts:23 OVERLAP_SLOP,
+// hull.ts:1410 minH, distance.ts:1154 kToleranceSquared — plus eight sites equal to the C
+// reference only by coincidence); S2 moved the three and wrapped the eight, and the check now
+// pins 0 so a regression (a new bare non-exact literal) reds rather than drifting silently.
 const REAL_ROOT = resolve(import.meta.dir, "../src/standard/tumble");
 
 // Fixture trees live under the OS tmpdir, never the repo — same `--root`-style isolation as
@@ -461,11 +461,12 @@ describe("sweepLiterals — B1: identifier ending in e/E before +/- is not an ex
 
 // F1 — the structural legs (template awareness, comment awareness, quote awareness, nested
 // call-argument traversal) are armed only at the leaf (direct calls to `maskLiterals` /
-// `splitTopLevel`). The real-corpus floor arm runs `sweep(REAL_ROOT)` and asserts 11 findings,
-// but none of the 11 depends on those legs — so deleting any leg reds only the leaf arms, never
-// the composition. This arm gives the composition its own synthetic fixture root carrying a shape
-// per leg, driven through the same `sweep`/`sweepLiterals`/`sweepUnparsed` entry the real run
-// uses, asserting content and cardinality — not just a count.
+// `splitTopLevel`). The real-corpus floor arm runs `sweep(REAL_ROOT)` and asserts 0 findings
+// (after S2 wrapped all 11 sites), but none of the former 11 depended on those legs — so
+// deleting any leg reds only the leaf arms, never the composition. This arm gives the
+// composition its own synthetic fixture root carrying a shape per leg, driven through the same
+// `sweep`/`sweepLiterals`/`sweepUnparsed` entry the real run uses, asserting content and
+// cardinality — not just a count.
 describe("sweep — F1: composition fixture exercising every structural leg", () => {
     // One small tree carrying a shape per leg:
     //   - a literal inside a template interpolation (template awareness)
@@ -636,35 +637,12 @@ describe("sweep — template literal with unbalanced brace is not zero findings 
 });
 
 describe("sweep — the real engine tree, pinned floor", () => {
-    test("measures exactly 11 live findings against the current tumble engine source", async () => {
+    test("measures exactly 0 live findings against the current tumble engine source", async () => {
         const findings = await sweep(REAL_ROOT);
-        // Full site list pinned (not just the count) so a predicate drift shows exactly which
-        // site moved, not just that the number did.
-        const sites = findings.map((f) => `${f.file}:${f.line}`).sort();
-        expect(sites).toEqual(
-            [
-                "engine/api.ts:1716",
-                "engine/api.ts:2178",
-                "engine/core.ts:16",
-                "engine/core.ts:23",
-                "engine/core.ts:29",
-                "engine/distance.ts:1154",
-                "engine/distance.ts:1249",
-                "engine/geometry.ts:334",
-                "engine/hull.ts:1410",
-                "engine/manifold.ts:1049",
-                "engine/types.ts:244",
-            ].sort(),
-        );
-        expect(findings).toHaveLength(11);
-    });
-
-    test("the three spec-named live findings are among them", async () => {
-        const findings = await sweep(REAL_ROOT);
-        const sites = new Set(findings.map((f) => `${f.file}:${f.line}`));
-        expect(sites.has("engine/core.ts:23")).toBe(true); // OVERLAP_SLOP
-        expect(sites.has("engine/hull.ts:1410")).toBe(true); // minH
-        expect(sites.has("engine/distance.ts:1154")).toBe(true); // kToleranceSquared
+        // S2 wrapped all 11 sites S1 flagged into rule 1a's fround-correct form, so the floor
+        // is 0. The site list is empty — a regression (a new bare non-exact literal) reds rather
+        // than drifting silently.
+        expect(findings).toHaveLength(0);
     });
 
     test("the trig arm is clean against the real tree — only the two allowlisted deviations exist", async () => {
@@ -681,19 +659,20 @@ describe("sweep — the real engine tree, pinned floor", () => {
 // F2 — the "exits non-zero" claim is prose nothing gates. The script's docblock and help text
 // claim a loud inconclusive exits non-zero; every arm calls `sweep*` directly and none reads the
 // CLI's exit status. This arm spawns the CLI (`Bun.spawnSync`, same pattern as `format-gate.test.ts`)
-// and reads the exit code — both directions: non-zero when there are findings (the real tree),
-// and zero on a synthetic clean root pointed at via `--root`. The clean-root direction also reads
-// the CLI's stdout as a launch witness: an empty root exits 0 too, so `exitCode === 0` alone cannot
-// tell "swept the fixture and found nothing" from "swept no files at all" — the stdout assertion
-// discriminates a launch that never happened (a glob scanning nothing) from a real clean sweep.
+// and reads the exit code — both directions: zero when the sweep is clean (the real tree, post-S2),
+// and non-zero on a synthetic root carrying a planted violation pointed at via `--root`. The
+// clean-root direction also reads the CLI's stdout as a launch witness: an empty root exits 0 too,
+// so `exitCode === 0` alone cannot tell "swept the fixture and found nothing" from "swept no files
+// at all" — the stdout assertion discriminates a launch that never happened (a glob scanning
+// nothing) from a real clean sweep.
 describe("CLI exit code — F2: the loud inconclusive exits non-zero", () => {
-    test("exits non-zero when the sweep finds violations (the real engine tree)", () => {
+    test("exits zero when the sweep is clean (the real engine tree, post-S2)", () => {
         const proc = Bun.spawnSync(["bun", SCRIPT, "--root", REAL_ROOT], {
             stdout: "pipe",
             stderr: "pipe",
         });
-        expect(proc.exitCode).not.toBe(0);
-        expect(proc.exitCode).toBe(1);
+        expect(proc.exitCode).toBe(0);
+        expect(proc.stdout.toString()).toContain("0 findings");
     });
 
     test("exits zero on a synthetic clean root pointed at via --root", () => {
@@ -709,5 +688,16 @@ describe("CLI exit code — F2: the loud inconclusive exits non-zero", () => {
         // real clean sweep from a launch that never happened. The clean-sweep report on stdout is
         // what proves the CLI actually swept the fixture and found nothing.
         expect(proc.stdout.toString()).toContain("0 findings");
+    });
+
+    test("exits non-zero on a synthetic root carrying a planted violation", () => {
+        const root = fixture({
+            "engine/bad.ts": "export const bad = f32(0.1 * mass);\n",
+        });
+        const proc = Bun.spawnSync(["bun", SCRIPT, "--root", root], {
+            stdout: "pipe",
+            stderr: "pipe",
+        });
+        expect(proc.exitCode).toBe(1);
     });
 });

--- a/scripts/check-tumble-fp.ts
+++ b/scripts/check-tumble-fp.ts
@@ -21,10 +21,10 @@ import { TEST_TIER_SUFFIXES } from "../packages/shallot/tests/test-tiers";
 // not return to zero, is *reported as an unparsed site* and exits non-zero. Safety rests on
 // exhaustiveness over the region set plus a loud inconclusive — never on a sample.
 //
-// `bun run scripts/check-tumble-fp.ts` is EXPECTED to exit 1 at S1 (audit-tumble-engine-
-// bitexact-literals) — the check is built and pinned red before the three live divergences
-// move (S2). Wiring it into `bun run check` is S2's job, not this one's: wiring a red check in
-// would ship a red default gate.
+// `bun run scripts/check-tumble-fp.ts` is wired into `bun run check` (S2,
+// audit-tumble-engine-bitexact-literals). S1 built and pinned it red at 11 before the three live
+// divergences moved; S2 wrapped all 11 sites into rule 1a's fround-correct form, so the sweep is
+// now green (0 findings) and the default gate stays green.
 //
 // `--root <dir>` points the sweep at an alternate tree (fixture-driven proof — same shape as
 // `check-boundary.ts` / `check-scripts.ts`'s own `--root`), so the arm can drive real assertions

--- a/scripts/probe-edge-ccd.ts
+++ b/scripts/probe-edge-ccd.ts
@@ -1,0 +1,94 @@
+// `bun run scripts/probe-edge-ccd.ts` — the distance.ts:1154 differential reading.
+//
+// Stage S2 of audit-tumble-engine-bitexact-literals moved `kToleranceSquared` at
+// `distance.ts:1154` from `f32(0.05 * 0.05)` (= 0.0024999999441206455) to
+// `f32(f32(0.05) * f32(0.05))` (= 0.002500000176951289) to match C's `0.05f * 0.05f`.
+// That constant sits inside `makeSeparationFunction`'s edge/edge sub-branch
+// (`cache.count === 2 && uniqueCountA === 2 && uniqueCountB === 2`), reached during
+// CCD conservative advancement. The spec's Validation criterion owes a differential
+// reading: a continuous scene whose `SeparationType` branch is exercised, before and after.
+//
+// This script constructs that scene — two boxes at non-parallel orientations under CCD —
+// steps it through the world, and prints the per-step FNV-1a world-state hash. The scene
+// reaches the edge/edge branch (cache.count=2, uniqueCountA=2, uniqueCountB=2) on the first
+// CCD step, selecting `SeparationType.Edges` because the cross-product length squared
+// (≈0.992) far exceeds the tolerance (≈0.0025). The differential is taken by running this
+// script with the old and new `kToleranceSquared` values (see the reproduction commands
+// in the report); the branch does not flip because the length squared is orders of
+// magnitude above the tolerance either way.
+//
+// Scene: "ccd-edge-edge" — a static box at the origin rotated 90° around Z, and a dynamic
+// bullet box at [0, 2, 0] rotated 5° around Y falling at -20 m/s. The non-parallel edge
+// orientations drive the GJK simplex to count=2 (edge/edge) during the CCD sweep.
+
+import { hashWorldState } from "../packages/shallot/src/standard/tumble/engine/hash";
+import { BodyType, makeBoxHull, World } from "../packages/shallot/src/standard/tumble/engine/index";
+import { init, shutdown } from "../packages/shallot/src/standard/tumble/engine/kernel";
+import { DEG_TO_RAD, quat } from "../packages/shallot/src/standard/tumble/engine/math";
+
+function toHex(h: bigint): string {
+    return `0x${h.toString(16).padStart(16, "0")}`;
+}
+
+async function main() {
+    await init({ threads: 0 });
+
+    const q90z = quat.fromAxisAngle({ x: 0, y: 0, z: 1 }, DEG_TO_RAD * 90);
+    const q5y = quat.fromAxisAngle({ x: 0, y: 1, z: 0 }, DEG_TO_RAD * 5);
+
+    const world = new World({
+        gravity: { x: 0, y: -10, z: 0 },
+        enableSleep: false,
+        enableContinuous: true,
+    });
+
+    // Static box at origin, rotated 90° around Z — its long axis now points along X.
+    const ground = world.createBody({
+        type: BodyType.Static,
+        position: { x: 0, y: 0, z: 0 },
+        rotation: { v: { x: q90z.v.x, y: q90z.v.y, z: q90z.v.z }, s: q90z.s },
+    });
+    ground.createHull({}, makeBoxHull(0.5, 0.5, 0.5));
+
+    // Dynamic bullet box at [0, 2, 0], rotated 5° around Y, falling at -20 m/s.
+    const bullet = world.createBody({
+        type: BodyType.Dynamic,
+        position: { x: 0, y: 2, z: 0 },
+        rotation: { v: { x: q5y.v.x, y: q5y.v.y, z: q5y.v.z }, s: q5y.s },
+        linearVelocity: { x: 0, y: -20, z: 0 },
+        isBullet: true,
+    });
+    bullet.createHull({}, makeBoxHull(0.5, 0.5, 0.5));
+
+    const dt = 1 / 60;
+    const stepCount = 60;
+    const hashes: string[] = [];
+
+    for (let step = 0; step < stepCount; ++step) {
+        world.step(dt, 4);
+        hashes.push(toHex(hashWorldState(world.state)));
+    }
+
+    // Report: the reachability proof (if instrumentation is present) and the hash series.
+    const edgeEdgeCount = (globalThis as any).__edgeEdgeCount ?? "n/a (no instrumentation)";
+    const lastLengthSq = (globalThis as any).__lastLengthSq ?? "n/a";
+    const lastKTol = (globalThis as any).__lastKTol ?? "n/a";
+    const lastSepType = (globalThis as any).__lastSepType ?? "n/a";
+    const sepName = lastSepType === 1 ? "Vertices" : lastSepType === 2 ? "Edges" : "n/a";
+
+    console.log("ccd-edge-edge probe");
+    console.log(`  edgeEdgeCount: ${edgeEdgeCount}`);
+    console.log(`  lastLengthSq:  ${lastLengthSq}`);
+    console.log(`  lastKTol:      ${lastKTol}`);
+    console.log(`  sepType:       ${sepName}`);
+    console.log(`  stepCount:     ${stepCount}`);
+    console.log(`  hashes:`);
+    for (let i = 0; i < hashes.length; ++i) {
+        console.log(`    [${i}] = ${hashes[i]}`);
+    }
+
+    world.destroy();
+    await shutdown();
+}
+
+main();

--- a/scripts/probe-edge-ccd.ts
+++ b/scripts/probe-edge-ccd.ts
@@ -1,4 +1,4 @@
-// `bun run scripts/probe-edge-ccd.ts` — the distance.ts:1154 differential reading.
+// `bun run scripts/probe-edge-ccd.ts` — the distance.ts:1154 reachability reading.
 //
 // Stage S2 of audit-tumble-engine-bitexact-literals moved `kToleranceSquared` at
 // `distance.ts:1154` from `f32(0.05 * 0.05)` (= 0.0024999999441206455) to
@@ -9,13 +9,19 @@
 // reading: a continuous scene whose `SeparationType` branch is exercised, before and after.
 //
 // This script constructs that scene — two boxes at non-parallel orientations under CCD —
-// steps it through the world, and prints the per-step FNV-1a world-state hash. The scene
-// reaches the edge/edge branch (cache.count=2, uniqueCountA=2, uniqueCountB=2) on the first
-// CCD step, selecting `SeparationType.Edges` because the cross-product length squared
-// (≈0.992) far exceeds the tolerance (≈0.0025). The differential is taken by running this
-// script with the old and new `kToleranceSquared` values (see the reproduction commands
-// in the report); the branch does not flip because the length squared is orders of
-// magnitude above the tolerance either way.
+// steps it through the world, and prints the per-step FNV-1a world-state hash. What it
+// establishes: the scene reaches the line-1154 edge/edge comparison (1 call to
+// `makeSeparationFunction`, `cache.count === 2`, `uniqueCountA === 2 && uniqueCountB === 2`),
+// where `lengthSquared` = 0.992161214351654 against `kToleranceSquared` =
+// 0.002500000176951289 selects `SeparationType.Edges`; the operands differ by ~400× and the
+// constants by 1 ULP, so the branch outcome is invariant to the 1-ULP move (the old
+// `f32(0.05 * 0.05)` = 0.0024999999441206455 still selects `Edges`).
+//
+// What it does not establish: the printed hash series does not discriminate the
+// `SeparationType` branch at this site — forcing the opposite (`Vertices`) branch leaves the
+// series byte-identical (measured), so hash identity here is not evidence about that branch.
+// Re-establishing the reachability reading requires temporary instrumentation of
+// `makeSeparationFunction`; the committed probe reprints hashes only.
 //
 // Scene: "ccd-edge-edge" — a static box at the origin rotated 90° around Z, and a dynamic
 // bullet box at [0, 2, 0] rotated 5° around Y falling at -20 m/s. The non-parallel edge


### PR DESCRIPTION
- **audit-tumble-engine-bitexact-literals: s2 wrap 11 f32 literal sites, wire check into bun run check**
- **audit-tumble-engine-bitexact-literals: s2 distance.ts:1154 differential reading probe**
- **audit-tumble-engine-bitexact-literals: s2 correct probe comment on vacuous hash evidence**
