### PR TITLE
audit gltf pool dead worker/s1

### DIFF
--- a/packages/shallot/src/extras/gltf/pool.test.ts
+++ b/packages/shallot/src/extras/gltf/pool.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { poolDecode } from "./pool";
+import type { DecodeReply } from "./worker";
+
+// pool.ts's transport wiring (spawn/settle/fail) — the seam scheduler.test.ts leaves to the real Chrome gym
+// run. Here we fake the Worker to exercise the pool's own error handling: a worker that errors outside a
+// pending request. No pool.test.ts existed; this is the new arm, placed beside the module it tests.
+
+// a fake Worker the pool's `spawn` wires onto. postMessage replies on the next microtask with a failure (the
+// test only needs to observe that the dispatch settles, not that decode succeeds). `alive` models a real
+// worker's lifecycle: once dead, postMessage goes nowhere — the defect's hang.
+class FakeWorker {
+    onmessage: ((e: MessageEvent<DecodeReply>) => void) | null = null;
+    onerror: ((e: ErrorEvent) => void) | null = null;
+    onmessageerror: (() => void) | null = null;
+    terminated = false;
+    alive = true;
+
+    postMessage(_msg: unknown): void {
+        if (!this.alive) return;
+        queueMicrotask(() => {
+            this.onmessage?.({ data: { ok: false, error: "fake" } } as MessageEvent<DecodeReply>);
+        });
+    }
+
+    terminate(): void {
+        this.terminated = true;
+        this.alive = false;
+    }
+}
+
+// flush the microtask queue (bounded — the scheduler's .then/.finally chain is a fixed depth)
+async function flush(): Promise<void> {
+    for (let i = 0; i < 20; i++) await Promise.resolve();
+}
+
+describe("decode pool", () => {
+    const realWorker = globalThis.Worker;
+    const realLocation = globalThis.location;
+    const realHwConcurrency = navigator.hardwareConcurrency;
+    let workers: FakeWorker[];
+
+    afterEach(() => {
+        globalThis.Worker = realWorker;
+        globalThis.location = realLocation;
+        Object.defineProperty(navigator, "hardwareConcurrency", {
+            value: realHwConcurrency,
+            configurable: true,
+            writable: true,
+        });
+    });
+
+    test("a worker that errors outside a pending request does not leave its slot hung", async () => {
+        workers = [];
+        globalThis.Worker = function (this: unknown, _url: URL, _opts?: unknown) {
+            const w = new FakeWorker();
+            workers.push(w);
+            return w;
+        } as unknown as typeof Worker;
+        globalThis.location = { href: "http://localhost/" } as unknown as Location;
+        Object.defineProperty(navigator, "hardwareConcurrency", {
+            value: 2,
+            configurable: true,
+            writable: true,
+        });
+
+        // first dispatch creates the pool (1 slot) and goes to worker 0; it replies (rejects) — catch and move on
+        await poolDecode("http://localhost/box.glb").catch(() => {});
+        await flush();
+
+        expect(workers).toHaveLength(1);
+        expect(workers[0].terminated).toBe(false);
+
+        // the worker dies — postMessage will go nowhere, like a real dead worker
+        workers[0].alive = false;
+        // the worker errors with no pending request — the defect: error is dropped, slot stays broken
+        workers[0].onerror?.(new ErrorEvent("error", { message: "died at load" }));
+
+        // second dispatch: pre-fix it hangs (the dead worker never replies); post-fix the respawned worker
+        // handles it and the promise settles. Detect a hang without a sleep: flush microtasks (bounded depth)
+        // and check the promise settled — a never-settling promise is the defect, made observable.
+        let settled = false;
+        poolDecode("http://localhost/box.glb").then(
+            () => {
+                settled = true;
+            },
+            () => {
+                settled = true;
+            },
+        );
+        await flush();
+        expect(settled).toBe(true);
+    });
+});

--- a/packages/shallot/src/extras/gltf/pool.test.ts
+++ b/packages/shallot/src/extras/gltf/pool.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { poolDecode } from "./pool";
+import { _resetPool, poolDecode } from "./pool";
 import type { DecodeReply } from "./worker";
 
 // pool.ts's transport wiring (spawn/settle/fail) — the seam scheduler.test.ts leaves to the real Chrome gym
@@ -48,9 +48,10 @@ describe("decode pool", () => {
             configurable: true,
             writable: true,
         });
+        _resetPool();
     });
 
