### PR TITLE
audit gate roster coverage/s1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ Thumbs.db
 # Debug/testing artifacts
 .debug/
 
+# format-gate test fixtures — must live under repo root because format.ts anchors its
+# scan on import.meta.dir/..; relocating to tmpdir() would break the anchor proof.
+/_format-gate-fixtures/
+
 # AVBD fixtures (regenerable via packages/shallot/tests/avbd/gen-fixtures.ts)
 packages/shallot/tests/fixtures/avbd/
 

--- a/packages/shallot/tests/format-gate.test.ts
+++ b/packages/shallot/tests/format-gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 // Arm for `scripts/format.ts`'s report-only mode — the mechanism that lets `check`
@@ -10,13 +10,20 @@ import { join, resolve } from "node:path";
 
 const SCRIPT = join(import.meta.dir, "../../../scripts/format.ts");
 const REPO_ROOT = resolve(import.meta.dir, "../../..");
+// Fixtures live under the gitignored `_format-gate-fixtures/` dir (see .gitignore) so a
+// process-level kill (SIGTERM from the per-file test cap) that bypasses `finally` cleanup
+// cannot leave untracked dirs in the tracked tree. The dir is non-dot and directly under
+// the repo root, so the glob scanner finds the fixtures and the import.meta.dir anchor
+// proof stays real.
+const FIXTURE_ROOT = join(REPO_ROOT, "_format-gate-fixtures");
+mkdirSync(FIXTURE_ROOT, { recursive: true });
 
 // A .scene that normalization would change: no trailing newline. The script does
 // `stringify(nodes) + "\n"`, so any scene missing the final newline is in the would-change set.
 const UNFORMATTED_SCENE = "<scene>\n    <a part />\n</scene>";
 
 function fixtureScene(): { dir: string; scenePath: string } {
-    const dir = mkdtempSync(join(REPO_ROOT, "_format-gate-tmp-"));
+    const dir = mkdtempSync(join(FIXTURE_ROOT, "_format-gate-tmp-"));
     const scenePath = join(dir, "test.scene");
     writeFileSync(scenePath, UNFORMATTED_SCENE);
     return { dir, scenePath };
@@ -91,11 +98,11 @@ describe("format.ts report-only mode — Validation 2: gates and still writes", 
 
 describe("format.ts ignore matching — segment, not substring", () => {
     // Mutation witness: reverting segment matching to path.includes(dir) makes this test fail —
-    // "distortion-xxx/test.scene".includes("dist") is true, so the file is silently skipped and
+    // "_format-gate-fixtures/distortion-xxx/test.scene".includes("dist") is true, so the file is silently skipped and
     // --check exits 0 (green) despite unformatted content. The segment match (split on "/")
     // correctly distinguishes "distortion-xxx" from "dist".
     test("a dist-substring directory (distortion/) is not skipped by the dist ignore entry", () => {
-        const dir = mkdtempSync(join(REPO_ROOT, "distortion-"));
+        const dir = mkdtempSync(join(FIXTURE_ROOT, "distortion-"));
         const scenePath = join(dir, "test.scene");
         writeFileSync(scenePath, UNFORMATTED_SCENE);
         try {

--- a/packages/shallot/tests/format-gate.test.ts
+++ b/packages/shallot/tests/format-gate.test.ts
@@ -1,30 +1,32 @@
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 // Arm for `scripts/format.ts`'s report-only mode — the mechanism that lets `check`
 // stop writing the tree it judges (spec: shallot-gate-never-writes, Validation 1 & 2).
-// `scripts/format.ts` scans `process.cwd()` for `**/*.scene`, so each test points the
-// subprocess at an OS-tmpdir fixture tree (never a tracked file). The script's own
-// imports resolve relative to the script file, not cwd, so the engine loads regardless.
+// `scripts/format.ts` scans from `import.meta.dir/..` (the repo root) for `**/*.scene`,
+// so each test creates a temp fixture tree under the repo root (never a tracked file).
+// The script's own imports resolve relative to the script file, not cwd, so the engine loads regardless.
 
 const SCRIPT = join(import.meta.dir, "../../../scripts/format.ts");
+const REPO_ROOT = resolve(import.meta.dir, "../../..");
 
 // A .scene that normalization would change: no trailing newline. The script does
 // `stringify(nodes) + "\n"`, so any scene missing the final newline is in the would-change set.
 const UNFORMATTED_SCENE = "<scene>\n    <a part />\n</scene>";
 
 function fixtureScene(): { dir: string; scenePath: string } {
-    const dir = mkdtempSync(join(tmpdir(), "format-gate-"));
+    const dir = mkdtempSync(join(REPO_ROOT, "_format-gate-tmp-"));
     const scenePath = join(dir, "test.scene");
     writeFileSync(scenePath, UNFORMATTED_SCENE);
     return { dir, scenePath };
 }
 
-function runFormat(args: string[], cwd: string) {
+function runFormat(args: string[]) {
+    // run from a subdirectory so the test proves the import.meta.dir anchor —
+    // with the old process.cwd() scan, the fixture under REPO_ROOT would not be found
     return Bun.spawnSync(["bun", SCRIPT, ...args], {
-        cwd,
+        cwd: join(REPO_ROOT, "scripts"),
         stdout: "pipe",
         stderr: "pipe",
     });
@@ -35,7 +37,7 @@ describe("format.ts report-only mode — Validation 1: check does not write", ()
         const { dir, scenePath } = fixtureScene();
         try {
             const before = readFileSync(scenePath, "utf-8");
-            runFormat(["--check"], dir);
+            runFormat(["--check"]);
             const after = readFileSync(scenePath, "utf-8");
             expect(after).toBe(before);
         } finally {
@@ -47,10 +49,10 @@ describe("format.ts report-only mode — Validation 1: check does not write", ()
         const { dir, scenePath } = fixtureScene();
         try {
             // normalize first via write mode
-            runFormat([], dir);
+            runFormat([]);
             const normalized = readFileSync(scenePath, "utf-8");
 
-            const proc = runFormat(["--check"], dir);
+            const proc = runFormat(["--check"]);
             expect(proc.exitCode).toBe(0);
             expect(readFileSync(scenePath, "utf-8")).toBe(normalized);
         } finally {
@@ -60,10 +62,13 @@ describe("format.ts report-only mode — Validation 1: check does not write", ()
 });
 
 describe("format.ts report-only mode — Validation 2: gates and still writes", () => {
+    // Mutation witness: reverting the import.meta.dir anchor to process.cwd() makes both tests
+    // below fail — the subprocess runs from REPO_ROOT/scripts, so process.cwd() no longer reaches
+    // the fixture under REPO_ROOT, and --check exits 0 (vacuously green) despite unformatted content.
     test("--check reds (exits nonzero) on a fixture normalization would change", () => {
         const { dir } = fixtureScene();
         try {
-            const proc = runFormat(["--check"], dir);
+            const proc = runFormat(["--check"]);
             expect(proc.exitCode).not.toBe(0);
         } finally {
             rmSync(dir, { recursive: true, force: true });
@@ -74,10 +79,32 @@ describe("format.ts report-only mode — Validation 2: gates and still writes", 
         const { dir, scenePath } = fixtureScene();
         try {
             const before = readFileSync(scenePath, "utf-8");
-            const proc = runFormat([], dir);
+            const proc = runFormat([]);
             expect(proc.exitCode).toBe(0);
             const after = readFileSync(scenePath, "utf-8");
             expect(after).not.toBe(before);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("format.ts ignore matching — segment, not substring", () => {
+    // Mutation witness: reverting segment matching to path.includes(dir) makes this test fail —
+    // "distortion-xxx/test.scene".includes("dist") is true, so the file is silently skipped and
+    // --check exits 0 (green) despite unformatted content. The segment match (split on "/")
+    // correctly distinguishes "distortion-xxx" from "dist".
+    test("a dist-substring directory (distortion/) is not skipped by the dist ignore entry", () => {
+        const dir = mkdtempSync(join(REPO_ROOT, "distortion-"));
+        const scenePath = join(dir, "test.scene");
+        writeFileSync(scenePath, UNFORMATTED_SCENE);
+        try {
+            const proc = runFormat(["--check"]);
+            const out = proc.stdout.toString() + proc.stderr.toString();
+            // the fixture path must appear in the would-change output — it was not skipped
+            const relPath = scenePath.slice(REPO_ROOT.length + 1);
+            expect(out).toContain(relPath);
+            expect(proc.exitCode).not.toBe(0);
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }

--- a/scripts/format.ts
+++ b/scripts/format.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import { Glob } from "bun";
 import { setupGlobals } from "bun-webgpu";
 import type { Node } from "../packages/shallot/src";
@@ -60,11 +61,18 @@ let wouldChange = 0;
 let unchanged = 0;
 let errors = 0;
 
-for await (const path of glob.scan({ cwd: process.cwd() })) {
-    if (ignore.some((dir) => path.includes(dir))) continue;
+// anchor on the script location, not process.cwd(), so --check is not vacuously green
+// when run from a subdirectory (siblings use import.meta.dir for the same reason)
+const root = resolve(import.meta.dir, "..");
+
+for await (const path of glob.scan({ cwd: root })) {
+    // segment match so an ignore entry "dist" does not also match "distortion/"
+    const segments = path.split("/");
+    if (ignore.some((dir) => segments.includes(dir))) continue;
 
     try {
-        const content = await Bun.file(path).text();
+        const fullPath = resolve(root, path);
+        const content = await Bun.file(fullPath).text();
         const nodes = parse(content);
         normalizeNodes(nodes);
         const output = stringify(nodes) + "\n";
@@ -74,7 +82,7 @@ for await (const path of glob.scan({ cwd: process.cwd() })) {
                 console.log(`would format: ${path}`);
                 wouldChange++;
             } else {
-                await Bun.write(path, output);
+                await Bun.write(fullPath, output);
                 console.log(`formatted: ${path}`);
                 formatted++;
             }


### PR DESCRIPTION
- **audit-gate-roster-coverage: s1 — anchor format.ts on import.meta.dir, segment-match ignore**
- **audit-gate-roster-coverage: s1 — update format-gate test for import.meta.dir anchor + segment ignore**
- **audit-gate-roster-coverage: s1 — relocate format-gate fixtures under gitignored _format-gate-fixtures/**
