### PR TITLE
audit silent zero fallback/s1

### DIFF
--- a/packages/shallot/src/standard/part/pack.test.ts
+++ b/packages/shallot/src/standard/part/pack.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { body, flat, integerDiscipline } from "../../../tests/wgsl";
 import { capacity } from "../../engine";
+import { Meshes, Surfaces } from "../render/core";
 import { packWgsl } from "./pack";
+import { PartTraits } from "./part";
 
 // The pack kernels' device-free structural seam. Real-GPU truth — survivor counts, survivor identity,
 // per-view slot offsets — is the gym `render` scenario (`bun bench --scenario render`); what's assertable
@@ -71,5 +73,73 @@ describe("folded constants", () => {
         expect(main).not.toContain("drawArgs[idx].firstIndex");
         expect(main).not.toContain("drawArgs[idx].baseVertex");
         expect(main).toContain(`slot * ${capacity}u`); // the slot's packedEids region base
+    });
+});
+
+// PartTraits.defaults resolves Surfaces.id("default") and Meshes.id("cube") at entity-creation time.
+// A miss (no SearPlugin → "default" unregistered, or PartPlugin not initialized → "cube" unregistered)
+// must be loud — warn, matching the sear module's warn+skip idiom (the batch-drop warn in atlas.ts).
+// The pre-fix `?? 0` silently bound whatever surface/mesh held registry id 0 — a plausible-wrong resource
+// invisible to every green gate. The fix warns at the call site, naming the wiring bug, while still
+// returning 0 (the same fallback value) so a valid Part-without-SearPlugin build (the conformance roster)
+// doesn't abort.
+describe("PartTraits defaults — miss is loud", () => {
+    test("defaults() warns when the default surface is unregistered (no SearPlugin)", () => {
+        const savedSurfaces = [...Surfaces.values()];
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            // "cube" must be registered (PartPlugin.initialize → initMeshes) so only the surface miss fires
+            if (Meshes.id("cube") === undefined) Meshes.register({ name: "cube" } as any);
+            Surfaces.clear();
+            const result = PartTraits.defaults();
+            // the miss is loud: a warning names the wiring bug
+            expect(warn).toHaveBeenCalled();
+            expect(warn.mock.calls.some((c) => /default/.test(c[0] as string))).toBe(true);
+            // the fallback is still 0 (same value as pre-fix, but now warned)
+            expect(result.surface).toBe(0);
+        } finally {
+            Surfaces.clear();
+            for (const s of savedSurfaces) Surfaces.register(s);
+            warn.mockRestore();
+        }
+    });
+
+    test("defaults() warns when the cube mesh is unregistered (PartPlugin not initialized)", () => {
+        const savedMeshes = [...Meshes.values()];
+        const savedSurfaces = [...Surfaces.values()];
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            // "default" must be registered so only the mesh miss fires
+            if (Surfaces.id("default") === undefined) Surfaces.register({ name: "default" } as any);
+            Meshes.clear();
+            const result = PartTraits.defaults();
+            expect(warn).toHaveBeenCalled();
+            expect(warn.mock.calls.some((c) => /cube/.test(c[0] as string))).toBe(true);
+            expect(result.mesh).toBe(0);
+        } finally {
+            Meshes.clear();
+            for (const m of savedMeshes) Meshes.register(m);
+            Surfaces.clear();
+            for (const s of savedSurfaces) Surfaces.register(s);
+            warn.mockRestore();
+        }
+    });
+
+    test("defaults() does not warn when both are registered", () => {
+        const savedSurfaces = [...Surfaces.values()];
+        const savedMeshes = [...Meshes.values()];
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            if (Surfaces.id("default") === undefined) Surfaces.register({ name: "default" } as any);
+            if (Meshes.id("cube") === undefined) Meshes.register({ name: "cube" } as any);
+            PartTraits.defaults();
+            expect(warn).not.toHaveBeenCalled();
+        } finally {
+            Surfaces.clear();
+            for (const s of savedSurfaces) Surfaces.register(s);
+            Meshes.clear();
+            for (const m of savedMeshes) Meshes.register(m);
+            warn.mockRestore();
+        }
     });
 });

--- a/packages/shallot/src/standard/part/pack.test.ts
+++ b/packages/shallot/src/standard/part/pack.test.ts
@@ -77,20 +77,47 @@ describe("folded constants", () => {
 });
 
 // PartTraits.defaults resolves Surfaces.id("default") and Meshes.id("cube") at entity-creation time.
