### PR TITLE
audit shallot ecs contract fixes/s2

### DIFF
--- a/packages/shallot/src/engine/ecs/component.ts
+++ b/packages/shallot/src/engine/ecs/component.ts
@@ -385,6 +385,12 @@ export interface Membership {
     /** membership words per entity (31 components each); fixes the mirror size */
     readonly generations: number;
     /**
+     * lock the generation count after `build` has assigned every registered
+     * component its bit. A later component that would require a new generation
+     * is refused rather than silently outsizing the fixed GPU mirror.
+     */
+    freeze(): void;
+    /**
      * report every entity whose membership changed since the last call, then
      * clear the pending set; returns false when nothing changed. The standard
      * membership mirror is the sole caller — it copies each `(eid, gen, word)`
@@ -397,6 +403,7 @@ export interface Membership {
 export class Components implements Membership {
     private _nextBit = 0;
     private _gen = 0;
+    private _frozen = false;
     // keyed by component id (idOf), not the object — a reloaded component handle
     // re-attaches by id. Array-by-id, since ids are small and monotonic.
     private _meta: ({ gen: number; bit: number } | undefined)[] = [];
@@ -445,6 +452,11 @@ export class Components implements Membership {
         return this._gen + 1;
     }
 
+    /** {@inheritDoc Membership.freeze} */
+    freeze(): void {
+        this._frozen = true;
+    }
+
     /** {@inheritDoc Membership.drain} */
     drain(visit: (eid: number, gen: number, word: number) => void): boolean {
         if (this._dirty.size === 0) return false;
@@ -461,6 +473,13 @@ export class Components implements Membership {
         const existing = this._meta[id];
         if (existing) return existing;
         if (this._nextBit >= BITS_PER_GEN) {
+            if (this._frozen) {
+                throw new Error(
+                    `membership: generation count is frozen at ${this._gen + 1} after build; ` +
+                        `a new component would require generation ${this._gen + 2} — ` +
+                        `rebuild to add more than ${BITS_PER_GEN} components per generation`,
+                );
+            }
             this._gen++;
             this._nextBit = 0;
             this._masks.push([]);

--- a/packages/shallot/src/engine/ecs/component.ts
+++ b/packages/shallot/src/engine/ecs/component.ts
@@ -477,7 +477,7 @@ export class Components implements Membership {
                 throw new Error(
                     `membership: generation count is frozen at ${this._gen + 1} after build; ` +
                         `a new component would require generation ${this._gen + 2} — ` +
-                        `rebuild to add more than ${BITS_PER_GEN} components per generation`,
+                        `rebuild to register more than ${(this._gen + 1) * BITS_PER_GEN} components`,
                 );
             }
             this._gen++;

--- a/packages/shallot/src/engine/ecs/invariants.test.ts
+++ b/packages/shallot/src/engine/ecs/invariants.test.ts
@@ -137,4 +137,56 @@ describe("Entity lifecycle invariants", () => {
         const second = q[Symbol.iterator]();
         expect(second).toBe(first); // return() pushed it back on break
     });
+
+    // ecs.md: the membership generation count is fixed for a State's life — build assigns every
+    // component its bit up front. A post-build component that would require a new generation
+    // (the 32nd, filling generation 0's 31 bits) must be refused rather than silently outsizing
+    // the fixed GPU mirror SlabPlugin allocates at warm. Bare-marker adds that fit in an existing
+    // generation are sanctioned; only growing the generation count past build is refused.
+    test("post-freeze component add that grows membership generation past build-fixed count is refused", () => {
+        const state = new State();
+        const eid = state.create();
+        // fill generation 0 (31 bits)
+        const comps = Array.from({ length: 31 }, () => ({ x: [] as number[] }));
+        for (const c of comps) state.add(eid, c);
+        expect(state.membership.generations).toBe(1);
+        // freeze the generation count (as warm does via allocMembership)
+        state.membership.freeze();
+        // a 32nd component would require generation 1 — refused
+        const comp32 = { x: [] as number[] };
+        expect(() => state.add(eid, comp32)).toThrow();
+        expect(state.membership.generations).toBe(1);
+    });
+
+    // The class doc on RegisteredQuery narrows safe mutation during iteration to the current-eid case:
+    // a swap-remove of the current eid overwrites an already-visited slot, so every original member is
+    // still visited exactly once. Removing a *not-yet-visited* eid mid-iteration is not safe — the
+    // swap-remove moves the tail into the unvisited slot, so the tail member is visited twice and the
+    // removed one skipped. This arm pins that narrowed contract: the double-visit is the expected
+    // behavior, not a bug to fix (fixing it would break the zero-alloc iterator or the current-eid case).
+    test("removing a not-yet-visited eid mid-iteration double-visits the tail and skips the removed", () => {
+        const state = new State();
+        const eids: number[] = [];
+        for (let i = 0; i < 5; i++) {
+            const eid = state.create();
+            state.add(eid, A);
+            eids.push(eid);
+        }
+
+        const visited: number[] = [];
+        for (const eid of state.query([A])) {
+            visited.push(eid);
+            // remove a not-yet-visited eid (eids[2]) on the first iteration
+            if (eid === eids[0]) state.remove(eids[2], A);
+        }
+
+        // the removed eid is skipped (swap-remove overwrites its slot with the tail)
+        expect(visited).not.toContain(eids[2]);
+        // the tail member (eids[4]) is visited twice: once at the swapped-in slot, once at its stale copy
+        const counts = new Map<number, number>();
+        for (const v of visited) counts.set(v, (counts.get(v) ?? 0) + 1);
+        expect(counts.get(eids[4])).toBe(2);
+        // every other visited member appears exactly once
+        for (const [eid, c] of counts) if (eid !== eids[4]) expect(c).toBe(1);
+    });
 });

--- a/packages/shallot/src/engine/ecs/query.ts
+++ b/packages/shallot/src/engine/ecs/query.ts
@@ -101,8 +101,14 @@ class QueryIterator implements Iterator<number> {
 /**
  * matched-entity set + iteration for one registered query. owns sparse-set
  * state inline (no wrapper class). iteration snapshots count at start so
- * callers can mutate during iteration, e.g. `for (const eid of state.query([Spawn,
- * not(Initialized)])) state.add(eid, Initialized)`.
+ * callers can mutate the *current* eid during iteration — adding a marker to
+ * or removing a component from the eid being visited swap-removes it from the
+ * query mid-loop, yet every original member is still visited exactly once (the
+ * swap only overwrites already-visited slots). Removing a *not-yet-visited*
+ * eid mid-iteration is not safe: the swap-remove moves the tail into the
+ * unvisited slot, so that tail member is visited twice and the removed one
+ * skipped. e.g. `for (const eid of state.query([Spawn, not(Initialized)]))
+ * state.add(eid, Initialized)`.
  */
 export class RegisteredQuery implements Iterable<number> {
     readonly required: any[] = [];

--- a/packages/shallot/src/standard/slab/membership.ts
+++ b/packages/shallot/src/standard/slab/membership.ts
@@ -24,6 +24,7 @@ let _mirror: Uint32Array<ArrayBuffer> | null = null;
  * @internal
  */
 export function allocMembership(state: State): void {
+    state.membership.freeze();
     _gpu?.destroy();
     _mirror = new Uint32Array(state.membership.generations * capacity);
     _gpu = Compute.device.createBuffer({


### PR DESCRIPTION
- **audit-shallot-ecs-contract-fixes: s2 — membership generation invariant + query mid-iteration removal**
- **audit-shallot-ecs-contract-fixes: s2 review fix — refusal message states total component budget**
