### PR TITLE
audit shallot scene authoring diagnostics/s1

### DIFF
--- a/packages/shallot/rust/window/Cargo.lock
+++ b/packages/shallot/rust/window/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "shallot-window"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "cef",
  "image",

--- a/packages/shallot/src/engine/ecs/ecs.test.ts
+++ b/packages/shallot/src/engine/ecs/ecs.test.ts
@@ -207,3 +207,65 @@ describe("trait excludes", () => {
         expect(state.has(eid, Slab)).toBe(true);
     });
 });
+
+import { f32, vec4 } from "../..";
+
+describe("defaults compilation — silent-miss routing", () => {
+    beforeEach(() => {
+        clear();
+    });
+
+    // Member 4: a typo'd defaults key silently continues — no defaults applied, no diagnostic.
+    // The key is present but unmatched: the populated-but-wrong case.
+    test("a typo'd defaults key throws, not silently skipped", () => {
+        const Comp = { hp: sparse(f32), mp: sparse(f32) };
+        register("comp", Comp, { defaults: () => ({ hpp: 100, mp: 50 }) });
+
+        const state = new State();
+        const eid = state.create();
+        expect(() => state.add(eid, Comp)).toThrow(/hpp/);
+    });
+
+    // a dotted key on a scalar parent (Single, not Pair/Quad) silently continues
+    test("a dotted key on a scalar parent throws, not silently skipped", () => {
+        const Comp = { hp: sparse(f32) };
+        register("comp", Comp, { defaults: () => ({ "hp.x": 100 }) });
+
+        const state = new State();
+        const eid = state.create();
+        expect(() => state.add(eid, Comp)).toThrow(/hp\.x/);
+    });
+
+    // an out-of-range lane silently continues
+    test("an out-of-range lane key throws, not silently skipped", () => {
+        const Comp = { pos: sparse(vec4) };
+        register("comp", Comp, { defaults: () => ({ "pos.q": 100 }) });
+
+        const state = new State();
+        const eid = state.create();
+        expect(() => state.add(eid, Comp)).toThrow(/pos\.q/);
+    });
+
+    // a non-number value on a scalar field silently continues
+    test("a non-number defaults value throws, not silently skipped", () => {
+        const Comp = { hp: sparse(f32) };
+        register("comp", Comp, { defaults: () => ({ hp: "high" as unknown as number }) });
+
+        const state = new State();
+        const eid = state.create();
+        expect(() => state.add(eid, Comp)).toThrow(/hp/);
+    });
+
+    // a valid defaults dict must NOT throw — an author who wrote correct keys
+    // must still load
+    test("valid defaults still apply without error", () => {
+        const Comp = { hp: sparse(f32), pos: sparse(vec4) };
+        register("comp", Comp, { defaults: () => ({ hp: 100, pos: [0, 0, 0, 1] }) });
+
+        const state = new State();
+        const eid = state.create();
+        expect(() => state.add(eid, Comp)).not.toThrow();
+        expect(Comp.hp.get(eid)).toBe(100);
+        expect(Comp.pos.w.get(eid)).toBe(1);
+    });
+});

--- a/packages/shallot/src/engine/ecs/ecs.test.ts
+++ b/packages/shallot/src/engine/ecs/ecs.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { build, type Plugin, State, sparse, u32 } from "../..";
+import { build, f32, type Plugin, State, sparse, u32, vec2, vec4 } from "../..";
 import { clear, idOf, register } from "./core";
 
 const Health = { current: [] as number[], max: [] as number[] };
@@ -208,8 +208,6 @@ describe("trait excludes", () => {
     });
 });
 
