### PR TITLE
audit-shallot-contract-vs-code-fixes/s2: consolidate vite.ts classifier, fix double-fire

### DIFF
--- a/packages/shallot/src/project/vite.test.ts
+++ b/packages/shallot/src/project/vite.test.ts
@@ -3,7 +3,15 @@ import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Rollup } from "vite";
-import { assetSrc, discoverScenes, findPublicDirs, orphanedAssets, projectPlugin } from "./vite";
+import {
+    assetSrc,
+    classifyProjectFile,
+    discoverScenes,
+    findPublicDirs,
+    manifestPath,
+    orphanedAssets,
+    projectPlugin,
+} from "./vite";
 
 // a fresh project dir per test, cleaned up after — the shape every fs-reader / hook test needs
 function projectDir(): string {
@@ -153,6 +161,41 @@ describe("findPublicDirs", () => {
     });
 });
 
+// the extracted classifier both onProjectFile and handleHotUpdate call — contract pins (not red-first:
+// the classifier is a pure extraction, so these pin its contract directly rather than guarding a bug).
+describe("classifyProjectFile", () => {
+    const absDir = "/proj";
+    const publicDirs = ["/proj/public", "/shared/public"];
+
+    test("a .glb under a public dir is an asset change", () => {
+        expect(classifyProjectFile("/proj/public/box.glb", absDir, publicDirs)).toBe("asset");
+    });
+
+    test("a .scene under the project dir is a project change", () => {
+        expect(classifyProjectFile("/proj/scenes/main.scene", absDir, publicDirs)).toBe("project");
+    });
+
+    test("the manifest path under the project dir is a project change", () => {
+        expect(classifyProjectFile(manifestPath(absDir), absDir, publicDirs)).toBe("project");
+    });
+
+    test("a .scene outside the project dir is null — not a project change", () => {
+        expect(classifyProjectFile("/other/main.scene", absDir, publicDirs)).toBeNull();
+    });
+
+    test("a .ts source file is null — rides default HMR", () => {
+        expect(classifyProjectFile("/proj/src/Local.ts", absDir, publicDirs)).toBeNull();
+    });
+
+    test("a model outside every public dir is null", () => {
+        expect(classifyProjectFile("/proj/src/box.glb", absDir, publicDirs)).toBeNull();
+    });
+
+    test("a model under a shared parent public dir is an asset change (checked before the absDir guard)", () => {
+        expect(classifyProjectFile("/shared/public/tree.glb", absDir, publicDirs)).toBe("asset");
+    });
+});
+
 // projectPlugin's hooks — a plain object, each callable against a stub `this` / server (Locked decision:
 // "every seam this unit needs already exists as a parameter"). The stubs below are duck-typed to the
 // members each hook actually touches, never the full Vite/Rollup types, and every hook property is cast
