### PR TITLE
audit-orbit-overlay-lifecycle: key overlay to State/canvas lifetime, fix fade-hold text, add test arms

### DIFF
--- a/packages/shallot/src/extras/orbit/orbit.test.ts
+++ b/packages/shallot/src/extras/orbit/orbit.test.ts
@@ -3,6 +3,7 @@ import { attach } from "../../../tests/helpers";
 import {
     InputPlugin,
     Orbit,
+    OrbitOverlayPlugin,
     OrbitPick,
     OrbitPlugin,
     State,
@@ -723,5 +724,265 @@ describe("OrbitSystem touch gestures", () => {
         // own cached position, not the departed pointer's.
         const dYaw = Orbit.yaw.get(cam) - yawAfterLift;
         expect(dYaw).toBeCloseTo(-30 * 0.005, 4);
+    });
+});
+
+// The fly-speed overlay's module-scope runtime state (`_overlay`, `_lastSpeed`, `_shownUntil`) must be
+// keyed to State/canvas lifetime per the ecs reload-safety rule. The collapse exemplar's shape is the
+// contract: `mountOverlay(canvas, state)` for the disposing path, a module-scope cleanup cleared at
+// top-of-warm for the re-warm/swap path, and State-derived time (no module-level accumulator). These arms
+// cover the gate roster: rebuild-against-new-canvas, visibility window, fade-hold text, flying-camera
+// selection, the negative-last-speed sentinel, and destroy(). DOM-mocked with the same `globalThis.document`
+// stub shape the fly-mode block above uses, extended with `createElement` / `querySelector` for the overlay's
+// DOM construction.
+type MockEl = {
+    style: Record<string, string>;
+    children: MockEl[];
+    removed: boolean;
+    textContent: string;
+    attributes: Record<string, string>;
+    parentElement: MockEl | null;
+    appendChild(child: MockEl): MockEl;
+    append(...children: MockEl[]): void;
+    setAttribute(name: string, value: string): void;
+    remove(): void;
+};
+
+function mockEl(): MockEl {
+    const el: MockEl = {
+        style: {},
+        children: [],
+        removed: false,
+        textContent: "",
+        attributes: {},
+        parentElement: null,
+        appendChild(child: MockEl) {
+            this.children.push(child);
+            child.parentElement = this;
+            return child;
+        },
+        append(...kids: MockEl[]) {
+            for (const kid of kids) {
+                this.children.push(kid);
+                kid.parentElement = this;
+            }
+        },
+        setAttribute(name: string, value: string) {
+            this.attributes[name] = value;
+        },
+        remove() {
+            this.removed = true;
+            if (this.parentElement) {
+                const idx = this.parentElement.children.indexOf(this);
+                if (idx >= 0) this.parentElement.children.splice(idx, 1);
+            }
+            this.parentElement = null;
+        },
+    };
+    return el;
+}
+
+describe("OrbitOverlayPlugin lifecycle", () => {
+    let state: State;
+    let canvas: MockEl;
+    let canvasParent: MockEl;
+    let savedDocument: typeof globalThis.document;
+
+    beforeEach(() => {
+        clear();
+        canvasParent = mockEl();
+        canvas = mockEl();
+        canvas.parentElement = canvasParent;
+        savedDocument = globalThis.document;
+        globalThis.document = {
+            querySelector: (sel: string) => (sel === "canvas" ? canvas : null),
+            createElement: () => mockEl(),
+        } as unknown as typeof document;
+
+        state = new State();
+        register("Transform", Transform, TransformsPlugin.traits?.Transform);
+        register("Orbit", Orbit, OrbitPlugin.traits?.Orbit);
+        register("OrbitSmooth", OrbitSmooth);
+        Slab.collect();
+        attach(state, OrbitOverlayPlugin);
+    });
+
+    afterEach(() => {
+        OrbitOverlayPlugin.dispose?.(state);
+        state.dispose();
+        globalThis.document = savedDocument;
+    });
+
+    // traverse: canvasParent → overlay (mountOverlay) → root (data-orbit-overlay) → [speedEl, boostEl]
+    function overlayRoot(): MockEl | null {
+        for (const overlay of canvasParent.children) {
+            for (const root of overlay.children) {
+                if (root.attributes["data-orbit-overlay"] !== undefined) return root;
+            }
+        }
+        return null;
+    }
+
+    function speedEl(): MockEl | null {
+        const root = overlayRoot();
+        return root ? ((root.children[0] as MockEl) ?? null) : null;
+    }
+
+    // the overlay div returned by mountOverlay (direct child of canvasParent)
+    function overlayDiv(): MockEl | null {
+        return canvasParent.children.length > 0 ? (canvasParent.children[0] as MockEl) : null;
+    }
+
+    function makeFlyingCam(speed = 5): number {
+        const cam = state.create();
+        state.add(cam, Orbit);
+        state.add(cam, OrbitSmooth);
+        OrbitSmooth.flyActive.set(cam, 1);
+        Orbit.flySpeed.set(cam, speed);
+        return cam;
+    }
+
+    // a non-flying camera (flyActive = 0)
+    function makeOrbitingCam(): number {
+        const cam = state.create();
+        state.add(cam, Orbit);
+        state.add(cam, OrbitSmooth);
+        OrbitSmooth.flyActive.set(cam, 0);
+        return cam;
+    }
+
+    // ── destroy() / state-owned teardown ──────────────────────────────────────
+
+    // binds finding :108 — mountOverlay must receive `state` so state.onDispose registers the overlay's
+    // removal. A direct state.dispose() (not App.dispose) fires onDispose but never the plugin dispose hook,
+    // so without the state argument the overlay node leaks.
+    test("a state-bound overlay auto-removes on state dispose", () => {
+        makeFlyingCam();
+        state.step(1 / 60); // update creates the overlay lazily
+        expect(overlayRoot()).not.toBeNull();
+        const div = overlayDiv()!;
+        expect(div.removed).toBe(false);
+
+        state.dispose();
+        expect(div.removed).toBe(true); // onDispose fired → overlay.remove()
+    });
+
+    // ── rebuild against a new canvas ───────────────────────────────────────────
+
+    // binds finding :71 — _overlay is module-cached forever; after a rebuild against a new canvas the
+    // readout stays parented to the old canvas's overlay host. Keying the overlay to its canvas (clearing
+    // on canvas change) makes update re-create it against the new canvas's parent.
+    test("rebuild against a new canvas re-parents the overlay to the new canvas", () => {
+        makeFlyingCam();
+        state.step(1 / 60);
+        const oldOverlayDiv = overlayDiv();
+        expect(oldOverlayDiv).not.toBeNull();
+        // the overlay is parented to canvas A's parent
+        expect(canvasParent.children).toContain(oldOverlayDiv as MockEl);
+
+        // simulate a rebuild: dispose the old State, swap in a new canvas + State
+        state.dispose();
+        const newCanvasParent = mockEl();
+        const newCanvas = mockEl();
+        newCanvas.parentElement = newCanvasParent;
+        (
+            globalThis.document as unknown as { querySelector: (s: string) => MockEl | null }
+        ).querySelector = (sel: string) => (sel === "canvas" ? newCanvas : null);
+
+        state = new State();
+        register("Transform", Transform, TransformsPlugin.traits?.Transform);
+        register("Orbit", Orbit, OrbitPlugin.traits?.Orbit);
+        register("OrbitSmooth", OrbitSmooth);
+        Slab.collect();
+        attach(state, OrbitOverlayPlugin);
+        OrbitOverlayPlugin.warm?.(state); // top-of-warm clears module-scope state (swap fallback)
+
+        makeFlyingCam();
+        state.step(1 / 60);
+
+        // the new overlay is parented to the NEW canvas's parent, not the old one
+        const newOverlayDiv = newCanvasParent.children[0] as MockEl | undefined;
+        expect(newOverlayDiv).toBeDefined();
+        expect(canvasParent.children).not.toContain(newOverlayDiv as MockEl);
+        expect(newCanvasParent.children).toContain(newOverlayDiv as MockEl);
+    });
+
+    // ── visibility window + negative-last-speed sentinel ──────────────────────
+
+    // binds finding :99 — _shownUntil survives a rebuild while state.time.elapsed resets to 0, so a fresh
+    // State can inherit a stale visible window. Also covers the _lastSpeed < 0 (negative sentinel) branch:
+    // entering fly arms the readout without showing it. After a rebuild with _shownUntil reset, the first
+    // flying frame must NOT show the overlay (armed, not visible).
+    test("a fresh State does not inherit a stale visibility window — entering fly arms without showing", () => {
+        // State A: fly and change speed to set _shownUntil well into the future
+        const cam = makeFlyingCam(5);
+        state.step(1 / 60); // first flying frame: _lastSpeed goes from -1 to 5 (armed, not shown)
+        expect(overlayRoot()?.style.opacity).toBe("0"); // armed, not visible
+
+        // change speed to set _shownUntil = elapsed + HoldSeconds
+        Orbit.flySpeed.set(cam, 8);
+        state.step(1 / 60); // speed changed → _shownUntil set, visible
+        expect(overlayRoot()?.style.opacity).toBe("1");
+
+        // simulate a rebuild: dispose, new State, warm
+        state.dispose();
+        state = new State();
+        register("Transform", Transform, TransformsPlugin.traits?.Transform);
+        register("Orbit", Orbit, OrbitPlugin.traits?.Orbit);
+        register("OrbitSmooth", OrbitSmooth);
+        Slab.collect();
+        attach(state, OrbitOverlayPlugin);
+        OrbitOverlayPlugin.warm?.(state);
+
+        // fresh State: elapsed is 0, _shownUntil must be 0 (not stale from State A)
+        makeFlyingCam(5);
+        state.step(1 / 60); // first flying frame: _lastSpeed < 0 → arm without showing
+        expect(overlayRoot()?.style.opacity).toBe("0"); // NOT visible — no stale window
+    });
+
+    // ── fade-hold text ─────────────────────────────────────────────────────────
+
+    // binds finding :92 — the not-flying path called set(0, 0, false, false), rewriting the text to
+    // "fly 0.0 u/s" mid-fade, contradicting set's own comment that the last value reads as it dims out.
+    // After the fix, set only updates text while visible, so the last flying speed holds during the fade.
+    test("the readout holds its last text while fading out", () => {
+        const cam = makeFlyingCam(5);
+        state.step(1 / 60); // armed
+        Orbit.flySpeed.set(cam, 7);
+        state.step(1 / 60); // speed changed → visible, text = "fly 7.0 u/s"
+        expect(speedEl()?.textContent).toBe("fly 7.0 u/s");
+        expect(overlayRoot()?.style.opacity).toBe("1");
+
+        // stop flying — the overlay fades out but must keep showing "fly 7.0 u/s", not "fly 0.0 u/s"
+        OrbitSmooth.flyActive.set(cam, 0);
+        state.step(1 / 60);
+        expect(overlayRoot()?.style.opacity).toBe("0"); // fading
+        expect(speedEl()?.textContent).toBe("fly 7.0 u/s"); // last value holds, not rewritten to 0
+    });
+
+    // ── flying-camera selection ───────────────────────────────────────────────
+
+    // covers the flying-camera selection gate: the first flying camera in query order owns the readout.
+    // Also binds the state-owned teardown (finding :108): state.dispose() must remove the overlay.
+    test("the first flying camera in query order owns the readout", () => {
+        const idle = makeOrbitingCam(); // not flying — should NOT own the readout
+        Orbit.flySpeed.set(idle, 3);
+        const flying = makeFlyingCam(7); // flying — should own the readout
+        state.step(1 / 60); // first flying frame: arm without showing
+        Orbit.flySpeed.set(flying, 9); // change speed → visible on next frame
+        state.step(1 / 60);
+
+        expect(speedEl()?.textContent).toBe("fly 9.0 u/s"); // flying cam's speed, not the idle cam's
+
+        // the idle cam starts flying instead — now it's first in query order, so it takes over
+        OrbitSmooth.flyActive.set(idle, 1);
+        OrbitSmooth.flyActive.set(flying, 0);
+        state.step(1 / 60);
+        expect(speedEl()?.textContent).toBe("fly 3.0 u/s"); // idle cam's speed now
+
+        // state-owned teardown: dispose removes the overlay node
+        const div = overlayDiv()!;
+        state.dispose();
+        expect(div.removed).toBe(true);
     });
 });