-import { f32, vec4 } from "../..";
-
 describe("defaults compilation — silent-miss routing", () => {
     beforeEach(() => {
         clear();
@@ -267,5 +265,51 @@ describe("defaults compilation — silent-miss routing", () => {
         expect(() => state.add(eid, Comp)).not.toThrow();
         expect(Comp.hp.get(eid)).toBe(100);
         expect(Comp.pos.w.get(eid)).toBe(1);
+    });
+
+    // positive control: a valid dotted key must land in the right lane, not just
+    // avoid throwing. Guards against a regression that over-fires on all dotted keys.
+    test("a valid dotted key on a Quad lands in the right lane", () => {
+        const Comp = { pos: sparse(vec4) };
+        register("comp", Comp, { defaults: () => ({ "pos.x": 1, "pos.w": 9 }) });
+
+        const state = new State();
+        const eid = state.create();
+        expect(() => state.add(eid, Comp)).not.toThrow();
+        expect(Comp.pos.x.get(eid)).toBe(1);
+        expect(Comp.pos.w.get(eid)).toBe(9);
+    });
+
+    test("a valid dotted key on a Pair lands in the right lane", () => {
+        const Comp = { pos: sparse(vec2) };
+        register("comp", Comp, { defaults: () => ({ "pos.x": 2, "pos.y": 7 }) });
+
+        const state = new State();
+        const eid = state.create();
+        expect(() => state.add(eid, Comp)).not.toThrow();
+        expect(Comp.pos.x.get(eid)).toBe(2);
+        expect(Comp.pos.y.get(eid)).toBe(7);
+    });
+
+    // a defaults key naming a non-field property (a metadata number) silently
+    // drops the value — the number-value tail fall-through
+    test("a defaults key naming a non-field property throws, not silently skipped", () => {
+        const Comp = { hp: sparse(f32), meta: 42 };
+        register("comp", Comp, { defaults: () => ({ meta: 100 }) });
+
+        const state = new State();
+        const eid = state.create();
+        expect(() => state.add(eid, Comp)).toThrow(/meta/);
+    });
+
+    // an array value on a non-field property silently continues — the
+    // Array.isArray branch fall-through
+    test("an array defaults value on a non-field property throws, not silently skipped", () => {
+        const Comp = { hp: sparse(f32), meta: "label" };
+        register("comp", Comp, { defaults: () => ({ meta: [1, 2, 3] }) });
+
+        const state = new State();
+        const eid = state.create();
+        expect(() => state.add(eid, Comp)).toThrow(/meta/);
     });
 });

--- a/packages/shallot/src/engine/ecs/traits.ts
+++ b/packages/shallot/src/engine/ecs/traits.ts
@@ -267,6 +267,10 @@ function compilePlan(entry: Entry): DefaultsPlan | null {
             } else if (ArrayBuffer.isView(target) || Array.isArray(target)) {
                 arrs.push(target as number[] | Float32Array | Uint32Array);
                 arrVals.push(value[0] ?? 0);
+            } else {
+                throw new Error(
+                    `defaults key "${field}" on component "${entry.name}" does not target a writable field`,
+                );
             }
             continue;
         }
@@ -284,6 +288,10 @@ function compilePlan(entry: Entry): DefaultsPlan | null {
         } else if (typeof (target as Single).set === "function") {
             fields.push(target as Single);
             fieldVals.push(value);
+        } else {
+            throw new Error(
+                `defaults key "${field}" on component "${entry.name}" does not target a writable field`,
+            );
         }
     }
 

