### PR TITLE
audit-shallot-ecs-contract-fixes: sparse stride-1 scalar parity

### DIFF
--- a/packages/shallot/src/engine/ecs/sparse.test.ts
+++ b/packages/shallot/src/engine/ecs/sparse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { entity, f16, f32, i32, slab, sparse, u8, u32, vec2, vec4 } from "../..";
+import { entity, f16, f32, i32, Slab, slab, sparse, u8, u32, vec2, vec4 } from "../..";
 import { lanes, refs } from "./core";
 
 describe("sparse scalar", () => {
@@ -37,6 +37,35 @@ describe("sparse scalar", () => {
         expect(field.get(5)).toBe(Infinity);
         field.set(5, -70000);
         expect(field.get(5)).toBe(-Infinity);
+    });
+
+    test("sparse(u8) truncates to the descriptor's element type, matching slab(u8)", () => {
+        // 300 wraps to 44 in a Uint8Array (300 & 0xFF). Before the fix the stride-1
+        // path stored raw JS doubles in a Map and never touched type.ctor, so
+        // sparse(u8) kept 300 while slab(u8) and the stride-2/4 paths truncated.
+        const cpu = sparse(u8);
+        cpu.set(3, 300);
+        expect(cpu.get(3)).toBe(44);
+
+        // parity against the sibling storage under the same descriptor — the
+        // check that cannot be satisfied by restating your own arithmetic
+        const gpu = new Slab(u8);
+        gpu.alloc();
+        gpu.set(3, 300);
+        expect(cpu.get(3)).toBe(gpu.get(3));
+    });
+
+    test("sparse(u32) wraps signed values to unsigned, matching slab(u32)", () => {
+        // -1 wraps to 0xFFFFFFFF (4294967295) in a Uint32Array. Before the fix
+        // the stride-1 path kept the raw -1.
+        const cpu = sparse(u32);
+        cpu.set(3, -1);
+        expect(cpu.get(3)).toBe(4294967295);
+
+        const gpu = new Slab(u32);
+        gpu.alloc();
+        gpu.set(3, -1);
+        expect(cpu.get(3)).toBe(gpu.get(3));
     });
 
     test("unset eids return the type's zero", () => {

--- a/packages/shallot/src/engine/ecs/sparse.ts
+++ b/packages/shallot/src/engine/ecs/sparse.ts
@@ -33,9 +33,14 @@ export function sparse(type: Type): Single | Pair | Quad {
 
     if (stride === 1) {
         const map = new Map<number, number>();
+        // truncate through the descriptor's ctor so the scalar path matches the
+        // TypedArray-backed stride-2/4 paths and slab(type) — e.g. sparse(u8)
+        // wraps 300 to 44, sparse(u32) wraps -1 to 0xFFFFFFFF
+        const scratch = new type.ctor(1);
         const out: Single = {
             set: (eid: number, v: number) => {
-                map.set(eid, enc(v));
+                scratch[0] = enc(v);
+                map.set(eid, scratch[0]);
             },
             get: (eid: number) => {
                 const raw = map.get(eid);

--- a/packages/shallot/src/extras/tween/tween.test.ts
+++ b/packages/shallot/src/extras/tween/tween.test.ts
@@ -329,17 +329,21 @@ describe("tween sequence", () => {
 
         expect(Sequence.duration.get(seq)).toBeCloseTo(0.2, 5); // period spans both children
 
+        // sparse(f32) truncates to f32 on each write, so elapsed accumulates
+        // f32 rounding across steps — precision 5 for the 75%-point values (a
+        // few ULP), precision 4 for the 25%-point values where the accumulated
+        // elapsed rounding lands further from the exact rational
         state.step(0.025); // up at 25% → 25 (down idle, before its window)
-        expect(Probe.value.get(target)).toBeCloseTo(25, 10);
+        expect(Probe.value.get(target)).toBeCloseTo(25, 5);
         state.step(0.05); // elapsed 0.075, up at 75% → 75
-        expect(Probe.value.get(target)).toBeCloseTo(75, 10);
+        expect(Probe.value.get(target)).toBeCloseTo(75, 5);
         state.step(0.05); // elapsed 0.125, up released, down at 25% → 75 (falling)
-        expect(Probe.value.get(target)).toBeCloseTo(75, 10);
+        expect(Probe.value.get(target)).toBeCloseTo(75, 5);
         state.step(0.05); // elapsed 0.175, down at 75% → 25
-        expect(Probe.value.get(target)).toBeCloseTo(25, 10);
+        expect(Probe.value.get(target)).toBeCloseTo(25, 4);
         state.step(0.05); // elapsed 0.225 → wraps to 0.025, up at 25% → 25
         expect(Sequence.state.get(seq)).toBe(TweenState.Playing); // loops, never completes
-        expect(Probe.value.get(target)).toBeCloseTo(25, 10);
+        expect(Probe.value.get(target)).toBeCloseTo(25, 4);
     });
 
     test("a non-looping sequence completes and holds the final pose", () => {
@@ -449,15 +453,17 @@ describe("tween scene wiring", () => {
 
         state.step(0.025); // setup grows the period to 0.2, then the clock advances
         expect(Sequence.duration.get(seq)).toBeCloseTo(0.2, 5);
-        expect(Probe.value.get(p)).toBeCloseTo(25, 10); // rise at 25%
+        // sparse(f32) truncates to f32 on each write — see the looping-clock
+        // test above for the precision rationale (5 for 75%-point, 4 for 25%-point)
+        expect(Probe.value.get(p)).toBeCloseTo(25, 5); // rise at 25%
         state.step(0.05); // elapsed 0.075, rise at 75%
-        expect(Probe.value.get(p)).toBeCloseTo(75, 10);
+        expect(Probe.value.get(p)).toBeCloseTo(75, 5);
         state.step(0.05); // elapsed 0.125, rise released, fall at 25% → 75 (falling)
-        expect(Probe.value.get(p)).toBeCloseTo(75, 10);
+        expect(Probe.value.get(p)).toBeCloseTo(75, 5);
         state.step(0.05); // elapsed 0.175, fall at 75% → 25
-        expect(Probe.value.get(p)).toBeCloseTo(25, 10);
+        expect(Probe.value.get(p)).toBeCloseTo(25, 4);
         state.step(0.05); // elapsed 0.225 → wraps to 0.025, rise at 25%
         expect(Sequence.state.get(seq)).toBe(TweenState.Playing); // loops, never completes
-        expect(Probe.value.get(p)).toBeCloseTo(25, 10);
+        expect(Probe.value.get(p)).toBeCloseTo(25, 4);
     });
 });


### PR DESCRIPTION
The stride-1 path in sparse() stored raw JS doubles in a Map via
enc/dec and never used type.ctor, so sparse(u8) kept 300 and sparse(u32)
kept -1 while the stride-2/4 paths (TypedArray-backed) and every slab(type)
truncated to the descriptor's element type — two round-trip semantics under
one descriptor. The header docblock and ecs.md both state the opposite ("same
surface, so consumers don't see the difference"), so the locked direction is
to fix the code.

Fix: route the stride-1 set through a 1-element type.ctor scratch buffer,
truncating the value to the descriptor's element type before storing it in
the Map. This matches the stride-2/4 paths (which store into a per-entity
TypedArray) and slab(type) (which stores into a capacity-sized TypedArray)
exactly.

Red-first witness: sparse(u8) stores 300 → reads 300 (expected 44);
sparse(u32) stores -1 → reads -1 (expected 4294967295). Both now pass,
with parity assertions against slab(type) under the same descriptor.

The tween sequence/scene-wiring tests stored elapsed/duration in sparse(f32)
and asserted toBeCloseTo(value, 10), which was appropriate for the old
double-precision storage but too tight for f32-truncated accumulation across
looping steps. Lowered to precision 5 (75%-point) / 4 (25%-point) with a
comment explaining the f32 truncation rationale.

Prose reconciliation: neither sparse.ts:8 nor ecs.md:58 needs a precision
edit — the fix makes both "same surface, so consumers don't see the
difference" claims true, since the value semantics are now aligned across
all storage paths.
