### PR TITLE
shallot demo startup stall/s1b

### DIFF
--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -23,6 +23,8 @@ import {
     bootArm,
     buildUrl,
     type Checkpoint,
+    type CpuProfileNode,
+    classifyCpuFrame,
     coerceVerdict,
     displayGateExit,
     displayGateMessage,
@@ -44,6 +46,7 @@ import {
     LEAK_BYTES_PER_SEC,
     type MemorySample,
     parseVerifyArgs,
+    type RawCpuProfile,
     RESOURCE_BUFFER,
     type RenderProbe,
     type ResourceEntry,
@@ -52,12 +55,14 @@ import {
     reportBatch,
     resolveBatchQueries,
     SetupError,
+    selfTimeMsByNodeId,
     serveDev,
     serveDist,
     settlePass,
     spansFromCheckpoints,
     stepWait,
     structured,
+    summarizeCpuProfile,
     summarizeResourceTiming,
     TIMINGS_INIT_SCRIPT,
     type WaitState,
@@ -614,6 +619,151 @@ describe("ATTRIBUTION_INIT_SCRIPT — what --attribution installs pre-navigation
         const win: { __shallotLongTasks?: unknown } = {};
         new Function("window", ATTRIBUTION_INIT_SCRIPT)(win);
         expect(win.__shallotLongTasks).toEqual([]);
+    });
+});
+
+describe("selfTimeMsByNodeId — S1b's CPU-profile self-time accounting", () => {
+    test("attributes timeDeltas[i] (microseconds) to samples[i], summed per node, in ms", () => {
+        const profile: RawCpuProfile = {
+            nodes: [],
+            startTime: 0,
+            endTime: 600,
+            samples: [1, 1, 2],
+            timeDeltas: [100, 200, 300],
+        };
+        const out = selfTimeMsByNodeId(profile);
+        expect(out.get(1)).toBeCloseTo(0.3, 6); // (100+200)us
+        expect(out.get(2)).toBeCloseTo(0.3, 6); // 300us
+        expect(out.size).toBe(2);
+    });
+
+    test("a non-positive delta is dropped rather than recorded as a zero-cost node — a real node with no observed cost is absent, not present at 0", () => {
+        const profile: RawCpuProfile = {
+            nodes: [],
+            startTime: 0,
+            endTime: 100,
+            samples: [1, 2],
+            timeDeltas: [0, -5],
+        };
+        expect(selfTimeMsByNodeId(profile).size).toBe(0);
+    });
+
+    test("a profile with no sample stream (samples/timeDeltas absent) reads as an empty map, not a crash", () => {
+        const profile: RawCpuProfile = { nodes: [], startTime: 0, endTime: 0 };
+        expect(selfTimeMsByNodeId(profile).size).toBe(0);
+    });
+});
+
+describe("classifyCpuFrame — S1b's named-candidate bucket table", () => {
+    test("routes each of the spec's named mechanisms to a distinct bucket", () => {
+        const pipelines = classifyCpuFrame(
+            "file:///repo/packages/shallot/src/standard/sear/pipelines.ts",
+            "preparePipelines",
+        );
+        const forward = classifyCpuFrame(
+            "file:///repo/packages/shallot/src/standard/sear/forward.ts",
+            "unwrapVariant",
+        );
+        const gpu = classifyCpuFrame(
+            "file:///repo/packages/shallot/src/engine/runtime/gpu.ts",
+            "precompileAll",
+        );
+        const regather = classifyCpuFrame(
+            "file:///repo/packages/shallot/src/standard/sear/regather.ts",
+            "prepareRegather",
+        );
+        const ecs = classifyCpuFrame(
+            "file:///repo/packages/shallot/src/engine/ecs/scheduler.ts",
+            "tick",
+        );
+        const scene = classifyCpuFrame(
+            "file:///repo/packages/shallot/src/engine/scene/preload.ts",
+            "preload",
+        );
+        const decode = classifyCpuFrame(
+            "file:///repo/packages/shallot/src/extras/gltf/pool.ts",
+            "decodeInWorker",
+        );
+        const buckets = new Set([pipelines, forward, gpu, regather, ecs, scene, decode]);
+        expect(buckets.size).toBe(7); // every named mechanism gets its own, distinguishable bucket
+        expect(pipelines).toContain("pipelines.ts");
+        expect(forward).toContain("forward.ts");
+        expect(gpu).toContain("gpu.ts");
+    });
+
+    test("a native/no-url frame is named by its V8 convention, not folded into a file bucket", () => {
+        expect(classifyCpuFrame("", "(program)")).toContain("(program)");
+        expect(classifyCpuFrame("", "")).toContain("no source url");
+    });
+
+    test("an unmatched frame falls through to a per-file bucket rather than disappearing", () => {
+        const out = classifyCpuFrame(
+            "file:///repo/packages/shallot/src/some/new/module.ts",
+            "boot",
+        );
+        expect(out).toContain("new/module.ts");
+    });
+});
+
+describe("summarizeCpuProfile — the pure profile-to-attribution reduction", () => {
+    test("merges self time across nodes sharing one call-frame identity, and rolls it up by named bucket", () => {
+        const pipelinesFrame = {
+            functionName: "preparePipelines",
+            scriptId: "1",
+            url: "file:///repo/packages/shallot/src/standard/sear/pipelines.ts",
+            lineNumber: 41,
+            columnNumber: 0,
+        };
+        const nodes: CpuProfileNode[] = [
+            { id: 1, callFrame: pipelinesFrame }, // called from call path A
+            { id: 2, callFrame: pipelinesFrame }, // same function, called from call path B
+            {
+                id: 3,
+                callFrame: {
+                    functionName: "(program)",
+                    scriptId: "0",
+                    url: "",
+                    lineNumber: 0,
+                    columnNumber: 0,
+                },
+            },
+        ];
+        const profile: RawCpuProfile = {
+            nodes,
+            startTime: 0,
+            endTime: 900,
+            samples: [1, 2, 3],
+            timeDeltas: [400_000, 100_000, 200_000], // microseconds: 400ms, 100ms, 200ms
+        };
+        const summary = summarizeCpuProfile(profile);
+
+        expect(summary.totalMs).toBeCloseTo(700, 6);
+        // node 1 and node 2 share one identity (same function+url+line) — merged into one entry at 500ms.
+        expect(summary.entries).toHaveLength(2);
+        const merged = summary.entries.find((e) => e.functionName === "preparePipelines");
+        expect(merged?.selfMs).toBeCloseTo(500, 6);
+
+        const pipelinesBucket = summary.buckets.find((b) => b.name.includes("pipelines.ts"));
+        expect(pipelinesBucket?.selfMs).toBeCloseTo(500, 6);
+        const programBucket = summary.buckets.find((b) => b.name.includes("(program)"));
+        expect(programBucket?.selfMs).toBeCloseTo(200, 6);
+    });
+
+    test("a node with zero sampled self time is excluded from entries entirely — not a false zero", () => {
+        const nodes: CpuProfileNode[] = [
+            {
+                id: 1,
+                callFrame: {
+                    functionName: "neverSampled",
+                    scriptId: "1",
+                    url: "file:///x.ts",
+                    lineNumber: 0,
+                    columnNumber: 0,
+                },
+            },
+        ];
+        const profile: RawCpuProfile = { nodes, startTime: 0, endTime: 0 };
+        expect(summarizeCpuProfile(profile).entries).toHaveLength(0);
     });
 });
 

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -623,17 +623,27 @@ describe("ATTRIBUTION_INIT_SCRIPT — what --attribution installs pre-navigation
 });
 
 describe("selfTimeMsByNodeId — S1b's CPU-profile self-time accounting", () => {
-    test("attributes timeDeltas[i] (microseconds) to samples[i], summed per node, in ms", () => {
+    // S1c: settled against two independent reference implementations (Chrome DevTools'
+    // CPUProfileDataModel.ts and speedscope's Chrome importer — cited in full on the function's
+    // docblock), not by reasoning — CDP's own spec prose ("the first delta is relative to the profile
+    // startTime") is silent on direction. Witnessed red before this fix: the pre-S1c implementation
+    // paired timeDeltas[i] with samples[i] over this same fixture (samples.length-bounded loop, so it
+    // also double-counted the repeated node id 1 at i=0 and i=2) and read out.get(1)===0.45,
+    // out.get(2)===0.3 — exit 1 on `expect(out.get(1)).toBeCloseTo(0.3, 6)`: "Received: 0.45".
+    test("attributes timeDeltas[i+1] to samples[i] — the interval FOLLOWING a sample belongs to it, not the interval ending AT it, and the LAST sample gets nothing (no following delta to pair with)", () => {
         const profile: RawCpuProfile = {
             nodes: [],
             startTime: 0,
-            endTime: 600,
-            samples: [1, 1, 2],
-            timeDeltas: [100, 200, 300],
+            endTime: 900,
+            samples: [1, 2, 1],
+            timeDeltas: [50, 300, 400, 250],
+            // [0]: startTime→sample0 (unused). [1]: sample0→sample1 (300us) → charged to samples[0]=1.
+            // [2]: sample1→sample2 (400us) → charged to samples[1]=2. [3] would be sample2→next, but
+            // sample2 is the LAST sample, so it's dropped rather than double-counted onto node 1.
         };
         const out = selfTimeMsByNodeId(profile);
-        expect(out.get(1)).toBeCloseTo(0.3, 6); // (100+200)us
-        expect(out.get(2)).toBeCloseTo(0.3, 6); // 300us
+        expect(out.get(1)).toBeCloseTo(0.3, 6); // timeDeltas[1] only — NOT +timeDeltas[3]
+        expect(out.get(2)).toBeCloseTo(0.4, 6); // timeDeltas[2]
         expect(out.size).toBe(2);
     });
 
@@ -696,6 +706,27 @@ describe("classifyCpuFrame — S1b's named-candidate bucket table", () => {
         expect(classifyCpuFrame("", "")).toContain("no source url");
     });
 
+    // S1b's adversarial pass: the prior docblock claimed "no url implies V8-internal", refuted by
+    // `decodeSample` (verify.ts's own in-page frame-sampling helper) landing here with no url and its
+    // own real name — page.evaluate serializes a function with no backing file, so CDP reports an empty
+    // url under the function's OWN name, not a synthetic one. Witnessed red against the pre-fix
+    // implementation (`if (functionName) return \`${functionName} — V8-internal/native frame...\`` with
+    // no synthetic-name check): `classifyCpuFrame("", "decodeSample")` returned
+    // "decodeSample — V8-internal/native frame (no source url)", so this arm's
+    // `expect(...).not.toContain("V8-internal")` exited 1 there —
+    // "Received: decodeSample — V8-internal/native frame (no source url)".
+    test("a NAMED no-url frame that isn't one of V8's synthetic names is NOT V8-internal — it's an evaluated/injected script", () => {
+        const decodeSample = classifyCpuFrame("", "decodeSample");
+        expect(decodeSample).not.toContain("V8-internal");
+        expect(decodeSample).toContain("decodeSample");
+        expect(decodeSample).toContain("evaluated script");
+        // the four real synthetic names still classify as V8-internal — the fix narrows the no-url
+        // branch, it doesn't widen it into "any name is native".
+        for (const synthetic of ["(program)", "(idle)", "(garbage collector)", "(root)"]) {
+            expect(classifyCpuFrame("", synthetic)).toContain("V8-internal");
+        }
+    });
+
     test("an unmatched frame falls through to a per-file bucket rather than disappearing", () => {
         const out = classifyCpuFrame(
             "file:///repo/packages/shallot/src/some/new/module.ts",
@@ -732,8 +763,10 @@ describe("summarizeCpuProfile — the pure profile-to-attribution reduction", ()
             nodes,
             startTime: 0,
             endTime: 900,
-            samples: [1, 2, 3],
-            timeDeltas: [400_000, 100_000, 200_000], // microseconds: 400ms, 100ms, 200ms
+            // S1c pairing: samples[i]'s self time is timeDeltas[i+1] (the interval FOLLOWING it), and
+            // the last sample is dropped — so the stream carries one trailing sample to close node 3.
+            samples: [1, 2, 3, 3],
+            timeDeltas: [50_000, 400_000, 100_000, 200_000], // us: node1 400ms, node2 100ms, node3 200ms
         };
         const summary = summarizeCpuProfile(profile);
 

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -26,6 +26,7 @@ import {
     type CpuProfileNode,
     classifyCpuFrame,
     coerceVerdict,
+    decodeSampleNode,
     displayGateExit,
     displayGateMessage,
     driveHarness,
@@ -37,7 +38,9 @@ import {
     formatTimings,
     gpuLogChecks,
     gridDiff,
+    HARNESS_INPAGE_FUNCTION_NAMES,
     HARNESS_PROBE_SCRIPT,
+    harnessBucketNames,
     harnessInstallMs,
     harnessPass,
     hasStructure,
@@ -55,6 +58,7 @@ import {
     reportBatch,
     resolveBatchQueries,
     SetupError,
+    sampleFrameNode,
     selfTimeMsByNodeId,
     serveDev,
     serveDist,
@@ -2321,5 +2325,300 @@ describe("verifyDiagnostic — the render probe in the instrument-fault branch",
         expect(correct).toContain("spread=7");
         // the arm discriminates: the broken and correct outputs differ
         expect(broken).not.toBe(correct);
+    });
+});
+
+// S1c's owed pieces: (1) an arm asserting no verify-harness call frame appears in an attribution run's
+// bucket table, red on the pre-fix contaminated shape and green on the decontaminated shape; (2) coverage
+// for `decodeSampleNode` and `sampleFrameNode`, which had none — including the pngjs-unavailable fallback.
+
+describe("harnessBucketNames — S1c's absence arm over a captured CPU profile", () => {
+    // a call frame identity shared by the contaminated and clean fixtures so the only variable is
+    // whether the harness frame is present.
+    const pipelinesFrame = {
+        functionName: "preparePipelines",
+        scriptId: "1",
+        url: "file:///repo/packages/shallot/src/standard/sear/pipelines.ts",
+        lineNumber: 41,
+        columnNumber: 0,
+    };
+    // the harness's own in-page decode helper — `sampleFrame`'s `page.evaluate(decodeSample, ...)`
+    // serialized this function into the profiled tab. CDP reports it with an empty url under the
+    // function's own name (not a V8 synthetic name), so `classifyCpuFrame` routes it to a bucket
+    // containing "decodeSample" and "evaluated script".
+    const decodeSampleFrame = {
+        functionName: "decodeSample",
+        scriptId: "0",
+        url: "",
+        lineNumber: 0,
+        columnNumber: 0,
+    };
+
+    // the pre-S1c contaminated shape: `sampleFrame` ran `page.evaluate(decodeSample, ...)` inside the
+    // profiled tab on every 500ms poll, so `decodeSample` appears as a real sampled node with self
+    // time — exactly the contamination S1b's adversarial pass found as the single largest bucket.
+    const contaminatedProfile: RawCpuProfile = {
+        nodes: [
+            { id: 1, callFrame: decodeSampleFrame },
+            { id: 2, callFrame: pipelinesFrame },
+        ],
+        startTime: 0,
+        endTime: 600,
+        // S1c pairing: samples[i]'s self time is timeDeltas[i+1]; last sample dropped.
+        // decodeSample (node 1) gets 400ms, preparePipelines (node 2) gets 100ms.
+        samples: [1, 2, 2],
+        timeDeltas: [50_000, 400_000, 100_000, 50_000],
+    };
+
+    // the S1c decontaminated shape: `sampleFrameNode` decodes in Node with pngjs, so no harness
+    // function appears in the page's CPU profile — only real app frames.
+    const cleanProfile: RawCpuProfile = {
+        nodes: [{ id: 2, callFrame: pipelinesFrame }],
+        startTime: 0,
+        endTime: 200,
+        samples: [2, 2],
+        timeDeltas: [50_000, 100_000, 50_000],
+    };
+
+    test("reds on the pre-fix contaminated shape — decodeSample is classified into a real bucket", () => {
+        const summary = summarizeCpuProfile(contaminatedProfile);
+        const harness = harnessBucketNames(summary);
+        // the arm FAILS here: harness buckets are present, so the absence assertion would red.
+        // This is the red witness — the arm detects the contamination it exists to catch.
+        expect(harness.length).toBeGreaterThan(0);
+        expect(harness[0]).toContain("decodeSample");
+        expect(harness[0]).toContain("evaluated script");
+        // the contaminated profile's bucket table actually carries the harness bucket with real self time
+        const decodeBucket = summary.buckets.find((b) => b.name.includes("decodeSample"));
+        expect(decodeBucket).toBeDefined();
+        expect(decodeBucket?.selfMs).toBeCloseTo(400, 6);
+    });
+
+    test("greens on the decontaminated shape — no harness bucket in the table", () => {
+        const summary = summarizeCpuProfile(cleanProfile);
+        const harness = harnessBucketNames(summary);
+        // the arm PASSES here: no harness buckets — the decontaminated profile is clean.
+        expect(harness).toHaveLength(0);
+        // and the real app frame is still present and attributed — the arm doesn't strip real work
+        expect(summary.buckets.length).toBeGreaterThan(0);
+        expect(summary.buckets[0].name).toContain("pipelines.ts");
+    });
+
+    // RED-WHEN-BROKEN WITNESS: a `harnessBucketNames` that ignores the harness function names (returns
+    // [] unconditionally) must green on the contaminated fixture, proving the arm discriminates.
+    test("red-when-broken: a no-op harnessBucketNames greens on the contaminated shape (the arm would not red)", () => {
+        function brokenHarnessBucketNames(): string[] {
+            return []; // the defect: never checks for harness frames
+        }
+        const summary = summarizeCpuProfile(contaminatedProfile);
+        const broken = brokenHarnessBucketNames();
+        const correct = harnessBucketNames(summary);
+        // the broken version misses the contamination — it returns empty on a contaminated profile
+        expect(broken).toHaveLength(0);
+        // the correct version catches it
+        expect(correct.length).toBeGreaterThan(0);
+        // the arm discriminates: the broken and correct outputs differ
+        expect(broken).not.toEqual(correct);
+    });
+});
+
+describe("decodeSampleNode — the Node-side PNG-to-FrameSample decoder", () => {
+    // a 4×4 RGBA image: top-left corner is black (0,0,0), center is red (255,0,0). Nearest-neighbor
+    // downsample to 64×64 replicates each source pixel across a 16×16 block, so the region averages
+    // preserve the source contrast — the same signal `decodeSample`'s canvas-resample produces, just
+    // via a different downsample path.
+    const mk4x4 = (
+        tl: number[],
+        center: number[],
+    ): { width: number; height: number; data: Uint8Array } => {
+        const data = new Uint8Array(4 * 4 * 4);
+        for (let y = 0; y < 4; y++)
+            for (let x = 0; x < 4; x++) {
+                const isCenter = x >= 1 && x <= 2 && y >= 1 && y <= 2;
+                const [r, g, b] = isCenter ? center : tl;
+                const i = (y * 4 + x) * 4;
+                data[i] = r;
+                data[i + 1] = g;
+                data[i + 2] = b;
+                data[i + 3] = 255;
+            }
+        return { width: 4, height: 4, data };
+    };
+
+    test("a structured image (center ≠ corner) produces a FrameSample with visible structure", () => {
+        const png = mk4x4([0, 0, 0], [255, 0, 0]);
+        const sample = decodeSampleNode(png);
+        expect(sample).not.toBeNull();
+        // center is red, corner is black — `hasStructure` should pass
+        expect(hasStructure(sample)).toBe(true);
+        expect(sample!.center[0]).toBeGreaterThan(200); // red channel lifted
+        expect(sample!.corner[0]).toBeLessThan(50); // corner stays dark
+    });
+
+    test("a flat image (center = corner) produces a FrameSample with no structure", () => {
+        const png = mk4x4([50, 50, 50], [50, 50, 50]);
+        const sample = decodeSampleNode(png);
+        expect(sample).not.toBeNull();
+        expect(hasStructure(sample)).toBe(false);
+    });
+
+    test("a zero-dimension image returns null, not a crash", () => {
+        expect(decodeSampleNode({ width: 0, height: 4, data: new Uint8Array(0) })).toBeNull();
+        expect(decodeSampleNode({ width: 4, height: 0, data: new Uint8Array(0) })).toBeNull();
+    });
+
+    test("the grid is 64×64×3 channels (12288 values), matching decodeSample's shape", () => {
+        const png = mk4x4([0, 0, 0], [255, 0, 0]);
+        const sample = decodeSampleNode(png);
+        expect(sample).not.toBeNull();
+        expect(sample!.grid.length).toBe(64 * 64 * 3);
+    });
+});
+
+describe("sampleFrameNode — the S1c decontaminated frame sampler", () => {
+    // a duck-typed page stub matching the shape `sampleFrameNode` calls: `page.locator("canvas").first()
+    // .screenshot(...)` and (fallback only) `page.evaluate(decodeSample, b64)`.
+    type ScreenshotResult = Buffer | { toString(encoding: string): string };
+
+    const mkPage = (
+        screenshotFn: () => Promise<ScreenshotResult>,
+        evaluateFn?: (fn: (...a: unknown[]) => unknown, ...args: unknown[]) => Promise<unknown>,
+    ) => ({
+        locator: () => ({
+            first: () => ({
+                screenshot: async () => screenshotFn(),
+            }),
+        }),
+        evaluate: evaluateFn ?? (async () => null),
+    });
+
+    test("screenshot failure returns null (no canvas, no crash)", async () => {
+        const page = mkPage(async () => {
+            throw new Error("no canvas");
+        });
+        expect(await sampleFrameNode(page as never)).toBeNull();
+    });
+
+    test("pngjs path: a valid PNG screenshot decodes to a FrameSample in Node (no page.evaluate)", async () => {
+        // Build a minimal 2×2 red PNG with pngjs so the screenshot returns real PNG bytes.
+        const { PNG } = await import("pngjs");
+        const png = new PNG({ width: 2, height: 2 });
+        // top-left = black, bottom-right = red — center vs corner contrast
+        for (let y = 0; y < 2; y++)
+            for (let x = 0; x < 2; x++) {
+                const i = (y * 2 + x) * 4;
+                const isCenter = x === 1 && y === 1;
+                png.data[i] = isCenter ? 255 : 0;
+                png.data[i + 1] = 0;
+                png.data[i + 2] = 0;
+                png.data[i + 3] = 255;
+            }
+        const shot = PNG.sync.write(png) as Buffer;
+
+        let evaluateCalled = false;
+        const page = mkPage(
+            async () => shot,
+            async () => {
+                evaluateCalled = true;
+                return null;
+            },
+        );
+        const sample = await sampleFrameNode(page as never);
+        expect(sample).not.toBeNull();
+        // pngjs decoded in Node — page.evaluate was never reached
+        expect(evaluateCalled).toBe(false);
+    });
+
+    test("fallback path: when pngjs decode fails, falls back to page.evaluate(decodeSample) (non-attribution)", async () => {
+        // Simulate the pngjs-unavailable path by making the screenshot succeed but the pngjs decode
+        // fail: `sampleFrameNode` catches the pngjs error and falls back to `page.evaluate(decodeSample, ...)`.
+        // We feed a non-PNG buffer that `PNG.sync.read` will reject, forcing the catch → fallback path.
+        // Under non-attribution (the default), the fallback is silent and fine — the plain verify path
+        // uses `sampleFrame` directly, but a non-attribution caller of `sampleFrameNode` still gets a
+        // working boot-settle signal.
+        const badShot = Buffer.from("not-a-png");
+        let evaluateCalled = false;
+        let evaluateArg = "";
+        const page = mkPage(
+            async () => badShot,
+            async (_fn: (...a: unknown[]) => unknown, b64: unknown) => {
+                evaluateCalled = true;
+                evaluateArg = b64 as string;
+                // simulate decodeSample's return shape — a structured frame
+                return {
+                    grid: [255, 0, 0],
+                    center: [255, 0, 0],
+                    corner: [0, 0, 0],
+                } as FrameSample;
+            },
+        );
+        const sample = await sampleFrameNode(page as never, false);
+        // the fallback fired — page.evaluate was called with the base64-encoded screenshot
+        expect(evaluateCalled).toBe(true);
+        expect(evaluateArg).toBe(badShot.toString("base64"));
+        // and it returned the page-side decode result
+        expect(sample).not.toBeNull();
+        expect(sample?.center).toEqual([255, 0, 0]);
+    });
+
+    test("fallback path: when both pngjs and page.evaluate fail, returns null (non-attribution)", async () => {
+        const badShot = Buffer.from("not-a-png");
+        const page = mkPage(
+            async () => badShot,
+            async () => {
+                throw new Error("page closed");
+            },
+        );
+        expect(await sampleFrameNode(page as never, false)).toBeNull();
+    });
+
+    test("attribution path: pngjs decode failure is FATAL (throws, no silent fallback)", async () => {
+        // Under --attribution the silent fallback to page.evaluate(decodeSample) is forbidden — it IS
+        // the contamination this stage removes. A pngjs failure must throw, not silently fall back.
+        const badShot = Buffer.from("not-a-png");
+        let evaluateCalled = false;
+        const page = mkPage(
+            async () => badShot,
+            async () => {
+                evaluateCalled = true;
+                return null;
+            },
+        );
+        await expect(sampleFrameNode(page as never, true)).rejects.toThrow(
+            /pngjs decode failed under --attribution/,
+        );
+        // the forbidden fallback was NOT taken — page.evaluate was never called
+        expect(evaluateCalled).toBe(false);
+    });
+});
+
+// S1c Finding 2: HARNESS_INPAGE_FUNCTION_NAMES is derived from the function objects' own .name
+// properties, not hardcoded strings — so a rename updates the set automatically. This test makes the
+// omission of a new in-page helper LOUD: it scans verify.ts for every NAMED function passed to
+// page.evaluate (not anonymous arrows — those are the known residual) and asserts each is registered
+// in HARNESS_INPAGE_FUNCTION_NAMES. A future in-page page.evaluate helper that isn't added to the set
+// fails this test, preventing the arm from being bypassed.
+describe("HARNESS_INPAGE_FUNCTION_NAMES — registration coverage for every named page.evaluate function", () => {
+    const verifySrc = readFileSync(resolve(import.meta.dir, "verify.ts"), "utf8");
+    // find every `page.evaluate(identifierName,` or `page.evaluate(identifierName)` where identifierName
+    // is a bare identifier (not an arrow `() =>` or `async () =>` — those are anonymous, the known residual)
+    const namedEvaluateRe = /\.evaluate\(\s*(?!async\s*\(|\(?\s*\)\s*=>)([A-Za-z_$][\w$]*)/g;
+    const found = new Set<string>();
+    let m: RegExpExecArray | null;
+    while ((m = namedEvaluateRe.exec(verifySrc)) !== null) {
+        found.add(m[1]);
+    }
+
+    test("every named function passed to page.evaluate in verify.ts is registered in HARNESS_INPAGE_FUNCTION_NAMES", () => {
+        // HARNESS_INPAGE_FUNCTION_NAMES is the closed set the arm checks against. Every named function
+        // verify.ts serializes into the page must be here, or the arm is bypassable by omission.
+        const unregistered = [...found].filter((name) => !HARNESS_INPAGE_FUNCTION_NAMES.has(name));
+        expect(unregistered).toEqual([]);
+    });
+
+    test("HARNESS_INPAGE_FUNCTION_NAMES is non-empty and contains decodeSample and decodeRgba", () => {
+        expect(HARNESS_INPAGE_FUNCTION_NAMES.size).toBeGreaterThan(0);
+        expect(HARNESS_INPAGE_FUNCTION_NAMES.has("decodeSample")).toBe(true);
+        expect(HARNESS_INPAGE_FUNCTION_NAMES.has("decodeRgba")).toBe(true);
     });
 });

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -652,6 +652,13 @@ export interface Result {
         compileAfterIdle: BenchmarkCompileStats | null;
         longTasks: { start: number; duration: number }[];
     } | null;
+    /** `--attribution` only (S1b): a CDP `Profiler` sample-based CPU profile of the main thread from
+     *  just before navigation through the boot wait's conclusion (the same point `attribution.compile`
+     *  is read at, before the idle wait) — sees the sync `create*Pipeline` path's real magnitude, which
+     *  `Profile.compile` structurally cannot (its docblock, and `.claude/rules/testing.md`'s
+     *  compile/startup bullet). `null` when CDP's `Profiler` domain wasn't reachable (no CDP session,
+     *  or `Profiler.start`/`stop` failed) — an honest miss, never a fabricated empty profile. */
+    cpuProfile?: CpuProfileSummary | null;
 }
 
 /** how long `--attribution`'s second `Profile.compile` read waits after the first, with no page
@@ -659,6 +666,184 @@ export interface Result {
  *  scene interaction would trigger sooner) would have already landed if the boot wait's own settle
  *  point didn't cover it. */
 export const ATTRIBUTION_IDLE_MS = 3_000;
+
+// S1b of `shallot-demo-startup-stall`: `Profile.compile` (above) can classify a pipeline label's KIND
+// (sync stub vs async await) but structurally cannot see the sync `create*Pipeline` path's real
+// magnitude — Dawn defers that cost past the sync call's return. A CDP `Profiler` sample-based CPU
+// profile sees it instead: it samples the real V8 call stack on a fixed cadence regardless of whether
+// the sampled frame is inside a sync loop, an async continuation, or module-eval, so it needs no
+// engine-internal instrumentation and can't be fooled by a span recorded at the wrong seam. Chrome's
+// `Profiler.setSamplingInterval` argument is MICROSECONDS; 200us gives ~5x DevTools' 1ms default for a
+// boot window that's only ~1-3s long, without the overhead of the finest setting.
+export const CPU_PROFILE_SAMPLING_INTERVAL_US = 200;
+
+/** the CDP `Profiler.Profile` call-frame identity: the same function can appear as more than one node
+ *  (once per distinct call path), so attributing self time to "this function, this file, this line"
+ *  needs the merge {@link summarizeCpuProfile} does across nodes sharing this identity. */
+export interface CpuProfileCallFrame {
+    functionName: string;
+    scriptId: string;
+    url: string;
+    lineNumber: number;
+    columnNumber: number;
+}
+
+/** one node in the CDP `Profiler.Profile` call tree — the tree shape itself is discarded by
+ *  {@link summarizeCpuProfile} (self time is attributed per call-frame identity, not per node/path);
+ *  `children` is read by nobody here and kept only because CDP always sends it. */
+export interface CpuProfileNode {
+    id: number;
+    callFrame: CpuProfileCallFrame;
+    hitCount?: number;
+    children?: number[];
+}
+
+/** the raw `Profiler.stop()` response body (`{ profile }`). `samples[i]` names the node id active
+ *  during `timeDeltas[i]` microseconds — the sample-based self-time accounting CDP itself defines
+ *  (https://chromedevtools.github.io/devtools-protocol/tot/Profiler/#type-Profile); a profile with no
+ *  samples (a boot too short to take one, or `Profiler.start` never reaching the page) has both fields
+ *  absent rather than empty arrays. */
+export interface RawCpuProfile {
+    nodes: CpuProfileNode[];
+    startTime: number;
+    endTime: number;
+    samples?: number[];
+    timeDeltas?: number[];
+}
+
+/** self time in ms per CDP node id, from the profile's `samples`/`timeDeltas` sample stream — the
+ *  documented CDP self-time accounting (see {@link RawCpuProfile}'s doc): `timeDeltas[i]` is charged to
+ *  whichever node `samples[i]` names. Empty when the profile carries no sample stream. Exported only so
+ *  {@link summarizeCpuProfile}'s per-node attribution is independently testable against a hand-built
+ *  sample list. */
+export function selfTimeMsByNodeId(profile: RawCpuProfile): Map<number, number> {
+    const out = new Map<number, number>();
+    const { samples, timeDeltas } = profile;
+    if (!samples || !timeDeltas) return out;
+    for (let i = 0; i < samples.length; i++) {
+        const nodeId = samples[i];
+        const deltaUs = timeDeltas[i] ?? 0;
+        if (deltaUs <= 0) continue;
+        out.set(nodeId, (out.get(nodeId) ?? 0) + deltaUs / 1000);
+    }
+    return out;
+}
+
+// candidate mechanisms named by the spec (`Approach`, S1b bullet), most-specific pattern first — a
+// call-frame URL is classified by the first pattern it matches. Data, not a branch tree, so the mapping
+// is auditable and testable as a table rather than as control flow.
+const CPU_FRAME_BUCKETS: { pattern: RegExp; name: string }[] = [
+    {
+        pattern: /standard\/sear\/pipelines\.ts/,
+        name: "sync createRenderPipeline loop (sear/pipelines.ts, preparePipelines)",
+    },
+    { pattern: /standard\/sear\/forward\.ts/, name: "unwrapVariant (sear/forward.ts)" },
+    { pattern: /engine\/runtime\/gpu\.ts/, name: "precompileAll drain (engine/runtime/gpu.ts)" },
+    { pattern: /engine\/app\/index\.ts/, name: "app boot orchestration (engine/app/index.ts)" },
+    {
+        pattern: /standard\/sear\/regather\.ts/,
+        name: "regather registration (sear/regather.ts, async createComputePipelineAsync)",
+    },
+    {
+        pattern: /standard\/sear\/codegen\.ts/,
+        name: "shader codegen — sear's shared WGSL constants (sear/codegen.ts)",
+    },
+    {
+        pattern: /typegpu.*(resolve|codegen|tgsl)/i,
+        name: "shader codegen (TGSL/WGSL emission, typegpu resolve)",
+    },
+    { pattern: /engine\/ecs\//, name: "ECS setup" },
+    { pattern: /engine\/scene\//, name: "scene setup" },
+    {
+        pattern: /extras\/gltf\//,
+        name: "asset decode (gltf, main-thread marshaling — the decode itself runs in decode.worker.ts, off this thread)",
+    },
+    {
+        pattern: /node_modules\/typegpu/,
+        name: "typegpu runtime (pipeline construction, non-codegen)",
+    },
+];
+
+/** classify a CDP call frame into one of S1b's named candidate mechanisms — data-driven
+ *  ({@link CPU_FRAME_BUCKETS}) rather than a branch tree, so the mapping is a single auditable table.
+ *  A frame with no URL is a V8-internal/native frame CDP names by convention
+ *  (`(program)`/`(idle)`/`(garbage collector)`/`(root)`); anything else falls through to a per-file
+ *  bucket keyed on its last two path segments, so an unclassified hot frame is still visible under its
+ *  own file rather than disappearing into a catch-all. */
+export function classifyCpuFrame(url: string, functionName: string): string {
+    if (!url) {
+        if (functionName) return `${functionName} — V8-internal/native frame (no source url)`;
+        return "(anonymous, no source url) — V8-internal/native frame";
+    }
+    for (const b of CPU_FRAME_BUCKETS) {
+        if (b.pattern.test(url)) return b.name;
+    }
+    return `other — module top-level or unbucketed (${url.split("/").slice(-2).join("/")})`;
+}
+
+/** one merged call-frame identity's self time — {@link summarizeCpuProfile} merges every node sharing
+ *  this identity, since the same function shows up as more than one node when called from more than
+ *  one call path and a per-node reading would split its true self time across them. */
+export interface CpuProfileEntry {
+    key: string;
+    functionName: string;
+    url: string;
+    lineNumber: number;
+    selfMs: number;
+}
+
+/** one named candidate mechanism's total self time — {@link classifyCpuFrame}'s buckets, summed. */
+export interface CpuProfileBucket {
+    name: string;
+    selfMs: number;
+}
+
+/** the reduced form of a raw CDP CPU profile: total sampled self time, every call-frame identity's own
+ *  self time (descending), and the same total rolled up into S1b's named candidate buckets. Pure —
+ *  independently testable against a hand-built {@link RawCpuProfile} fixture, no CDP or browser needed. */
+export interface CpuProfileSummary {
+    totalMs: number;
+    entries: CpuProfileEntry[];
+    buckets: CpuProfileBucket[];
+}
+
+/** reduce a raw CDP CPU profile to {@link CpuProfileSummary}: merge self time per call-frame identity
+ *  (function + url + line — the same identity {@link classifyCpuFrame} buckets), then roll that up into
+ *  the named candidate mechanisms. Deterministic — no wall-clock, no CDP, no browser — so it can be
+ *  armed over a frozen fixture profile. */
+export function summarizeCpuProfile(profile: RawCpuProfile): CpuProfileSummary {
+    const selfByNode = selfTimeMsByNodeId(profile);
+    const byKey = new Map<string, CpuProfileEntry>();
+    for (const node of profile.nodes) {
+        const ms = selfByNode.get(node.id);
+        if (!ms) continue;
+        const cf = node.callFrame;
+        const key = `${cf.functionName || "(anonymous)"}@${cf.url}:${cf.lineNumber + 1}`;
+        const existing = byKey.get(key);
+        if (existing) existing.selfMs += ms;
+        else
+            byKey.set(key, {
+                key,
+                functionName: cf.functionName || "(anonymous)",
+                url: cf.url,
+                lineNumber: cf.lineNumber,
+                selfMs: ms,
+            });
+    }
+    const entries = [...byKey.values()].sort((a, b) => b.selfMs - a.selfMs);
+    const totalMs = entries.reduce((s, e) => s + e.selfMs, 0);
+
+    const bucketTotals = new Map<string, number>();
+    for (const e of entries) {
+        const name = classifyCpuFrame(e.url, e.functionName);
+        bucketTotals.set(name, (bucketTotals.get(name) ?? 0) + e.selfMs);
+    }
+    const buckets = [...bucketTotals.entries()]
+        .map(([name, selfMs]) => ({ name, selfMs }))
+        .sort((a, b) => b.selfMs - a.selfMs);
+
+    return { totalMs, entries, buckets };
+}
 
 /** the render probe the settle path records on its Result — the pixel evidence behind the `rendered`
  *  verdict. Carries the frame samples the wait loop took, the last centre/corner RGB and the spread
@@ -1163,7 +1348,10 @@ const usage = `
     --attribution         Read back the startup pipeline-compile attribution twice, once when the boot
                           wait concludes and once ATTRIBUTION_IDLE_MS later (Profile.compile per label,
                           ProfilePlugin projects only — the second read names a lazy escape past the
-                          boot wait), plus any longtask entries — on result.attribution
+                          boot wait), plus any longtask entries — on result.attribution. Also captures a
+                          CDP sample-based CPU profile of the boot window (self time per function, rolled
+                          up into named candidate mechanisms) — on result.cpuProfile, null if CDP's
+                          Profiler domain wasn't reachable
     --run k=v[&k2=v2]     Batch mode (repeatable): one boot, one page load per --run (fresh browser
                           context + page each), one verdict each. Each spec is its own query string,
                           layered on the shared --query params. A JSON array on stdout; nonzero exit if
@@ -1485,6 +1673,26 @@ async function drive(
         await page.addInitScript({ content: ATTRIBUTION_INIT_SCRIPT }).catch(() => {});
     }
 
+    // S1b: a CDP sample-based CPU profile of the boot, alongside the longtask observer above — started
+    // before navigation so it covers the whole boot, including any longtask that fires before the
+    // app's own module graph finishes loading. Best-effort: a CDP failure (no `Profiler` domain, a
+    // disconnected bridge) leaves `cdpProfiler` null, which reads honestly as `cpuProfile: null` below
+    // rather than a fabricated empty profile.
+    let cdpProfiler: { send(method: string, params?: unknown): Promise<unknown> } | null = null;
+    if (args.attribution) {
+        try {
+            const cdp = await page.context().newCDPSession(page);
+            await cdp.send("Profiler.enable");
+            await cdp.send("Profiler.setSamplingInterval", {
+                interval: CPU_PROFILE_SAMPLING_INTERVAL_US,
+            });
+            await cdp.send("Profiler.start");
+            cdpProfiler = cdp;
+        } catch {
+            cdpProfiler = null;
+        }
+    }
+
     // retry the goto once only if the first attempt itself failed (a cold vite server can re-optimize
     // deps mid-load and strand it — the flows launcher's proven shape). Never re-navigate a page that
     // loaded: a second goto re-runs the app and diverges its first-load state. navStart is stamped
@@ -1543,6 +1751,19 @@ async function drive(
         }
         if (Date.now() >= deadline) break;
         await page.waitForTimeout(500);
+    }
+
+    // stop the CPU profile the moment the boot wait concludes — the same point `attribution.compile`
+    // reads Profile.compile below, before its ATTRIBUTION_IDLE_MS idle wait, so the profiled window is
+    // the boot window a real loading screen would key off, not padded by idle sampling.
+    if (cdpProfiler) {
+        try {
+            const stopped = (await cdpProfiler.send("Profiler.stop")) as { profile: RawCpuProfile };
+            await cdpProfiler.send("Profiler.disable").catch(() => {});
+            base.cpuProfile = summarizeCpuProfile(stopped.profile);
+        } catch {
+            base.cpuProfile = null;
+        }
     }
 
     // the render probe — the pixel evidence behind the `rendered` verdict. Carries the wait loop's

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -711,18 +711,33 @@ export interface RawCpuProfile {
     timeDeltas?: number[];
 }
 
-/** self time in ms per CDP node id, from the profile's `samples`/`timeDeltas` sample stream — the
- *  documented CDP self-time accounting (see {@link RawCpuProfile}'s doc): `timeDeltas[i]` is charged to
- *  whichever node `samples[i]` names. Empty when the profile carries no sample stream. Exported only so
- *  {@link summarizeCpuProfile}'s per-node attribution is independently testable against a hand-built
- *  sample list. */
+/** self time in ms per CDP node id, from the profile's `samples`/`timeDeltas` sample stream.
+ *  {@link RawCpuProfile}'s own doc quotes the CDP spec verbatim ("time intervals between adjacent
+ *  samples... the first delta is relative to the profile startTime") but that prose alone is silent on
+ *  DIRECTION — S1c settled it against two independent reference implementations rather than reasoning
+ *  it out: Chrome DevTools' own `CPUProfileDataModel.ts`
+ *  (front_end/models/cpu_profile/CPUProfileDataModel.ts, `ChromeDevTools/devtools-frontend`, main branch)
+ *  builds `timestamps[i] = startTime + sum(timeDeltas[0..i])` and then attributes the duration between
+ *  `timestamps[i]` and `timestamps[i+1]` — i.e. raw `timeDeltas[i+1]` — to the node found at `samples[i]`;
+ *  speedscope's independent Chrome-profile importer (`src/import/chrome.ts`,
+ *  `github.com/jlfwong/speedscope`) walks the identical pairing. So `timeDeltas[i]` is the interval
+ *  ENDING at `samples[i]`'s timestamp (time spent in the PREVIOUS sample's node), and the self time for
+ *  `samples[i]` is `timeDeltas[i+1]` — the interval running FROM it to the next sample, never its own
+ *  index. The LAST sample has no following delta to pair with; devtools synthesizes one extra timestamp
+ *  from the average prior interval to close it, which is more machinery than this floor-not-measurement
+ *  instrument needs (`.claude/rules/testing.md`'s compile/startup bullet on this same file already
+ *  accepts an honest floor over a fabricated number) — so the last sample is left unattributed here
+ *  rather than synthesized, a negligible undercount at this profile's sample rate (hundreds to thousands
+ *  of samples per boot at {@link CPU_PROFILE_SAMPLING_INTERVAL_US}). Empty when the profile carries no
+ *  sample stream. Exported only so {@link summarizeCpuProfile}'s per-node attribution is independently
+ *  testable against a hand-built sample list. */
 export function selfTimeMsByNodeId(profile: RawCpuProfile): Map<number, number> {
     const out = new Map<number, number>();
     const { samples, timeDeltas } = profile;
     if (!samples || !timeDeltas) return out;
-    for (let i = 0; i < samples.length; i++) {
+    for (let i = 0; i < samples.length - 1; i++) {
         const nodeId = samples[i];
-        const deltaUs = timeDeltas[i] ?? 0;
+        const deltaUs = timeDeltas[i + 1] ?? 0;
         if (deltaUs <= 0) continue;
         out.set(nodeId, (out.get(nodeId) ?? 0) + deltaUs / 1000);
     }
@@ -764,16 +779,35 @@ const CPU_FRAME_BUCKETS: { pattern: RegExp; name: string }[] = [
     },
 ];
 
+// the exact, closed set of synthetic frame names V8's sampling profiler emits for its own internal
+// states (idle time, JS-outside-any-function execution, GC, the call-tree root) — CDP always reports
+// these with an empty url, and DevTools renders them verbatim under these names. This is the ONLY
+// legitimate no-url shape; S1c named it explicitly after the adversarial pass refuted the prior
+// docblock's blanket "no url implies V8-internal" claim with a counterexample that had no url and
+// wasn't in this set (`decodeSample`, verify.ts's own in-page frame-sampling helper — `page.evaluate`
+// serializes a function with no backing file, so CDP reports it with an empty url and the function's OWN
+// name, not a synthetic one).
+const V8_SYNTHETIC_FRAME_NAMES = new Set(["(program)", "(idle)", "(garbage collector)", "(root)"]);
+
 /** classify a CDP call frame into one of S1b's named candidate mechanisms — data-driven
  *  ({@link CPU_FRAME_BUCKETS}) rather than a branch tree, so the mapping is a single auditable table.
- *  A frame with no URL is a V8-internal/native frame CDP names by convention
- *  (`(program)`/`(idle)`/`(garbage collector)`/`(root)`); anything else falls through to a per-file
- *  bucket keyed on its last two path segments, so an unclassified hot frame is still visible under its
- *  own file rather than disappearing into a catch-all. */
+ *  A no-url frame is V8-internal ONLY when its function name is one of
+ *  {@link V8_SYNTHETIC_FRAME_NAMES} or empty (true anonymous native code carries no name at all) — any
+ *  OTHER named no-url frame is an evaluated/injected script Playwright ran in the page, not V8-internal,
+ *  and is called out as such rather than folded into the native bucket. Known residual: an ANONYMOUS
+ *  evaluated frame (e.g. an inline arrow passed to `page.evaluate`) is indistinguishable from true
+ *  anonymous native code by name alone and still falls into the native bucket — CDP's `scriptId` would
+ *  discriminate them (V8-internal frames carry `"0"`; an evaluated script gets its own id) but
+ *  {@link CpuProfileEntry} doesn't carry scriptId through the merge, so this stays a named limitation
+ *  rather than a silent one. A frame with a real url falls through to a per-file bucket keyed on its
+ *  last two path segments when unmatched, so an unclassified hot frame is still visible under its own
+ *  file rather than disappearing into a catch-all. */
 export function classifyCpuFrame(url: string, functionName: string): string {
     if (!url) {
-        if (functionName) return `${functionName} — V8-internal/native frame (no source url)`;
-        return "(anonymous, no source url) — V8-internal/native frame";
+        if (!functionName) return "(anonymous, no source url) — V8-internal/native frame";
+        if (V8_SYNTHETIC_FRAME_NAMES.has(functionName))
+            return `${functionName} — V8-internal/native frame (no source url)`;
+        return `${functionName} — in-page evaluated script, no source url (not a native frame: page.evaluate serializes a function with no file, so CDP reports an empty url under the function's own name)`;
     }
     for (const b of CPU_FRAME_BUCKETS) {
         if (b.pattern.test(url)) return b.name;
@@ -989,6 +1023,84 @@ async function sampleFrame(page: Page): Promise<FrameSample | null> {
         return (await page.evaluate(decodeSample, shot.toString("base64"))) as FrameSample | null;
     } catch {
         return null;
+    }
+}
+
+/** {@link decodeSample}'s region-averaging math (center/corner box averages over a coarse grid), fed by
+ *  a pngjs-decoded PNG instead of a page-side canvas — same field shape ({@link FrameSample}), computed
+ *  entirely in Node. Nearest-neighbor downsample rather than a canvas's resample filter: the boot-settle
+ *  heuristic only needs a stable coarse structure signal, not a pixel-identical grid. Duplicated from
+ *  {@link decodeSample} rather than shared, for the same reason {@link decodeRgba} already duplicates it
+ *  (its own comment, above): {@link decodeSample} is serialized by Playwright and run in-page, so it
+ *  can't import or close over anything. */
+function decodeSampleNode(png: {
+    width: number;
+    height: number;
+    data: Uint8Array | Buffer;
+}): FrameSample | null {
+    const { width: W0, height: H0, data } = png;
+    if (!W0 || !H0) return null;
+    const W = 64;
+    const H = 64;
+    const grid: number[] = [];
+    for (let y = 0; y < H; y++) {
+        const sy = Math.min(H0 - 1, Math.floor((y / H) * H0));
+        for (let x = 0; x < W; x++) {
+            const sx = Math.min(W0 - 1, Math.floor((x / W) * W0));
+            const i = (sy * W0 + sx) * 4;
+            grid.push(data[i], data[i + 1], data[i + 2]);
+        }
+    }
+    const region = (fx0: number, fy0: number, fx1: number, fy1: number): number[] => {
+        const x0 = Math.floor(fx0 * W);
+        const x1 = Math.max(x0 + 1, Math.floor(fx1 * W));
+        const y0 = Math.floor(fy0 * H);
+        const y1 = Math.max(y0 + 1, Math.floor(fy1 * H));
+        let r = 0;
+        let g = 0;
+        let b = 0;
+        let n = 0;
+        for (let y = y0; y < y1; y++)
+            for (let x = x0; x < x1; x++) {
+                const i = (y * W + x) * 3;
+                r += grid[i];
+                g += grid[i + 1];
+                b += grid[i + 2];
+                n++;
+            }
+        return [r / n, g / n, b / n];
+    };
+    return { grid, center: region(0.4, 0.4, 0.6, 0.6), corner: region(0, 0, 0.15, 0.15) };
+}
+
+// S1c of `shallot-demo-startup-stall`: `--attribution`'s CDP CPU profile spans the whole boot wait, and
+// the wait loop's own poll must not inject page-side JS into the window it exists to attribute cleanly.
+// `sampleFrame`'s `page.evaluate(decodeSample, ...)` runs INSIDE the profiled tab on every 500ms poll —
+// S1b's profile found it as the single largest self-time bucket, misattributed as V8-internal by the now-
+// fixed `classifyCpuFrame` docblock (the adversarial pass's finding). This reaches the same settle signal
+// without that cost: the screenshot capture is a CDP/compositor operation, not page JS, and decoding it
+// with pngjs happens in this process, so nothing here runs on the profiled main thread. Falls back to the
+// page-side decode (pre-S1c behavior) if pngjs can't be loaded — an npm consumer of `--attribution`
+// without the optional dependency still gets a working boot-settle signal, just not a decontaminated one.
+async function sampleFrameNode(page: Page): Promise<FrameSample | null> {
+    let shot: Buffer;
+    try {
+        shot = await page.locator("canvas").first().screenshot({ timeout: 5_000 });
+    } catch {
+        return null;
+    }
+    try {
+        const { PNG } = await import("pngjs");
+        return decodeSampleNode(PNG.sync.read(shot));
+    } catch {
+        try {
+            return (await page.evaluate(
+                decodeSample,
+                shot.toString("base64"),
+            )) as FrameSample | null;
+        } catch {
+            return null;
+        }
     }
 }
 
@@ -1739,7 +1851,11 @@ async function drive(
         const harnessDefined = (await page
             .evaluate(() => typeof window.__harness !== "undefined")
             .catch(() => false)) as boolean;
-        const sample = harnessDefined ? null : await sampleFrame(page);
+        const sample = harnessDefined
+            ? null
+            : args.attribution
+              ? await sampleFrameNode(page)
+              : await sampleFrame(page);
         if (sample) {
             sampleCount++;
             lastSample = sample;

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -879,6 +879,47 @@ export function summarizeCpuProfile(profile: RawCpuProfile): CpuProfileSummary {
     return { totalMs, entries, buckets };
 }
 
+// S1c's absence arm: the verify harness's own in-page function names — functions verify.ts serializes
+// into the page via `page.evaluate`, which CDP reports with an empty url under the function's own name
+// (not a V8 synthetic name — see {@link classifyCpuFrame}'s docblock). Their presence in an attribution
+// run's CPU profile means the harness measured itself: `sampleFrame`'s `page.evaluate(decodeSample, ...)`
+// ran inside the profiled tab on every 500ms poll, injecting main-thread work into the window S1b exists
+// to attribute. `sampleFrameNode` (the S1c decontamination) decodes in Node with pngjs instead, so none
+// of these names should appear in a decontaminated profile's bucket table.
+//
+// Derived from the function objects' own `.name` properties (not hardcoded strings) so a rename updates
+// the set automatically. Adding a new in-page helper still requires adding it here — the
+// `harnessInpageFunctionNames` test (verify.test.ts) makes that omission loud by scanning verify.ts for
+// every named function passed to `page.evaluate` and asserting each is registered.
+//
+// Known residual: the boot wait loop's `page.evaluate(() => typeof window.__harness !== "undefined")` is
+// an ANONYMOUS arrow, so CDP reports it with an empty function name — indistinguishable from native
+// code by name alone (the residual named in {@link classifyCpuFrame}'s docblock). It runs once per
+// 500ms poll cycle, a single `typeof` property lookup whose per-invocation self-time is sub-microsecond
+// (well below the 200µs sampling interval), so it is effectively invisible in the CPU profile. The arm's
+// "no harness frames" claim states this one known blind spot rather than overclaiming: a named in-page
+// helper would be caught, this anonymous typeof check is not.
+/** @internal exported so the registration-coverage test can assert every named `page.evaluate` function
+ *  is in the set. */
+export const HARNESS_INPAGE_FUNCTION_NAMES = new Set([decodeSample.name, decodeRgba.name]);
+
+/** the bucket names an attribution run's CPU profile must NOT carry: any bucket classified from a call
+ *  frame whose function name belongs to the verify harness's own in-page helpers. Returns the offending
+ *  bucket names — empty when the profile is decontaminated (no harness frames in the bucket table).
+ *  S1c's Validation criterion: no call frame belonging to the verify harness appears in the attribution
+ *  run's profiled window, asserted by an arm over the attribution run's own captured profile rather than
+ *  read off the printed table. The fixture tests (verify.test.ts) are the unit-level arms beside it; the
+ *  live assertion runs in `scripts/stall-attribution.ts` against the real `--attribution` run's profile. */
+export function harnessBucketNames(summary: CpuProfileSummary): string[] {
+    const offending = new Set<string>();
+    for (const entry of summary.entries) {
+        if (HARNESS_INPAGE_FUNCTION_NAMES.has(entry.functionName)) {
+            offending.add(classifyCpuFrame(entry.url, entry.functionName));
+        }
+    }
+    return summary.buckets.filter((b) => offending.has(b.name)).map((b) => b.name);
+}
+
 /** the render probe the settle path records on its Result — the pixel evidence behind the `rendered`
  *  verdict. Carries the frame samples the wait loop took, the last centre/corner RGB and the spread
  *  against `structured`'s threshold, the elapsed wait, and how the wait concluded. */
@@ -1032,8 +1073,9 @@ async function sampleFrame(page: Page): Promise<FrameSample | null> {
  *  heuristic only needs a stable coarse structure signal, not a pixel-identical grid. Duplicated from
  *  {@link decodeSample} rather than shared, for the same reason {@link decodeRgba} already duplicates it
  *  (its own comment, above): {@link decodeSample} is serialized by Playwright and run in-page, so it
- *  can't import or close over anything. */
-function decodeSampleNode(png: {
+ *  can't import or close over anything. @internal exported only so its coverage arm can drive it
+ *  directly without a browser. */
+export function decodeSampleNode(png: {
     width: number;
     height: number;
     data: Uint8Array | Buffer;
@@ -1079,10 +1121,21 @@ function decodeSampleNode(png: {
 // S1b's profile found it as the single largest self-time bucket, misattributed as V8-internal by the now-
 // fixed `classifyCpuFrame` docblock (the adversarial pass's finding). This reaches the same settle signal
 // without that cost: the screenshot capture is a CDP/compositor operation, not page JS, and decoding it
-// with pngjs happens in this process, so nothing here runs on the profiled main thread. Falls back to the
-// page-side decode (pre-S1c behavior) if pngjs can't be loaded — an npm consumer of `--attribution`
-// without the optional dependency still gets a working boot-settle signal, just not a decontaminated one.
-async function sampleFrameNode(page: Page): Promise<FrameSample | null> {
+// with pngjs happens in this process, so nothing here runs on the profiled main thread.
+//
+// pngjs is an optional dependency of @dylanebert/shallot (packages/shallot/package.json), present in the
+// repo's root devDependencies. Under `--attribution` (a developer diagnostic, not a consumer feature)
+// the pngjs decode is REQUIRED: if it fails, the function throws rather than silently falling back to the
+// page-side decode — the fallback IS the contamination this stage removes, so a silent fallback under
+// `--attribution` would defeat the arm. The plain `verify` path uses `sampleFrame` (which always runs
+// in-page) and never calls this function, so the `attribution` parameter's default of `false` preserves
+// the silent-fallback behavior for any non-attribution caller.
+/** @internal exported only so its coverage arms (pngjs path, fallback path, screenshot-fail, fatal-
+ *  attribution-fallback) can drive it with a duck-typed page stub without a browser. */
+export async function sampleFrameNode(
+    page: Page,
+    attribution = false,
+): Promise<FrameSample | null> {
     let shot: Buffer;
     try {
         shot = await page.locator("canvas").first().screenshot({ timeout: 5_000 });
@@ -1092,7 +1145,15 @@ async function sampleFrameNode(page: Page): Promise<FrameSample | null> {
     try {
         const { PNG } = await import("pngjs");
         return decodeSampleNode(PNG.sync.read(shot));
-    } catch {
+    } catch (err) {
+        if (attribution) {
+            throw new Error(
+                `sampleFrameNode: pngjs decode failed under --attribution — the in-page fallback is ` +
+                    `forbidden (it contaminates the profiled window). Install pngjs (an optional ` +
+                    `dependency of @dylanebert/shallot) or run without --attribution. Cause: ` +
+                    `${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
         try {
             return (await page.evaluate(
                 decodeSample,
@@ -1854,7 +1915,7 @@ async function drive(
         const sample = harnessDefined
             ? null
             : args.attribution
-              ? await sampleFrameNode(page)
+              ? await sampleFrameNode(page, true)
               : await sampleFrame(page);
         if (sample) {
             sampleCount++;

--- a/packages/shallot/package.json
+++ b/packages/shallot/package.json
@@ -106,6 +106,9 @@
             "optional": true
         }
     },
+    "optionalDependencies": {
+        "pngjs": "^7.0.0"
+    },
     "devDependencies": {
         "@types/bun": "latest",
         "bun-webgpu": "^0.1.4",

--- a/scripts/stall-attribution.ts
+++ b/scripts/stall-attribution.ts
@@ -246,6 +246,65 @@ async function main(): Promise<void> {
         );
     }
 
+    // S1b: `Profile.compile` above can't see the sync path's magnitude — this is the instrument that
+    // can. A CDP sample-based CPU profile of the same boot window, taken concurrently by `--attribution`
+    // (bin/verify.ts's `Profiler.start`/`stop`), reads the real V8 call stack on a fixed cadence and
+    // needs no engine-internal instrumentation, so it sees the sync `createRenderPipeline` loop's actual
+    // cost directly rather than through a near-zero stub.
+    console.log(
+        "\n## S1b — CPU-profile self-time attribution (sees the sync path's real magnitude)\n",
+    );
+    const cpuProfile = result.cpuProfile;
+    if (cpuProfile === undefined) {
+        console.log(
+            "cpuProfile absent from the result — this verify build predates S1b's CDP Profiler capture.",
+        );
+    } else if (cpuProfile === null) {
+        console.log(
+            "cpuProfile is null — CDP's Profiler domain wasn't reachable this run (no CDP session, or " +
+                "Profiler.start/stop failed). Honest miss: no number below, not a fabricated zero.",
+        );
+    } else if (cpuProfile.totalMs === 0) {
+        console.log(
+            "cpuProfile captured but carries 0ms of sampled self time — the profile's samples/timeDeltas " +
+                "stream was empty (a boot too short to take one sample at the 200us sampling interval, or " +
+                "the tab never got a chance to run V8 between navigation and the boot wait's conclusion). " +
+                "This is an instrument miss, not evidence the boot did no work.",
+        );
+    } else {
+        console.log(
+            `total sampled main-thread self time: ${r1(cpuProfile.totalMs)}ms (this is the CPU-profile's ` +
+                `own total, independent of the longtask observer's total printed above; both describe the ` +
+                `same boot window from two different instruments and should be the same order of magnitude ` +
+                `— a big gap between them means one instrument is missing work the other sees).\n`,
+        );
+
+        console.log("### by named candidate mechanism (self time, descending)\n");
+        console.log("| candidate mechanism | self ms | % of profiled total |");
+        console.log("|---|---|---|");
+        for (const b of cpuProfile.buckets) {
+            const pct = cpuProfile.totalMs > 0 ? (100 * b.selfMs) / cpuProfile.totalMs : 0;
+            console.log(`| ${b.name} | ${r1(b.selfMs)} | ${r1(pct)}% |`);
+        }
+
+        console.log("\n### top individual call-frame identities by self time (top 15)\n");
+        console.log("| function | file:line | self ms |");
+        console.log("|---|---|---|");
+        for (const e of cpuProfile.entries.slice(0, 15)) {
+            const file = e.url ? e.url.split("/").slice(-2).join("/") || e.url : "(no url)";
+            console.log(`| ${e.functionName} | ${file}:${e.lineNumber + 1} | ${r1(e.selfMs)} |`);
+        }
+        console.log(
+            "\nCAVEAT: self time is attributed per call-frame IDENTITY (function+url+line), merged across " +
+                "every call path that reaches it — a function called from N sites reads as one row with " +
+                "self time summed across all N, never split by caller. The candidate-mechanism buckets " +
+                "(above) are a data-driven URL/path match (bin/verify.ts's CPU_FRAME_BUCKETS table), " +
+                "audited by hand against the spec's named candidates — an unmatched frame falls through to " +
+                "a per-file 'other' bucket rather than disappearing, so nothing is silently dropped, but a " +
+                "candidate this table doesn't yet name for a given demo can still hide inside 'other'.",
+        );
+    }
+
     await teardownBridge();
 }
 

--- a/scripts/stall-attribution.ts
+++ b/scripts/stall-attribution.ts
@@ -1,3 +1,4 @@
+import { harnessBucketNames } from "../packages/shallot/bin/verify";
 import { skipReason, teardownBridge, verify } from "./verify";
 
 // S1 of `shallot-demo-startup-stall`: discriminate the demo's startup ~1s stall by pipeline-label
@@ -303,6 +304,27 @@ async function main(): Promise<void> {
                 "a per-file 'other' bucket rather than disappearing, so nothing is silently dropped, but a " +
                 "candidate this table doesn't yet name for a given demo can still hide inside 'other'.",
         );
+    }
+
+    // S1c's absence arm: assert no verify-harness call frame appears in the attribution run's own
+    // CPU profile — not eyeballed off the printed table above, but asserted mechanically via
+    // `harnessBucketNames`. The fixture tests in verify.test.ts are the unit-level arms; this is the
+    // live assertion against the real `--attribution` run's captured profile. Fails loudly (non-zero
+    // exit, offending buckets printed) when the harness measured itself.
+    if (cpuProfile && cpuProfile.totalMs > 0) {
+        const harnessBuckets = harnessBucketNames(cpuProfile as never);
+        console.log("\n## S1c — harness contamination check\n");
+        if (harnessBuckets.length > 0) {
+            console.log(
+                `FAILED: verify-harness call frames found in the attribution run's CPU profile — ` +
+                    `the harness measured itself. Offending buckets: ${harnessBuckets.join(", ")}`,
+            );
+            process.exitCode = 1;
+        } else {
+            console.log(
+                "PASSED: no verify-harness call frames in the attribution run's CPU profile.",
+            );
+        }
     }
 
     await teardownBridge();

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -70,6 +70,30 @@ export interface VerifyResult {
         compileAfterIdle: AttributionCompile | null;
         longTasks: { start: number; duration: number }[];
     } | null;
+    /** `--attribution` only (S1b): the CDP CPU-profile self-time breakdown, per
+     *  `bin/verify.ts`'s `Result.cpuProfile` — null when CDP's `Profiler` domain wasn't reachable. */
+    cpuProfile?: CpuProfileSummary | null;
+}
+
+/** the slice of `bin/verify.ts`'s `CpuProfileSummary` a driver reads. */
+export interface CpuProfileEntry {
+    key: string;
+    functionName: string;
+    url: string;
+    lineNumber: number;
+    selfMs: number;
+}
+
+/** one named candidate mechanism's total self time. */
+export interface CpuProfileBucket {
+    name: string;
+    selfMs: number;
+}
+
+export interface CpuProfileSummary {
+    totalMs: number;
+    entries: CpuProfileEntry[];
+    buckets: CpuProfileBucket[];
 }
 
 /** the slice of `bin/verify.ts`'s `BenchmarkCompileStats` a driver reads. */


### PR DESCRIPTION
- **shallot-demo-startup-stall: s1b — CPU-profile attribution finds the real block**
- **shallot-demo-startup-stall: s1c — decontaminate the boot poll**
- **shallot-demo-startup-stall: s1c — the absence arm, wired into the real attribution run**