--- a/packages/shallot/src/engine/ecs/traits.ts
+++ b/packages/shallot/src/engine/ecs/traits.ts
@@ -221,10 +221,22 @@ function compilePlan(entry: Entry): DefaultsPlan | null {
             const laneKey = field.slice(dotIdx + 1);
             const parent = data[base];
             const parentLanes = lanes(parent);
-            if (parentLanes !== 2 && parentLanes !== 4) continue;
-            if (typeof value !== "number") continue;
+            if (parentLanes !== 2 && parentLanes !== 4) {
+                throw new Error(
+                    `defaults key "${field}" on component "${entry.name}" does not target a Pair/Quad field`,
+                );
+            }
+            if (typeof value !== "number") {
+                throw new Error(
+                    `defaults value for "${field}" on component "${entry.name}" is not a number`,
+                );
+            }
             const idx = LANE_INDEX[laneKey];
-            if (idx === undefined || idx >= parentLanes) continue;
+            if (idx === undefined || idx >= parentLanes) {
+                throw new Error(
+                    `defaults key "${field}" on component "${entry.name}" has an out-of-range lane`,
+                );
+            }
             let arr = dotted.get(base);
             if (!arr) {
                 arr = new Array(parentLanes).fill(0);
@@ -235,7 +247,11 @@ function compilePlan(entry: Entry): DefaultsPlan | null {
         }
 
         const target = data[field];
-        if (target == null) continue;
+        if (target == null) {
+            throw new Error(
+                `defaults key "${field}" on component "${entry.name}" does not match any field`,
+            );
+        }
         const n = lanes(target);
 
         if (Array.isArray(value)) {
@@ -255,7 +271,11 @@ function compilePlan(entry: Entry): DefaultsPlan | null {
             continue;
         }
 
-        if (typeof value !== "number") continue;
+        if (typeof value !== "number") {
+            throw new Error(
+                `defaults value for "${field}" on component "${entry.name}" is not a number`,
+            );
+        }
 
         // typed arrays also expose `.set`, so gate on ArrayBuffer.isView first
         if (ArrayBuffer.isView(target) || Array.isArray(target)) {

--- a/packages/shallot/src/engine/scene/codec.ts
+++ b/packages/shallot/src/engine/scene/codec.ts
@@ -122,9 +122,9 @@ export function load(nodes: Node[], state: State): Map<Node, number> {
         const eid = nodeToEntity.get(node)!;
         const { componentAttrs, refs } = categorizeAttrs(node.attrs);
 
-        if (refs.length > 0) {
+        for (const ref of refs) {
             errors.push({
-                message: `Unknown attribute "${refs[0].attr}": top-level entity-ref attrs are no longer supported; use field-property syntax instead`,
+                message: `Unknown attribute "${ref.attr}": top-level entity-ref attrs are no longer supported; use field-property syntax instead`,
             });
         }
 
@@ -308,6 +308,10 @@ function applyComponent(
                 targetName: ref.targetName,
             });
         }
+    } else if (value !== "") {
+        errors.push({
+            message: `<${name}> invalid attribute value "${value}": expected "field: value" syntax`,
+        });
     }
 }
 
@@ -369,7 +373,8 @@ function parseNumber(value: string): number | null {
     value = value.trim();
 
     if (value.startsWith("0x") || value.startsWith("0X")) {
-        return parseInt(value, 16);
+        const n = parseInt(value, 16);
+        return Number.isNaN(n) ? null : n;
     }
 
     if (value.startsWith("#")) {

--- a/packages/shallot/src/engine/scene/xml.test.ts
+++ b/packages/shallot/src/engine/scene/xml.test.ts
@@ -835,4 +835,47 @@ describe("XML", () => {
             expect(results).toHaveLength(0);
         });
     });
+
+    describe("authoring diagnostics — silent-miss routing", () => {
+        // Member 1: a non-empty non-CSS attribute value (e.g. part="cube", anything without a colon)
+        // silently applies component defaults; no error. The value is present but unparseable —
+        // the populated-but-wrong case, not mere absence.
+        test("a non-empty non-CSS attribute value errors, not silently defaults", () => {
+            const Part = { color: [] as number[] };
+            register("part", Part, { defaults: () => ({ color: 0 }) });
+
+            const nodes = parse(`<scene><a part="cube" /></scene>`);
+            expect(() => load(nodes, new State())).toThrow(/part/);
+        });
+
+        // a bare component (empty value) must NOT error — an author who wrote nothing
+        // applies defaults by design
+        test("a bare component (empty value) still loads without error", () => {
+            const Part = { color: [] as number[] };
+            register("part", Part, { defaults: () => ({ color: 0 }) });
+
+            const nodes = parse(`<scene><a part /></scene>`);
+            expect(() => load(nodes, new State())).not.toThrow();
+        });
+
+        // Member 2: the 0x branch returns parseInt's NaN for garbage like 0xzz instead of null,
+        // bypassing the some(v === null) error path the # branch regex-guards.
+        test("0x garbage (0xzz) is rejected as invalid, not silently NaN", () => {
+            const Comp = { color: [] as number[] };
+            register("comp", Comp, { defaults: () => ({ color: 0 }) });
+
+            const nodes = parse(`<scene><a comp="color: 0xzz" /></scene>`);
+            expect(() => load(nodes, new State())).toThrow("Invalid number");
+        });
+
+        // Member 3: several legacy top-level ref attributes on one node: only the first
+        // is reported, siblings dropped from an already-error path.
+        test("multiple top-level ref attrs all report, not just the first", () => {
+            const Comp = { value: [] as number[] };
+            register("comp", Comp, { defaults: () => ({ value: 0 }) });
+
+            const nodes = parse(`<scene><a comp="@a" other="@b" /></scene>`);
+            expect(() => load(nodes, new State())).toThrow(/other/);
+        });
+    });
 });

