### PR TITLE
audit input suspend edge semantics/s1

### DIFF
--- a/packages/shallot/src/standard/input/index.ts
+++ b/packages/shallot/src/standard/input/index.ts
@@ -18,7 +18,7 @@ export interface Mouse {
     right: boolean;
     /** middle button held */
     middle: boolean;
-    /** pointer is over a bound canvas */
+    /** pointer is over a bound canvas, or a drag is active (hover holds true for the whole drag) */
     hover: boolean;
     /** pointer x within the focused canvas, CSS pixels from the left edge */
     x: number;
@@ -111,7 +111,7 @@ export const Inputs: Inputs = {
         return enabled ? (inputState?.touch ?? DEFAULT_TOUCH) : DEFAULT_TOUCH;
     },
     get focused(): number {
-        return inputState?.focused ?? -1;
+        return enabled ? (inputState?.focused ?? -1) : -1;
     },
     isKeyDown(code: string): boolean {
         return enabled ? (inputState?.keys.has(code) ?? false) : false;
@@ -146,6 +146,7 @@ export function setInputEnabled(on: boolean): void {
         inputState.keys.clear();
         inputState.keysPressed.clear();
         inputState.keysReleased.clear();
+        inputState.keyPressedAt.clear();
         clearAllButtons(inputState.mouse);
         inputState.mouse.deltaX = 0;
         inputState.mouse.deltaY = 0;
@@ -333,6 +334,9 @@ function createHandlers(s: InputState): void {
     };
 
     s.keyUp = (e: KeyboardEvent) => {
+        if (!enabled) return;
+        const locked = document.pointerLockElement as HTMLCanvasElement | null;
+        if (!s.canvasFocused && !(locked && s.canvases.has(locked))) return;
         s.keys.delete(e.code);
         s.keysReleased.add(e.code);
     };
@@ -373,11 +377,13 @@ function createHandlers(s: InputState): void {
         if (!s.canvases.has(e.target as HTMLCanvasElement)) {
             s.canvasFocused = false;
             s.keys.clear();
+            s.keysPressed.clear();
         }
     };
 
     s.windowBlur = () => {
         s.canvasFocused = false;
+        for (const code of s.keys) s.keysReleased.add(code);
         s.keys.clear();
         s.keysPressed.clear();
     };
@@ -544,6 +550,8 @@ function setup(state: State, canvasElements: HTMLCanvasElement[]): void {
         element.style.touchAction = "none";
     }
 
+    enabled = true; // a fresh bind starts live — never inherit a prior State's suspended gate
+
     if (canvases.size === 0) return;
 
     const s: InputState = {
@@ -587,7 +595,6 @@ function setup(state: State, canvasElements: HTMLCanvasElement[]): void {
         attachCanvas(s, canvas, state.signal);
     }
 
-    enabled = true; // a fresh bind starts live — never inherit a prior State's suspended gate
     inputState = s;
     // drop the module ref when this State tears down, so a disposed app reads neutral; guarded so a
     // newer build's inputState isn't clobbered. Listener detach is the signal's job (attach* above).

--- a/packages/shallot/src/standard/input/index.ts
+++ b/packages/shallot/src/standard/input/index.ts
@@ -132,7 +132,7 @@ export const Inputs: Inputs = {
 /**
  * suspend or resume all input. While suspended, every {@link Inputs} read reports neutral: no keys held, no
  * mouse buttons, zero deltas, so a menu or cutscene freezes every consumer (movement, look, grab) with one
- * call, and a pointer-lock controller releases its lock. Resets to enabled on each State (re)bind.
+ * call, and a pointer-lock controller releases its lock. Resets to enabled on a bind that attaches at least one canvas.
  *
  * @example
  * ```
@@ -550,8 +550,6 @@ function setup(state: State, canvasElements: HTMLCanvasElement[]): void {
         element.style.touchAction = "none";
     }
 
-    enabled = true; // a fresh bind starts live — never inherit a prior State's suspended gate
-
     if (canvases.size === 0) return;
 
     const s: InputState = {
@@ -595,6 +593,7 @@ function setup(state: State, canvasElements: HTMLCanvasElement[]): void {
         attachCanvas(s, canvas, state.signal);
     }
 
+    enabled = true; // a fresh bind starts live — never inherit a prior State's suspended gate
     inputState = s;
     // drop the module ref when this State tears down, so a disposed app reads neutral; guarded so a
     // newer build's inputState isn't clobbered. Listener detach is the signal's job (attach* above).

--- a/packages/shallot/src/standard/input/input.test.ts
+++ b/packages/shallot/src/standard/input/input.test.ts
@@ -179,6 +179,20 @@ describe("InputPlugin", () => {
         expect(Inputs.isKeyDown("KeyA")).toBe(true);
     });
 
+    test("isKeyReleased pulses for one frame on key release", () => {
+        onWindow("keydown")({ code: "KeyA" });
+        onWindow("keyup")({ code: "KeyA" });
+        expect(Inputs.isKeyReleased("KeyA")).toBe(true);
+        state.step();
+        expect(Inputs.isKeyReleased("KeyA")).toBe(false); // pulse cleared next frame
+    });
+
+    test("isKeyPressedWithin reports whether a key's last press was within the window", () => {
+        onWindow("keydown")({ code: "Space" });
+        expect(Inputs.isKeyPressedWithin("Space", 10)).toBe(true); // just pressed, within 10s
+        expect(Inputs.isKeyPressedWithin("KeyD", 10)).toBe(false); // never pressed
+    });
+
     test("a blur clears held keys and gates further keys until refocus", () => {
         onWindow("keydown")({ code: "KeyW" });
         expect(Inputs.isKeyDown("KeyW")).toBe(true);
@@ -205,6 +219,59 @@ describe("InputPlugin", () => {
         expect(inputEnabled()).toBe(true);
         onWindow("keydown")({ code: "KeyD" });
         expect(Inputs.isKeyDown("KeyD")).toBe(true); // control resumes
+    });
+
+    test("Inputs.focused reports neutral while input is suspended", () => {
+        expect(Inputs.focused).toBe(0); // canvas is focused
+        setInputEnabled(false);
+        expect(Inputs.focused).toBe(-1); // neutral while suspended
+        setInputEnabled(true);
+        expect(Inputs.focused).toBe(0); // restored
+    });
+
+    test("setInputEnabled(false) clears keyPressedAt — no buffered press survives resume", () => {
+        onWindow("keydown")({ code: "Space" });
+        expect(Inputs.isKeyPressedWithin("Space", 10)).toBe(true); // within 10s window
+        setInputEnabled(false);
+        setInputEnabled(true);
+        expect(Inputs.isKeyPressedWithin("Space", 10)).toBe(false); // keyPressedAt was cleared
+    });
+
+    test("keyUp is gated on enabled and canvas focus — an unaccepted key never writes keysReleased", () => {
+        // canvas-focus gate: blur unfocuses, keyUp for a key the engine never accepted
+        onWindow("blur")();
+        onWindow("keyup")({ code: "KeyW" });
+        expect(Inputs.isKeyReleased("KeyW")).toBe(false);
+
+        // enabled gate: re-focus, suspend, keyUp
+        onCanvas("pointerdown")({
+            target: canvas,
+            pointerId: 1,
+            button: 0,
+            buttons: 1,
+            clientX: 0,
+            clientY: 0,
+            preventDefault() {},
+        });
+        setInputEnabled(false);
+        onWindow("keyup")({ code: "KeyA" });
+        setInputEnabled(true);
+        expect(Inputs.isKeyReleased("KeyA")).toBe(false);
+    });
+
+    test("windowBlur records release edges for held keys — isKeyReleased pulses on focus loss", () => {
+        onWindow("keydown")({ code: "KeyW" });
+        expect(Inputs.isKeyDown("KeyW")).toBe(true);
+        onWindow("blur")();
+        expect(Inputs.isKeyReleased("KeyW")).toBe(true); // held key pulses release on focus loss
+    });
+
+    test("windowPointerDown clears keysPressed on click-off — no stale press edge for a force-released key", () => {
+        onWindow("keydown")({ code: "KeyW" });
+        expect(Inputs.isKeyPressed("KeyW")).toBe(true);
+        onWindow("pointerdown")({ target: {} as HTMLCanvasElement });
+        expect(Inputs.isKeyPressed("KeyW")).toBe(false); // press edge cleared on click-off
+        expect(Inputs.isKeyDown("KeyW")).toBe(false); // held key cleared too
     });
 
     test("a fresh input bind starts enabled — never inherits a suspended gate", () => {
@@ -254,6 +321,34 @@ describe("InputPlugin", () => {
             preventDefault() {},
         });
         expect(Inputs.mouse.left).toBe(true);
+    });
+
+    test("requirePointerLock(false) restores immediate button reading", () => {
+        requirePointerLock(true);
+        setLock(false);
+        onCanvas("pointerdown")({
+            target: canvas,
+            pointerId: 1,
+            button: 0,
+            buttons: 1,
+            clientX: 0,
+            clientY: 0,
+            preventDefault() {},
+        });
+        expect(Inputs.mouse.left).toBe(false); // requireLock on, not locked → no button
+        onWindow("pointerup")({ pointerId: 1, button: 0, buttons: 0, preventDefault() {} });
+
+        requirePointerLock(false);
+        onCanvas("pointerdown")({
+            target: canvas,
+            pointerId: 1,
+            button: 0,
+            buttons: 1,
+            clientX: 0,
+            clientY: 0,
+            preventDefault() {},
+        });
+        expect(Inputs.mouse.left).toBe(true); // requireLock off → button reads immediately
     });
 
     test("pointer down captures the pointer and tracks the pressed button", () => {
@@ -375,6 +470,17 @@ describe("InputPlugin", () => {
         expect(Inputs.mouse.scroll).toBe(120);
     });
 
+    test("contextmenu on a bound canvas is prevented", () => {
+        let prevented = false;
+        onCanvas("contextmenu")({
+            target: canvas,
+            preventDefault() {
+                prevented = true;
+            },
+        });
+        expect(prevented).toBe(true);
+    });
+
     test("InputResetSystem clears per-frame state but keeps held keys", () => {
         onWindow("keydown")({ code: "KeyA" });
         onCanvas("wheel")({ target: canvas, deltaY: 40, preventDefault() {} });
@@ -403,20 +509,6 @@ describe("InputPlugin", () => {
         expect(canvas.tracker.added.length).toBe(beforeAttach);
     });
 
-    // RED-FIRST WITNESS (stage 9, roads-interactive.md): while a pointer is active, the window-level
-    // pointermove handler must keep mouse.x/y tracking even when the pointer's target is not the canvas.
-    // Against the shipped shape, mouse.x/y were written only by the canvas-scoped pointerHover handler
-    // (which early-returns unless e.target is a registered canvas), so a pointermove dispatched at a
-    // non-canvas target froze the coordinates while hover stayed true (pointerLeave only clears hover
-    // when activePointerId === null). The failure text witnessed before the fix:
-    //   "Expected: 300, Received: 100" (mouse.x stayed at the initial 100 when the window-level
-    //   pointermove fired at a non-canvas target — the canvas-scoped pointerHover early-returned, so
-    //   mouse.x/y were never written for the off-canvas move)
-    // The fix: the window-level pointerMove handler writes mouse.x/y using the active canvas's rect.
-    // multi-touch: a second finger no longer just gets ignored (the old
-    // `activePointerId` early-return) — it's tracked in a per-pointerId cache
-    // (MDN multi-touch pattern) that feeds `Inputs.touch`, independent of the
-    // single-pointer `Mouse` capture path above.
     test("a second touch pointer registers in Inputs.touch.count without disturbing Mouse", () => {
         onCanvas("pointerdown")({
             target: canvas,
@@ -752,6 +844,13 @@ describe("InputPlugin", () => {
         expect(Inputs.mouse.y).toBe(400);
         // hover stays true — the drag survives leaving the canvas
         expect(Inputs.mouse.hover).toBe(true);
+    });
+
+    test("pointerLeave clears hover when no pointer is active", () => {
+        onCanvas("pointerenter")({ target: canvas });
+        expect(Inputs.mouse.hover).toBe(true);
+        onCanvas("pointerleave")({ target: canvas });
+        expect(Inputs.mouse.hover).toBe(false); // no active pointer → hover clears
     });
 });
 

--- a/packages/shallot/src/standard/input/input.test.ts
+++ b/packages/shallot/src/standard/input/input.test.ts
@@ -264,6 +264,7 @@ describe("InputPlugin", () => {
         expect(Inputs.isKeyDown("KeyW")).toBe(true);
         onWindow("blur")();
         expect(Inputs.isKeyReleased("KeyW")).toBe(true); // held key pulses release on focus loss
+        expect(Inputs.isKeyReleased("KeyQ")).toBe(false); // a never-held key does not pulse release
     });
 
     test("windowPointerDown clears keysPressed on click-off — no stale press edge for a force-released key", () => {


### PR DESCRIPTION
- **audit-input-suspend-edge-semantics: fix transition edges and add coverage**
- **audit-input-suspend-edge-semantics: review corrections — restore setup reset placement, scope JSDoc, pin never-held release edge**
