### PR TITLE
shallot demo slow frame attribution/s1

### DIFF
--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { Glob } from "bun";
 import { type DemoEntry, ROSTER } from "../site/roster";
-import { RUM_CONFIG, RUM_INJECTION_MARKER } from "../site/rum-config";
+import { RUM_CONFIG, RUM_ENV_SNIPPET, RUM_INJECTION_MARKER } from "../site/rum-config";
 
 // `bun run site` — build every showcase demo as an ejected consumer of the *published* package,
 // then assemble the site index. Each demo is copied out of the workspace to a scratch tree under
@@ -48,7 +48,8 @@ function datadogInitSnippet(): string {
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
 })(window,document,'script','${DATADOG_RUM_CDN_URL}','DD_RUM')
 window.DD_RUM.onReady(function() {
-    window.DD_RUM.init(${JSON.stringify(RUM_CONFIG)});
+    ${RUM_ENV_SNIPPET}
+    window.DD_RUM.init(Object.assign({env:ddEnv},${JSON.stringify(RUM_CONFIG)}));
 });
 </script>
 `;

--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -3,7 +3,12 @@ import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { Glob } from "bun";
 import { type DemoEntry, ROSTER } from "../site/roster";
-import { RUM_CONFIG, RUM_ENV_SNIPPET, RUM_INJECTION_MARKER } from "../site/rum-config";
+import {
+    RUM_CONFIG,
+    RUM_ENV_SNIPPET,
+    RUM_ENV_USAGE,
+    RUM_INJECTION_MARKER,
+} from "../site/rum-config";
 
 // `bun run site` — build every showcase demo as an ejected consumer of the *published* package,
 // then assemble the site index. Each demo is copied out of the workspace to a scratch tree under
@@ -49,7 +54,7 @@ function datadogInitSnippet(): string {
 })(window,document,'script','${DATADOG_RUM_CDN_URL}','DD_RUM')
 window.DD_RUM.onReady(function() {
     ${RUM_ENV_SNIPPET}
-    window.DD_RUM.init(Object.assign({env:ddEnv},${JSON.stringify(RUM_CONFIG)}));
+    window.DD_RUM.init(${RUM_ENV_USAGE}${JSON.stringify(RUM_CONFIG)});
 });
 </script>
 `;