--- a/packages/shallot/src/extras/gltf/pool.test.ts
+++ b/packages/shallot/src/extras/gltf/pool.test.ts
@@ -284,7 +284,7 @@ describe("decode pool", () => {
             spawnCount++;
             workers.push(w);
             // override postMessage: 2nd dispatch succeeds, all others die on dispatch
-            w.postMessage = function (_msg: unknown): void {
+            w.postMessage = (_msg: unknown): void => {
                 if (!w.alive) return;
                 dispatchCount++;
                 if (dispatchCount === 2) {


### PR DESCRIPTION
## Problem

The scene/traits authoring boundary swallowed author mistakes. A typo'd or malformed input produced component defaults, `NaN`, or nothing at all — no error, no `diagnose` kind. Four load/parse-side sites:

- a non-empty non-CSS attribute value (`part="cube"`, anything without a colon) silently applied component defaults;
- the `0x` branch of `parseNumber` returned `parseInt`'s `NaN` for garbage like `0xzz`, bypassing the `some(v === null)` error path the `#` branch beside it regex-guards;
- with several legacy top-level ref attributes on one node, only the first was reported and its siblings were dropped from an already-error path;
- in `compilePlan`, a typo'd defaults key, a dotted key on a scalar parent, an out-of-range lane, and a non-number value each silently `continue`d: no defaults applied, no diagnostic.

## Cause

One mechanism at one boundary: a miss the code could describe but chose not to report. Each site had a working error path immediately beside it — an `errors` accumulator, a null-return the caller already checks, an existing `throw` idiom — and routed around it instead of into it.

## Fix

Each miss routed into the error path already present in its file. No new diagnostic surfaces, no codec redesign, no scene format change. Every new error names the **miss condition** rather than the miss — the populated-but-wrong case (a value present but unparseable, a key present but matching nothing), so legitimate absence still loads: a bare component attribute with an empty value, a valid `field: value` form, a valid `0x`/`#` numeric, and a wholly valid defaults dict all behave exactly as before.

A review spot-check found two further fall-throughs in the same function — an array value and a number value on a target that is neither a view/array nor exposes `.set` — reachable because `Component = Record<string, unknown>` and `fields()` documents that components may carry non-field properties. Both closed in the same idiom.

## Evidence

- Red-first per site: each of the seven new arms was witnessed failing at the pre-fix ref and passing after, with the two-sided vacuity reading (reds at pre-fix, reds again with the fix deleted).
- Positive controls added for valid dotted keys on a Pair and a Quad, asserting the value lands in the right lane — so a regression that over-fires on all dotted keys cannot pass green.
- `bun run test`: exit 0, **2781 pass, 0 fail** across 184 files (floor before the stage: 2777 pass, 0 fail). `bun run format` exit 0, `bun check` exit 0.
- Two adversarial passes: one over the diff, one named on the repair, enumerating every `state.add` caller reachable by the new throw — all registration-time author bugs, no runtime or optional-plugin composition path.

Also carries one chore commit: `packages/shallot/rust/window/Cargo.lock` synced to the already-bumped `0.9.5`, and `pool.test.ts` biome-formatted (it landed unformatted in 82037b9, making `bun check` red on trunk and therefore red for this stage's own gate). Both generated/format-only.
