### PR TITLE
audit profile row reorder/s1

### DIFF
--- a/packages/shallot/src/extras/profile/index.test.ts
+++ b/packages/shallot/src/extras/profile/index.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { Compute, State } from "../../engine";
 import { UnsupportedError } from "../../engine/runtime";
-import { Profile, ProfilePlugin, reorderRows } from "./index";
+import { Profile, ProfilePlugin } from "./index";
+import { reorderRows } from "./reorder";
 
 // `ProfilePlugin.features` declares `timestamp-query`, and `acquireDevice` throws on a device that can't
 // grant it — but `requestGPU(externalDevice)` / `run({ device })` adopts a device as-is, so a declared

--- a/packages/shallot/src/extras/profile/index.test.ts
+++ b/packages/shallot/src/extras/profile/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Compute, State } from "../../engine";
 import { UnsupportedError } from "../../engine/runtime";
-import { Profile, ProfilePlugin } from "./index";
+import { Profile, ProfilePlugin, reorderRows } from "./index";
 
 // `ProfilePlugin.features` declares `timestamp-query`, and `acquireDevice` throws on a device that can't
 // grant it — but `requestGPU(externalDevice)` / `run({ device })` adopts a device as-is, so a declared
@@ -208,5 +208,34 @@ describe("ProfilePlugin", () => {
         Compute.precompiled?.("sear-typed-variants", 0, 0.16);
         expect(Profile.compile.get("sear-typed-variants")).toBe(0.16);
         expect(Profile.compiledPipelines.has("sear-typed-variants")).toBe(false);
+    });
+});
+
+describe("reorderRows", () => {
+    // The hysteresis reorder splices `next` in place but re-inserts the element
+    // from the *original* array at index i (`order[i]`) instead of the element
+    // it actually removed. After the first move, `next` and `order` diverge —
+    // `next[i]` is no longer `order[i]` — so a later move re-inserts the
+    // wrong name: the removed name is dropped and `order[i]` is duplicated.
+    //
+    // order = [a, b, c, d, e], rank = {b:0, d:1, e:2, a:3, c:4}
+    //   move 1 (i=0): removes "a", re-inserts order[0]="a" at 3 → [b,c,d,a,e]
+    //   move 2 (i=1): next[1]="c" ≠ order[1]="b"; removes "c", re-inserts
+    //                 order[1]="b" at 4 → [b,d,a,e,b]
+    //   move 3 (i=4): next[4]="b" ≠ order[4]="e"; removes "b", re-inserts
+    //                 order[4]="e" at 0 → [e,b,d,a,e]
+    // Pre-fix witness: output was ["e","b","d","a","e"] — "e" duplicated, "c" dropped.
+    test("a permutation whose second move exposes prev[i] !== next[i] yields a permutation of the input", () => {
+        const order = ["a", "b", "c", "d", "e"];
+        const rank = new Map<string, number>([
+            ["b", 0],
+            ["d", 1],
+            ["e", 2],
+            ["a", 3],
+            ["c", 4],
+        ]);
+        const result = reorderRows(order, rank);
+        // same multiset — no duplicate, no drop
+        expect(result.slice().sort()).toEqual(order.slice().sort());
     });
 });

--- a/packages/shallot/src/extras/profile/index.ts
+++ b/packages/shallot/src/extras/profile/index.ts
@@ -2,6 +2,7 @@ import type { LazyAlloc, Plugin, State, System } from "../../engine";
 import { Compute, mountOverlay } from "../../engine";
 import { UnsupportedError } from "../../engine/runtime";
 import { createMeasure, foldIndirect, INDIRECT_FLOOR_US } from "./benchmark";
+import { reorderRows } from "./reorder";
 
 export type {
     BenchmarkAPI,
@@ -640,21 +641,6 @@ function tickPool(pool: RowPool, entries: Iterable<[string, number]>): void {
         pool.accum.set(name, (pool.accum.get(name) ?? 0) + raw);
     }
     pool.frames++;
-}
-
-/** hysteresis row reorder: nudge each row toward its ranked position only when
- *  it's displaced by ≥2 slots (avoids 1-slot jitter). Pure — takes the current
- *  display order and a map of name→ranked-index, returns the new order. */
-export function reorderRows(order: string[], rank: Map<string, number>): string[] {
-    const next = order.slice();
-    for (let i = 0; i < next.length; i++) {
-        const desired = rank.get(next[i])!;
-        if (Math.abs(desired - i) >= 2) {
-            const [moved] = next.splice(i, 1);
-            next.splice(desired, 0, moved);
-        }
-    }
-    return next;
 }
 
 // fold the current window's accumulator into the cross-window EMA, evict

--- a/packages/shallot/src/extras/profile/index.ts
+++ b/packages/shallot/src/extras/profile/index.ts
@@ -642,6 +642,21 @@ function tickPool(pool: RowPool, entries: Iterable<[string, number]>): void {
     pool.frames++;
 }
 
+/** hysteresis row reorder: nudge each row toward its ranked position only when
+ *  it's displaced by ≥2 slots (avoids 1-slot jitter). Pure — takes the current
+ *  display order and a map of name→ranked-index, returns the new order. */
+export function reorderRows(order: string[], rank: Map<string, number>): string[] {
+    const next = order.slice();
+    for (let i = 0; i < next.length; i++) {
+        const desired = rank.get(next[i])!;
+        if (Math.abs(desired - i) >= 2) {
+            const [moved] = next.splice(i, 1);
+            next.splice(desired, 0, moved);
+        }
+    }
+    return next;
+}
+
 // fold the current window's accumulator into the cross-window EMA, evict
 // long-dead rows, sort with hysteresis, and return sorted display rows + the
 // sum of all live smoothed values (== visible row sum). Called per refresh.
@@ -690,15 +705,7 @@ function flushPool(
     if (prev.length !== sorted.length || sorted.some(([name]) => !prev.includes(name))) {
         pool.order = sorted.map(([name]) => name);
     } else {
-        const next = prev.slice();
-        for (let i = 0; i < next.length; i++) {
-            const desired = rank.get(next[i])!;
-            if (Math.abs(desired - i) >= 2) {
-                next.splice(i, 1);
-                next.splice(desired, 0, prev[i]);
-            }
-        }
-        pool.order = next;
+        pool.order = reorderRows(prev, rank);
     }
 
     const byName = new Map<string, [string, string]>();

--- a/packages/shallot/src/extras/profile/reorder.ts
+++ b/packages/shallot/src/extras/profile/reorder.ts
@@ -1,0 +1,14 @@
+/** hysteresis row reorder: nudge each row toward its ranked position only when
+ *  it's displaced by ≥2 slots (avoids 1-slot jitter). Pure — takes the current
+ *  display order and a map of name→ranked-index, returns the new order. */
+export function reorderRows(order: string[], rank: Map<string, number>): string[] {
+    const next = order.slice();
+    for (let i = 0; i < next.length; i++) {
+        const desired = rank.get(next[i])!;
+        if (Math.abs(desired - i) >= 2) {
+            const [moved] = next.splice(i, 1);
+            next.splice(desired, 0, moved);
+        }
+    }
+    return next;
+}


### PR DESCRIPTION
- **audit-profile-row-reorder: extract+fix hysteresis reorder as pure fn**
- **audit-profile-row-reorder: move reorderRows off the public barrel**
