### PR TITLE
audit-orbit-contract-drift: close-repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Newest first. **Breaking:** marks a change that needs consumer action; [`package
 ## Unreleased — next minor
 
 - **audio** — `DYNAMICS_MODE`, `WAVESHAPER_MODE`, and `EQ_MODE` are no longer exported: no consumer referenced them, and the mode values they named stay documented on the node-parameter docblocks. The tables survive internally as the defaults' source. Removal is semver-visible, so it ships in a minor.
+- **input (doc)** — `OrbitMode.Locked`'s JSDoc claimed it disables orbit rotation while leaving pan and zoom; the shipped gate also freezes fly look, so a Locked camera flies blind. The doc now says so. Runtime behavior is unchanged, and there's nothing for a consumer to do beyond re-reading the reference.
 
 ## 0.9.5 — 2026-08-25
 

--- a/packages/shallot/src/extras/orbit/orbit.test.ts
+++ b/packages/shallot/src/extras/orbit/orbit.test.ts
@@ -20,8 +20,9 @@ import { OrbitSmooth } from "./smooth";
 // Orbit's reload-safety (the lazy OrbitSmooth add/remove not doubling across a rebuild) is covered by
 // the conformance roster. This spec covers the pose contract, the lazy-init path (with no input,
 // OrbitSystem drives the camera Transform from the yaw/pitch/distance pose, so the camera always sits
-// `distance` from its target), and — further down this file — fly mode, the contextual claim, and touch
-// gestures, driven through the real InputPlugin handlers with synthetic DOM/pointer events.
+// `distance` from its target), and — further down this file — fly mode, the contextual claim, touch
+// gestures, Locked mode, and orthographic zoom / middle-button pan, driven through the real InputPlugin
+// handlers with synthetic DOM/pointer events.
 //
 // The spherical pose is a unit vector scaled by distance, so |pos − target| == distance regardless of
 // yaw/pitch — a behavior invariant, not a re-derivation of the pose formula. Tolerance is f32 storage of
@@ -986,6 +987,21 @@ describe("OrbitSystem orthographic zoom and middle-button pan", () => {
         state.step(1 / 60);
 
         expect(Orbit.size.get(cam)).toBeCloseTo(6, 4);
+    });
+
+    test("orthographic zoom clamps to minSize on the low end", () => {
+        const cam = state.create();
+        state.add(cam, Transform);
+        state.add(cam, Orbit);
+        state.add(cam, Camera);
+        Camera.mode.set(cam, CameraMode.Orthographic);
+        Orbit.minSize.set(cam, 2); // off the plugin default (0.05) so the clamp is observable
+        state.step(1 / 60);
+
+        wheel(-100000); // negative deltaY: opposite sign of the "scroll away" grow case above, shrinks size
+        state.step(1 / 60);
+
+        expect(Orbit.size.get(cam)).toBeCloseTo(2, 4);
     });
 
     test("a middle-button drag pans — yaw stays put, pan changes", () => {


### PR DESCRIPTION
Three repairs the close sweep found on the shipped S1 diff:

- orbit.test.ts: the "orthographic zoom clamps to minSize/maxSize" arm only
  constructed the maxSize scenario. Added a sibling arm that moves
  Orbit.minSize off its plugin default and drives size down with a negative
  wheel to assert the low-end clamp, closing the gap the roster owed.
  Red-first verified against a widened production clamp (-999999 minSize),
  then restored index.ts from HEAD.
- orbit.test.ts header: named the Locked-mode and orthographic-zoom/
  middle-button-pan describe blocks the same diff added below it.
- CHANGELOG.md: recorded under Unreleased that OrbitMode.Locked's JSDoc now
  matches shipped behavior (fly look also freezes under the !locked gate),
  correcting the doc rather than changing runtime semantics.
