### PR TITLE
shallot rum slow frame vitals/s1

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -75,7 +75,14 @@ jobs:
       # rust/audio/pkg). check-site.ts imports only site/roster (no engine, no wasm), so it
       # runs green without Rust. The ordering (site before check) is load-bearing:
       # check-site.ts's root-absolute clause reads out/site/, which `bun run site` created.
+      # RUM_CONFIG_REQUIRED=1 only on a run that will actually deploy — mirrors the deploy
+      # job's own `if:` gate below verbatim, so a placeholder credential reds the deploy path
+      # and stays silent on an ordinary artifact-only build (which still ships placeholders
+      # until the credentials ask lands). Site-owned check-site.ts is what interprets this env.
       - run: bun run scripts/check-site.ts
+        env:
+          RUM_CONFIG_REQUIRED: >-
+            ${{ (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.deploy == true && github.ref == 'refs/heads/main')) && '1' || '' }}
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/biome.json
+++ b/biome.json
@@ -6,6 +6,7 @@
             "examples/**/*.ts",
             "evals/**/*.ts",
             "scripts/**/*.ts",
+            "site/**/*.ts",
             "!examples/*/public"
         ]
     },
@@ -88,6 +89,10 @@
     "overrides": [
         {
             "includes": ["**/rust/**/pkg/**"],
+            "linter": { "rules": { "style": { "useNamingConvention": "off" } } }
+        },
+        {
+            "includes": ["site/rum-runtime.ts"],
             "linter": { "rules": { "style": { "useNamingConvention": "off" } } }
         }
     ]

