### PR TITLE
shallot mobile controls/s3

### DIFF
--- a/packages/shallot/src/extras/orbit/index.ts
+++ b/packages/shallot/src/extras/orbit/index.ts
@@ -38,7 +38,8 @@ export const OrbitMode = { Free: 0, Locked: 1 } as const;
 export const OrbitPick: { claim?: (x: number, y: number) => boolean } = {};
 
 /**
- * orbit camera controls: drag to rotate around a target, scroll to zoom
+ * orbit camera controls: drag to rotate around a target, scroll to zoom;
+ * on touch, one finger rotates, two-finger pinch zooms, two-finger drag pans
  */
 export const Orbit = {
     /** horizontal orbit angle around the target, radians */

--- a/packages/shallot/src/extras/orbit/index.ts
+++ b/packages/shallot/src/extras/orbit/index.ts
@@ -167,9 +167,21 @@ const OrbitSystem: System = {
             const hasCamera = state.has(eid, Camera);
             const isOrtho = hasCamera && Camera.mode.get(eid) === CameraMode.Orthographic;
             const locked = Orbit.mode.get(eid) === OrbitMode.Locked;
-            const orbitHeld = isButton(input.mouse, Orbit.orbitButton.get(eid));
-            const panHeld = isButton(input.mouse, Orbit.panButton.get(eid));
-            const flyHeld = isButton(input.mouse, Orbit.flyButton.get(eid));
+            const touchCount = input.touch.count;
+            // touch overrides the mouse-button read entirely rather than adding to it, while any finger
+            // is down: the first finger's continued capture keeps `mouse.left` synthesized true for the
+            // whole gesture (the old incidental path), so reading it during a two-finger pinch/pan would
+            // orbit alongside the intended gesture. Gesture count alone decides the mode instead — one
+            // finger rotates, two-plus pan, matching three.js OrbitControls' / Babylon's touch map. Fly
+            // has no touch equivalent (out of scope), so any touch keeps it held-off.
+            const orbitHeld =
+                touchCount > 0
+                    ? touchCount === 1
+                    : isButton(input.mouse, Orbit.orbitButton.get(eid));
+            const panHeld =
+                touchCount > 0 ? touchCount >= 2 : isButton(input.mouse, Orbit.panButton.get(eid));
+            const flyHeld =
+                touchCount > 0 ? false : isButton(input.mouse, Orbit.flyButton.get(eid));
             // the held button picks the mode; fly engages only while the fly button is held (hold-to-fly, the
             // Unity/UE scene-view idiom), and orbit/pan win over it. bare WASD/QE never fly, so a gameplay
             // scene owns the movement keys by default — the camera only takes them while fly is held.
@@ -216,33 +228,45 @@ const OrbitSystem: System = {
                           Math.tan((hasCamera ? Camera.fov.get(eid) : 60) * Deg2Rad * 0.5)) /
                       input.mouse.canvasHeight;
 
-                const dx = input.mouse.deltaX * worldPerPixel;
-                const dy = input.mouse.deltaY * worldPerPixel;
+                // two-finger centroid drag while touching; single-pointer capture delta otherwise —
+                // `Touch.deltaX/deltaY` is only ever populated at two fingers (input/index.ts), so this
+                // never reads a stale value.
+                const dragX = touchCount > 0 ? input.touch.deltaX : input.mouse.deltaX;
+                const dragY = touchCount > 0 ? input.touch.deltaY : input.mouse.deltaY;
+                const dx = dragX * worldPerPixel;
+                const dy = dragY * worldPerPixel;
                 panX += dy * upX - dx * rightX;
                 panY += dy * upY;
                 panZ += dy * upZ - dx * rightZ;
             }
 
-            if (input.mouse.scroll !== 0) {
+            // pinch shares the wheel's geometric zoom step (same distanceScale/sizeScale/zoomSpeed), just
+            // negated: `mouse.scroll`'s own JSDoc states positive = zoom out/away, while `touch.pinchDelta`
+            // spreading positive means zoom in — so a spread pinch subtracts. The two never fire together
+            // (pinch needs two fingers down, which zeroes orbitHeld/panHeld's fly gate but not this read),
+            // so combining them into one input is just addition, not a priority choice.
+            const pinch = touchCount > 0 ? input.touch.pinchDelta : 0;
+            const zoomInput = input.mouse.scroll - pinch;
+            if (zoomInput !== 0) {
                 if (flying) {
                     // flying drives Transform directly, so the orbit distance is invisible — scroll
                     // retargets to fly speed, multiplicative like Unity's scene-view accelerator.
                     flySpd = clamp(
-                        flySpd * Math.exp(-input.mouse.scroll * FlyScrollRate),
+                        flySpd * Math.exp(-zoomInput * FlyScrollRate),
                         Orbit.flyMin.get(eid),
                         Orbit.flyMax.get(eid),
                     );
                 } else if (isOrtho) {
                     const sizeScale = Math.max(0.1, sizeO * 0.08);
                     sizeO = clamp(
-                        sizeO + input.mouse.scroll * zoomSpeed * sizeScale,
+                        sizeO + zoomInput * zoomSpeed * sizeScale,
                         Orbit.minSize.get(eid),
                         Orbit.maxSize.get(eid),
                     );
                 } else {
                     const distanceScale = Math.max(0.3, distO * 0.08);
                     distO = clamp(
-                        distO + input.mouse.scroll * zoomSpeed * distanceScale,
+                        distO + zoomInput * zoomSpeed * distanceScale,
                         Orbit.minDistance.get(eid),
                         Orbit.maxDistance.get(eid),
                     );

--- a/packages/shallot/src/extras/orbit/orbit.test.ts
+++ b/packages/shallot/src/extras/orbit/orbit.test.ts
@@ -524,3 +524,160 @@ describe("OrbitSystem contextual claim (left-click partition)", () => {
         expect(Orbit.yaw.get(cam)).not.toBeCloseTo(yaw0, 6);
     });
 });
+
+// Touch gestures (three.js OrbitControls' / Babylon ArcRotateCameraPointersInput's touch map): one
+// finger rotates, a two-finger drag pans, a two-finger pinch zooms. Touch overrides the mouse-button
+// read while any finger is down rather than adding to it — the first finger's continued capture
+// synthesizes `mouse.left` true for the whole gesture (`standard/input`'s pointer-capture path), so
+// reading that bit during a two-finger pinch/pan would incidentally orbit alongside the intended
+// gesture. `OrbitPick.claim` suppression must survive on the one-finger (rotate) path too, since a
+// road's handle-drag claim doesn't know whether the press came from a mouse or a finger. Driven
+// through the real InputPlugin handlers with synthetic touch PointerEvents (`input.test.ts`'s pattern).
+describe("OrbitSystem touch gestures", () => {
+    let state: State;
+    let canvas: HTMLCanvasElement;
+    let windowTracker: ListenerTracker;
+    let savedWindow: typeof globalThis.window;
+    let savedDocument: typeof globalThis.document;
+
+    // a real (non-zero) rect: unlike the rotate-only suites above, pan and pinch project a screen-space
+    // delta into world units via `canvasHeight` (`worldPerPixel`), so a zero-rect stub would divide by
+    // zero here.
+    function mockSizedCanvas(width: number, height: number): HTMLCanvasElement {
+        const tracker = new ListenerTracker();
+        return {
+            addEventListener: tracker.addEventListener,
+            removeEventListener: tracker.removeEventListener,
+            setPointerCapture() {},
+            releasePointerCapture() {},
+            hasPointerCapture: () => false,
+            getBoundingClientRect: () => ({ left: 0, top: 0, width, height }) as DOMRect,
+            style: {} as CSSStyleDeclaration,
+            tracker,
+        } as unknown as HTMLCanvasElement;
+    }
+
+    beforeEach(() => {
+        clear();
+        windowTracker = new ListenerTracker();
+        (windowTracker as unknown as { focus: () => void }).focus = () => {};
+        savedWindow = globalThis.window;
+        savedDocument = globalThis.document;
+        globalThis.window = windowTracker as unknown as typeof window;
+        canvas = mockSizedCanvas(800, 600);
+        globalThis.document = {
+            pointerLockElement: null,
+            querySelectorAll: (sel: string) => (sel === "canvas" ? [canvas] : []),
+        } as unknown as typeof document;
+
+        state = new State();
+        register("Transform", Transform, TransformsPlugin.traits?.Transform);
+        register("Orbit", Orbit, OrbitPlugin.traits?.Orbit);
+        for (const [n, c] of Object.entries(InputPlugin.components ?? {}))
+            register(n, c, InputPlugin.traits?.[n]);
+        Slab.collect();
+        attach(state, InputPlugin);
+        attach(state, OrbitPlugin);
+        state.step(1 / 60); // InputSystem.setup binds the DOM handlers on its first run
+    });
+
+    afterEach(() => {
+        OrbitPick.claim = undefined;
+        state.dispose();
+        globalThis.window = savedWindow;
+        globalThis.document = savedDocument;
+    });
+
+    const onWindow = (type: string): Fn => windowTracker.added.find(([t]) => t === type)![1];
+    const onCanvas = (type: string): Fn =>
+        (canvas as unknown as { tracker: ListenerTracker }).tracker.added.find(
+            ([t]) => t === type,
+        )![1];
+
+    const touchDown = (pointerId: number, clientX: number, clientY: number): void => {
+        onCanvas("pointerdown")({
+            target: canvas,
+            pointerId,
+            pointerType: "touch",
+            button: 0,
+            buttons: 1,
+            clientX,
+            clientY,
+            preventDefault() {},
+        });
+    };
+
+    const touchMove = (pointerId: number, clientX: number, clientY: number): void => {
+        onWindow("pointermove")({
+            pointerId,
+            pointerType: "touch",
+            buttons: 1,
+            clientX,
+            clientY,
+            preventDefault() {},
+        });
+    };
+
+    const makeCam = (): number => {
+        const cam = state.create();
+        state.add(cam, Transform);
+        state.add(cam, Orbit); // default distance 10, yaw Math.PI/6
+        state.step(1 / 60); // pose once
+        return cam;
+    };
+
+    test("a one-finger drag rotates — yaw changes", () => {
+        const cam = makeCam();
+        const yaw0 = Orbit.yaw.get(cam);
+
+        touchDown(1, 0, 0);
+        touchMove(1, 40, 0);
+        state.step(1 / 60);
+
+        expect(Orbit.yaw.get(cam)).not.toBeCloseTo(yaw0, 6);
+    });
+
+    test("a two-finger drag pans — yaw stays put, pan changes", () => {
+        const cam = makeCam();
+        const yaw0 = Orbit.yaw.get(cam);
+        const pan0X = Orbit.pan.x.get(cam);
+
+        touchDown(1, 100, 100);
+        touchDown(2, 200, 100); // initial centroid (150, 100), distance 100
+
+        touchMove(1, 130, 100);
+        touchMove(2, 230, 100); // centroid → (180, 100), distance unchanged: a pure pan, no pinch
+
+        state.step(1 / 60);
+
+        expect(Orbit.yaw.get(cam)).toBeCloseTo(yaw0, 6); // two fingers never orbit
+        expect(Orbit.pan.x.get(cam)).not.toBeCloseTo(pan0X, 6);
+    });
+
+    test("a two-finger pinch zooms — spreading fingers decreases distance", () => {
+        const cam = makeCam();
+        const dist0 = Orbit.distance.get(cam);
+
+        touchDown(1, 100, 100);
+        touchDown(2, 200, 100); // initial distance 100
+
+        touchMove(1, 80, 100);
+        touchMove(2, 220, 100); // distance → 140: a spread pinch, zoom in
+
+        state.step(1 / 60);
+
+        expect(Orbit.distance.get(cam)).toBeLessThan(dist0);
+    });
+
+    test("a claimed one-finger drag never orbits — the pick claim latches on touch too", () => {
+        const cam = makeCam();
+        const yaw0 = Orbit.yaw.get(cam);
+        OrbitPick.claim = () => true;
+
+        touchDown(1, 0, 0);
+        touchMove(1, 40, 0);
+        state.step(1 / 60);
+
+        expect(Orbit.yaw.get(cam)).toBeCloseTo(yaw0, 6);
+    });
+});

--- a/packages/shallot/src/extras/orbit/orbit.test.ts
+++ b/packages/shallot/src/extras/orbit/orbit.test.ts
@@ -618,6 +618,16 @@ describe("OrbitSystem touch gestures", () => {
         });
     };
 
+    const touchUp = (pointerId: number): void => {
+        onWindow("pointerup")({
+            pointerId,
+            pointerType: "touch",
+            button: 0,
+            buttons: 0,
+            preventDefault() {},
+        });
+    };
+
     const makeCam = (): number => {
         const cam = state.create();
         state.add(cam, Transform);
@@ -651,7 +661,10 @@ describe("OrbitSystem touch gestures", () => {
         state.step(1 / 60);
 
         expect(Orbit.yaw.get(cam)).toBeCloseTo(yaw0, 6); // two fingers never orbit
-        expect(Orbit.pan.x.get(cam)).not.toBeCloseTo(pan0X, 6);
+        // direction, not just magnitude: at the default yaw (30°) a rightward centroid drag projects
+        // onto -rightX, so panX goes negative — the same sign a mouse pan produces for a rightward drag
+        // at this pose (worldPerPixel * dragX * -cos(yawS)).
+        expect(Orbit.pan.x.get(cam)).toBeLessThan(pan0X);
     });
 
     test("a two-finger pinch zooms — spreading fingers decreases distance", () => {
@@ -679,5 +692,36 @@ describe("OrbitSystem touch gestures", () => {
         state.step(1 / 60);
 
         expect(Orbit.yaw.get(cam)).toBeCloseTo(yaw0, 6);
+    });
+
+    // RED-FIRST WITNESS: `standard/input`'s `activePointerId` capture is never reassigned to an
+    // already-down second finger, so lifting the FIRST (capturing) finger of a two-finger gesture left
+    // the survivor's moves hitting `pointerMove`'s `e.pointerId !== activePointerId` early return —
+    // rotation froze for the rest of the touch sequence even though `Inputs.touch.count` (1) reads as a
+    // live single-finger drag. Fixed by `standard/input`'s `recaptureTouch`.
+    test("ending a two-finger gesture by lifting the first finger keeps rotating from the survivor", () => {
+        const cam = makeCam();
+        const yaw0 = Orbit.yaw.get(cam);
+
+        touchDown(1, 100, 100); // captures first
+        touchDown(2, 200, 100); // joins the touch cache, never captures
+
+        touchUp(1); // the capturing finger lifts; pointer 2 is still down
+        state.step(1 / 60); // touchCount is now 1 — orbitHeld reads true, but nothing has moved yet
+
+        const yawAfterLift = Orbit.yaw.get(cam);
+        expect(yawAfterLift).toBeCloseTo(yaw0, 6); // the hand-off itself produces no rotation
+
+        touchMove(2, 230, 100); // survivor's own +30px move from its cached (200, 100)
+        state.step(1 / 60);
+
+        expect(Orbit.yaw.get(cam)).not.toBeCloseTo(yawAfterLift, 6); // rotation did not freeze
+
+        // magnitude, not just direction: Δyaw must be the survivor's own +30px move at the default
+        // sensitivity (0.005), never a jump across the two fingers' initial 100px gap (which would
+        // read Δyaw ≈ -0.5 instead of -0.15) — proves `lastPointerX/Y` was seeded from the survivor's
+        // own cached position, not the departed pointer's.
+        const dYaw = Orbit.yaw.get(cam) - yawAfterLift;
+        expect(dYaw).toBeCloseTo(-30 * 0.005, 4);
     });
 });

--- a/packages/shallot/src/standard/input/index.ts
+++ b/packages/shallot/src/standard/input/index.ts
@@ -281,6 +281,26 @@ function releaseCapture(s: InputState): void {
     s.lastPointerY = 0;
 }
 
+// re-captures the active pointer to a remaining touch finger when the one currently captured lifts
+// (or cancels) but others are still held — `pointerMove` only writes `mouse.deltaX/Y` and `mouse.x/y`
+// while `e.pointerId === activePointerId` (below), and `pointerDown` never reassigns capture to an
+// already-down second finger, so without this a still-held survivor's moves would early-return and
+// every Mouse-reading consumer (drag rotate, a claimed cursor) would freeze for the rest of the touch
+// sequence. Seeds `lastPointerX/Y` from the survivor's own cached position (not the departing
+// pointer's) so its first post-transition move reports its own delta, not a jump across the two
+// fingers' gap.
+function recaptureTouch(s: InputState, canvas: HTMLCanvasElement): void {
+    const [nextId, pos] = [...s.touchPoints.entries()][0];
+    s.activePointerId = nextId;
+    s.activeButton = 0;
+    s.activeCanvas = canvas;
+    s.lastPointerX = pos.x;
+    s.lastPointerY = pos.y;
+    try {
+        canvas.setPointerCapture(nextId);
+    } catch {}
+}
+
 function createHandlers(s: InputState): void {
     s.pointerHover = (e: PointerEvent) => {
         const target = e.target as HTMLCanvasElement;
@@ -363,7 +383,8 @@ function createHandlers(s: InputState): void {
     };
 
     s.pointerUp = (e: PointerEvent) => {
-        if (s.touchPoints.delete(e.pointerId)) {
+        const wasTouch = s.touchPoints.delete(e.pointerId);
+        if (wasTouch) {
             s.touch.count = s.touchPoints.size;
             updatePinchBaseline(s);
         }
@@ -375,21 +396,34 @@ function createHandlers(s: InputState): void {
             // release only a capture actually held — pointerDown's capture is
             // best-effort (a synthetic pointer can't be captured), and releasing
             // an unheld pointer throws NotFoundError.
-            if (s.activeCanvas?.hasPointerCapture(e.pointerId)) {
-                s.activeCanvas.releasePointerCapture(e.pointerId);
+            const canvas = s.activeCanvas;
+            if (canvas?.hasPointerCapture(e.pointerId)) {
+                canvas.releasePointerCapture(e.pointerId);
             }
-            releaseCapture(s);
+            // a still-held second finger keeps the gesture alive — hand capture to it rather than
+            // dropping to no active pointer, or its moves would freeze Mouse for the rest of the touch.
+            if (wasTouch && canvas && s.touchPoints.size > 0) {
+                recaptureTouch(s, canvas);
+            } else {
+                releaseCapture(s);
+            }
         }
     };
 
     s.pointerCancel = (e: PointerEvent) => {
-        if (s.touchPoints.delete(e.pointerId)) {
+        const wasTouch = s.touchPoints.delete(e.pointerId);
+        if (wasTouch) {
             s.touch.count = s.touchPoints.size;
             updatePinchBaseline(s);
         }
         if (e.pointerId !== s.activePointerId) return;
         clearAllButtons(s.mouse);
-        releaseCapture(s);
+        const canvas = s.activeCanvas;
+        if (wasTouch && canvas && s.touchPoints.size > 0) {
+            recaptureTouch(s, canvas);
+        } else {
+            releaseCapture(s);
+        }
     };
 
     s.pointerMove = (e: PointerEvent) => {

--- a/packages/shallot/src/standard/input/input.test.ts
+++ b/packages/shallot/src/standard/input/input.test.ts
@@ -624,6 +624,62 @@ describe("InputPlugin", () => {
         expect(Inputs.touch.pinchDelta).toBe(5);
     });
 
+    // RED-FIRST WITNESS: `pointerDown` never reassigns `activePointerId` to an already-down second
+    // finger, and it was only ever cleared (never re-seeded) on the captured pointer's up/cancel. So
+    // lifting the FIRST finger of a two-finger gesture left `activePointerId` null (or the departed
+    // id) for the rest of the sequence — the survivor's moves hit `pointerMove`'s
+    // `e.pointerId !== s.activePointerId` early return and `Mouse.deltaX/Y`/`x`/`y` froze until the
+    // whole gesture ended, silently, since `Inputs.touch.count` (1) still read as a live single-finger
+    // drag. The fix re-captures to a remaining touch pointer on up/cancel.
+    test("lifting the capturing finger re-captures to the surviving finger — Mouse tracking doesn't freeze", () => {
+        onCanvas("pointerdown")({
+            target: canvas,
+            pointerId: 1,
+            pointerType: "touch",
+            button: 0,
+            buttons: 1,
+            clientX: 100,
+            clientY: 100,
+            preventDefault() {},
+        }); // pointer 1 captures (first down)
+        onCanvas("pointerdown")({
+            target: canvas,
+            pointerId: 2,
+            pointerType: "touch",
+            button: 0,
+            buttons: 1,
+            clientX: 200,
+            clientY: 100,
+            preventDefault() {},
+        }); // pointer 2 joins the touch cache but never captures
+
+        onWindow("pointerup")({
+            pointerId: 1,
+            pointerType: "touch",
+            button: 0,
+            buttons: 0,
+            preventDefault() {},
+        }); // the capturing finger lifts — pointer 2 is still down
+        expect(Inputs.touch.count).toBe(1);
+
+        onWindow("pointermove")({
+            pointerId: 2,
+            pointerType: "touch",
+            buttons: 1,
+            clientX: 230,
+            clientY: 100,
+            preventDefault() {},
+        }); // survivor moves +30 from its own (200, 100) — not from pointer 1's old (100, 100)
+
+        // without the fix this reads 0 (frozen): pointer 2 was never the captured pointer, so its
+        // move hit the early return
+        expect(Inputs.mouse.deltaX).toBe(30);
+        // seeded from pointer 2's own cached position, not the departed pointer 1's — so the first
+        // post-transition move reports its own +30 shift, never the 100px gap between the two fingers
+        expect(Inputs.mouse.deltaX).not.toBe(130);
+        expect(Inputs.mouse.x).toBe(230);
+    });
+
     test("setInputEnabled(false) neutralizes touch reads and clears the cache", () => {
         onCanvas("pointerdown")({
             target: canvas,


### PR DESCRIPTION
- **shallot-mobile-controls: orbit consumes touch gestures (pinch zoom, two-finger pan, one-finger rotate)**
- **shallot-mobile-controls: re-capture active pointer to a surviving finger on touch lift; directional pan assertion**
- **shallot-mobile-controls: note touch gestures in Orbit JSDoc**
