### PR TITLE
audit-orbit-contract-drift: close-repair-2

### DIFF
--- a/packages/shallot/src/extras/orbit/orbit.test.ts
+++ b/packages/shallot/src/extras/orbit/orbit.test.ts
@@ -974,7 +974,7 @@ describe("OrbitSystem orthographic zoom and middle-button pan", () => {
         expect(Camera.size.get(cam)).toBeCloseTo(Orbit.size.get(cam), 2);
     });
 
-    test("orthographic zoom clamps to minSize/maxSize", () => {
+    test("orthographic zoom clamps to maxSize on the high end", () => {
         const cam = state.create();
         state.add(cam, Transform);
         state.add(cam, Orbit);


### PR DESCRIPTION
The ortho maxSize arm still claimed both bounds in its name after the
minSize arm was split out beside it, so the name stated a scenario its
fixture does not construct. Narrowed it to the bound it actually drives,
paralleling the minSize arm's name.