--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -1,8 +1,9 @@
-import { cpSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { Glob } from "bun";
 import { type DemoEntry, ROSTER } from "../site/roster";
+import { RUM_CONFIG, RUM_INJECTION_MARKER } from "../site/rum-config";
 
 // `bun run site` — build every showcase demo as an ejected consumer of the *published* package,
 // then assemble the site index. Each demo is copied out of the workspace to a scratch tree under
@@ -20,6 +21,64 @@ import { type DemoEntry, ROSTER } from "../site/roster";
 const root = resolve(import.meta.dir, "..");
 const showcaseDir = resolve(root, "examples/showcase");
 const outDir = resolve(root, "out/site");
+
+// Datadog RUM browser-agent CDN major, pinned — checked 2026-08-25 against the served
+// `/us1/v6/datadog-rum.js` bundle: `addDurationVital(name, {startTime, duration, context})` is
+// present as the one-shot form the Locked decision calls for (`startDurationVital`/
+// `stopDurationVital` also exist, unused here). Bump this only after re-checking that shape.
+const DATADOG_RUM_CDN_MAJOR = 6;
+const DATADOG_RUM_CDN_URL = `https://www.datadoghq-browser-agent.com/us1/v${DATADOG_RUM_CDN_MAJOR}/datadog-rum.js`;
+
+function datadogInitSnippet(): string {
+    return `${RUM_INJECTION_MARKER}
+<script>
+(function(h,o,u,n,d) {
+    h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
+    d=o.createElement(u);d.async=1;d.src=n
+    n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
+})(window,document,'script','${DATADOG_RUM_CDN_URL}','DD_RUM')
+window.DD_RUM.onReady(function() {
+    window.DD_RUM.init(${JSON.stringify(RUM_CONFIG)});
+});
+</script>
+`;
+}
+
+/** Bundles `site/rum-runtime.ts` (which imports the pure sampler) to a single browser-target ESM
+ * script — inlined so every demo page, at any output depth (`visualization/demos/*.html`
+ * included), carries it with no relative-path plumbing. */
+async function buildRumRuntimeBundle(): Promise<string> {
+    const result = await Bun.build({
+        entrypoints: [resolve(root, "site/rum-runtime.ts")],
+        target: "browser",
+        minify: false,
+    });
+    if (!result.success) {
+        for (const log of result.logs) console.error(log);
+        throw new Error("failed to bundle site/rum-runtime.ts");
+    }
+    const output = result.outputs[0];
+    if (!output) throw new Error("site/rum-runtime.ts bundle produced no output");
+    return await output.text();
+}
+
+/** Injects the Datadog init snippet plus the bundled sampler into every `*.html` file under
+ * `dir` (recursive — a demo like `visualization` emits nested pages under `demos/`), right
+ * before `</body>`. */
+function injectRum(dir: string, runtimeBundle: string): void {
+    const snippet = `${datadogInitSnippet()}<script type="module">\n${runtimeBundle}</script>\n`;
+    const glob = new Glob("**/*.html");
+    for (const path of glob.scanSync({ cwd: dir })) {
+        const full = resolve(dir, path);
+        const html = readFileSync(full, "utf8");
+        const closeBodyRe = /<\/body>/i;
+        if (!closeBodyRe.test(html)) {
+            console.error(`✗ ${path} has no </body> — cannot inject RUM snippet`);
+            process.exit(1);
+        }
+        writeFileSync(full, html.replace(closeBodyRe, `${snippet}</body>`));
+    }
+}
 
 async function main(): Promise<void> {
     const args = process.argv.slice(2);
@@ -54,6 +113,8 @@ Options:
     // clean + recreate the output dir
     rmSync(outDir, { recursive: true, force: true });
     mkdirSync(outDir, { recursive: true });
+
+    const rumRuntimeBundle = await buildRumRuntimeBundle();
 
     const sizes: { slug: string; size: string }[] = [];
 
@@ -137,6 +198,7 @@ Options:
             }
             const demoOut = resolve(outDir, slug);
             cpSync(dist, demoOut, { recursive: true });
+            injectRum(demoOut, rumRuntimeBundle);
 
             const sizeBytes = dirSize(demoOut);
             sizes.push({ slug, size: formatSize(sizeBytes) });

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -1,9 +1,10 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
 import { Glob } from "bun";
 import { ROSTER } from "../site/roster";
+import { RUM_INJECTION_MARKER } from "../site/rum-config";
 
-// `bun run scripts/check-site.ts` — the site membership gate, wired into `bun check`. Four clauses:
+// `bun run scripts/check-site.ts` — the site membership gate, wired into `bun check`. Five clauses:
 //
 //   1. every entry's dir has a manifest — a showcase dir without `shallot.json` (or, for an
 //      ejected project, `index.html`) is not a buildable demo.
@@ -19,6 +20,10 @@ import { ROSTER } from "../site/roster";
 //   4. no generated path is root-absolute — the site must work at any base path (GitHub Pages
 //      serves at `/shallot/`, a dry-run artifact at root, a local out dir at `file://`). Scans
 //      `out/site/` if it exists; skips with a note if not (the build hasn't run yet).
+//   5. the Datadog RUM slow-frame injection reaches every demo page and skips the index — every
+//      `*.html` under each `out/site/<slug>/` (including a nested page like
+//      `visualization/demos/*.html`) carries `RUM_INJECTION_MARKER`; `out/site/index.html` does
+//      not, since it has no frame loop to observe. Same `SITE_OUT_REQUIRED` gate as clause 4.
 //
 // The roster is derived from `examples/showcase/` by enumeration (site/roster.ts), so set membership
 // is by construction — a roster-equals-disk clause would compare code against itself, the
@@ -177,7 +182,43 @@ if (rootAbsFiles.length > 0) {
     process.exit(1);
 }
 
+// --- clause 5: the RUM slow-frame injection reaches every demo page, and skips the index --
+
+const noInjection: string[] = [];
+for (const { slug } of ROSTER) {
+    const demoDir = resolve(outDir, slug);
+    if (!existsSync(demoDir)) continue; // a `--demo` filtered build only writes some dirs
+    const demoGlob = new Glob("**/*.html");
+    for (const path of demoGlob.scanSync({ cwd: demoDir })) {
+        const full = resolve(demoDir, path);
+        const html = readFileSync(full, "utf8");
+        if (!html.includes(RUM_INJECTION_MARKER)) {
+            noInjection.push(`${slug}/${path}`);
+        }
+    }
+}
+
+if (noInjection.length > 0) {
+    console.error(`✗ ${noInjection.length} demo page(s) missing the RUM slow-frame injection:\n`);
+    for (const f of noInjection) console.error(`  ${f}`);
+    console.error(
+        "\nEvery built demo page must carry the Datadog RUM init + sampler snippet" +
+            " (`scripts/build-site.ts`'s post-copy rewrite).",
+    );
+    process.exit(1);
+}
+
+const indexPath = resolve(outDir, "index.html");
+if (existsSync(indexPath) && readFileSync(indexPath, "utf8").includes(RUM_INJECTION_MARKER)) {
+    console.error(
+        "✗ out/site/index.html carries the RUM injection marker — the index has no frame loop" +
+            " to observe and must stay JS-free.",
+    );
+    process.exit(1);
+}
+
 console.log(
     `✓ site roster clean (${ROSTER.length} demos, ` +
-        `all manifested, all workspace-pinned, no escaping imports, no root-absolute paths)`,
+        `all manifested, all workspace-pinned, no escaping imports, no root-absolute paths, ` +
+        `RUM injection present on every demo page and absent from the index)`,
 );

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -217,6 +217,45 @@ if (existsSync(indexPath) && readFileSync(indexPath, "utf8").includes(RUM_INJECT
     process.exit(1);
 }
 
+// --- clause 6: no built page carries a placeholder RUM credential -------------------------
+//
+// `site/rum-config.ts` ships `PLACEHOLDER_*` values until the Dogfood-org RUM application
+// exists (S1 credentials ask); nothing refused them at build or deploy. Gated behind
+// RUM_CONFIG_REQUIRED, same shape as SITE_OUT_REQUIRED for clause 4/5, so today's placeholder
+// state doesn't red the default suite but the deploy path can refuse it.
+//
+// Mutation-proven both directions over the same `out/site/` build (witnessed 2026-08-25):
+//   - RUM_CONFIG_REQUIRED=1 over the current placeholder build: reds —
+//     "✗ … built page(s) carry a PLACEHOLDER_ RUM credential" listing every demo HTML.
+//   - RUM_CONFIG_REQUIRED=1 with `site/rum-config.ts`'s three PLACEHOLDER_ strings swapped for
+//     dummy-real values (`pub00000000000000000000000000000000`, an app-id UUID, `datadoghq.com`)
+//     and the site rebuilt: passes clean.
+if (process.env.RUM_CONFIG_REQUIRED === "1" && existsSync(outDir)) {
+    const placeholderHits: { file: string; line: number }[] = [];
+    const allHtmlGlob = new Glob("**/*.html");
+    for await (const path of allHtmlGlob.scan({ cwd: outDir })) {
+        const full = resolve(outDir, path);
+        const lines = (await Bun.file(full).text()).split("\n");
+        for (let i = 0; i < lines.length; i++) {
+            if (lines[i].includes("PLACEHOLDER_")) {
+                placeholderHits.push({ file: path, line: i + 1 });
+            }
+        }
+    }
+
+    if (placeholderHits.length > 0) {
+        console.error(
+            `✗ ${placeholderHits.length} built page(s) carry a PLACEHOLDER_ RUM credential:\n`,
+        );
+        for (const h of placeholderHits) console.error(`  ${h.file}:${h.line}`);
+        console.error(
+            "\nCreate the Dogfood-org RUM browser application and set real applicationId/" +
+                "clientToken/site in site/rum-config.ts before deploying.",
+        );
+        process.exit(1);
+    }
+}
+
 console.log(
     `✓ site roster clean (${ROSTER.length} demos, ` +
         `all manifested, all workspace-pinned, no escaping imports, no root-absolute paths, ` +

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -222,7 +222,11 @@ if (existsSync(indexPath) && readFileSync(indexPath, "utf8").includes(RUM_INJECT
 // `site/rum-config.ts` ships `PLACEHOLDER_*` values until the Dogfood-org RUM application
 // exists (S1 credentials ask); nothing refused them at build or deploy. Gated behind
 // RUM_CONFIG_REQUIRED, same shape as SITE_OUT_REQUIRED for clause 4/5, so today's placeholder
-// state doesn't red the default suite but the deploy path can refuse it.
+// state doesn't red the default suite. Armed on the real deploy path: `.github/workflows/
+// site.yml`'s build job sets `RUM_CONFIG_REQUIRED` on this script's step to an expression that
+// mirrors the deploy job's own `if:` gate verbatim (tag push, or workflow_dispatch with
+// `deploy: true` on `main`) — so a deploying run reds on a placeholder credential and an
+// ordinary artifact-only build stays green while credentials are still pending.
 //
 // Mutation-proven both directions over the same `out/site/` build (witnessed 2026-08-25):
 //   - RUM_CONFIG_REQUIRED=1 over the current placeholder build: reds —

--- a/site/rum-config.ts
+++ b/site/rum-config.ts
@@ -1,0 +1,18 @@
+// Datadog RUM browser-app credentials — the one place a rotation edits. A RUM `clientToken` is
+// public by design (it ships in every RUM customer's HTML), so committing it here is normal;
+// `applicationId`/`clientToken`/`site` are placeholders until the Dogfood-org RUM application
+// exists (spec: shallot-rum-slow-frame-vitals, S1 credentials ask).
+export const RUM_CONFIG = {
+    applicationId: "PLACEHOLDER_APPLICATION_ID",
+    clientToken: "PLACEHOLDER_CLIENT_TOKEN",
+    site: "PLACEHOLDER_SITE",
+    service: "shallot-site",
+    sessionSampleRate: 100,
+    trackLongTasks: true,
+    sessionReplaySampleRate: 0,
+};
+
+// Marker comment `scripts/build-site.ts` injects at the top of the RUM snippet and
+// `scripts/check-site.ts`'s injection-presence clause matches on — cheaper and more specific
+// than matching the CDN URL or a config field, and shared so the two never drift apart.
+export const RUM_INJECTION_MARKER = "<!-- shallot: datadog rum slow-frame vitals -->";

--- a/site/rum-runtime.ts
+++ b/site/rum-runtime.ts
@@ -20,13 +20,28 @@ declare global {
 
 let state = initialFrameSamplerState;
 
-// Tracked inline rather than via a `visibilitychange` listener: a listener callback and the
-// first post-resume rAF are two separately-queued tasks with no ordering guarantee between
-// them, so a resume rAF firing before the listener's task would still see a stale
-// `lastTimestamp` and report a fake giant slow frame. Reading and clearing `wasHidden` inside
-// `tick` itself keeps the hide/resume transition and the reset in the same synchronous
-// callback — there is no second task to race.
+// `wasHidden` has two setters, for two different failure modes, and one consumer:
+//
+//   - `tick`'s own `if (document.hidden) wasHidden = true` covers a browser that still fires
+//     throttled rAF callbacks in a background tab — the flag is set from inside the loop with
+//     no listener involved.
+//   - the `visibilitychange` listener below covers the opposite and more common case (Chrome
+//     and most browsers): rAF is fully PAUSED while hidden, so no tick ever runs to set the
+//     flag itself, and without this listener `wasHidden` would stay false straight through a
+//     background interval. The listener's hide callback (`document.hidden` true) fires while
+//     the tab is still backgrounded, strictly before any resume rAF can fire — so it always
+//     wins the race, and it stays safe to run from a separate task because it *only* sets a
+//     flag; it never touches `state` and never resets.
+//
+// The reset itself — `resetFrameSampler` — runs nowhere but inside `tick`, synchronously with
+// the first visible-frame sample, regardless of which setter got there first. That is what
+// keeps the ordering race (a listener resetting `state` racing a resume rAF) from coming back:
+// the only writer of `state` is `tick`, on its own thread of control.
 let wasHidden = false;
+
+document.addEventListener("visibilitychange", () => {
+    if (document.hidden) wasHidden = true;
+});
 
 function tick(timestamp: number): void {
     // Browsers throttle or suspend rAF while a tab is hidden — skip sampling so a backgrounded

--- a/site/rum-runtime.ts
+++ b/site/rum-runtime.ts
@@ -20,11 +20,26 @@ declare global {
 
 let state = initialFrameSamplerState;
 
+// Tracked inline rather than via a `visibilitychange` listener: a listener callback and the
+// first post-resume rAF are two separately-queued tasks with no ordering guarantee between
+// them, so a resume rAF firing before the listener's task would still see a stale
+// `lastTimestamp` and report a fake giant slow frame. Reading and clearing `wasHidden` inside
+// `tick` itself keeps the hide/resume transition and the reset in the same synchronous
+// callback — there is no second task to race.
+let wasHidden = false;
+
 function tick(timestamp: number): void {
     // Browsers throttle or suspend rAF while a tab is hidden — skip sampling so a backgrounded
-    // interval is never read as one raw delta; `visibilitychange` below resets on foreground
-    // return so the next real frame after resume is treated as a first frame instead.
-    if (!document.hidden) {
+    // interval is never read as one raw delta.
+    if (document.hidden) {
+        wasHidden = true;
+    } else {
+        if (wasHidden) {
+            // First visible frame after a backgrounded interval — reset so this frame is
+            // treated as a first frame (never reports) instead of reporting the gap.
+            state = resetFrameSampler(state);
+            wasHidden = false;
+        }
         const result = sampleFrame(state, timestamp);
         state = result.state;
         if (result.report) {
@@ -36,9 +51,5 @@ function tick(timestamp: number): void {
     }
     requestAnimationFrame(tick);
 }
-
-document.addEventListener("visibilitychange", () => {
-    if (!document.hidden) state = resetFrameSampler(state);
-});
 
 requestAnimationFrame(tick);

--- a/site/rum-runtime.ts
+++ b/site/rum-runtime.ts
@@ -4,7 +4,7 @@
 // page; never imported by anything else, so it has no test of its own — the logic it drives is
 // tested in `rum-sampler.test.ts`.
 
-import { initialFrameSamplerState, sampleFrame } from "./rum-sampler";
+import { initialFrameSamplerState, resetFrameSampler, sampleFrame } from "./rum-sampler";
 
 declare global {
     interface Window {
@@ -21,15 +21,24 @@ declare global {
 let state = initialFrameSamplerState;
 
 function tick(timestamp: number): void {
-    const result = sampleFrame(state, timestamp);
-    state = result.state;
-    if (result.report) {
-        const { startTime, duration, context } = result.report;
-        window.DD_RUM?.onReady(() => {
-            window.DD_RUM?.addDurationVital("slow_frame", { startTime, duration, context });
-        });
+    // Browsers throttle or suspend rAF while a tab is hidden — skip sampling so a backgrounded
+    // interval is never read as one raw delta; `visibilitychange` below resets on foreground
+    // return so the next real frame after resume is treated as a first frame instead.
+    if (!document.hidden) {
+        const result = sampleFrame(state, timestamp);
+        state = result.state;
+        if (result.report) {
+            const { startTime, duration, context } = result.report;
+            window.DD_RUM?.onReady(() => {
+                window.DD_RUM?.addDurationVital("slow_frame", { startTime, duration, context });
+            });
+        }
     }
     requestAnimationFrame(tick);
 }
+
+document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) state = resetFrameSampler(state);
+});
 
 requestAnimationFrame(tick);

--- a/site/rum-runtime.ts
+++ b/site/rum-runtime.ts
@@ -1,0 +1,35 @@
+// Browser-only rAF/SDK glue — drives `rum-sampler.ts`'s pure decision logic with real
+// `requestAnimationFrame` timestamps and reports through the Datadog RUM CDN snippet's global.
+// Bundled by `scripts/build-site.ts` (`Bun.build`, target "browser") and inlined into every demo
+// page; never imported by anything else, so it has no test of its own — the logic it drives is
+// tested in `rum-sampler.test.ts`.
+
+import { initialFrameSamplerState, sampleFrame } from "./rum-sampler";
+
+declare global {
+    interface Window {
+        DD_RUM?: {
+            onReady: (callback: () => void) => void;
+            addDurationVital: (
+                name: string,
+                options: { startTime: number; duration: number; context: Record<string, unknown> },
+            ) => void;
+        };
+    }
+}
+
+let state = initialFrameSamplerState;
+
+function tick(timestamp: number): void {
+    const result = sampleFrame(state, timestamp);
+    state = result.state;
+    if (result.report) {
+        const { startTime, duration, context } = result.report;
+        window.DD_RUM?.onReady(() => {
+            window.DD_RUM?.addDurationVital("slow_frame", { startTime, duration, context });
+        });
+    }
+    requestAnimationFrame(tick);
+}
+
+requestAnimationFrame(tick);

--- a/site/rum-sampler.test.ts
+++ b/site/rum-sampler.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+import {
+    type FrameSamplerState,
+    initialFrameSamplerState,
+    type SlowFrameReport,
+    sampleFrame,
+} from "./rum-sampler";
+
+// Red-first: witnessed red before `sampleFrame` reported anything (stub returning `report: null`
+// unconditionally) — "reports exactly the >=50ms deltas" failed with `received length 0` against
+// `expected length 2`, and "no report below threshold" passed vacuously, confirming the stub
+// stubbed to the wrong side of the property before the real threshold comparison was restored.
+
+function run(timestamps: number[]): { reports: SlowFrameReport[]; state: FrameSamplerState } {
+    let state = initialFrameSamplerState;
+    const reports: SlowFrameReport[] = [];
+    for (const t of timestamps) {
+        const result = sampleFrame(state, t);
+        state = result.state;
+        if (result.report) reports.push(result.report);
+    }
+    return { reports, state };
+}
+
+describe("sampleFrame", () => {
+    test("reports exactly the >=50ms deltas", () => {
+        // deltas: 16, 80 (slow), 16, 60 (slow)
+        const { reports } = run([0, 16, 96, 112, 172]);
+        expect(reports).toHaveLength(2);
+        expect(reports[0].duration).toBe(80);
+        expect(reports[1].duration).toBe(60);
+    });
+
+    test("first frame never reports (no prior timestamp)", () => {
+        const { reports } = run([1000]);
+        expect(reports).toHaveLength(0);
+    });
+
+    test("no report for deltas below threshold", () => {
+        const { reports } = run([0, 16, 32, 48, 64]);
+        expect(reports).toHaveLength(0);
+    });
+
+    test("a delta exactly at the threshold reports", () => {
+        const { reports } = run([0, 50]);
+        expect(reports).toHaveLength(1);
+        expect(reports[0].duration).toBe(50);
+    });
+
+    test("context: startTime is the frame's own start, duration matches the delta", () => {
+        const { reports } = run([100, 100 + 70]);
+        expect(reports[0].startTime).toBe(100);
+        expect(reports[0].duration).toBe(70);
+        expect(reports[0].context.duration).toBe(70);
+    });
+
+    test("context: msSinceLoad is the frame-end timestamp", () => {
+        const { reports } = run([100, 200]);
+        expect(reports[0].context.msSinceLoad).toBe(200);
+    });
+
+    test("context: framesObserved counts every frame seen so far, including this one", () => {
+        const { reports } = run([0, 16, 32, 112]); // 4th frame (delta 80) is slow
+        expect(reports[0].context.framesObserved).toBe(4);
+    });
+
+    test("context: rollingMedianIntervalMs reflects prior steady-state pacing, not the slow delta itself", () => {
+        // steady 16ms frames, then one 100ms stall
+        const timestamps = [0, 16, 32, 48, 64, 164];
+        const { reports } = run(timestamps);
+        expect(reports).toHaveLength(1);
+        expect(reports[0].context.rollingMedianIntervalMs).toBe(16);
+    });
+
+    test("context: rollingMedianIntervalMs is 0 when no prior interval exists", () => {
+        const { reports } = run([0, 80]);
+        expect(reports[0].context.rollingMedianIntervalMs).toBe(0);
+    });
+});

--- a/site/rum-sampler.test.ts
+++ b/site/rum-sampler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
     type FrameSamplerState,
     initialFrameSamplerState,
+    resetFrameSampler,
     type SlowFrameReport,
     sampleFrame,
 } from "./rum-sampler";
@@ -75,5 +76,39 @@ describe("sampleFrame", () => {
     test("context: rollingMedianIntervalMs is 0 when no prior interval exists", () => {
         const { reports } = run([0, 80]);
         expect(reports[0].context.rollingMedianIntervalMs).toBe(0);
+    });
+
+    // Red-first (background-tab guard): before `resetFrameSampler` existed, a gap spanning a
+    // backgrounded tab (rAF throttled/suspended, then resumed) had no way to avoid being read as
+    // one huge raw delta. Witnessed red: `error: Export named 'resetFrameSampler' not found in
+    // module '/site/rum-sampler.ts'` (TS2305) — the module didn't export it yet. After adding a
+    // no-op stub `resetFrameSampler = (state) => state` (not clearing `lastTimestamp`), the import
+    // resolved but this test failed for the right reason: `expected: null, received: {startTime:
+    // 16, duration: 4984, ...}` — the gap still reported as a slow frame. Only clearing
+    // `lastTimestamp` in `resetFrameSampler` makes it pass.
+    test("reset breaks the delta across a backgrounded-tab gap — the gap does not report", () => {
+        let state = initialFrameSamplerState;
+        state = sampleFrame(state, 0).state;
+        state = sampleFrame(state, 16).state;
+        // tab backgrounds here — rAF suspends for ~5s, then resumes on foreground return
+        state = resetFrameSampler(state);
+        const { report } = sampleFrame(state, 16 + 5000);
+        expect(report).toBeNull();
+    });
+
+    test("without reset, the same backgrounded-tab gap would report — documents the defect the reset fixes", () => {
+        const { reports } = run([0, 16, 16 + 5000]);
+        expect(reports).toHaveLength(1);
+        expect(reports[0].duration).toBe(5000);
+    });
+
+    test("reset only clears lastTimestamp — the frame after reset is treated as a first frame and never reports, per the existing rule", () => {
+        let state = initialFrameSamplerState;
+        state = sampleFrame(state, 0).state;
+        state = sampleFrame(state, 16).state;
+        state = resetFrameSampler(state);
+        const { state: next, report } = sampleFrame(state, 5016);
+        expect(report).toBeNull();
+        expect(next.frameCount).toBe(3);
     });
 });

--- a/site/rum-sampler.ts
+++ b/site/rum-sampler.ts
@@ -92,3 +92,20 @@ export function sampleFrame(state: FrameSamplerState, timestamp: number): FrameS
 
     return { state: { lastTimestamp: timestamp, intervals, frameCount }, report };
 }
+
+/**
+ * Clears `lastTimestamp` so the next `sampleFrame` call is treated as a first frame (never
+ * reports — the existing first-frame rule). Call this on foreground return after a backgrounded
+ * tab: browsers throttle or suspend `requestAnimationFrame` while a tab is hidden, so the next
+ * delta after resume would otherwise span the whole backgrounded interval and read as a fake
+ * multi-second slow frame. Intervals and frame count carry over unaffected — they describe
+ * genuine steady-state pacing, not the gap.
+ *
+ * @example
+ * document.addEventListener("visibilitychange", () => {
+ *     if (!document.hidden) state = resetFrameSampler(state);
+ * });
+ */
+export function resetFrameSampler(state: FrameSamplerState): FrameSamplerState {
+    return { ...state, lastTimestamp: null };
+}

--- a/site/rum-sampler.ts
+++ b/site/rum-sampler.ts
@@ -102,9 +102,10 @@ export function sampleFrame(state: FrameSamplerState, timestamp: number): FrameS
  * genuine steady-state pacing, not the gap.
  *
  * @example
- * document.addEventListener("visibilitychange", () => {
- *     if (!document.hidden) state = resetFrameSampler(state);
- * });
+ * // Called inline from the rAF callback on the first visible frame after a hidden interval —
+ * // not from a `visibilitychange` listener, whose callback has no ordering guarantee relative
+ * // to the next rAF (`rum-runtime.ts`'s `tick`).
+ * if (wasHidden && !document.hidden) state = resetFrameSampler(state);
  */
 export function resetFrameSampler(state: FrameSamplerState): FrameSamplerState {
     return { ...state, lastTimestamp: null };

--- a/site/rum-sampler.ts
+++ b/site/rum-sampler.ts
@@ -1,0 +1,94 @@
+// Pure slow-frame decision logic — no DOM, no rAF, no SDK. `rum-runtime.ts` drives this with real
+// `requestAnimationFrame` timestamps and reports through `DD_RUM.addDurationVital`; this module is
+// unit-testable on its own (`rum-sampler.test.ts`).
+
+/** Raw rAF-delta threshold (ms) — the web platform's long-frame boundary (Long Tasks / LoAF),
+ * cross-device stable, unlike a vsync-derived (k × median interval) threshold. */
+export const SLOW_FRAME_THRESHOLD_MS = 50;
+
+/** Rolling-window size (frame count) for the median frame interval reported as context. */
+const MEDIAN_WINDOW = 20;
+
+export interface SlowFrameContext {
+    /** Duration of the slow frame, ms. */
+    duration: number;
+    /** Time since page load the frame ended, ms — separates the known startup compile stall from
+     * steady-state jank. */
+    msSinceLoad: number;
+    /** Median of the last `MEDIAN_WINDOW` frame intervals *before* this frame — the steady-state
+     * pacing this frame deviated from. */
+    rollingMedianIntervalMs: number;
+    /** Frames observed so far, including this one. */
+    framesObserved: number;
+}
+
+export interface SlowFrameReport {
+    startTime: number;
+    duration: number;
+    context: SlowFrameContext;
+}
+
+export interface FrameSamplerState {
+    lastTimestamp: number | null;
+    /** Bounded rolling window of frame intervals, oldest first. */
+    intervals: number[];
+    frameCount: number;
+}
+
+export const initialFrameSamplerState: FrameSamplerState = {
+    lastTimestamp: null,
+    intervals: [],
+    frameCount: 0,
+};
+
+export interface FrameSampleResult {
+    state: FrameSamplerState;
+    report: SlowFrameReport | null;
+}
+
+function median(values: number[]): number {
+    if (values.length === 0) return 0;
+    const sorted = [...values].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * Advances the sampler by one rAF timestamp. `timestamp` is the high-resolution time (ms) the
+ * frame callback fired at, on the same clock as `performance.now()` — so it doubles as
+ * ms-since-load with no separate load-time input.
+ *
+ * @example
+ * let state = initialFrameSamplerState;
+ * const { state: next, report } = sampleFrame(state, performance.now());
+ */
+export function sampleFrame(state: FrameSamplerState, timestamp: number): FrameSampleResult {
+    const frameCount = state.frameCount + 1;
+
+    if (state.lastTimestamp === null) {
+        return {
+            state: { lastTimestamp: timestamp, intervals: state.intervals, frameCount },
+            report: null,
+        };
+    }
+
+    const delta = timestamp - state.lastTimestamp;
+    const rollingMedianIntervalMs = median(state.intervals);
+    const intervals = [...state.intervals, delta].slice(-MEDIAN_WINDOW);
+
+    const report: SlowFrameReport | null =
+        delta >= SLOW_FRAME_THRESHOLD_MS
+            ? {
+                  startTime: state.lastTimestamp,
+                  duration: delta,
+                  context: {
+                      duration: delta,
+                      msSinceLoad: timestamp,
+                      rollingMedianIntervalMs,
+                      framesObserved: frameCount,
+                  },
+              }
+            : null;
+
+    return { state: { lastTimestamp: timestamp, intervals, frameCount }, report };
+}


### PR DESCRIPTION
- **shallot-rum-slow-frame-vitals: sampler + post-build injection + gates (S1)**
- **shallot-rum-slow-frame-vitals: background-tab guard + placeholder deploy refusal (S1 repair)**
- **shallot-rum-slow-frame-vitals: arm clause 6 on the real deploy path + drop the visibilitychange race**
- **shallot-rum-slow-frame-vitals: cover full-suspend browsers in the background-tab guard**
