### PR TITLE
audit audio abi mirror gate/s1

### DIFF
--- a/packages/shallot/src/standard/audio/abi.parity.test.ts
+++ b/packages/shallot/src/standard/audio/abi.parity.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Cross-language ABI parity gate: the TS audio layer hand-mirrors five capacity
+ * constants and the 15-entry NodeType discriminant map from the Rust worklet
+ * source. A mismatch silently corrupts the worklet ABI, and `cargo test` sees
+ * only the Rust side. This arm parses the Rust source and asserts the TS mirrors
+ * equal it — resolving each mirror by importing the module, never by re-parsing
+ * or re-spelling its value.
+ *
+ * Witnessed red (mutation proof, run in place):
+ *   - MAX_VOICES in rust/audio/src/lib.rs changed 64 → 65: arm red, exit 1.
+ *   - NODE_TYPE_ID discriminant reorder: swapped `phaser: 14` and `tremolo: 15`
+ *     in the Rust enum (graph.rs): arm red, exit 1.
+ *   Both restored with `git show HEAD:<path> > <path>`.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { MAX_VOICES } from "./core";
+import { MAX_BUFFERS, MAX_INSTRUMENTS, NODE_TYPE_ID } from "./instrument";
+import { MAX_SAMPLES } from "./sample";
+import { MAX_TRANSPORTS } from "./worklet";
+
+const libRs = readFileSync(new URL("../../../rust/audio/src/lib.rs", import.meta.url), "utf8");
+const graphRs = readFileSync(new URL("../../../rust/audio/src/graph.rs", import.meta.url), "utf8");
+
+/** Parse `pub const NAME: TYPE = VALUE;` from Rust source. */
+function parseRustConst(source: string, name: string): number {
+    const re = new RegExp(`pub\\s+const\\s+${name}\\s*:\\s*\\w+\\s*=\\s*(\\d+)`);
+    const m = source.match(re);
+    if (!m) throw new Error(`Rust constant ${name} not found in source`);
+    return Number(m[1]);
+}
+
+/**
+ * Parse the Rust `NodeType` enum's variant→discriminant mapping from graph.rs.
+ * Returns a Map<PascalCase, number> for every variant including `None = 0`.
+ */
+function parseNodeTypeEnum(source: string): Map<string, number> {
+    const enumMatch = source.match(/pub\s+enum\s+NodeType\s*\{([^}]+)\}/);
+    if (!enumMatch) throw new Error("NodeType enum not found in graph.rs");
+    const body = enumMatch[1];
+    const variants = new Map<string, number>();
+    for (const line of body.split("\n")) {
+        const m = line.match(/^\s*(\w+)\s*=\s*(\d+)\s*,/);
+        if (m) variants.set(m[1], Number(m[2]));
+    }
+    return variants;
+}
+
+describe("audio ABI parity (Rust source ↔ TS mirrors)", () => {
+    test("five capacity constants match the Rust source", () => {
+        const rustMaxVoices = parseRustConst(libRs, "MAX_VOICES");
+        const rustMaxSamples = parseRustConst(libRs, "MAX_SAMPLES");
+        const rustMaxTransports = parseRustConst(libRs, "MAX_TRANSPORTS");
+        const rustMaxInstruments = parseRustConst(graphRs, "MAX_INSTRUMENTS");
+        const rustMaxBuffers = parseRustConst(graphRs, "MAX_BUFFERS");
+
+        expect(MAX_VOICES).toBe(rustMaxVoices);
+        expect(rustMaxVoices).toBe(MAX_VOICES);
+        expect(MAX_SAMPLES).toBe(rustMaxSamples);
+        expect(rustMaxSamples).toBe(MAX_SAMPLES);
+        expect(MAX_TRANSPORTS).toBe(rustMaxTransports);
+        expect(rustMaxTransports).toBe(MAX_TRANSPORTS);
+        expect(MAX_INSTRUMENTS).toBe(rustMaxInstruments);
+        expect(rustMaxInstruments).toBe(MAX_INSTRUMENTS);
+        expect(MAX_BUFFERS).toBe(rustMaxBuffers);
+        expect(rustMaxBuffers).toBe(MAX_BUFFERS);
+    });
+
+    test("NODE_TYPE_ID map mirrors the Rust NodeType discriminant order", () => {
+        const rustVariants = parseNodeTypeEnum(graphRs);
+
+        // Derive the expected TS entry count from the Rust parse: every variant
+        // except `None` (discriminant 0, which the TS union type omits).
+        const expectedCount = [...rustVariants.values()].filter((v) => v !== 0).length;
+        expect(Object.keys(NODE_TYPE_ID).length).toBe(expectedCount);
+
+        // Bidirectional whole-equality: every non-None Rust variant appears in
+        // the TS map with the same discriminant, and every TS map entry appears
+        // in the Rust enum with the same value.
+        const tsEntries = Object.entries(NODE_TYPE_ID);
+
+        // Rust → TS: every non-None variant must be in the TS map.
+        for (const [rustName, rustVal] of rustVariants) {
+            if (rustVal === 0) continue;
+            const tsKey = rustName.toLowerCase();
+            expect(NODE_TYPE_ID).toHaveProperty(tsKey);
+            expect(NODE_TYPE_ID[tsKey as keyof typeof NODE_TYPE_ID]).toBe(rustVal);
+        }
+
+        // TS → Rust: every TS map entry must be in the Rust enum with the same value.
+        for (const [tsKey, tsVal] of tsEntries) {
+            const rustName = tsKey.charAt(0).toUpperCase() + tsKey.slice(1);
+            expect(rustVariants.has(rustName)).toBe(true);
+            expect(rustVariants.get(rustName)).toBe(tsVal);
+        }
+    });
+});

