### PR TITLE
shallot-demo-startup-stall: s1e — LoAF observer beside longtask under --attribution

### DIFF
--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -624,6 +624,40 @@ describe("ATTRIBUTION_INIT_SCRIPT — what --attribution installs pre-navigation
         new Function("window", ATTRIBUTION_INIT_SCRIPT)(win);
         expect(win.__shallotLongTasks).toEqual([]);
     });
+
+    // S1e: the LoAF observer is installed beside the longtask one, same guard shape — an unsupported
+    // entryTypes throws synchronously in the observer constructor, caught so a missing LoAF degrades
+    // to an empty array rather than killing the init script.
+    test("initializes the LoAF sink before observing, and never throws on a missing API", () => {
+        expect(ATTRIBUTION_INIT_SCRIPT.indexOf("__shallotLoAF = []")).toBeLessThan(
+            ATTRIBUTION_INIT_SCRIPT.indexOf("long-animation-frame"),
+        );
+    });
+
+    test("initializes the LoAF sink to an empty array regardless of PerformanceObserver support", () => {
+        const win: { __shallotLoAF?: unknown } = {};
+        new Function("window", ATTRIBUTION_INIT_SCRIPT)(win);
+        expect(win.__shallotLoAF).toEqual([]);
+    });
+
+    // the unsupported-engine path exercised: an engine that supports longtask but NOT long-animation-
+    // frame (the current Playwright chromium's LoAF support is the open question this test arms over)
+    // must degrade the LoAF sink to an empty array while keeping the longtask sink working.
+    test("degrades the LoAF sink to [] when the observer constructor throws on long-animation-frame, while keeping longtask working", () => {
+        const win: Record<string, unknown> = {};
+        win.PerformanceObserver = ((_cb: (list: { getEntries(): unknown[] }) => void) => ({
+            observe(opts: { entryTypes: string[] }) {
+                if (opts.entryTypes.includes("long-animation-frame")) {
+                    throw new TypeError(
+                        "The provided value 'long-animation-frame' is not a valid enum value",
+                    );
+                }
+            },
+        })) as unknown as PerformanceObserver;
+        new Function("window", ATTRIBUTION_INIT_SCRIPT)(win);
+        expect(win.__shallotLoAF).toEqual([]);
+        expect(win.__shallotLongTasks).toEqual([]);
+    });
 });
 
 describe("selfTimeMsByNodeId — S1b's CPU-profile self-time accounting", () => {

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -289,6 +289,18 @@ export const HARNESS_PROBE_SCRIPT = `(${installHarnessProbe.toString()})(window)
  *  exists to measure. */
 export const RESOURCE_BUFFER = 20_000;
 
+/** a single `long-animation-frame` PerformanceObserver entry, reduced to the fields the readout
+ *  surfaces. `renderStart`/`styleAndLayoutStart` are present on a supporting engine and absent
+ *  (undefined) on one that doesn't provide them — the init script forwards them unconditionally and
+ *  the readout treats `undefined` as 'not reported'. */
+export interface LoAFEntry {
+    start: number;
+    duration: number;
+    blockingDuration: number;
+    renderStart: number | undefined;
+    styleAndLayoutStart: number | undefined;
+}
+
 /** everything `--timings` installs before navigation: the harness-install probe plus the raised
  *  resource-timing buffer. Both must be in place before the first request, so they share one init
  *  script rather than racing two. */
@@ -299,7 +311,19 @@ export const TIMINGS_INIT_SCRIPT = `performance.setResourceTimingBufferSize(${RE
  * concurrently-reported async span (e.g. `Compute.precompiled`'s awaited elapsed time) if something
  * else pinned the main thread for that same window, since an `await` itself yields. Best-effort: an
  * unsupported `entryTypes` throws synchronously in the observer constructor on some engines, caught so
- * a missing API degrades to an empty array rather than failing the whole init script. */
+ * a missing API degrades to an empty array rather than failing the whole init script.
+ *
+ * S1e: a `long-animation-frame` (LoAF) observer is installed beside the longtask one on
+ * `window.__shallotLoAF`. A LoAF entry names a single *frame* whose main-thread-side work (script,
+ * style, layout, paint coordination) delayed it past the 50ms rendering threshold — one entry per
+ * delayed frame, summing that frame's work including many sub-50ms chunks the longtask observer
+ * cannot see individually. This is the signal class the Goal's prod RUM `slow_frame` derives from
+ * (W3C Long Animation Frames), so a local LoAF number and a prod `slow_frame` number are the same
+ * measurement, where a longtask total is not. Each entry carries `startTime`, `duration`,
+ * `blockingDuration`, and `renderStart`/`styleAndLayoutStart` where the engine provides them. Guarded
+ * the same way as longtask: an unsupported `entryTypes` throws synchronously in the observer
+ * constructor, caught so a missing LoAF degrades to an empty array rather than killing the init
+ * script. */
 export const ATTRIBUTION_INIT_SCRIPT = `
 (() => {
     window.__shallotLongTasks = [];
@@ -309,6 +333,20 @@ export const ATTRIBUTION_INIT_SCRIPT = `
                 window.__shallotLongTasks.push({ start: e.startTime, duration: e.duration });
             }
         }).observe({ entryTypes: ["longtask"] });
+    } catch {}
+    window.__shallotLoAF = [];
+    try {
+        new PerformanceObserver((list) => {
+            for (const e of list.getEntries()) {
+                window.__shallotLoAF.push({
+                    start: e.startTime,
+                    duration: e.duration,
+                    blockingDuration: e.blockingDuration,
+                    renderStart: e.renderStart,
+                    styleAndLayoutStart: e.styleAndLayoutStart,
+                });
+            }
+        }).observe({ entryTypes: ["long-animation-frame"] });
     } catch {}
 })();
 `;
@@ -646,11 +684,16 @@ export interface Result {
      *  `totalMs` increase with no new label, one already-known label recompiling) is a compile that
      *  landed after the boot wait concluded, i.e. past wherever a project's own loading screen gates on
      *  that same signal. `longTasks` is every `longtask` PerformanceObserver entry recorded from page
-     *  init through the second read. Absent when `--attribution` wasn't passed. */
+     *  init through the second read. `longAnimationFrames` is every `long-animation-frame` (LoAF)
+     *  PerformanceObserver entry recorded over the same window — one entry per delayed frame, summing
+     *  that frame's script/style/layout/paint-coordination work including sub-50ms chunks the longtask
+     *  observer cannot see (S1e: the signal class matching the Goal's prod `slow_frame`). Absent when
+     *  `--attribution` wasn't passed. */
     attribution?: {
         compile: BenchmarkCompileStats | null;
         compileAfterIdle: BenchmarkCompileStats | null;
         longTasks: { start: number; duration: number }[];
+        longAnimationFrames: LoAFEntry[];
     } | null;
     /** `--attribution` only (S1b): a CDP `Profiler` sample-based CPU profile of the main thread from
      *  just before navigation through the boot wait's conclusion (the same point `attribution.compile`
@@ -2009,6 +2052,12 @@ async function drive(
                                 __shallotLongTasks?: { start: number; duration: number }[];
                             }
                         ).__shallotLongTasks ?? [],
+                    longAnimationFrames:
+                        (
+                            window as unknown as {
+                                __shallotLoAF?: LoAFEntry[];
+                            }
+                        ).__shallotLoAF ?? [],
                 };
             }, ATTRIBUTION_IDLE_MS)
             .catch(() => null)) as Result["attribution"];

--- a/scripts/stall-attribution.ts
+++ b/scripts/stall-attribution.ts
@@ -1,4 +1,4 @@
-import { harnessBucketNames } from "../packages/shallot/bin/verify";
+import { harnessBucketNames, type LoAFEntry } from "../packages/shallot/bin/verify";
 import { skipReason, teardownBridge, verify } from "./verify";
 
 // S1 of `shallot-demo-startup-stall`: discriminate the demo's startup ~1s stall by pipeline-label
@@ -216,6 +216,82 @@ async function main(): Promise<void> {
             `cannot align an individual longtask entry to an individual label in either case (` +
             `Profile.compile carries no absolute per-entry timestamp) — only totals.`,
     );
+
+    // S1e: Long Animation Frames — the signal class the Goal's prod RUM `slow_frame` derives from.
+    // A LoAF entry is one per delayed *frame*, summing that frame's script/style/layout/paint-
+    // coordination work, including many sub-50ms chunks the longtask observer above cannot see
+    // individually. On a supporting engine this is the local measurement comparable to prod's
+    // slow_frame; on an unsupported engine the guard degrades to an empty array (the init script's
+    // try/catch), reported here rather than silently dropped.
+    const loafEntries: LoAFEntry[] = attribution.longAnimationFrames ?? [];
+    const loafTotalMs = loafEntries.reduce((s, e) => s + e.duration, 0);
+    const loafBlockingMs = loafEntries.reduce((s, e) => s + e.blockingDuration, 0);
+    const loafWorst =
+        loafEntries.length > 0
+            ? loafEntries.reduce((a, b) => (b.duration > a.duration ? b : a))
+            : null;
+    console.log(
+        `\n## S1e — Long Animation Frames (LoAF) — the Goal's prod slow_frame signal class\n`,
+    );
+    if (loafEntries.length === 0) {
+        console.log(
+            `0 LoAF entries — the engine does not support long-animation-frame (or no frame crossed ` +
+                `the 50ms rendering threshold this boot). The longtask total above (${r1(longTaskMs)}ms) ` +
+                `remains the only main-thread signal, and is NOT comparable to the Goal's prod ` +
+                `slow_frame numbers (sandbox 1100ms / roads 879ms) — longtask fires only on a single ` +
+                `task ≥50ms, while LoAF sums per-frame work including sub-50ms chunks.`,
+        );
+    } else {
+        console.log(
+            `${loafEntries.length} LoAF entries, ${r1(loafTotalMs)}ms total frame duration, ` +
+                `${r1(loafBlockingMs)}ms total blockingDuration across the boot window.`,
+        );
+        console.log(
+            `worst single frame: ${r1(loafWorst!.duration)}ms (start ${r1(loafWorst!.start)}ms, ` +
+                `blocking ${r1(loafWorst!.blockingDuration)}ms, ` +
+                `renderStart ${loafWorst!.renderStart !== undefined ? r1(loafWorst!.renderStart) + "ms" : "n/a"}, ` +
+                `styleAndLayoutStart ${loafWorst!.styleAndLayoutStart !== undefined ? r1(loafWorst!.styleAndLayoutStart) + "ms" : "n/a"}).`,
+        );
+        console.log("");
+        console.log(
+            "| # | start (ms) | duration (ms) | blocking (ms) | renderStart | styleAndLayoutStart |",
+        );
+        console.log("|---|---|---|---|---|---|");
+        loafEntries
+            .slice()
+            .sort((a, b) => a.start - b.start)
+            .forEach((e, i) => {
+                console.log(
+                    `| ${i + 1} | ${r1(e.start)} | ${r1(e.duration)} | ${r1(e.blockingDuration)} | ` +
+                        `${e.renderStart !== undefined ? r1(e.renderStart) : "n/a"} | ` +
+                        `${e.styleAndLayoutStart !== undefined ? r1(e.styleAndLayoutStart) : "n/a"} |`,
+                );
+            });
+    }
+    // the same-order-or-below verdict: is the local worst LoAF frame the same order as the Goal's prod
+    // worst frames (sandbox 1100ms / roads 879ms)? An order below means the local seat does not
+    // reproduce the prod stall's magnitude.
+    const ProdWorstSandbox = 1100;
+    const ProdWorstRoads = 879;
+    const prodWorst = args.dir.endsWith("roads") ? ProdWorstRoads : ProdWorstSandbox;
+    if (loafWorst) {
+        const ratio = loafWorst.duration / prodWorst;
+        const verdict =
+            ratio >= 0.5 ? "same order" : ratio >= 0.1 ? "within an order" : "an order below";
+        console.log(
+            `\nLoAF-vs-prod verdict: local worst frame ${r1(loafWorst.duration)}ms vs prod worst ` +
+                `${prodWorst}ms (${args.dir.endsWith("roads") ? "roads" : "sandbox"}) — ratio ` +
+                // three decimals deliberately: the verdict's thresholds are 0.5 and 0.1, so a
+                // one-decimal ratio rounds 0.069 to "0.1" and reads as if it contradicted the
+                // "an order below" verdict it produced.
+                `${ratio.toFixed(3)}, ${verdict}.`,
+        );
+    } else {
+        console.log(
+            `\nLoAF-vs-prod verdict: no LoAF entries to compare — the local instrument cannot ` +
+                `produce a number in the Goal's signal class for this run.`,
+        );
+    }
 
     console.log("\n## Lazy-escape check (compile vs compileAfterIdle)\n");
     const after = attribution.compileAfterIdle;

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -69,6 +69,7 @@ export interface VerifyResult {
         compile: AttributionCompile | null;
         compileAfterIdle: AttributionCompile | null;
         longTasks: { start: number; duration: number }[];
+        longAnimationFrames: LoAFEntry[];
     } | null;
     /** `--attribution` only (S1b): the CDP CPU-profile self-time breakdown, per
      *  `bin/verify.ts`'s `Result.cpuProfile` — null when CDP's `Profiler` domain wasn't reachable. */
