### PR TITLE
shallot avbd stiffness guard/S1

### DIFF
--- a/packages/shallot/src/standard/physics/constraints.test.ts
+++ b/packages/shallot/src/standard/physics/constraints.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { load, parse, State } from "../..";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { load, parse, State } from "../../engine";
 import { clear, register } from "../../engine/ecs/core";
 import { Slab } from "../slab";
 import {
@@ -12,6 +12,7 @@ import {
     jointTraits,
     type PhysicsBackend,
     Spring,
+    type SpringDef,
     springTraits,
     uninstallBackend,
 } from "./index";
@@ -151,5 +152,198 @@ describe("constraint re-upload on an endpoint realias", () => {
 
         ConstraintSystem.update?.(state);
         expect(joints.length).toBe(2); // re-uploaded so the backend joint rebinds to the new occupant
+    });
+});
+
+// The stiffness guard at the backend-neutral authoring layer (jointDefs/springDefs in index.ts): a
+// negative or NaN stiffnessAng/stiffness is dropped with a warnOnce before reaching either backend, so
+// both backends inherit one behavior. The recording backend is a proxy for any backend (tumble or AVBD)
+// since the guard sits in the shared ConstraintSystem path. Valid authored values (0, finite-positive, ∞)
+// pass through unchanged — the grant arm pins that the guard does not over-refuse.
+describe("stiffness guard (authoring layer)", () => {
+    let state: State;
+    let joints: JointDef[][];
+    let springs: SpringDef[][];
+
+    function recordingBackend(): PhysicsBackend {
+        return {
+            step() {},
+            readBody: () => null,
+            setKinematic() {},
+            setVelocity() {},
+            setSprings(s) {
+                springs.push([...s]);
+            },
+            setJoints(j) {
+                joints.push([...j]);
+            },
+            get gravity() {
+                return -10;
+            },
+            get dt() {
+                return 1 / 60;
+            },
+            compose() {},
+        };
+    }
+
+    beforeEach(() => {
+        clear();
+        state = new State();
+        register("body", Body, bodyTraits);
+        register("spring", Spring, springTraits);
+        register("joint", Joint, jointTraits);
+        Slab.collect();
+        joints = [];
+        springs = [];
+        uninstallBackend();
+        installBackend(recordingBackend());
+    });
+
+    afterEach(() => {
+        uninstallBackend();
+    });
+
+    // witnessed red: exit code 1 — without the guard branch in jointDefs, the -1 def passes through and
+    // setJoints receives a 1-element array; the assertion `expect(joints[0]).toHaveLength(0)` fails.
+    test("a negative stiffnessAng joint is dropped — no joint reaches the backend", () => {
+        const anchor = state.create();
+        state.add(anchor, Body);
+        Body.mass.set(anchor, 0);
+        const bob = state.create();
+        state.add(bob, Body);
+        Body.pos.set(bob, 0, -2, 0, 0);
+
+        const joint = state.create();
+        state.add(joint, Joint);
+        Joint.a.set(joint, anchor);
+        Joint.b.set(joint, bob);
+        Joint.stiffnessAng.set(joint, -1);
+
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            ConstraintSystem.update?.(state);
+            expect(joints.length).toBe(1);
+            expect(joints[0]).toHaveLength(0); // the invalid def was dropped — no joint for the backend
+            expect(warn).toHaveBeenCalled();
+            const msg = warn.mock.calls.find((c) => String(c[0]).includes("joint"))?.[0];
+            expect(msg).toBeDefined();
+            expect(String(msg)).toContain("skipped");
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // witnessed red: exit code 1 — without the guard, NaN passes the comparison-only checks (NaN < 0 is
+    // false) and setJoints receives a 1-element array with NaN stiffnessAng; the length assertion fails.
+    test("a NaN stiffnessAng joint is dropped — no joint reaches the backend", () => {
+        const anchor = state.create();
+        state.add(anchor, Body);
+        Body.mass.set(anchor, 0);
+        const bob = state.create();
+        state.add(bob, Body);
+        Body.pos.set(bob, 0, -2, 0, 0);
+
+        const joint = state.create();
+        state.add(joint, Joint);
+        Joint.a.set(joint, anchor);
+        Joint.b.set(joint, bob);
+        Joint.stiffnessAng.set(joint, Number.NaN);
+
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            ConstraintSystem.update?.(state);
+            expect(joints.length).toBe(1);
+            expect(joints[0]).toHaveLength(0); // NaN was dropped — comparison-only guards can't catch it
+            expect(warn).toHaveBeenCalled();
+            const msg = warn.mock.calls.find((c) => String(c[0]).includes("joint"))?.[0];
+            expect(msg).toBeDefined();
+            expect(String(msg)).toContain("skipped");
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // witnessed red: exit code 1 — without the guard, the -1 stiffness passes through and setSprings
+    // receives a 1-element array; the length assertion fails.
+    test("a negative stiffness spring is dropped — no spring reaches the backend", () => {
+        const anchor = state.create();
+        state.add(anchor, Body);
+        Body.mass.set(anchor, 0);
+        const bob = state.create();
+        state.add(bob, Body);
+
+        const spring = state.create();
+        state.add(spring, Spring);
+        Spring.a.set(spring, anchor);
+        Spring.b.set(spring, bob);
+        Spring.stiffness.set(spring, -1);
+        Spring.rest.set(spring, 4);
+
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            ConstraintSystem.update?.(state);
+            expect(springs.length).toBe(1);
+            expect(springs[0]).toHaveLength(0);
+            expect(warn).toHaveBeenCalled();
+            const msg = warn.mock.calls.find((c) => String(c[0]).includes("spring"))?.[0];
+            expect(msg).toBeDefined();
+            expect(String(msg)).toContain("skipped");
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // witnessed red: exit code 1 — without the guard, NaN passes the comparison-only checks and
+    // setSprings receives a 1-element array with NaN stiffness; the length assertion fails.
+    test("a NaN stiffness spring is dropped — no spring reaches the backend", () => {
+        const anchor = state.create();
+        state.add(anchor, Body);
+        Body.mass.set(anchor, 0);
+        const bob = state.create();
+        state.add(bob, Body);
+
+        const spring = state.create();
+        state.add(spring, Spring);
+        Spring.a.set(spring, anchor);
+        Spring.b.set(spring, bob);
+        Spring.stiffness.set(spring, Number.NaN);
+        Spring.rest.set(spring, 4);
+
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            ConstraintSystem.update?.(state);
+            expect(springs.length).toBe(1);
+            expect(springs[0]).toHaveLength(0);
+            expect(warn).toHaveBeenCalled();
+            const msg = warn.mock.calls.find((c) => String(c[0]).includes("spring"))?.[0];
+            expect(msg).toBeDefined();
+            expect(String(msg)).toContain("skipped");
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // grant arm: a finite-positive stiffnessAng passes the guard and builds a joint — the over-refusal
+    // check no refusal arm can show. Always green (the guard admits finite-positive); the red-first
+    // discipline applies to the skip arms, not the grant.
+    test("a finite-positive stiffnessAng joint passes the guard (grant arm)", () => {
+        const anchor = state.create();
+        state.add(anchor, Body);
+        Body.mass.set(anchor, 0);
+        const bob = state.create();
+        state.add(bob, Body);
+        Body.pos.set(bob, 0, -2, 0, 0);
+
+        const joint = state.create();
+        state.add(joint, Joint);
+        Joint.a.set(joint, anchor);
+        Joint.b.set(joint, bob);
+        Joint.stiffnessAng.set(joint, 1000);
+
+        ConstraintSystem.update?.(state);
+        expect(joints.length).toBe(1);
+        expect(joints[0]).toHaveLength(1);
+        expect(joints[0][0]?.stiffnessAng).toBe(1000);
     });
 });

--- a/packages/shallot/src/standard/physics/index.ts
+++ b/packages/shallot/src/standard/physics/index.ts
@@ -281,6 +281,8 @@ let jointSig = FNV_BASIS;
 function resetSignatures(): void {
     springSig = FNV_BASIS;
     jointSig = FNV_BASIS;
+    warnedJointEids.clear();
+    warnedSpringEids.clear();
 }
 
 function springSignature(state: State): number {
@@ -331,15 +333,36 @@ function jointSignature(state: State): number {
     return h;
 }
 
+// warned-eid dedupe for the stiffness guard — keyed on entity id so a re-upload triggered by an
+// unrelated constraint change does not re-warn the same invalid def. Cleared on backend reinstall
+// (resetSignatures) so a fresh backend re-warns. A def whose stiffness is fixed (invalid → valid) is
+// removed from the set so a later regression to invalid re-warns.
+const warnedJointEids = new Set<number>();
+const warnedSpringEids = new Set<number>();
+
 function springDefs(state: State): SpringDef[] {
     const out: SpringDef[] = [];
     for (const eid of state.query([Spring])) {
+        const stiffness = Spring.stiffness.get(eid);
+        // NaN is transparent to comparison-only guards (NaN < 0 is false), so state finiteness explicitly.
+        // 0 and ∞ are valid authored values (0 = non-positive → downstream skip; ∞ = rigid) — only negative
+        // and NaN are rejected, at the backend-neutral authoring layer so both backends inherit one behavior.
+        if (Number.isNaN(stiffness) || stiffness < 0) {
+            if (!warnedSpringEids.has(eid)) {
+                console.warn(
+                    `[physics] spring (a: ${Spring.a.get(eid)}, b: ${Spring.b.get(eid)}) has negative or NaN stiffness — skipped`,
+                );
+                warnedSpringEids.add(eid);
+            }
+            continue;
+        }
+        warnedSpringEids.delete(eid);
         out.push({
             a: Spring.a.get(eid),
             b: Spring.b.get(eid),
             rA: [Spring.rA.x.get(eid), Spring.rA.y.get(eid), Spring.rA.z.get(eid)],
             rB: [Spring.rB.x.get(eid), Spring.rB.y.get(eid), Spring.rB.z.get(eid)],
-            stiffness: Spring.stiffness.get(eid),
+            stiffness,
             rest: Spring.rest.get(eid),
         });
     }
@@ -349,12 +372,28 @@ function springDefs(state: State): SpringDef[] {
 function jointDefs(state: State): JointDef[] {
     const out: JointDef[] = [];
     for (const eid of state.query([Joint])) {
+        const stiffnessAng = Joint.stiffnessAng.get(eid);
+        // NaN is transparent to comparison-only guards (NaN < 0 is false), so state finiteness explicitly.
+        // 0 (spherical) and ∞ (fixed) are valid authored values — only negative and NaN are rejected, at the
+        // backend-neutral authoring layer so both backends inherit one behavior. JointDef carries only
+        // stiffnessAng today (no stiffnessLin-class field to guard); the AVBD-extended JointDef's optional
+        // stiffnessLin/motor ride the escape hatch, not this path.
+        if (Number.isNaN(stiffnessAng) || stiffnessAng < 0) {
+            if (!warnedJointEids.has(eid)) {
+                console.warn(
+                    `[physics] joint (a: ${Joint.a.get(eid)}, b: ${Joint.b.get(eid)}) has negative or NaN angular stiffness — skipped`,
+                );
+                warnedJointEids.add(eid);
+            }
+            continue;
+        }
+        warnedJointEids.delete(eid);
         out.push({
             a: Joint.a.get(eid),
             b: Joint.b.get(eid),
             rA: [Joint.rA.x.get(eid), Joint.rA.y.get(eid), Joint.rA.z.get(eid)],
             rB: [Joint.rB.x.get(eid), Joint.rB.y.get(eid), Joint.rB.z.get(eid)],
-            stiffnessAng: Joint.stiffnessAng.get(eid),
+            stiffnessAng,
         });
     }
     return out;

--- a/packages/shallot/src/standard/tumble/joints.test.ts
+++ b/packages/shallot/src/standard/tumble/joints.test.ts
@@ -29,6 +29,17 @@ describe("stiffnessHertz", () => {
         expect(stiffnessHertz(100, 0, 0)).toBe(0);
         expect(stiffnessHertz(0, 1, 1)).toBe(0);
     });
+
+    // witnessed red: exit code 1 — without the Number.isFinite guard, NaN passes the comparison-only
+    // check (NaN <= 0 is false) and Math.sqrt(NaN / meff) / (2π) yields NaN; expect(NaN).toBe(0) fails.
+    // ∞ is exempted (rigid stiffness is valid), so the finite check must not reject it.
+    test("NaN stiffness returns 0 (the finite guard — comparison-only checks are NaN-transparent)", () => {
+        expect(stiffnessHertz(Number.NaN, 1, 1)).toBe(0);
+    });
+
+    test("∞ stiffness still computes a finite-or-infinite hertz (the finite guard exempts ∞)", () => {
+        expect(stiffnessHertz(Number.POSITIVE_INFINITY, 1, 1)).toBe(Number.POSITIVE_INFINITY);
+    });
 });
 
 describe("syncSet", () => {
@@ -288,6 +299,87 @@ describe("tumble constraint mapping", () => {
             // y = 2.5 + ½·(−10)·2² = −17.5 (±1.0 for solver slop). A clamp-to-spherical would hold
             // the body at y ≈ 2.5 — far outside this band — so the arm separates the directions.
             expect(Math.abs((arm?.pos[1] ?? 0) - -17.5)).toBeLessThan(1.0);
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // witnessed red: exit code 1 — without the authoring-layer guard, NaN passes tumble's comparison-only
+    // `< 0` guard (NaN < 0 is false) and the stiffnessHertz Number.isFinite guard returns 0 → angularHertz
+    // 0 → rigid weld → body pinned at y ≈ 2.5, far outside the free-fall band. With the authoring-layer
+    // guard, NaN is dropped at jointDefs → no joint → free fall.
+    test("a NaN stiffnessAng joint is dropped at the authoring layer (warn+skip, free-fall under tumble)", async () => {
+        const { state, eids } = await build([
+            { pos: [0, 2, 0], mass: 0 },
+            { pos: [1.5, 2.5, 0], mass: 1, half: [0.25, 0.25, 0.25] },
+        ]);
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            addJoint(state, eids[0], eids[1], [1.5, 0.5, 0], [0, 0, 0], Number.NaN);
+            stepFor(state, 2);
+            const arm = Physics.backend?.readBody(eids[1]);
+            expect(arm).not.toBeNull();
+            expect(warn).toHaveBeenCalled();
+            const jointWarn = warn.mock.calls.find((c) => String(c[0]).includes("joint"));
+            expect(jointWarn).toBeDefined();
+            expect(String(jointWarn?.[0])).toContain("skipped");
+            // skip half: no joint created, body falls freely — y = 2.5 + ½·(−10)·2² = −17.5 (±1.0).
+            // A rigid weld (the NaN→0→rigid path without the guard) would hold the body at y ≈ 2.5.
+            expect(Math.abs((arm?.pos[1] ?? 0) - -17.5)).toBeLessThan(1.0);
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // reference floor (green either way): the tumble layer already catches negative stiffness via
+    // stiffnessHertz(-1, ...) → 0 (stiffness <= 0) → hertz 0 → warn+skip at createSpring. The
+    // authoring-layer guard is redundant for this case but the arm pins the end-to-end effect (free-fall)
+    // under the tumble backend so the behavior is witnessed, not just at the recording backend.
+    test("a negative stiffness spring is skipped — free-fall under tumble", async () => {
+        const { state, eids } = await build([
+            { pos: [0, 10, 0], mass: 0, half: [0.1, 0.1, 0.1] },
+            { pos: [0, 6, 0], mass: 8 },
+        ]);
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            addSpring(state, eids[0], eids[1], -1, 4);
+            stepFor(state, 2);
+            const body = Physics.backend?.readBody(eids[1]);
+            expect(body).not.toBeNull();
+            expect(warn).toHaveBeenCalled();
+            const springWarn = warn.mock.calls.find((c) => String(c[0]).includes("spring"));
+            expect(springWarn).toBeDefined();
+            expect(String(springWarn?.[0])).toContain("skipped");
+            // free-fall: y = 6 + ½·(−10)·2² = −14 (±1.0). A spring holding the body would be near 6.
+            expect(Math.abs((body?.pos[1] ?? 0) - -14)).toBeLessThan(1.0);
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // witnessed red: exit code 1 — removing both the authoring-layer spring guard AND the
+    // stiffnessHertz Number.isFinite guard: NaN passes tumble's comparison-only `stiffness <= 0`
+    // (NaN <= 0 is false) and stiffnessHertz returns NaN → hertz NaN → createDistanceJoint with NaN
+    // hertz → no warn, body not at free-fall. With either guard in place, NaN is caught: the
+    // authoring-layer guard drops it at springDefs (no spring, [physics] warn); the stiffnessHertz
+    // guard returns 0 → hertz 0 → warn+skip at createSpring ([tumble] warn). Both paths → free fall.
+    test("a NaN stiffness spring is skipped — free-fall under tumble", async () => {
+        const { state, eids } = await build([
+            { pos: [0, 10, 0], mass: 0, half: [0.1, 0.1, 0.1] },
+            { pos: [0, 6, 0], mass: 8 },
+        ]);
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            addSpring(state, eids[0], eids[1], Number.NaN, 4);
+            stepFor(state, 2);
+            const body = Physics.backend?.readBody(eids[1]);
+            expect(body).not.toBeNull();
+            expect(warn).toHaveBeenCalled();
+            const springWarn = warn.mock.calls.find((c) => String(c[0]).includes("spring"));
+            expect(springWarn).toBeDefined();
+            expect(String(springWarn?.[0])).toContain("skipped");
+            // free-fall: y = 6 + ½·(−10)·2² = −14 (±1.0).
+            expect(Math.abs((body?.pos[1] ?? 0) - -14)).toBeLessThan(1.0);
         } finally {
             warn.mockRestore();
         }

--- a/packages/shallot/src/standard/tumble/joints.test.ts
+++ b/packages/shallot/src/standard/tumble/joints.test.ts
@@ -2,7 +2,7 @@ import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test";
 import { attach, stepFor } from "../../../tests/helpers";
 import { State, Time } from "../../engine";
 import { clear, register } from "../../engine/ecs/core";
-import { Body, bodyTraits, type JointDef, Joint, jointTraits, Physics, Spring, springTraits } from "../physics";
+import { Body, bodyTraits, Joint, jointTraits, Physics, Spring, springTraits } from "../physics";
 import { Slab } from "../slab";
 import { shutdown, type Joint as TumbleJoint } from "./engine";
 import { Tumble, TumblePlugin } from "./index";

--- a/packages/shallot/src/standard/tumble/joints.test.ts
+++ b/packages/shallot/src/standard/tumble/joints.test.ts
@@ -1,11 +1,11 @@
 import { afterAll, afterEach, describe, expect, spyOn, test } from "bun:test";
 import { attach, stepFor } from "../../../tests/helpers";
-import { State } from "../../engine";
+import { State, Time } from "../../engine";
 import { clear, register } from "../../engine/ecs/core";
-import { Body, bodyTraits, Joint, jointTraits, Physics, Spring, springTraits } from "../physics";
+import { Body, bodyTraits, type JointDef, Joint, jointTraits, Physics, Spring, springTraits } from "../physics";
 import { Slab } from "../slab";
 import { shutdown, type Joint as TumbleJoint } from "./engine";
-import { TumblePlugin } from "./index";
+import { Tumble, TumblePlugin } from "./index";
 import { stiffnessHertz, syncSet } from "./joints";
 
 // The Spring/Joint → tumble mapping (joints.ts): the stiffness→hertz conversion law, the content-keyed
@@ -196,6 +196,15 @@ function addJoint(
     Joint.stiffnessAng.set(e, stiffnessAng);
 }
 
+// Step the tumble world directly (bypassing ConstraintSystem) for `duration` seconds — the escape-hatch
+// path: Tumble.world / imperative spawn calls setJoints directly, not through jointDefs. stepFor would run
+// ConstraintSystem, which re-uploads jointDefs(state) (empty when no Joint entities exist) and wipe any
+// joint set directly. The SUBSTEPS count matches the production backend step (tumble/index.ts).
+function stepWorldDirect(duration: number): void {
+    const ticks = Math.round(duration / Time.FIXED_DT);
+    for (let i = 0; i < ticks; i++) Tumble.world?.step(Time.FIXED_DT, 4);
+}
+
 describe("tumble constraint mapping", () => {
     test("a spring settles at the mg/k equilibrium — the stiffness→hertz law holds", async () => {
         // anchor at y=10, block (mass 8) hung on a rest-4 stiffness-100 spring: equilibrium extension
@@ -325,6 +334,76 @@ describe("tumble constraint mapping", () => {
             expect(String(jointWarn?.[0])).toContain("skipped");
             // skip half: no joint created, body falls freely — y = 2.5 + ½·(−10)·2² = −17.5 (±1.0).
             // A rigid weld (the NaN→0→rigid path without the guard) would hold the body at y ≈ 2.5.
+            expect(Math.abs((arm?.pos[1] ?? 0) - -17.5)).toBeLessThan(1.0);
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // ── escape-hatch arms: createJoint called directly via Physics.backend.setJoints, bypassing ──
+    // ── ConstraintSystem and the authoring-layer guard (the Tumble.world / imperative spawn path) ──
+
+    // witnessed red by mutation: exit code 1 — deleting the `|| Number.isNaN(def.stiffnessAng)` branch
+    // from createJoint's guard lets NaN pass (NaN < 0 is false) → stiffnessHertz(NaN) returns 0 (the
+    // finite guard) → angularHertz 0 → createWeldJoint → rigid weld → body pinned at y ≈ 2.5, far
+    // outside the free-fall band. With the NaN branch, createJoint warns+skips → no joint → free fall.
+    // The `< 0` branch mutation witness (exit code 1) is recorded in the negative arm below.
+    test("a NaN stiffnessAng reaching createJoint via the escape hatch is warned+skipped (free-fall)", async () => {
+        const { state, eids } = await build([
+            { pos: [0, 2, 0], mass: 0 },
+            { pos: [1.5, 2.5, 0], mass: 1, half: [0.25, 0.25, 0.25] },
+        ]);
+        // one tick to marshal the bodies into the tumble bodies map (SyncSystem runs on fixed tick)
+        stepFor(state, Time.FIXED_DT);
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            // bypass ConstraintSystem/jointDefs — call setJoints directly with a raw JointDef
+            Physics.backend?.setJoints([
+                { a: eids[0], b: eids[1], rA: [1.5, 0.5, 0], rB: [0, 0, 0], stiffnessAng: Number.NaN },
+            ]);
+            // step the world directly (not stepFor) so ConstraintSystem doesn't wipe the joint
+            stepWorldDirect(2);
+            const arm = Physics.backend?.readBody(eids[1]);
+            expect(arm).not.toBeNull();
+            // warn: createJoint's guard emitted a [tumble] joint ... skipped diagnostic
+            expect(warn).toHaveBeenCalled();
+            const jointWarn = warn.mock.calls.find((c) => String(c[0]).includes("joint"));
+            expect(jointWarn).toBeDefined();
+            expect(String(jointWarn?.[0])).toContain("skipped");
+            // effect: no joint created → free fall — y = 2.5 + ½·(−10)·2² = −17.5 (±1.0).
+            // Without the NaN branch: angularHertz 0 → rigid weld → body at y ≈ 2.5.
+            expect(Math.abs((arm?.pos[1] ?? 0) - -17.5)).toBeLessThan(1.0);
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    // witnessed red by mutation: exit code 1 — deleting the `def.stiffnessAng < 0` branch from
+    // createJoint's guard (leaving only the NaN check) lets -1 pass → stiffnessHertz(-1) returns 0
+    // (stiffness <= 0) → angularHertz 0 → createWeldJoint → rigid weld → body pinned at y ≈ 2.5,
+    // far outside the free-fall band. With the `< 0` branch, createJoint warns+skips → free fall.
+    // This arm exercises the escape-hatch path (setJoints direct), so the `< 0` branch's load-bearingness
+    // on the bypass path is measured, not assumed behind the authoring-layer guard.
+    test("a negative stiffnessAng reaching createJoint via the escape hatch is warned+skipped (free-fall)", async () => {
+        const { state, eids } = await build([
+            { pos: [0, 2, 0], mass: 0 },
+            { pos: [1.5, 2.5, 0], mass: 1, half: [0.25, 0.25, 0.25] },
+        ]);
+        stepFor(state, Time.FIXED_DT);
+        const warn = spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            Physics.backend?.setJoints([
+                { a: eids[0], b: eids[1], rA: [1.5, 0.5, 0], rB: [0, 0, 0], stiffnessAng: -1 },
+            ]);
+            stepWorldDirect(2);
+            const arm = Physics.backend?.readBody(eids[1]);
+            expect(arm).not.toBeNull();
+            expect(warn).toHaveBeenCalled();
+            const jointWarn = warn.mock.calls.find((c) => String(c[0]).includes("joint"));
+            expect(jointWarn).toBeDefined();
+            expect(String(jointWarn?.[0])).toContain("skipped");
+            // effect: no joint → free fall — y = 2.5 + ½·(−10)·2² = −17.5 (±1.0).
+            // Without the `< 0` branch: angularHertz 0 → rigid weld → body at y ≈ 2.5.
             expect(Math.abs((arm?.pos[1] ?? 0) - -17.5)).toBeLessThan(1.0);
         } finally {
             warn.mockRestore();

--- a/packages/shallot/src/standard/tumble/joints.ts
+++ b/packages/shallot/src/standard/tumble/joints.ts
@@ -248,11 +248,16 @@ function createJoint(
             localFrameB: frame(def.rB),
         });
     }
-    if (def.stiffnessAng < 0) {
+    // NaN is transparent to the comparison-only `< 0` guard (NaN < 0 is false), so state it explicitly —
+    // without this, NaN reaches stiffnessHertz, whose Number.isFinite guard returns 0 → angularHertz 0 →
+    // box3d's RIGID angular constraint → a rigid weld with no diagnostic (the exact defect the spec's Goal
+    // names). This is the escape-hatch defense: Tumble.world / imperative spawn bypasses ConstraintSystem and
+    // therefore the authoring-layer guard, so createJoint must be NaN-symmetric with its own negative case.
+    if (def.stiffnessAng < 0 || Number.isNaN(def.stiffnessAng)) {
         warnOnce(
             warned,
             `${key}|stiffness`,
-            `[tumble] joint (a: ${def.a}, b: ${def.b}) has negative angular stiffness — skipped`,
+            `[tumble] joint (a: ${def.a}, b: ${def.b}) has negative or NaN angular stiffness — skipped`,
         );
         return null;
     }

--- a/packages/shallot/src/standard/tumble/joints.ts
+++ b/packages/shallot/src/standard/tumble/joints.ts
@@ -34,7 +34,16 @@ const RIGID_THRESHOLD = 1e29;
 export function stiffnessHertz(stiffness: number, massA: number, massB: number): number {
     const meff =
         massA > 0 && massB > 0 ? (massA * massB) / (massA + massB) : Math.max(massA, massB);
-    if (meff <= 0 || stiffness <= 0) return 0;
+    // NaN is transparent to the comparison-only guard (NaN <= 0 is false), so state finiteness explicitly —
+    // defense in depth even after the authoring-layer guard, because the tumble singleton escape hatch
+    // (Tumble.world / imperative spawn scripts) bypasses ConstraintSystem. ∞ is a valid stiffness (rigid),
+    // so the finite check exempts it; -∞ is already caught by `stiffness <= 0`.
+    if (
+        meff <= 0 ||
+        stiffness <= 0 ||
+        (!Number.isFinite(stiffness) && stiffness !== Number.POSITIVE_INFINITY)
+    )
+        return 0;
     return Math.sqrt(stiffness / meff) / (2 * Math.PI);
 }
 


### PR DESCRIPTION
**Problem.** A negative `stiffnessAng` reached AVBD's position update sign-intact: `rec[11]` took any finite value, warmstart's clamp went negative on first init, and `mDiag(penAng)` applied an inverted restoring force with no warn, skip, or clamp. NaN slipped tumble's comparison-based guards on both the joint and spring paths (`NaN < 0` and `NaN > RIGID_THRESHOLD` are both false) and, under AVBD, silently became `RIGID_STIFFNESS` -- the stiffest possible joint, no diagnostic.

**Cause.** Comparison-only guards are NaN-transparent, and each backend carried its own partial guard rather than inheriting one shared bound.

**Fix.** Warn+skip at the backend-neutral authoring layer -- `jointDefs`/`springDefs` in `standard/physics/index.ts`, the one site both backends pass through -- so a negative or NaN `stiffnessAng` or `Spring.stiffness` drops the def instead of reaching either backend. `stiffnessHertz` additionally gets an explicit `Number.isFinite` guard, and tumble's `createJoint` guard is kept and NaN-symmetrized as defense-in-depth for the `Tumble.world` escape hatch, which bypasses `ConstraintSystem`. Rejected: clamping into AVBD's zero-means-spherical, which observably diverges the backends on one authored def; and duplicating the guard into AVBD's TS.

**Evidence.** 12 new arms, each red-first with the witnessed exit code in its docblock: 4 def-layer skip arms plus 1 grant arm (finite-positive 1000 still builds a joint through the guarded path), 3 `stiffnessHertz` arms, 4 tumble free-fall arms. Skip arms assert the effect -- no joint or spring reaches the backend, free-fall pose -- never only the warn string. Both `createJoint` guard branches mutation-witnessed at exit 1. `bun run test` 2191 -> 2208 pass with no new failures; `bun run check` unchanged at its pre-existing floor (one tsc error on the unbuilt audio wasm artifact). One adversarial review round returned a single finding, fixed here.