--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -54,7 +54,7 @@ function datadogInitSnippet(): string {
 })(window,document,'script','${DATADOG_RUM_CDN_URL}','DD_RUM')
 window.DD_RUM.onReady(function() {
     ${RUM_ENV_SNIPPET}
-    window.DD_RUM.init(${RUM_ENV_USAGE}${JSON.stringify(RUM_CONFIG)});
+    window.DD_RUM.init(${RUM_ENV_USAGE}${JSON.stringify(RUM_CONFIG)}));
 });
 </script>
 `;

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -25,9 +25,12 @@ import { RUM_ENV_SNIPPET, RUM_ENV_USAGE, RUM_INJECTION_MARKER } from "../site/ru
 //      `visualization/demos/*.html`) carries `RUM_INJECTION_MARKER`, `RUM_ENV_SNIPPET` (the
 //      hostname-derived `env: "prod" | "local"` derivation, `shallot-demo-slow-frame-attribution.md`
 //      Locked decision) and `RUM_ENV_USAGE` (the wiring that actually reads the derived `env`
-//      into `DD_RUM.init` — the derivation alone is a silent no-op if the wiring drops it);
-//      `out/site/index.html` does not, since it has no frame loop to observe. Same
-//      `SITE_OUT_REQUIRED` gate as clause 4.
+//      into `DD_RUM.init` — the derivation alone is a silent no-op if the wiring drops it); the
+//      injected `<script>` block also has to parse (`new Function(src)`) — the substring checks
+//      pin the seam, this pins that the composed call is runnable, since a dropped paren between
+//      two present fragments passes every substring check while still being broken syntax.
+//      `out/site/index.html` does not carry any of this, since it has no frame loop to observe.
+//      Same `SITE_OUT_REQUIRED` gate as clause 4.
 //
 // The roster is derived from `examples/showcase/` by enumeration (site/roster.ts), so set membership
 // is by construction — a roster-equals-disk clause would compare code against itself, the
@@ -191,6 +194,7 @@ if (rootAbsFiles.length > 0) {
 const noInjection: string[] = [];
 const noEnv: string[] = [];
 const noEnvUsage: string[] = [];
+const noParse: { file: string; error: string }[] = [];
 for (const { slug } of ROSTER) {
     const demoDir = resolve(outDir, slug);
     if (!existsSync(demoDir)) continue; // a `--demo` filtered build only writes some dirs
@@ -206,6 +210,36 @@ for (const { slug } of ROSTER) {
         }
         if (!html.includes(RUM_ENV_USAGE)) {
             noEnvUsage.push(`${slug}/${path}`);
+        }
+
+        // The substring checks above pin the seam (each fragment present) but not the
+        // composition — a paren dropped between `RUM_ENV_USAGE` and `JSON.stringify(RUM_CONFIG)`
+        // still contains every fragment while the composed call is unparseable (measured
+        // 2026-08-25: `window.DD_RUM.init(Object.assign({env:ddEnv},{...});` — missing
+        // `Object.assign`'s closing paren — threw `Unexpected token ';'` from every built page's
+        // real script and none of the substring checks caught it). Extract the injected
+        // `<script>` block after the marker (the plain inline one, not the
+        // `<script type="module">` sampler bundle right after it) and syntax-check it with
+        // `new Function(src)` — construction parses the body without executing it, so this is a
+        // syntax check, not an execution one.
+        const markerIdx = html.indexOf(RUM_INJECTION_MARKER);
+        if (markerIdx !== -1) {
+            const scriptMatch = html.slice(markerIdx).match(/<script>([\s\S]*?)<\/script>/);
+            if (!scriptMatch) {
+                noParse.push({
+                    file: `${slug}/${path}`,
+                    error: "no <script> block found after the RUM injection marker",
+                });
+            } else {
+                try {
+                    new Function(scriptMatch[1]);
+                } catch (err) {
+                    noParse.push({
+                        file: `${slug}/${path}`,
+                        error: err instanceof Error ? err.message : String(err),
+                    });
+                }
+            }
         }
     }
 }
@@ -238,6 +272,18 @@ if (noEnvUsage.length > 0) {
         "\nThe derived `env` must actually reach `DD_RUM.init` — every built demo page must" +
             " carry `site/rum-config.ts`'s `RUM_ENV_USAGE` literal (`RUM_ENV_SNIPPET` computing" +
             " `ddEnv` with nothing reading it is a silent no-op).",
+    );
+    process.exit(1);
+}
+
+if (noParse.length > 0) {
+    console.error(`✗ ${noParse.length} demo page(s) carry an unparseable RUM init script:\n`);
+    for (const { file, error } of noParse) console.error(`  ${file}: ${error}`);
+    console.error(
+        "\nThe injected `<script>` block after the RUM injection marker failed to parse" +
+            " (`new Function(src)`) — every fragment substring check above can pass while the" +
+            " composed call is still broken syntax (`scripts/build-site.ts`'s" +
+            " `datadogInitSnippet`).",
     );
     process.exit(1);
 }

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
 import { Glob } from "bun";
 import { ROSTER } from "../site/roster";
-import { RUM_ENV_SNIPPET, RUM_INJECTION_MARKER } from "../site/rum-config";
+import { RUM_ENV_SNIPPET, RUM_ENV_USAGE, RUM_INJECTION_MARKER } from "../site/rum-config";
 
 // `bun run scripts/check-site.ts` — the site membership gate, wired into `bun check`. Five clauses:
 //
@@ -22,10 +22,12 @@ import { RUM_ENV_SNIPPET, RUM_INJECTION_MARKER } from "../site/rum-config";
 //      `out/site/` if it exists; skips with a note if not (the build hasn't run yet).
 //   5. the Datadog RUM slow-frame injection reaches every demo page and skips the index — every
 //      `*.html` under each `out/site/<slug>/` (including a nested page like
-//      `visualization/demos/*.html`) carries `RUM_INJECTION_MARKER` and `RUM_ENV_SNIPPET` (the
-//      hostname-derived `env: "prod" | "local"` facet, `shallot-demo-slow-frame-attribution.md`
-//      Locked decision); `out/site/index.html` does not, since it has no frame loop to observe.
-//      Same `SITE_OUT_REQUIRED` gate as clause 4.
+//      `visualization/demos/*.html`) carries `RUM_INJECTION_MARKER`, `RUM_ENV_SNIPPET` (the
+//      hostname-derived `env: "prod" | "local"` derivation, `shallot-demo-slow-frame-attribution.md`
+//      Locked decision) and `RUM_ENV_USAGE` (the wiring that actually reads the derived `env`
+//      into `DD_RUM.init` — the derivation alone is a silent no-op if the wiring drops it);
+//      `out/site/index.html` does not, since it has no frame loop to observe. Same
+//      `SITE_OUT_REQUIRED` gate as clause 4.
 //
 // The roster is derived from `examples/showcase/` by enumeration (site/roster.ts), so set membership
 // is by construction — a roster-equals-disk clause would compare code against itself, the
@@ -188,6 +190,7 @@ if (rootAbsFiles.length > 0) {
 
 const noInjection: string[] = [];
 const noEnv: string[] = [];
+const noEnvUsage: string[] = [];
 for (const { slug } of ROSTER) {
     const demoDir = resolve(outDir, slug);
     if (!existsSync(demoDir)) continue; // a `--demo` filtered build only writes some dirs
@@ -200,6 +203,9 @@ for (const { slug } of ROSTER) {
         }
         if (!html.includes(RUM_ENV_SNIPPET)) {
             noEnv.push(`${slug}/${path}`);
+        }
+        if (!html.includes(RUM_ENV_USAGE)) {
+            noEnvUsage.push(`${slug}/${path}`);
         }
     }
 }
@@ -221,6 +227,17 @@ if (noEnv.length > 0) {
         '\nEvery built demo page must carry the hostname-derived `env: "prod" | "local"`' +
             " snippet (`site/rum-config.ts`'s `RUM_ENV_SNIPPET`, injected by" +
             " `scripts/build-site.ts`).",
+    );
+    process.exit(1);
+}
+
+if (noEnvUsage.length > 0) {
+    console.error(`✗ ${noEnvUsage.length} demo page(s) missing the RUM env wiring:\n`);
+    for (const f of noEnvUsage) console.error(`  ${f}`);
+    console.error(
+        "\nThe derived `env` must actually reach `DD_RUM.init` — every built demo page must" +
+            " carry `site/rum-config.ts`'s `RUM_ENV_USAGE` literal (`RUM_ENV_SNIPPET` computing" +
+            " `ddEnv` with nothing reading it is a silent no-op).",
     );
     process.exit(1);
 }

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -2,7 +2,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
 import { Glob } from "bun";
 import { ROSTER } from "../site/roster";
-import { RUM_INJECTION_MARKER } from "../site/rum-config";
+import { RUM_ENV_SNIPPET, RUM_INJECTION_MARKER } from "../site/rum-config";
 
 // `bun run scripts/check-site.ts` — the site membership gate, wired into `bun check`. Five clauses:
 //
@@ -22,8 +22,10 @@ import { RUM_INJECTION_MARKER } from "../site/rum-config";
 //      `out/site/` if it exists; skips with a note if not (the build hasn't run yet).
 //   5. the Datadog RUM slow-frame injection reaches every demo page and skips the index — every
 //      `*.html` under each `out/site/<slug>/` (including a nested page like
-//      `visualization/demos/*.html`) carries `RUM_INJECTION_MARKER`; `out/site/index.html` does
-//      not, since it has no frame loop to observe. Same `SITE_OUT_REQUIRED` gate as clause 4.
+//      `visualization/demos/*.html`) carries `RUM_INJECTION_MARKER` and `RUM_ENV_SNIPPET` (the
+//      hostname-derived `env: "prod" | "local"` facet, `shallot-demo-slow-frame-attribution.md`
+//      Locked decision); `out/site/index.html` does not, since it has no frame loop to observe.
+//      Same `SITE_OUT_REQUIRED` gate as clause 4.
 //
 // The roster is derived from `examples/showcase/` by enumeration (site/roster.ts), so set membership
 // is by construction — a roster-equals-disk clause would compare code against itself, the
@@ -185,6 +187,7 @@ if (rootAbsFiles.length > 0) {
 // --- clause 5: the RUM slow-frame injection reaches every demo page, and skips the index --
 
 const noInjection: string[] = [];
+const noEnv: string[] = [];
 for (const { slug } of ROSTER) {
     const demoDir = resolve(outDir, slug);
     if (!existsSync(demoDir)) continue; // a `--demo` filtered build only writes some dirs
@@ -195,6 +198,9 @@ for (const { slug } of ROSTER) {
         if (!html.includes(RUM_INJECTION_MARKER)) {
             noInjection.push(`${slug}/${path}`);
         }
+        if (!html.includes(RUM_ENV_SNIPPET)) {
+            noEnv.push(`${slug}/${path}`);
+        }
     }
 }
 
@@ -204,6 +210,17 @@ if (noInjection.length > 0) {
     console.error(
         "\nEvery built demo page must carry the Datadog RUM init + sampler snippet" +
             " (`scripts/build-site.ts`'s post-copy rewrite).",
+    );
+    process.exit(1);
+}
+
+if (noEnv.length > 0) {
+    console.error(`✗ ${noEnv.length} demo page(s) missing the RUM env-derivation snippet:\n`);
+    for (const f of noEnv) console.error(`  ${f}`);
+    console.error(
+        '\nEvery built demo page must carry the hostname-derived `env: "prod" | "local"`' +
+            " snippet (`site/rum-config.ts`'s `RUM_ENV_SNIPPET`, injected by" +
+            " `scripts/build-site.ts`).",
     );
     process.exit(1);
 }
@@ -263,5 +280,5 @@ if (process.env.RUM_CONFIG_REQUIRED === "1" && existsSync(outDir)) {
 console.log(
     `✓ site roster clean (${ROSTER.length} demos, ` +
         `all manifested, all workspace-pinned, no escaping imports, no root-absolute paths, ` +
-        `RUM injection present on every demo page and absent from the index)`,
+        `RUM injection + env snippet present on every demo page and absent from the index)`,
 );

--- a/site/rum-config.ts
+++ b/site/rum-config.ts
@@ -15,3 +15,14 @@ export const RUM_CONFIG = {
 // `scripts/check-site.ts`'s injection-presence clause matches on — cheaper and more specific
 // than matching the CDN URL or a config field, and shared so the two never drift apart.
 export const RUM_INJECTION_MARKER = "<!-- shallot: datadog rum slow-frame vitals -->";
+
+// Plain, dependency-free inline JS — runs in the visitor's browser before `DD_RUM.init`, so it
+// cannot import anything. Derives the Datadog `env` facet from the served hostname: "prod" for
+// dylanebert.com and any subdomain (the site is served at dylanebert.com/shallot/, README.md /
+// AGENTS.md), "local" otherwise (a `bun run verify`/dev preview at localhost, or a raw
+// `file://`/IP checkout) — the Locked decision's localhost-noise fix
+// (`shallot-demo-slow-frame-attribution.md`). One shared string: `scripts/build-site.ts` injects
+// it verbatim and `scripts/check-site.ts`'s env-presence clause matches on the same literal, so
+// the two never drift apart (mirrors `RUM_INJECTION_MARKER` above).
+export const RUM_ENV_SNIPPET =
+    "var ddEnv=/(^|\\.)dylanebert\\.com$/.test(location.hostname)?'prod':'local';";

--- a/site/rum-config.ts
+++ b/site/rum-config.ts
@@ -26,3 +26,11 @@ export const RUM_INJECTION_MARKER = "<!-- shallot: datadog rum slow-frame vitals
 // the two never drift apart (mirrors `RUM_INJECTION_MARKER` above).
 export const RUM_ENV_SNIPPET =
     "var ddEnv=/(^|\\.)dylanebert\\.com$/.test(location.hostname)?'prod':'local';";
+
+// The `env` wiring into `DD_RUM.init` — the derivation line above (`RUM_ENV_SNIPPET`) computes
+// `ddEnv` but does nothing until it's spread into the init call. `scripts/build-site.ts` opens
+// its `Object.assign(...)` call with this exact literal; `scripts/check-site.ts`'s clause 5
+// matches on it separately from `RUM_ENV_SNIPPET`, so a mutation that drops the derivation line
+// and one that drops the wiring (leaving `ddEnv` computed but never read) each red on their own
+// clause instead of one silently covering for the other.
+export const RUM_ENV_USAGE = "Object.assign({env:ddEnv},";


### PR DESCRIPTION
- **shallot-demo-slow-frame-attribution: add hostname-derived env facet to RUM init**
- **shallot-demo-slow-frame-attribution: pin the RUM env wiring, not just its derivation**
- **shallot-demo-slow-frame-attribution: restore Object.assign's closing paren, add parse arm**