--- a/packages/shallot/src/extras/orbit/overlay.ts
+++ b/packages/shallot/src/extras/orbit/overlay.ts
@@ -18,10 +18,14 @@ interface Overlay {
     destroy(): void;
 }
 
-function createOverlay(canvas: HTMLElement | null): Overlay {
+function createOverlay(canvas: HTMLElement | null, state: State): Overlay {
     // the readout lives in the engine's sandboxed overlay (canvas-bounded, can't spill into an
-    // embedding host page), the same surface `config.ui` hands an app
-    const parent = mountOverlay(canvas);
+    // embedding host page), the same surface `config.ui` hands an app. Passing `state` ties the
+    // overlay's removal to `state.onDispose` (auto-registers `overlay.remove()`), so a direct
+    // `state.dispose()` — which never fires the plugin `dispose` hook — still cleans up the DOM node.
+    // The module-scope cleanup cleared at top-of-warm (below) is the fallback for a host that re-warms
+    // without disposing (`swap()`), which `onDispose` doesn't fire for (collapse exemplar's shape).
+    const parent = mountOverlay(canvas, state);
     const root = document.createElement("div");
     Object.assign(root.style, {
         position: "absolute",
@@ -53,10 +57,13 @@ function createOverlay(canvas: HTMLElement | null): Overlay {
 
     return {
         set(speed, boost, shift, visible) {
-            // keep the text current even while fading, so the last value reads as it dims out
-            speedEl.textContent = `fly ${speed.toFixed(1)} u/s`;
-            speedEl.style.color = shift ? ACCENT : FG;
-            boostEl.textContent = shift ? `×${boost}` : "";
+            // only update the text while visible, so the last value reads as it dims out — the
+            // not-flying path fades the overlay without rewriting to "fly 0.0 u/s"
+            if (visible) {
+                speedEl.textContent = `fly ${speed.toFixed(1)} u/s`;
+                speedEl.style.color = shift ? ACCENT : FG;
+                boostEl.textContent = shift ? `×${boost}` : "";
+            }
             root.style.opacity = visible ? "1" : "0";
         },
         destroy() {
@@ -65,10 +72,12 @@ function createOverlay(canvas: HTMLElement | null): Overlay {
     };
 }
 
-// module-scoped so it survives a rebuild (the State is reused; the DOM node should be too). _lastSpeed
-// tracks the previous frame's speed to detect a scroll change; -1 means "not flying / uninitialized", so
-// entering fly doesn't flash the readout. _shownUntil is the elapsed time the fade-out begins.
+// module-scoped runtime state, keyed to the canvas/State it was built against. _lastSpeed tracks the
+// previous frame's speed to detect a scroll change; -1 means "not flying / uninitialized", so entering
+// fly doesn't flash the readout. _shownUntil is the elapsed time the fade-out begins. Both reset on a
+// rebuild (warm), so a fresh State can't inherit a stale visible window or a stale speed sentinel.
 let _overlay: Overlay | null = null;
+let _overlayCanvas: HTMLElement | null = null;
 let _lastSpeed = -1;
 let _shownUntil = 0;
 
@@ -89,7 +98,7 @@ const OrbitOverlaySystem: System = {
         }
         if (!flying) {
             _lastSpeed = -1;
-            _overlay?.set(0, 0, false, false);
+            _overlay?.set(0, 0, false, false); // fade out, keeping the last text
             return;
         }
 
@@ -105,7 +114,20 @@ const OrbitOverlaySystem: System = {
         // visible while a scroll change is fresh, or while shift is actively boosting
         const visible = shift || elapsed < _shownUntil;
 
-        if (!_overlay) _overlay = createOverlay(document.querySelector("canvas"));
+        const canvas = document.querySelector("canvas");
+        // a rebuild against a new canvas leaves the old overlay parented to the old canvas's host —
+        // detect the canvas change and tear down the stale overlay so update re-creates it on the new one
+        if (_overlay && _overlayCanvas !== canvas) {
+            _overlay.destroy();
+            _overlay = null;
+            _overlayCanvas = null;
+            _lastSpeed = -1;
+            _shownUntil = 0;
+        }
+        if (!_overlay) {
+            _overlay = createOverlay(canvas, state);
+            _overlayCanvas = canvas;
+        }
         _overlay.set(speed, Orbit.flyBoost.get(flying), shift, visible);
     },
 };
@@ -114,9 +136,19 @@ const OrbitOverlaySystem: System = {
 export const OrbitOverlayPlugin: Plugin = {
     name: "OrbitOverlay",
     systems: [OrbitOverlaySystem],
+    // swap fallback: a host that re-warms without disposing never fires onDispose, so clear the
+    // module-scope overlay here before update re-creates it (collapse's panelCleanup-at-top-of-warm)
+    warm() {
+        _overlay?.destroy();
+        _overlay = null;
+        _overlayCanvas = null;
+        _lastSpeed = -1;
+        _shownUntil = 0;
+    },
     dispose() {
         _overlay?.destroy();
         _overlay = null;
+        _overlayCanvas = null;
         _lastSpeed = -1;
         _shownUntil = 0;
     },


### PR DESCRIPTION
Adopt the collapse exemplar's shape for the orbit fly-speed overlay:
- mountOverlay(canvas, state) so state.onDispose registers the overlay's
  removal (finding :108 — a direct state.dispose() no longer leaks the node)
- module-scope cleanup cleared at top-of-warm for the re-warm/swap path
  (finding :71/:99 — _overlay, _lastSpeed, _shownUntil reset on rebuild)
- canvas-keying in update: detect a canvas change and tear down the stale
  overlay so the readout re-parents to the new canvas (finding :71)
- set() only updates text while visible, so the last flying speed reads as
  the overlay dims out instead of rewriting to 'fly 0.0 u/s' (finding :92)
- five red-first DOM-mocked arms in orbit.test.ts covering: state-bound
  dispose, rebuild-against-new-canvas, stale visibility window + negative
  last-speed sentinel, fade-hold text, flying-camera selection (finding :75)