@@ -166,9 +209,15 @@ describe("projectPlugin", () => {
         const sent: unknown[] = [];
         const invalidated: unknown[] = [];
         let moduleById: unknown;
+        const watcherCallbacks: Record<string, Array<(file: string) => void>> = {};
         const server = {
             middlewares: { use: (fn: unknown) => middlewareFns.push(fn as never) },
-            watcher: { add: () => {}, on: () => {} },
+            watcher: {
+                add: () => {},
+                on: (event: string, cb: (file: string) => void) => {
+                    (watcherCallbacks[event] ??= []).push(cb);
+                },
+            },
             ws: { send: (msg: unknown) => sent.push(msg) },
             moduleGraph: {
                 getModuleById: () => moduleById,
@@ -180,6 +229,7 @@ describe("projectPlugin", () => {
             middlewareFns,
             sent,
             invalidated,
+            watcherCallbacks,
             setModuleById: (m: unknown) => {
                 moduleById = m;
             },
@@ -356,7 +406,7 @@ describe("projectPlugin", () => {
             return plugin.configureServer as unknown as (server: unknown) => void;
         }
 
-        test("invalidates the virtual module and signals a reload on a .scene change, swallowing default HMR", () => {
+        test("invalidates the virtual module and swallows default HMR on a .scene change (the reload comes from the watcher path)", () => {
             const dir = projectDir();
             const plugin = projectPlugin(dir);
             const stub = stubServer();
@@ -368,10 +418,12 @@ describe("projectPlugin", () => {
 
             expect(result).toEqual([]);
             expect(stub.invalidated).toEqual([mod]);
-            expect(stub.sent).toEqual([{ type: "full-reload" }]);
+            // no full-reload from this path — the watcher's onProjectFile signals the reload, so a
+            // single .scene change fires one reload, not two
+            expect(stub.sent).toEqual([]);
         });
 
-        test("invalidates on a shallot.json change too", () => {
+        test("invalidates on a shallot.json change too (swallows default HMR, no reload signal)", () => {
             const dir = projectDir();
             const plugin = projectPlugin(dir);
             const stub = stubServer();
@@ -379,7 +431,7 @@ describe("projectPlugin", () => {
 
             const result = handleHotUpdateHook(plugin)({ file: join(dir, "shallot.json") });
             expect(result).toEqual([]);
-            expect(stub.sent).toEqual([{ type: "full-reload" }]);
+            expect(stub.sent).toEqual([]);
         });
 
         test("falls through to default HMR for an unrelated file", () => {
@@ -408,6 +460,77 @@ describe("projectPlugin", () => {
             expect(
                 handleHotUpdateHook(noProjectDir)({ file: "/whatever/main.scene" }),
             ).toBeUndefined();
+        });
+    });
+
+    // the double-fire defect: before the consolidation, onProjectFile and handleHotUpdate independently
+    // classified the same .scene change and each sent a full-reload — two reloads for one file. Vite's
+    // watcher fires both paths (the plugin's raw server.watcher listener and Vite's internal HMR handler
+    // that calls handleHotUpdate) for every change event, so a .scene change reached both. The fix: the
+    // HMR path only invalidates + swallows default HMR (returns []); the watcher path signals the reload.
+    // (handleHotUpdate runs only for update/change events in Vite 8 — add/unlink were always single-fire
+    // via the watcher path alone, so the double-fire existed on change events only.)
+    describe("double-fire prevention", () => {
+        function configureServerHook(plugin: ReturnType<typeof projectPlugin>) {
+            return plugin.configureServer as unknown as (server: unknown) => void;
+        }
+        function handleHotUpdateHook(plugin: ReturnType<typeof projectPlugin>) {
+            return plugin.handleHotUpdate as unknown as (ctx: {
+                file: string;
+            }) => unknown[] | undefined;
+        }
+
+        // red-first: fails before the fix because both paths independently signal a reload.
+        test("a single .scene change fires one full-reload, not one per path", () => {
+            const dir = projectDir();
+            const plugin = projectPlugin(dir);
+            const stub = stubServer();
+            configureServerHook(plugin)(stub.server);
+
+            const mod = { id: "\0virtual:project" };
+            stub.setModuleById(mod);
+
+            const file = join(dir, "main.scene");
+            // simulate the watcher path (onProjectFile — registered via server.watcher.on)
+            for (const cb of stub.watcherCallbacks.change ?? []) cb(file);
+            // simulate the HMR path (handleHotUpdate — called by Vite's internal handler)
+            handleHotUpdateHook(plugin)({ file });
+
+            const reloads = stub.sent.filter((m) => (m as { type: string }).type === "full-reload");
+            expect(reloads).toHaveLength(1);
+        });
+
+        // red-first: fails before the fix because both paths independently signal a reload.
+        test("a single shallot.json change fires one full-reload, not one per path", () => {
+            const dir = projectDir();
+            const plugin = projectPlugin(dir);
+            const stub = stubServer();
+            configureServerHook(plugin)(stub.server);
+
+            const file = join(dir, "shallot.json");
+            for (const cb of stub.watcherCallbacks.change ?? []) cb(file);
+            handleHotUpdateHook(plugin)({ file });
+
+            const reloads = stub.sent.filter((m) => (m as { type: string }).type === "full-reload");
+            expect(reloads).toHaveLength(1);
+        });
+
+        // contract pin: not red-first — handleHotUpdate never handled assets, so only the watcher path
+        // signaled before and after. Confirms the asymmetry survived the fix.
+        test("an asset change fires one full-reload from the watcher path only (handleHotUpdate does not handle assets)", () => {
+            const dir = projectDir();
+            mkdirSync(join(dir, "public"), { recursive: true });
+            writeFileSync(join(dir, "public", "box.glb"), "");
+            const plugin = projectPlugin(dir);
+            const stub = stubServer();
+            configureServerHook(plugin)(stub.server);
+
+            const file = join(dir, "public", "box.glb");
+            for (const cb of stub.watcherCallbacks.change ?? []) cb(file);
+            handleHotUpdateHook(plugin)({ file });
+
+            const reloads = stub.sent.filter((m) => (m as { type: string }).type === "full-reload");
+            expect(reloads).toHaveLength(1);
         });
     });
 

--- a/packages/shallot/src/project/vite.ts
+++ b/packages/shallot/src/project/vite.ts
@@ -171,10 +171,30 @@ export function orphanedAssets(bundle: Rollup.OutputBundle): string[] {
     return assets.filter((a) => !kept.has(a)).map((a) => a.fileName);
 }
 
+/**
+ * classify a changed project file: a model asset under a public dir (`"asset"`), a `.scene` or
+ * manifest under the project dir (`"project"`), or neither (`null`). Both the watcher listener
+ * (`onProjectFile`) and the HMR hook (`handleHotUpdate`) call this so the two paths cannot drift in
+ * how they classify an event — the watcher path signals a reload for both arms; the HMR path only
+ * invalidates + swallows default HMR for `"project"` (the reload comes from the watcher, so a single
+ * `.scene` change fires one reload, not two).
+ */
+export function classifyProjectFile(
+    file: string,
+    absDir: string,
+    publicDirs: string[],
+): "asset" | "project" | null {
+    if (assetSrc(file, publicDirs)) return "asset";
+    if (file.startsWith(absDir) && (file.endsWith(".scene") || file === manifestPath(absDir)))
+        return "project";
+    return null;
+}
+
 export function projectPlugin(projectDir?: string): Plugin {
     const virtualId = "virtual:project";
     const resolvedId = "\0" + virtualId;
     let viteServer: ViteDevServer | undefined;
+    let publicDirs: string[] = [];
 
     return {
         name: "shallot-project",
@@ -206,28 +226,29 @@ export function projectPlugin(projectDir?: string): Plugin {
             configureServer(server, projectDir);
             if (projectDir) {
                 const absDir = resolve(projectDir);
-                const publicDirs = findPublicDirs(absDir);
+                publicDirs = findPublicDirs(absDir);
                 server.watcher.add(absDir);
                 // a shared parent public/ sits outside the project dir, so add it explicitly (the project's
                 // own public/ is already covered by absDir) — a model there must still trigger the swap
                 for (const pub of publicDirs) if (!pub.startsWith(absDir)) server.watcher.add(pub);
                 // a `.scene` add/remove changes the scene list; a `shallot.json` edit changes the plugin
                 // set — both re-generate `virtual:project`, so invalidate + reload. Local plugin `.ts`
-                // edits ride HMR instead.
+                // edits ride HMR instead. The watcher path is the sole signaler — handleHotUpdate only
+                // invalidates + swallows default HMR, so a single `.scene` change fires one reload, not
+                // two (the two paths fire independently on the same change event — handleHotUpdate
+                // runs only for update/change events in Vite 8, so add/unlink were always single-fire
+                // via the watcher path alone).
                 const onProjectFile = (file: string) => {
-                    // a model asset (.glb/.gltf) under a public dir → full-reload so the page re-fetches
-                    // the model (no virtual:project change — the model isn't part of the generated
-                    // module). Checked first, before the absDir guard, so a shared parent public/ is
-                    // covered.
-                    if (assetSrc(file, publicDirs)) {
+                    const kind = classifyProjectFile(file, absDir, publicDirs);
+                    if (kind === "asset") {
                         signalChange(server);
                         return;
                     }
-                    if (!file.startsWith(absDir)) return;
-                    if (!file.endsWith(".scene") && file !== manifestPath(absDir)) return;
-                    const mod = server.moduleGraph.getModuleById(resolvedId);
-                    if (mod) server.moduleGraph.invalidateModule(mod);
-                    signalChange(server);
+                    if (kind === "project") {
+                        const mod = server.moduleGraph.getModuleById(resolvedId);
+                        if (mod) server.moduleGraph.invalidateModule(mod);
+                        signalChange(server);
+                    }
                 };
                 server.watcher.on("change", onProjectFile);
                 server.watcher.on("add", onProjectFile);
@@ -237,13 +258,12 @@ export function projectPlugin(projectDir?: string): Plugin {
         handleHotUpdate({ file }) {
             if (!projectDir || !viteServer) return;
             const absDir = resolve(projectDir);
-            if (
-                (file.endsWith(".scene") || file === manifestPath(absDir)) &&
-                file.startsWith(absDir)
-            ) {
+            if (classifyProjectFile(file, absDir, publicDirs) === "project") {
                 const mod = viteServer.moduleGraph.getModuleById(resolvedId);
                 if (mod) viteServer.moduleGraph.invalidateModule(mod);
-                signalChange(viteServer);
+                // no signalChange here — the watcher's onProjectFile already sent the full-reload, so
+                // signaling from both paths double-fires. Returning [] swallows vite's default HMR
+                // (a .scene is not a module, so default HMR would error on it).
                 return [];
             }
             // a project src/*.ts edit falls through to vite's default HMR: `virtual:project` imports the


### PR DESCRIPTION
Extract classifyProjectFile so onProjectFile and handleHotUpdate share one
classification path. The watcher path (onProjectFile) is the sole signaler;
handleHotUpdate only invalidates + swallows default HMR (returns []), fixing
the double-fire where a single .scene change sent two full-reloads — one from
each path, since Vite fires both the raw watcher listener and the HMR hook on
the same file change.