-    test("a worker that errors outside a pending request does not leave its slot hung", async () => {
+    function installFakes(): void {
         workers = [];
         globalThis.Worker = function (this: unknown, _url: URL, _opts?: unknown) {
             const w = new FakeWorker();
@@ -63,6 +64,10 @@ describe("decode pool", () => {
             configurable: true,
             writable: true,
         });
+    }
+
+    test("a worker that errors outside a pending request does not leave its slot hung", async () => {
+        installFakes();
 
         // first dispatch creates the pool (1 slot) and goes to worker 0; it replies (rejects) — catch and move on
         await poolDecode("http://localhost/box.glb").catch(() => {});
@@ -90,5 +95,83 @@ describe("decode pool", () => {
         );
         await flush();
         expect(settled).toBe(true);
+    });
+
+    test("a worker that fires onmessageerror outside a pending request does not leave its slot hung", async () => {
+        installFakes();
+
+        // first dispatch creates the pool and settles (worker replies with failure)
+        await poolDecode("http://localhost/box.glb").catch(() => {});
+        await flush();
+
+        expect(workers).toHaveLength(1);
+
+        // the worker dies — postMessage will go nowhere
+        workers[0].alive = false;
+        // onmessageerror with no pending request — pre-fix `fail`→`settle` drops it silently (same defect as
+        // onerror); post-fix routes through `workerError` and respawns the slot.
+        workers[0].onmessageerror?.();
+
+        // second dispatch must settle — the respawned worker handles it
+        let settled = false;
+        poolDecode("http://localhost/box.glb").then(
+            () => {
+                settled = true;
+            },
+            () => {
+                settled = true;
+            },
+        );
+        await flush();
+        expect(settled).toBe(true);
+    });
+
+    test("a worker that fails on every spawn has bounded respawns and rejects after budget", async () => {
+        workers = [];
+        let spawnCount = 0;
+        globalThis.Worker = function (this: unknown, _url: URL, _opts?: unknown) {
+            const w = new FakeWorker();
+            w.alive = false; // dies at load — postMessage goes nowhere
+            workers.push(w);
+            spawnCount++;
+            // fire onerror on the next microtask (dies at load)
+            queueMicrotask(() => {
+                if (!w.terminated)
+                    w.onerror?.(new ErrorEvent("error", { message: "died at load" }));
+            });
+            return w;
+        } as unknown as typeof Worker;
+        globalThis.location = { href: "http://localhost/" } as unknown as Location;
+        Object.defineProperty(navigator, "hardwareConcurrency", {
+            value: 2,
+            configurable: true,
+            writable: true,
+        });
+
+        // first dispatch: creates pool, dispatches to worker 0. Worker 0 fires onerror (microtask); at that
+        // point _pending[0] exists → fail + respawn. Subsequent respawned workers fire onerror with no pending
+        // → respawn until budget exhausted → mark dead.
+        await poolDecode("http://localhost/box.glb").catch(() => {});
+        await flush();
+
+        // 1 initial spawn + 3 respawns (MAX_RESPAWN) = 4 total — the respawn is bounded
+        expect(spawnCount).toBe(4);
+
+        // dispatch after budget exhausted: rejects (does not hang)
+        let settled = false;
+        let rejection: unknown = null;
+        poolDecode("http://localhost/box.glb").then(
+            () => {
+                settled = true;
+            },
+            (e) => {
+                settled = true;
+                rejection = e;
+            },
+        );
+        await flush();
+        expect(settled).toBe(true);
+        expect(rejection).toBeInstanceOf(Error);
+        expect((rejection as Error).message).toContain("dead");
     });
 });

--- a/packages/shallot/src/extras/gltf/pool.ts
+++ b/packages/shallot/src/extras/gltf/pool.ts
@@ -50,7 +50,7 @@ function spawn(slot: number): Worker {
         if (reply.ok) settle(slot, (p) => p.resolve(reply.decoded));
         else fail(slot, reply.error);
     };
-    w.onerror = (e) => fail(slot, `[gltf] decode worker error: ${e.message}`);
+    w.onerror = (e) => workerError(slot, `[gltf] decode worker error: ${e.message}`);
     w.onmessageerror = () => fail(slot, "[gltf] decode worker message deserialization failed");
     return w;
 }
@@ -63,6 +63,18 @@ function settle(slot: number, f: (p: Pending) => void): void {
 
 function fail(slot: number, msg: string): void {
     settle(slot, (p) => p.reject(new Error(msg)));
+}
+
+// a worker error outside a pending request leaves the slot broken — the worker is gone but the scheduler
+// still dispatches to it, so every future decode on that slot hangs forever. Reject the in-flight request if
+// one exists (the existing path); otherwise respawn the worker so the slot stays serviceable.
+function workerError(slot: number, msg: string): void {
+    if (_pending[slot]) {
+        fail(slot, msg);
+    } else {
+        _workers[slot]?.terminate();
+        _workers[slot] = spawn(slot);
+    }
 }
 
 function dispatch(slot: number, req: DecodeRequest): Promise<DecodedGltf> {

--- a/packages/shallot/src/extras/gltf/pool.ts
+++ b/packages/shallot/src/extras/gltf/pool.ts
@@ -16,6 +16,10 @@ import type { DecodeReply, DecodeRequest } from "./worker";
 // Draco / Basis wasm, so more workers cost memory (three.js' DRACOLoader defaults a workerLimit of 4). A
 // tuning constant.
 const MAX_WORKERS = 4;
+// a worker that dies at load (a real consumer-bundler failure mode for `new Worker(new URL(...))`) respawns
+// at most this many times per slot before the slot is marked dead — a bound that replaces the silent spin of
+// unbounded worker creations with an attributable rejection on dispatch.
+const MAX_RESPAWN = 3;
 
 function poolSize(): number {
     const cores = (typeof navigator !== "undefined" && navigator.hardwareConcurrency) || 4;
@@ -32,12 +36,16 @@ interface Pending {
 
 let _workers: Worker[] = [];
 let _pending: (Pending | null)[] = [];
+let _dead: boolean[] = [];
+let _respawnCount: number[] = [];
 let _scheduler: Scheduler<DecodeRequest, DecodedGltf> | null = null;
 
 function ensurePool(): Scheduler<DecodeRequest, DecodedGltf> {
     if (_scheduler) return _scheduler;
     const n = poolSize();
     _pending = new Array(n).fill(null);
+    _dead = new Array(n).fill(false);
+    _respawnCount = new Array(n).fill(0);
     _workers = Array.from({ length: n }, (_, slot) => spawn(slot));
     _scheduler = new Scheduler<DecodeRequest, DecodedGltf>({ slots: n, run: dispatch });
     return _scheduler;
@@ -51,7 +59,8 @@ function spawn(slot: number): Worker {
         else fail(slot, reply.error);
     };
     w.onerror = (e) => workerError(slot, `[gltf] decode worker error: ${e.message}`);
-    w.onmessageerror = () => fail(slot, "[gltf] decode worker message deserialization failed");
+    w.onmessageerror = () =>
+        workerError(slot, "[gltf] decode worker message deserialization failed");
     return w;
 }
 
@@ -65,20 +74,30 @@ function fail(slot: number, msg: string): void {
     settle(slot, (p) => p.reject(new Error(msg)));
 }
 
-// a worker error outside a pending request leaves the slot broken — the worker is gone but the scheduler
-// still dispatches to it, so every future decode on that slot hangs forever. Reject the in-flight request if
-// one exists (the existing path); otherwise respawn the worker so the slot stays serviceable.
+// a worker error leaves the slot broken — the worker is gone but the scheduler still dispatches to it, so
+// every future decode on that slot hangs forever. Reject the in-flight request if one exists (the existing
+// path); then respawn the worker (bounded) so the slot stays serviceable, or mark the slot dead once the
+// respawn budget is exhausted — subsequent dispatch rejects with an attributable message instead of hanging.
 function workerError(slot: number, msg: string): void {
-    if (_pending[slot]) {
-        fail(slot, msg);
-    } else {
+    if (_pending[slot]) fail(slot, msg);
+    if (_respawnCount[slot] < MAX_RESPAWN) {
+        _respawnCount[slot]++;
         _workers[slot]?.terminate();
         _workers[slot] = spawn(slot);
+    } else {
+        _workers[slot]?.terminate();
+        _dead[slot] = true;
     }
 }
 
 function dispatch(slot: number, req: DecodeRequest): Promise<DecodedGltf> {
     return new Promise<DecodedGltf>((resolve, reject) => {
+        if (_dead[slot]) {
+            reject(
+                new Error(`[gltf] decode worker slot ${slot} is dead (respawn budget exhausted)`),
+            );
+            return;
+        }
         _pending[slot] = { resolve, reject };
         _workers[slot].postMessage(req);
     });
@@ -138,4 +157,14 @@ export function decodeInWorker(url: string, opts: { clip?: number } = {}): Promi
     const device = Compute.device;
     if (!device) throw new Error("[gltf] no GPU device — call decodeInWorker after build()");
     return poolDecode(url, { clip: opts.clip ?? 0, targets: pickTargets(device) });
+}
+
+/** @internal tear down the pool singleton — test-only, so each test starts from a fresh pool. */
+export function _resetPool(): void {
+    for (const w of _workers) w?.terminate();
+    _workers = [];
+    _pending = [];
+    _dead = [];
+    _respawnCount = [];
+    _scheduler = null;
 }


### PR DESCRIPTION
- **audit-gltf-pool-dead-worker: respawn idle slot on unattributed worker error**
- **audit-gltf-pool-dead-worker: bound respawn, rewire onmessageerror, dead-slot reject**