--- a/packages/shallot/src/standard/audio/abi.parity.test.ts
+++ b/packages/shallot/src/standard/audio/abi.parity.test.ts
@@ -54,16 +54,14 @@ describe("audio ABI parity (Rust source ↔ TS mirrors)", () => {
         const rustMaxInstruments = parseRustConst(graphRs, "MAX_INSTRUMENTS");
         const rustMaxBuffers = parseRustConst(graphRs, "MAX_BUFFERS");
 
+        // Scalar equality is symmetric — one direction per constant is the whole
+        // check; the load-bearing half is that each left side is the *imported*
+        // mirror, so a module move or rename reds here rather than at a re-spelling.
         expect(MAX_VOICES).toBe(rustMaxVoices);
-        expect(rustMaxVoices).toBe(MAX_VOICES);
         expect(MAX_SAMPLES).toBe(rustMaxSamples);
-        expect(rustMaxSamples).toBe(MAX_SAMPLES);
         expect(MAX_TRANSPORTS).toBe(rustMaxTransports);
-        expect(rustMaxTransports).toBe(MAX_TRANSPORTS);
         expect(MAX_INSTRUMENTS).toBe(rustMaxInstruments);
-        expect(rustMaxInstruments).toBe(MAX_INSTRUMENTS);
         expect(MAX_BUFFERS).toBe(rustMaxBuffers);
-        expect(rustMaxBuffers).toBe(MAX_BUFFERS);
     });
 
     test("NODE_TYPE_ID map mirrors the Rust NodeType discriminant order", () => {

--- a/packages/shallot/src/standard/audio/audio.test.ts
+++ b/packages/shallot/src/standard/audio/audio.test.ts
@@ -4,7 +4,18 @@ import { State } from "../..";
 import { clear, register } from "../../engine/ecs/core";
 import { Transform } from "../transforms";
 import { AudioPlugin, play, Sound, sfx } from "./";
-import { Audio, alloc, byId, free, getParamPairs, instrument, polar, slotOf, valid } from "./core";
+import {
+    Audio,
+    alloc,
+    byId,
+    free,
+    getParamPairs,
+    instrument,
+    MAX_VOICES,
+    polar,
+    slotOf,
+    valid,
+} from "./core";
 import { markCooldown, withinCooldown } from "./policy";
 import { flushSamples, keepChannels, resetSampleUploads, Samples, sample } from "./sample";
 
@@ -416,8 +427,6 @@ describe("sample decode channels", () => {
 });
 
 type Cmd = { type: string; voiceId?: number; value?: number };
-
-const MAX_VOICES = 64;
 
 const TONE = {
     nodes: { osc: { type: "oscillator" }, out: { type: "gain", input: "osc" } },

--- a/packages/shallot/src/standard/audio/core.ts
+++ b/packages/shallot/src/standard/audio/core.ts
@@ -3,7 +3,7 @@ import { byId, getParamPairs, type Instrument } from "./instrument";
 import { flushSamples, resetSampleUploads } from "./sample";
 import { createWorkletURL } from "./worklet";
 
-const MAX_VOICES = 64;
+export const MAX_VOICES = 64;
 const SLOT_MASK = 0x7f;
 const GEN_MASK = 0xffffff;
 

--- a/packages/shallot/src/standard/audio/instrument.ts
+++ b/packages/shallot/src/standard/audio/instrument.ts
@@ -21,7 +21,7 @@ export type NodeType =
     | "phaser"
     | "tremolo";
 
-const NODE_TYPE_ID: Record<NodeType, number> = {
+export const NODE_TYPE_ID: Record<NodeType, number> = {
     oscillator: 1,
     filter: 2,
     envelope: 3,
@@ -224,7 +224,7 @@ const NO_BUF = 0xff;
  * plays silent. Mirrors `rust/audio/src/graph.rs`'s `[InstrumentDef; MAX_INSTRUMENTS]`.
  */
 export const MAX_INSTRUMENTS = 32;
-const MAX_BUFFERS = 8;
+export const MAX_BUFFERS = 8;
 
 /** every compiled instrument, keyed by name with a stable numeric ID */
 export const Instruments: Registry<Instrument> = new Registry<Instrument>();

--- a/packages/shallot/src/standard/audio/worklet.ts
+++ b/packages/shallot/src/standard/audio/worklet.ts
@@ -1,4 +1,4 @@
-const MAX_TRANSPORTS = 8;
+export const MAX_TRANSPORTS = 8;
 
 const WORKLET_CODE = `
 const MAX_TRANSPORTS = ${MAX_TRANSPORTS};


### PR DESCRIPTION
- **audit-audio-abi-mirror-gate: add Rust↔TS ABI parity test**
- **audit-audio-abi-mirror-gate: drop redundant symmetric equalities in the parity arm**