-// A miss (no SearPlugin → "default" unregistered, or PartPlugin not initialized → "cube" unregistered)
-// must be loud — warn, matching the sear module's warn+skip idiom (the batch-drop warn in atlas.ts).
-// The pre-fix `?? 0` silently bound whatever surface/mesh held registry id 0 — a plausible-wrong resource
-// invisible to every green gate. The fix warns at the call site, naming the wiring bug, while still
-// returning 0 (the same fallback value) so a valid Part-without-SearPlugin build (the conformance roster)
-// doesn't abort.
+// The miss condition is narrowed: a warn fires only when the registry is *populated* and the named
+// default is missing (`Surfaces.size > 0 && Surfaces.id("default") === undefined`). With no SearPlugin
+// the surface registry is empty, so id 0 is inert (no sear pass marshals it) — that build is sanctioned
+// (the conformance roster), and a warn there is a false alarm. The genuine wiring bug is the ordering
+// case: surfaces are registered but "default" is absent. The fallback return is still 0 — the same value
+// the pre-fix `?? 0` produced, but now named at the call site as a wiring bug on the populated-registry
+// path instead of silently binding whatever surface/mesh holds registry id 0.
 describe("PartTraits defaults — miss is loud", () => {
-    test("defaults() warns when the default surface is unregistered (no SearPlugin)", () => {
+    test("defaults() does not warn on the sanctioned empty-registry path (no SearPlugin)", () => {
         const savedSurfaces = [...Surfaces.values()];
+        const savedMeshes = [...Meshes.values()];
         const warn = spyOn(console, "warn").mockImplementation(() => {});
         try {
-            // "cube" must be registered (PartPlugin.initialize → initMeshes) so only the surface miss fires
+            // the sanctioned build: no SearPlugin → surface registry empty, PartPlugin not initialized →
+            // mesh registry empty. Both `size === 0`, so id 0 is inert and the warn must not fire.
+            Surfaces.clear();
+            Meshes.clear();
+            const result = PartTraits.defaults();
+            expect(warn).not.toHaveBeenCalled();
+            // the fallback is still 0 (the same value the pre-fix `?? 0` produced)
+            expect(result.surface).toBe(0);
+            expect(result.mesh).toBe(0);
+        } finally {
+            Surfaces.clear();
+            for (const s of savedSurfaces) Surfaces.register(s);
+            Meshes.clear();
+            for (const m of savedMeshes) Meshes.register(m);
+            warn.mockRestore();
+        }
+    });
+
+    test("defaults() warns when the registry is populated but the default surface is missing", () => {
+        const savedSurfaces = [...Surfaces.values()];
+        const savedMeshes = [...Meshes.values()];
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            // the wiring bug: surfaces are registered (so `Surfaces.size > 0`) but "default" is absent.
+            // "cube" is registered so only the surface miss can fire.
             if (Meshes.id("cube") === undefined) Meshes.register({ name: "cube" } as any);
             Surfaces.clear();
+            Surfaces.register({ name: "other" } as any); // populated, but no "default"
             const result = PartTraits.defaults();
             // the miss is loud: a warning names the wiring bug
             expect(warn).toHaveBeenCalled();
@@ -100,18 +127,22 @@ describe("PartTraits defaults — miss is loud", () => {
         } finally {
             Surfaces.clear();
             for (const s of savedSurfaces) Surfaces.register(s);
+            Meshes.clear();
+            for (const m of savedMeshes) Meshes.register(m);
             warn.mockRestore();
         }
     });
 
-    test("defaults() warns when the cube mesh is unregistered (PartPlugin not initialized)", () => {
+    test("defaults() warns when the registry is populated but the cube mesh is missing", () => {
         const savedMeshes = [...Meshes.values()];
         const savedSurfaces = [...Surfaces.values()];
         const warn = spyOn(console, "warn").mockImplementation(() => {});
         try {
-            // "default" must be registered so only the mesh miss fires
+            // the wiring bug: meshes are registered (so `Meshes.size > 0`) but "cube" is absent.
+            // "default" is registered so only the mesh miss can fire.
             if (Surfaces.id("default") === undefined) Surfaces.register({ name: "default" } as any);
             Meshes.clear();
+            Meshes.register({ name: "other" } as any); // populated, but no "cube"
             const result = PartTraits.defaults();
             expect(warn).toHaveBeenCalled();
             expect(warn.mock.calls.some((c) => /cube/.test(c[0] as string))).toBe(true);

--- a/packages/shallot/src/standard/part/part.ts
+++ b/packages/shallot/src/standard/part/part.ts
@@ -485,7 +485,25 @@ export function warmPart(state: State): void {
 
 export const PartTraits = {
     requires: [Transform],
-    defaults: () => ({ surface: Surfaces.id("default") ?? 0, mesh: Meshes.id("cube") ?? 0 }),
+    defaults: () => {
+        // a missing "default" surface (no SearPlugin) or "cube" mesh (PartPlugin not initialized) is a
+        // wiring bug. The module's miss idiom is throw (cullGroup, above), but `defaults()` runs at scene
+        // parse time (codec.ts) where a throw would abort a valid Part-without-SearPlugin build (the
+        // conformance roster exercises exactly that). So: warn loudly (the miss is visible, not silent)
+        // and fall back to 0 — the same value the pre-fix `?? 0` produced, but now named at the call site
+        // as a wiring bug instead of silently binding whatever surface/mesh holds registry id 0.
+        const surface = Surfaces.id("default");
+        const mesh = Meshes.id("cube");
+        if (surface === undefined)
+            console.warn(
+                '[part] default surface "default" is not registered — a SearPlugin or surface owner must register it; Part entities will bind whatever surface holds registry id 0',
+            );
+        if (mesh === undefined)
+            console.warn(
+                '[part] default mesh "cube" is not registered — PartPlugin.initialize() registers it via initMeshes(); Part entities will bind whatever mesh holds registry id 0',
+            );
+        return { surface: surface ?? 0, mesh: mesh ?? 0 };
+    },
     parse: {
         surface: (value: string) => Surfaces.id(value),
         mesh: (value: string) => Meshes.id(value),

--- a/packages/shallot/src/standard/part/part.ts
+++ b/packages/shallot/src/standard/part/part.ts
@@ -486,19 +486,24 @@ export function warmPart(state: State): void {
 export const PartTraits = {
     requires: [Transform],
     defaults: () => {
-        // a missing "default" surface (no SearPlugin) or "cube" mesh (PartPlugin not initialized) is a
-        // wiring bug. The module's miss idiom is throw (cullGroup, above), but `defaults()` runs at scene
-        // parse time (codec.ts) where a throw would abort a valid Part-without-SearPlugin build (the
-        // conformance roster exercises exactly that). So: warn loudly (the miss is visible, not silent)
-        // and fall back to 0 — the same value the pre-fix `?? 0` produced, but now named at the call site
-        // as a wiring bug instead of silently binding whatever surface/mesh holds registry id 0.
+        // a missing "default" surface or "cube" mesh is a wiring bug — but only when the registry is
+        // populated. With no SearPlugin the surface registry is empty (`Surfaces.size === 0`), so id 0 is
+        // inert: there is no sear pass to marshal it to. That build is sanctioned (the conformance roster
+        // exercises exactly that — `tests/conformance.test.ts:269`, plugins `Slab/Transforms/Render/Part`,
+        // no Sear), and a warn there is a false alarm that trains the reader to ignore it. The genuine
+        // wiring bug is the ordering case: surfaces *are* registered but "default" is absent (a SearPlugin
+        // or surface owner forgot to register the default). So: warn only when the registry is populated
+        // and the named default is missing (`Surfaces.size > 0 && Surfaces.id("default") === undefined`),
+        // and likewise for `Meshes`/"cube". The fallback return is still 0 — the same value the pre-fix
+        // `?? 0` produced, but now named at the call site as a wiring bug instead of silently binding
+        // whatever surface/mesh holds registry id 0.
         const surface = Surfaces.id("default");
         const mesh = Meshes.id("cube");
-        if (surface === undefined)
+        if (Surfaces.size > 0 && surface === undefined)
             console.warn(
                 '[part] default surface "default" is not registered — a SearPlugin or surface owner must register it; Part entities will bind whatever surface holds registry id 0',
             );
-        if (mesh === undefined)
+        if (Meshes.size > 0 && mesh === undefined)
             console.warn(
                 '[part] default mesh "cube" is not registered — PartPlugin.initialize() registers it via initMeshes(); Part entities will bind whatever mesh holds registry id 0',
             );

--- a/packages/shallot/src/standard/sear/atlas.ts
+++ b/packages/shallot/src/standard/sear/atlas.ts
@@ -253,6 +253,8 @@ const _drawPairs: number[] = [];
 // from the pool. The combo camera pool (`createComboCamera`) attaches a view per combo, so a missing
 // view is a wiring bug — the camera was detached or recycled. The combo is skipped (not marshaled as
 // slot 0) so the shadow pass never binds another camera's culled set into the missing combo's tile.
+// Latched while misses persist, reset on the first clean frame — the `_batchDropWarned` idiom (above),
+// so a persistent wiring bug warns once per episode, not once per frame (a render-loop log flood).
 let _comboMissWarned = false;
 
 /**
@@ -277,9 +279,14 @@ export function comboViewSlots(combos: number[]): { slots: number[]; indices: nu
         }
     }
     if (missed > 0) {
-        console.warn(
-            `sear: ${missed} combo view(s) missing — skipping combo(s) (wiring bug: the combo camera pool should have attached a view per combo)`,
-        );
+        if (!_comboMissWarned) {
+            _comboMissWarned = true;
+            console.warn(
+                `sear: ${missed} combo view(s) missing — skipping combo(s) (wiring bug: the combo camera pool should have attached a view per combo)`,
+            );
+        }
+    } else {
+        _comboMissWarned = false;
     }
     return { slots, indices };
 }

--- a/packages/shallot/src/standard/sear/atlas.ts
+++ b/packages/shallot/src/standard/sear/atlas.ts
@@ -39,7 +39,6 @@ import {
     type PointShadowFrame,
     pointAtlasSize,
     pointCasters,
-    pointComboCount,
     pointComboEids,
     pointComboMeta,
     pointFaceVP,
@@ -249,6 +248,41 @@ let _batchDropWarned = false;
 // renders (each fills then consumes them in turn within ShadowMapSystem)
 const _comboSlots: number[] = [];
 const _drawPairs: number[] = [];
+
+// warn-once (per episode — resets once a frame has zero missing combo views) for a combo view missing
+// from the pool. The combo camera pool (`createComboCamera`) attaches a view per combo, so a missing
+// view is a wiring bug — the camera was detached or recycled. The combo is skipped (not marshaled as
+// slot 0) so the shadow pass never binds another camera's culled set into the missing combo's tile.
+let _comboMissWarned = false;
+
+/**
+ * filter combo camera eids to their view slots, skipping any whose View is missing (a wiring bug —
+ * `createComboCamera` attaches a view per combo, so a miss means the camera was detached or recycled).
+ * Returns the dense combo slots and the original combo indices of the survivors, so the caller can
+ * compact the `faceVP`/`comboMeta` arrays to match the new dense index space. Simply not pushing would
+ * shift every later combo's dense index, misaligning the atlas VS's `faceVP.m[combo]` / `comboMeta.m[combo]`
+ * lookups — the `indices` return lets the caller compact those arrays in lockstep.
+ */
+export function comboViewSlots(combos: number[]): { slots: number[]; indices: number[] } {
+    const slots: number[] = [];
+    const indices: number[] = [];
+    let missed = 0;
+    for (let c = 0; c < combos.length; c++) {
+        const view = Views.get(combos[c]);
+        if (view) {
+            slots.push(view.slot);
+            indices.push(c);
+        } else {
+            missed++;
+        }
+    }
+    if (missed > 0) {
+        console.warn(
+            `sear: ${missed} combo view(s) missing — skipping combo(s) (wiring bug: the combo camera pool should have attached a view per combo)`,
+        );
+    }
+    return { slots, indices };
+}
 
 // ---- CSM cascade atlas: the GPU half (the cascade combo cameras + fit are in ./shadows) ----
 //
@@ -612,23 +646,54 @@ export function renderPointShadows(frameDraws: { draw: Draw; r: Recorded }[]): v
         0,
         tileRects.length,
     );
-    // the combo viewProjs the VS projects by + their (caster, face) meta (dense, CPU-side in updatePointShadows)
+    // the combo viewProjs the VS projects by + their (caster, face) meta (dense, CPU-side in updatePointShadows).
+    // A missing combo view (wiring bug) is skipped — comboViewSlots returns the survivors' slots + original
+    // indices so we compact faceVP/comboMeta to the new dense index space the re-gather's combo index uses
+    const combos = pointComboEids();
+    const { slots: comboSlots, indices: comboIndices } = comboViewSlots(combos);
     const faceVP = pointFaceVP();
-    Compute.device.queue.writeBuffer(
-        _faceVP!,
-        0,
-        faceVP as Float32Array<ArrayBuffer>,
-        0,
-        faceVP.length,
-    );
     const comboMeta = pointComboMeta();
-    Compute.device.queue.writeBuffer(
-        _comboMeta!,
-        0,
-        comboMeta as Uint32Array<ArrayBuffer>,
-        0,
-        comboMeta.length,
-    );
+    if (comboIndices.length === combos.length) {
+        // no misses — upload the full arrays as before
+        Compute.device.queue.writeBuffer(
+            _faceVP!,
+            0,
+            faceVP as Float32Array<ArrayBuffer>,
+            0,
+            faceVP.length,
+        );
+        Compute.device.queue.writeBuffer(
+            _comboMeta!,
+            0,
+            comboMeta as Uint32Array<ArrayBuffer>,
+            0,
+            comboMeta.length,
+        );
+    } else {
+        // compact to the survivors' dense index space
+        const n = comboIndices.length;
+        const compactedVP = new Float32Array(n * 16);
+        const compactedMeta = new Uint32Array(n * 4);
+        for (let i = 0; i < n; i++) {
+            const src = comboIndices[i];
+            compactedVP.set(faceVP.subarray(src * 16, src * 16 + 16), i * 16);
+            compactedMeta.set(comboMeta.subarray(src * 4, src * 4 + 4), i * 4);
+        }
+        Compute.device.queue.writeBuffer(
+            _faceVP!,
+            0,
+            compactedVP as Float32Array<ArrayBuffer>,
+            0,
+            n * 16,
+        );
+        Compute.device.queue.writeBuffer(
+            _comboMeta!,
+            0,
+            compactedMeta as Uint32Array<ArrayBuffer>,
+            0,
+            n * 4,
+        );
+    }
 
     // the casting draws (a compiled point pipeline + its point bind group) sharing the Part pack's one
     // indirect buffer — read from the Draws, not Part (sear stays part-agnostic). A producer owning its own
@@ -661,7 +726,7 @@ export function renderPointShadows(frameDraws: { draw: Draw; r: Recorded }[]): v
         _batchDropWarned = false;
     }
     const D = _castDraws.length;
-    const C = pointComboCount();
+    const C = comboSlots.length;
     const packed = Compute.buffers.get("eids");
     if (D === 0 || C === 0 || !drawArgs || !packed || pairCount === 0) return;
     pointRegather.reserve(D);
@@ -669,9 +734,8 @@ export function renderPointShadows(frameDraws: { draw: Draw; r: Recorded }[]): v
     // the re-gather inputs: the view slot each dense combo culled into, and the (surface,mesh) pair each
     // casting draw owns. `Regather.run` concatenates each mesh's per-combo culled members into one run +
     // a per-instance combo index (Pass A per-mesh args → Pass B scatter), in one compute pass
-    const combos = pointComboEids();
     _comboSlots.length = 0;
-    for (let c = 0; c < C; c++) _comboSlots.push(Views.get(combos[c])?.slot ?? 0);
+    for (const s of comboSlots) _comboSlots.push(s);
     _drawPairs.length = 0;
     for (let i = 0; i < D; i++)
         _drawPairs.push(Math.floor((_castDraws[i].draw.args.offset ?? 0) / SHADOW_ARG_STRIDE));
@@ -725,32 +789,76 @@ export function renderPointShadows(frameDraws: { draw: Draw; r: Recorded }[]): v
 export function renderCascades(frameDraws: { draw: Draw; r: Recorded }[]): void {
     const encoder = Render.encoder;
     if (!encoder || !_shadowReady) return;
-    const C = cascadeCount();
-    if (C === 0) {
+    const COriginal = cascadeCount();
+    if (COriginal === 0) {
         _sun = null;
         return;
     }
     ensureCascadeAtlas();
     cascadeRegather.ensure(MAX_CASCADES);
 
-    // upload the per-cascade folded tile viewProjs + meta + rects (CPU-computed in updateCascades)
+    // filter combo (cascade) cameras to those with an attached View — a missing view is a wiring bug
+    // (the cascade pool attaches a view per cascade). The survivors' original indices compact the
+    // faceVP/comboMeta arrays to the new dense index space the re-gather's combo index uses; the rects
+    // stay at the original cascade indices (the VS reads `tileRects.rects[meta.x]` where meta.x is the
+    // original cascade index, not the dense combo index)
+    const combos = cascadeComboEids();
+    const { slots: comboSlots, indices: comboIndices } = comboViewSlots(combos);
+    const C = comboSlots.length;
+    if (C === 0) {
+        _sun = null;
+        return;
+    }
+
+    // upload the per-cascade folded tile viewProjs + meta (compacted to the survivors' dense index space)
     const vp = cascadeFaceVP();
-    Compute.device.queue.writeBuffer(_cascadeVPBuf!, 0, vp as Float32Array<ArrayBuffer>, 0, C * 16);
     const meta = cascadeMeta();
-    Compute.device.queue.writeBuffer(
-        _cascadeMetaBuf!,
-        0,
-        meta as Uint32Array<ArrayBuffer>,
-        0,
-        C * 4,
-    );
+    if (C === COriginal) {
+        Compute.device.queue.writeBuffer(
+            _cascadeVPBuf!,
+            0,
+            vp as Float32Array<ArrayBuffer>,
+            0,
+            C * 16,
+        );
+        Compute.device.queue.writeBuffer(
+            _cascadeMetaBuf!,
+            0,
+            meta as Uint32Array<ArrayBuffer>,
+            0,
+            C * 4,
+        );
+    } else {
+        const compactedVP = new Float32Array(C * 16);
+        const compactedMeta = new Uint32Array(C * 4);
+        for (let i = 0; i < C; i++) {
+            const src = comboIndices[i];
+            compactedVP.set(vp.subarray(src * 16, src * 16 + 16), i * 16);
+            compactedMeta.set(meta.subarray(src * 4, src * 4 + 4), i * 4);
+        }
+        Compute.device.queue.writeBuffer(
+            _cascadeVPBuf!,
+            0,
+            compactedVP as Float32Array<ArrayBuffer>,
+            0,
+            C * 16,
+        );
+        Compute.device.queue.writeBuffer(
+            _cascadeMetaBuf!,
+            0,
+            compactedMeta as Uint32Array<ArrayBuffer>,
+            0,
+            C * 4,
+        );
+    }
+    // the rects are indexed by the original cascade index (meta.x), not the dense combo index
     const rects = cascadeTileRects();
     Compute.device.queue.writeBuffer(
         _cascadeRectsBuf!,
         0,
         rects as Float32Array<ArrayBuffer>,
         0,
-        C * 4,
+        COriginal * 4,
     );
 
     // Group culled draws by the Part pack's slot-major source, and view-independent producer draws by
@@ -798,9 +906,8 @@ export function renderCascades(frameDraws: { draw: Draw; r: Recorded }[]): void 
     }
 
     // the re-gather inputs: the view slot each cascade culled into, the (surface,mesh) pair each casting draw owns
-    const combos = cascadeComboEids();
     _comboSlots.length = 0;
-    for (let c = 0; c < C; c++) _comboSlots.push(Views.get(combos[c])?.slot ?? 0);
+    for (const s of comboSlots) _comboSlots.push(s);
     let maxBatchDraws = 0;
     for (let b = 0; b < batchCount; b++) {
         maxBatchDraws = Math.max(maxBatchDraws, _cascadeBatches[b].draws.length);
@@ -857,7 +964,9 @@ export function renderCascades(frameDraws: { draw: Draw; r: Recorded }[]): void 
 
     // write the per-cascade SunShadow params + publish the seam: the receiver selects a cascade by view-z and
     // samples the cascade atlas (`sampleSunShadow`). One atlas pixel in uv (`texel`) is the PCF tap step; each
-    // cascade carries its own world texel size (2·cover/resolution) for the normal-offset bias
+    // cascade carries its own world texel size (2·cover/resolution) for the normal-offset bias. The params
+    // are compacted to the survivors' dense index space (the receiver's cascade index matches the compacted
+    // faceVP/comboMeta), reading the original arrays via `comboIndices`
     const recv = cascadeRecvVP();
     const tileRects = cascadeTileRects();
     const fars = cascadeFars();
@@ -865,11 +974,12 @@ export function renderCascades(frameDraws: { draw: Draw; r: Recorded }[]): void 
     const res = sunResolution();
     _paramsF32.fill(0);
     for (let i = 0; i < C; i++) {
+        const src = comboIndices[i];
         const base = i * CASCADE_FLOATS;
-        _paramsF32.set(recv.subarray(i * 16, i * 16 + 16), base + SUN_PARAMS.cascade.viewProj);
-        _paramsF32.set(tileRects.subarray(i * 4, i * 4 + 4), base + SUN_PARAMS.cascade.rect);
-        _paramsF32[base + SUN_PARAMS.cascade.far] = fars[i];
-        _paramsF32[base + SUN_PARAMS.cascade.texelWorld] = (2 * covers[i]) / res;
+        _paramsF32.set(recv.subarray(src * 16, src * 16 + 16), base + SUN_PARAMS.cascade.viewProj);
+        _paramsF32.set(tileRects.subarray(src * 4, src * 4 + 4), base + SUN_PARAMS.cascade.rect);
+        _paramsF32[base + SUN_PARAMS.cascade.far] = fars[src];
+        _paramsF32[base + SUN_PARAMS.cascade.texelWorld] = (2 * covers[src]) / res;
     }
     const bias = sunBias();
     _paramsF32[SUN_PARAMS.globals.count] = C;

--- a/packages/shallot/src/standard/sear/shadows.test.ts
+++ b/packages/shallot/src/standard/sear/shadows.test.ts
@@ -6,6 +6,7 @@ import { Camera, CameraMode, DirectionalLight, PointLight } from "../render";
 import { computeViewProj, FRUSTUM_FLOATS, frustumPlanes, Views } from "../render/core";
 import { Slab } from "../slab";
 import { Transform, TransformsPlugin } from "../transforms";
+import { comboViewSlots } from "./atlas";
 import { pointFaceOf, pointReceiver } from "./shade";
 import {
     cascadeAtlasSize,
@@ -1120,5 +1121,56 @@ describe("updatePointShadows caster selection", () => {
         expect(pointComboEids().length).toBe(0);
         for (const e of eids) expect(Views.has(e)).toBe(false);
         warn.mockRestore();
+    });
+});
+
+// comboViewSlots filters combo camera eids to their view slots, skipping any whose View is missing
+// (a wiring bug — the combo camera pool attaches a view per combo). The pre-fix `?? 0` marshaled slot 0
+// for a missing view, binding another camera's culled set into the shadow pass. The fix skips the combo
+// entirely and returns the original indices so the caller can compact faceVP/comboMeta to the new dense
+// index space — simply not pushing would shift every later combo's index, misaligning the atlas VS's
+// faceVP.m[combo] / comboMeta.m[combo] lookups.
+describe("comboViewSlots — miss skips the combo, not marshals slot 0", () => {
+    test("a missing combo view is skipped, not marshaled as slot 0", () => {
+        const saved = new Map(Views);
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            Views.clear();
+            // three combo cameras: slots 5, 6, 7
+            Views.set(100, { slot: 5 } as any);
+            Views.set(101, { slot: 6 } as any);
+            Views.set(102, { slot: 7 } as any);
+            // eid 101's view is missing (detached/recycled)
+            Views.delete(101);
+            const combos = [100, 101, 102];
+            const { slots, indices } = comboViewSlots(combos);
+            // the missing combo (101) is skipped — not marshaled as slot 0
+            expect(slots).not.toContain(0);
+            expect(slots).toEqual([5, 7]);
+            expect(indices).toEqual([0, 2]);
+            expect(warn).toHaveBeenCalledTimes(1);
+        } finally {
+            Views.clear();
+            for (const [k, v] of saved) Views.set(k, v);
+            warn.mockRestore();
+        }
+    });
+
+    test("all-valid combos pass through unchanged", () => {
+        const saved = new Map(Views);
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            Views.clear();
+            Views.set(200, { slot: 3 } as any);
+            Views.set(201, { slot: 4 } as any);
+            const { slots, indices } = comboViewSlots([200, 201]);
+            expect(slots).toEqual([3, 4]);
+            expect(indices).toEqual([0, 1]);
+            expect(warn).not.toHaveBeenCalled();
+        } finally {
+            Views.clear();
+            for (const [k, v] of saved) Views.set(k, v);
+            warn.mockRestore();
+        }
     });
 });


### PR DESCRIPTION
- **audit-silent-zero-fallback: s1**
- **audit-silent-zero-fallback: s1 correction — narrow part warn, wire atlas combo-miss flag**