@@ -94,6 +95,17 @@ export interface CpuProfileSummary {
     totalMs: number;
     entries: CpuProfileEntry[];
     buckets: CpuProfileBucket[];
+}
+
+/** a single `long-animation-frame` PerformanceObserver entry (S1e) — mirrors `bin/verify.ts`'s
+ *  `LoAFEntry`. `renderStart`/`styleAndLayoutStart` are present on a supporting engine and undefined
+ *  on one that doesn't provide them. */
+export interface LoAFEntry {
+    start: number;
+    duration: number;
+    blockingDuration: number;
+    renderStart: number | undefined;
+    styleAndLayoutStart: number | undefined;
 }
 
 /** the slice of `bin/verify.ts`'s `BenchmarkCompileStats` a driver reads. */


### PR DESCRIPTION
Put one signal class on both sides of the Goal's comparison. The attribution
instrument's only main-thread signal was a longtask observer (a single task
>=50ms); the Goal's prod slow_frame derives from Long Animation Frames, one
entry per delayed frame. S1d measured ~420ms (sandbox) / ~240ms (roads) of
non-idle main-thread CPU of which only ~65ms surfaced as longtask.

Adds a long-animation-frame PerformanceObserver in ATTRIBUTION_INIT_SCRIPT
beside the existing one, same try/catch guard shape, with per-entry duration,
blockingDuration, renderStart and styleAndLayoutStart surfaced by
scripts/stall-attribution.ts beside the longtask list and a
same-order-or-below verdict against the Goal's prod worst frames. longtask
reporting is unchanged, so S1d's numbers stay re-readable. Three arms over the
shipped guard, including the unsupported-engine degradation path (the LoAF sink
empties, the longtask sink survives).

Reading, both demos, macOS/Metal: 1 LoAF entry each, worst frame 60-82ms
(sandbox 71-82, roads 60-63), blockingDuration 9-23ms, beside 1 longtask at
59-73ms. An order below prod's 1100ms/879ms in the same signal class — the
local seat does not reproduce the prod stall's magnitude.
