### PR TITLE
shallot-scaffold-typecheck: ship @types/node dep + ImportMeta.env augmentation, reorder install-test gate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -325,6 +325,7 @@
         "shallot": "./bin/cli.ts",
       },
       "dependencies": {
+        "@types/node": "^26.0.0",
         "@webgpu/types": "^0.1.70",
         "meshoptimizer": "^0.22.0",
         "unplugin-typegpu": "~0.12.1",

--- a/packages/create-shallot/index.ts
+++ b/packages/create-shallot/index.ts
@@ -43,7 +43,7 @@ export function template(name: string): Record<string, string> {
                         module: "ESNext",
                         moduleResolution: "bundler",
                         lib: ["ESNext", "DOM", "DOM.Iterable"],
-                        types: ["@webgpu/types"],
+                        types: ["@webgpu/types", "node"],
                         strict: true,
                         noEmit: true,
                         skipLibCheck: true,

--- a/packages/shallot/package.json
+++ b/packages/shallot/package.json
@@ -91,6 +91,7 @@
         "gen-tumble-gold": "bun run scripts/gen-tumble-gold.ts"
     },
     "dependencies": {
+        "@types/node": "^26.0.0",
         "@webgpu/types": "^0.1.70",
         "meshoptimizer": "^0.22.0",
         "unplugin-typegpu": "~0.12.1",

--- a/packages/shallot/src/index.ts
+++ b/packages/shallot/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference path="./types/env.d.ts" />
 export * from "./document";
 export * from "./engine";
 export * from "./extras";

--- a/packages/shallot/src/types/env.d.ts
+++ b/packages/shallot/src/types/env.d.ts
@@ -1,0 +1,8 @@
+// `import.meta.env` is read by the engine's own source (`view.ts`'s `devEnabled`), and the package
+// ships `.ts` — a consumer's tsc typechecks the dependency. `@types/node` (a runtime dep) provides
+// `process` and `node:worker_threads` but not `import.meta.env` (a Vite/bundler convention), so the
+// package ships this ambient augmentation. Referenced from the entrypoint (`src/index.ts`) so a
+// consumer's program picks it up with no consumer config.
+interface ImportMeta {
+    readonly env?: Record<string, unknown>;
+}

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -249,6 +249,16 @@ function createShallotFlow(work: string, engineTgz: string) {
         `exit ${noPw.exitCode}`,
     );
 
+    // the intact scaffold typechecks: spin.ts is present, so the program reaches the engine's shipped
+    // source in node_modules — the shipped types (@types/node dep + ImportMeta.env augmentation) must
+    // resolve every error a consumer's tsc would see.
+    const tscIntact = run(["bunx", "tsc", "--noEmit"], proj);
+    check(
+        "tsc --noEmit on the intact scaffold typechecks clean (program reaches the engine)",
+        tscIntact.ok,
+        tscIntact.ok ? "" : tscIntact.out.slice(-400),
+    );
+
     // the TS18003 trap: deleting the demo plugin (its comment invites it) empties src/ but must not break
     // the scaffold's documented `bunx tsc --noEmit` — the env.d.ts anchor keeps `include: ["src"]` matched.
     rmSync(join(proj, "src", "spin.ts"));


### PR DESCRIPTION
**Problem.** A fresh `create-shallot` scaffold failed `bunx tsc --noEmit` with six errors, every one inside `node_modules/@dylanebert/shallot/src/` (`standard/render/view.ts:159` `ImportMeta.env`; `standard/tumble/engine/pool.ts:148,155,160` `process` x3, `node:worker_threads`, implicit-any). Every scaffold user saw six errors they didn't write, and `evals/harness/result.ts` ranks `typecheckOk === false` above every other input, so no eval task could report PASS or INCOMPLETE.

**Cause.** The package ships `.ts` source, so a consumer's tsc typechecks the dependency — while the scaffold tsconfig carried only `@webgpu/types`, and the package shipped neither node types nor an `ImportMeta.env` declaration. The monorepo's own root tsc stayed green only because `*.test.ts` pulls `@types/bun` (node globals + `ImportMeta.env`) into the same program, an accident a consumer gets none of. The one consumer-side gate, `scripts/install-test.ts`, deleted `src/spin.ts` — the only file importing the engine — *before* running tsc, so it had been green on a program that never reached the engine.

**Fix.** `@types/node` moves into `packages/shallot` `dependencies`; the package ships an `ImportMeta.env` augmentation (`src/types/env.d.ts`, referenced from the entrypoint so a consumer picks it up with no config); the scaffold tsconfig adds `"node"` to `types`; `install-test.ts` now runs `bunx tsc --noEmit` on the *intact* scaffold before the spin.ts deletion, keeping the emptied-src TS18003 arm as the second run.

**Evidence.** Fresh scaffold (`evals/setup.ts red-box`, engine packed from this branch) `bunx tsc --noEmit`: exit 1 / six errors before, exit 0 / zero errors after. Red-first: the reordered gate reds at exit 1 with the package fix reverted and greens with it; the TS18003 arm stays green both ways. Eval grading: `typecheck.ok` true on a bare scaffold. Post-merge on trunk: `bun run test` 3058 pass / 0 fail (exit 0); `bun run check` exit 1 at the pre-existing built-demo-`<title>` arm only, identical to the recorded floor. Consumer-collision check: adding `vite/client` beside the shipped augmentation still typechecks clean (exit 0).
