### PR TITLE
shallot demo startup stall/s1f

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -339,6 +339,9 @@
         "typegpu": "~0.12.0",
         "wgpu-matrix": "^3.4.0",
       },
+      "optionalDependencies": {
+        "pngjs": "^7.0.0",
+      },
       "peerDependencies": {
         "playwright": "^1.0.0",
         "typegpu": "~0.12.0",

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -697,9 +697,10 @@ describe("ATTRIBUTION_INIT_SCRIPT — what --attribution installs pre-navigation
 
         // Fixture: a mix of normal frames (16ms), slow frames (>=50ms), a near-threshold frame
         // (45ms — below the 50ms threshold but above a perturbed 40ms threshold, so a threshold
-        // perturbation is detectable), and a first frame.
-        // deltas: first(0→0, no report), 16, 80(slow), 16, 60(slow), 16, 45(near), 16, 200(slow), 16, 1000(slow)
-        const timestamps = [0, 16, 96, 112, 172, 188, 233, 249, 449, 465, 1465];
+        // perturbation is detectable), an exact-threshold frame (50ms — the boundary case, reported
+        // by both sides because the comparison is >=), and a first frame.
+        // deltas: first(0→0, no report), 16, 80(slow), 16, 60(slow), 16, 45(near), 16, 200(slow), 16, 1000(slow), 50(boundary)
+        const timestamps = [0, 16, 96, 112, 172, 188, 233, 249, 449, 465, 1465, 1515];
 
         // Drive the mirror (extracted from the shipped init-script string)
         for (const t of timestamps) {

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -17,6 +17,7 @@ import {
 import { parsePhases, parseResources, parseTransformLine } from "../../../scripts/boot-cost";
 import { verifyDiagnostic } from "../../../scripts/install-test";
 import type { ShaderArtifactSummary, VerifyResult } from "../../../scripts/verify";
+import { initialFrameSamplerState, sampleFrame } from "../../../site/rum-sampler";
 import {
     ATTRIBUTION_INIT_SCRIPT,
     batchPass,
@@ -620,7 +621,8 @@ describe("ATTRIBUTION_INIT_SCRIPT — what --attribution installs pre-navigation
     });
 
     test("initializes the sink to an empty array regardless of PerformanceObserver support", () => {
-        const win: { __shallotLongTasks?: unknown } = {};
+        const win: Record<string, unknown> = {};
+        win.requestAnimationFrame = (() => 0) as unknown as typeof requestAnimationFrame;
         new Function("window", ATTRIBUTION_INIT_SCRIPT)(win);
         expect(win.__shallotLongTasks).toEqual([]);
     });
@@ -635,7 +637,8 @@ describe("ATTRIBUTION_INIT_SCRIPT — what --attribution installs pre-navigation
     });
 
     test("initializes the LoAF sink to an empty array regardless of PerformanceObserver support", () => {
-        const win: { __shallotLoAF?: unknown } = {};
+        const win: Record<string, unknown> = {};
+        win.requestAnimationFrame = (() => 0) as unknown as typeof requestAnimationFrame;
         new Function("window", ATTRIBUTION_INIT_SCRIPT)(win);
         expect(win.__shallotLoAF).toEqual([]);
     });
@@ -645,6 +648,7 @@ describe("ATTRIBUTION_INIT_SCRIPT — what --attribution installs pre-navigation
     // must degrade the LoAF sink to an empty array while keeping the longtask sink working.
     test("degrades the LoAF sink to [] when the observer constructor throws on long-animation-frame, while keeping longtask working", () => {
         const win: Record<string, unknown> = {};
+        win.requestAnimationFrame = (() => 0) as unknown as typeof requestAnimationFrame;
         win.PerformanceObserver = ((_cb: (list: { getEntries(): unknown[] }) => void) => ({
             observe(opts: { entryTypes: string[] }) {
                 if (opts.entryTypes.includes("long-animation-frame")) {
@@ -657,6 +661,72 @@ describe("ATTRIBUTION_INIT_SCRIPT — what --attribution installs pre-navigation
         new Function("window", ATTRIBUTION_INIT_SCRIPT)(win);
         expect(win.__shallotLoAF).toEqual([]);
         expect(win.__shallotLongTasks).toEqual([]);
+    });
+
+    // S1f: the rAF-delta sampler is installed beside the longtask and LoAF observers on
+    // `window.__shallotRafDeltas`. It mirrors `site/rum-sampler.ts`'s pure `sampleFrame` — same
+    // threshold (50ms), same `delta = timestamp - lastTimestamp`, same first-frame rule (never
+    // reports). An `addInitScript` string cannot import the module, so the mirror is a copy and
+    // drift is the exposure: the arm below feeds the same fixture timestamps to both the mirror
+    // (extracted from the shipped init-script string) and the real exported `sampleFrame`, asserting
+    // they agree on which frames are slow and what their deltas/timestamps are.
+    test("initializes the rAF-delta sink to an empty array", () => {
+        const win: { __shallotRafDeltas?: unknown; requestAnimationFrame?: unknown } = {};
+        win.requestAnimationFrame = (() => 0) as unknown as typeof requestAnimationFrame;
+        new Function("window", ATTRIBUTION_INIT_SCRIPT)(win);
+        expect(win.__shallotRafDeltas).toEqual([]);
+    });
+
+    test("rAF-delta mirror agrees with sampleFrame on a fixture timestamp sequence", () => {
+        // Evaluate the shipped init script in a mock environment to extract the rAF callback.
+        // The mock `requestAnimationFrame` captures the first callback (the one the IIFE registers)
+        // and ignores subsequent registrations (the callback's own recursive rAF call), so the test
+        // can drive the callback manually with fixture timestamps.
+        const win: Record<string, unknown> = {};
+        let rafCallback: ((timestamp: number) => void) | null = null;
+        win.requestAnimationFrame = ((cb: (timestamp: number) => void) => {
+            if (rafCallback === null) rafCallback = cb;
+            return 0;
+        }) as unknown as typeof requestAnimationFrame;
+        win.PerformanceObserver = class {
+            observe() {}
+        } as unknown as typeof PerformanceObserver;
+        new Function("window", ATTRIBUTION_INIT_SCRIPT)(win);
+        expect(rafCallback).not.toBeNull();
+        expect(win.__shallotRafDeltas).toEqual([]);
+
+        // Fixture: a mix of normal frames (16ms), slow frames (>=50ms), a near-threshold frame
+        // (45ms — below the 50ms threshold but above a perturbed 40ms threshold, so a threshold
+        // perturbation is detectable), and a first frame.
+        // deltas: first(0→0, no report), 16, 80(slow), 16, 60(slow), 16, 45(near), 16, 200(slow), 16, 1000(slow)
+        const timestamps = [0, 16, 96, 112, 172, 188, 233, 249, 449, 465, 1465];
+
+        // Drive the mirror (extracted from the shipped init-script string)
+        for (const t of timestamps) {
+            rafCallback!(t);
+        }
+        const mirrorDeltas = win.__shallotRafDeltas as { delta: number; timestamp: number }[];
+
+        // Drive the real exported `sampleFrame` with the same timestamps
+        let state = initialFrameSamplerState;
+        const moduleReports: { duration: number; msSinceLoad: number }[] = [];
+        for (const t of timestamps) {
+            const result = sampleFrame(state, t);
+            state = result.state;
+            if (result.report) {
+                moduleReports.push({
+                    duration: result.report.duration,
+                    msSinceLoad: result.report.context.msSinceLoad,
+                });
+            }
+        }
+
+        // Assert they agree: same count, same deltas, same timestamps (msSinceLoad)
+        expect(mirrorDeltas).toHaveLength(moduleReports.length);
+        for (let i = 0; i < mirrorDeltas.length; i++) {
+            expect(mirrorDeltas[i].delta).toBe(moduleReports[i].duration);
+            expect(mirrorDeltas[i].timestamp).toBe(moduleReports[i].msSinceLoad);
+        }
     });
 });
 

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -317,9 +317,15 @@ export const TIMINGS_INIT_SCRIPT = `performance.setResourceTimingBufferSize(${RE
  * `window.__shallotLoAF`. A LoAF entry names a single *frame* whose main-thread-side work (script,
  * style, layout, paint coordination) delayed it past the 50ms rendering threshold — one entry per
  * delayed frame, summing that frame's work including many sub-50ms chunks the longtask observer
- * cannot see individually. This is the signal class the Goal's prod RUM `slow_frame` derives from
- * (W3C Long Animation Frames), so a local LoAF number and a prod `slow_frame` number are the same
- * measurement, where a longtask total is not. Each entry carries `startTime`, `duration`,
+ * cannot see individually. LoAF is a *third* signal class beside longtask and the Goal's prod
+ * `slow_frame` vital — not a match for either. The Goal's `slow_frame` is shallot's own rAF-delta
+ * duration vital (`site/rum-sampler.ts`, `SLOW_FRAME_THRESHOLD_MS`, `delta = timestamp -
+ * state.lastTimestamp`, emitted via `DD_RUM.addDurationVital` in `site/rum-runtime.ts`), not a
+ * platform metric and not LoAF; a rAF delta counts everything that stops a frame being produced
+ * (main-thread block, compositor/GPU backpressure, any interval where rAF isn't dispatched), while
+ * LoAF names per-frame main-thread-side rendering work only. S1f installs the rAF-delta sampler on
+ * `window.__shallotRafDeltas` to match the Goal's own class; LoAF stays as a complementary
+ * per-frame main-thread signal. Each LoAF entry carries `startTime`, `duration`,
  * `blockingDuration`, and `renderStart`/`styleAndLayoutStart` where the engine provides them. Guarded
  * the same way as longtask: an unsupported `entryTypes` throws synchronously in the observer
  * constructor, caught so a missing LoAF degrades to an empty array rather than killing the init
@@ -348,6 +354,18 @@ export const ATTRIBUTION_INIT_SCRIPT = `
             }
         }).observe({ entryTypes: ["long-animation-frame"] });
     } catch {}
+    window.__shallotRafDeltas = [];
+    let __shallotRafLastTs = null;
+    window.requestAnimationFrame(function __shallotRafTick(timestamp) {
+        if (__shallotRafLastTs !== null) {
+            const delta = timestamp - __shallotRafLastTs;
+            if (delta >= 50) {
+                window.__shallotRafDeltas.push({ delta: delta, timestamp: timestamp });
+            }
+        }
+        __shallotRafLastTs = timestamp;
+        window.requestAnimationFrame(__shallotRafTick);
+    });
 })();
 `;
 
@@ -687,13 +705,17 @@ export interface Result {
      *  init through the second read. `longAnimationFrames` is every `long-animation-frame` (LoAF)
      *  PerformanceObserver entry recorded over the same window — one entry per delayed frame, summing
      *  that frame's script/style/layout/paint-coordination work including sub-50ms chunks the longtask
-     *  observer cannot see (S1e: the signal class matching the Goal's prod `slow_frame`). Absent when
-     *  `--attribution` wasn't passed. */
+     *  observer cannot see (S1e: a third signal class beside longtask and the Goal's prod `slow_frame` vital — not a match for either). `rafDeltas` is every rAF inter-callback gap ≥ 50ms recorded over the
+     *  same window (S1f: the Goal's own signal class — mirrors `site/rum-sampler.ts`'s `sampleFrame`,
+     *  same threshold, same `delta = timestamp - lastTimestamp`, same first-frame rule), each carrying
+     *  `delta` (the gap) and `timestamp` (the rAF timestamp, which is `msSinceLoad` on the vital's own
+     *  context axis). Absent when `--attribution` wasn't passed. */
     attribution?: {
         compile: BenchmarkCompileStats | null;
         compileAfterIdle: BenchmarkCompileStats | null;
         longTasks: { start: number; duration: number }[];
         longAnimationFrames: LoAFEntry[];
+        rafDeltas: { delta: number; timestamp: number }[];
     } | null;
     /** `--attribution` only (S1b): a CDP `Profiler` sample-based CPU profile of the main thread from
      *  just before navigation through the boot wait's conclusion (the same point `attribution.compile`
@@ -1696,7 +1718,13 @@ async function verifyCommand(raw: string[]): Promise<number> {
             browser = args.connect
                 ? await chromium.connect(args.connect, { timeout: 30_000 })
                 : await chromium.launch({
-                      headless: true,
+                      // S1f: headless rAF timestamps are derived from a display-less frame clock with no
+                      // real compositor/vsync, so they undershoot real block durations (probed:
+                      // 90ms→66.7ms, 120ms→100ms, below ~90ms never reported — `rum-intake-driver.ts:31-36`).
+                      // The rAF-delta sampler needs a real display to produce valid readings, so the
+                      // attribution run goes headed when `SHALLOT_HEADED` is set — scoped to `--attribution`
+                      // only, not the default for every `shallot verify` consumer.
+                      headless: !(args.attribution && process.env.SHALLOT_HEADED),
                       // the published real-GPU recipe (`src/harness/browser.ts`) — its JSDoc carries the
                       // headless-shell/SwiftShader finding this channel exists to avoid.
                       ...REAL_GPU_LAUNCH,
@@ -2058,6 +2086,12 @@ async function drive(
                                 __shallotLoAF?: LoAFEntry[];
                             }
                         ).__shallotLoAF ?? [],
+                    rafDeltas:
+                        (
+                            window as unknown as {
+                                __shallotRafDeltas?: { delta: number; timestamp: number }[];
+                            }
+                        ).__shallotRafDeltas ?? [],
                 };
             }, ATTRIBUTION_IDLE_MS)
             .catch(() => null)) as Result["attribution"];

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -716,6 +716,7 @@ export interface Result {
         longTasks: { start: number; duration: number }[];
         longAnimationFrames: LoAFEntry[];
         rafDeltas: { delta: number; timestamp: number }[];
+        userAgent: string;
     } | null;
     /** `--attribution` only (S1b): a CDP `Profiler` sample-based CPU profile of the main thread from
      *  just before navigation through the boot wait's conclusion (the same point `attribution.compile`
@@ -2092,6 +2093,7 @@ async function drive(
                                 __shallotRafDeltas?: { delta: number; timestamp: number }[];
                             }
                         ).__shallotRafDeltas ?? [],
+                    userAgent: navigator.userAgent,
                 };
             }, ATTRIBUTION_IDLE_MS)
             .catch(() => null)) as Result["attribution"];

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -965,6 +965,11 @@ export function summarizeCpuProfile(profile: RawCpuProfile): CpuProfileSummary {
 // (well below the 200µs sampling interval), so it is effectively invisible in the CPU profile. The arm's
 // "no harness frames" claim states this one known blind spot rather than overclaiming: a named in-page
 // helper would be caught, this anonymous typeof check is not.
+//
+// S1f: `__shallotRafTick` (the ATTRIBUTION_INIT_SCRIPT's in-page rAF callback) is deliberately NOT in this
+// set — it is the instrument itself, not injected polling, so flagging it would misread the sampler's own
+// necessary overhead as contamination. Measured self time ~0.6–2.6ms across runs, a negligible floor-level
+// presence the arm's "no contaminating harness frames" claim explicitly exempts.
 /** @internal exported so the registration-coverage test can assert every named `page.evaluate` function
  *  is in the set. */
 export const HARNESS_INPAGE_FUNCTION_NAMES = new Set([decodeSample.name, decodeRgba.name]);

--- a/scripts/stall-attribution.ts
+++ b/scripts/stall-attribution.ts
@@ -278,6 +278,25 @@ async function main(): Promise<void> {
     // two different signal classes — so it was not a reading of the Goal. The Goal's own class is
     // the rAF-delta vital, reported in the S1f section below.
 
+    // S1f: headed check — the rAF-delta sampler's validity depends on a real display. A headless,
+    // display-less frame clock undershoots real block durations (`rum-intake-driver.ts:31-36`:
+    // 90ms→66.7ms, 120ms→100ms, below ~90ms never reported). `stall-attribution.ts` sets
+    // `SHALLOT_HEADED=1` and `verify.ts` reads it to launch `headless: false`, but nothing tested
+    // that the setting actually took effect — the env is set unconditionally inside `main()`, so an
+    // external override cannot turn it off, and the launch flag was unarmed. This arm reads the
+    // browser's own `navigator.userAgent` back through the attribution result and asserts it does
+    // not contain `HeadlessChrome` — the discriminator Playwright's headed vs headless launches
+    // differ on (probed: headed = `Chrome/...`, headless = `HeadlessChrome/...`).
+    const userAgent = attribution.userAgent ?? "";
+    if (userAgent.includes("HeadlessChrome")) {
+        console.log(
+            `FATAL: attribution run launched headless (UA contains "HeadlessChrome") — ` +
+                `rAF-delta readings are invalid on a display-less frame clock. ` +
+                `Set SHALLOT_HEADED=1 or fix the launch path.`,
+        );
+        process.exitCode = 1;
+    }
+
     // S1f: rAF-delta sampler — the Goal's own signal class. `slow_frame` is shallot's rAF-delta
     // duration vital (`site/rum-sampler.ts`'s `sampleFrame`: `delta = timestamp - lastTimestamp`,
     // threshold 50ms, first frame never reports), not a platform metric and not LoAF. The

--- a/scripts/stall-attribution.ts
+++ b/scripts/stall-attribution.ts
@@ -295,6 +295,8 @@ async function main(): Promise<void> {
                 `Set SHALLOT_HEADED=1 or fix the launch path.`,
         );
         process.exitCode = 1;
+    } else {
+        console.log(`PASSED: attribution run launched headed — UA "${userAgent}".`);
     }
 
     // S1f: rAF-delta sampler — the Goal's own signal class. `slow_frame` is shallot's rAF-delta
@@ -436,7 +438,9 @@ async function main(): Promise<void> {
             process.exitCode = 1;
         } else {
             console.log(
-                "PASSED: no verify-harness call frames in the attribution run's CPU profile.",
+                "PASSED: no contaminating verify-harness call frames in the attribution run's CPU profile — " +
+                    "the instrument's own `__shallotRafTick` rAF callback is a known, deliberate, negligible " +
+                    "exception (the sampler itself, not injected polling).",
             );
         }
     }

--- a/scripts/stall-attribution.ts
+++ b/scripts/stall-attribution.ts
@@ -111,7 +111,8 @@ async function main(): Promise<void> {
         return;
     }
 
-    console.log(`booting ${args.dir} over the WSL bridge (--attribution)…`);
+    console.log(`booting ${args.dir} over the WSL bridge (--attribution, headed)…`);
+    process.env.SHALLOT_HEADED = "1";
     const result = await verify(args.dir, [
         "--attribution",
         "--timeout",
@@ -217,12 +218,16 @@ async function main(): Promise<void> {
             `Profile.compile carries no absolute per-entry timestamp) — only totals.`,
     );
 
-    // S1e: Long Animation Frames — the signal class the Goal's prod RUM `slow_frame` derives from.
-    // A LoAF entry is one per delayed *frame*, summing that frame's script/style/layout/paint-
-    // coordination work, including many sub-50ms chunks the longtask observer above cannot see
-    // individually. On a supporting engine this is the local measurement comparable to prod's
-    // slow_frame; on an unsupported engine the guard degrades to an empty array (the init script's
-    // try/catch), reported here rather than silently dropped.
+    // S1e: Long Animation Frames — a third signal class beside longtask and the Goal's prod
+    // `slow_frame` vital, not a match for either. A LoAF entry is one per delayed *frame*, summing
+    // that frame's script/style/layout/paint-coordination work, including many sub-50ms chunks the
+    // longtask observer above cannot see individually. The Goal's `slow_frame` is shallot's own
+    // rAF-delta duration vital (`site/rum-sampler.ts`, `SLOW_FRAME_THRESHOLD_MS`), not LoAF; a rAF
+    // delta counts everything that stops a frame being produced, while LoAF names per-frame
+    // main-thread-side rendering work only. S1f installs the rAF-delta sampler to match the Goal's
+    // own class; LoAF stays as a complementary per-frame main-thread signal. On an unsupported engine
+    // the guard degrades to an empty array (the init script's try/catch), reported here rather than
+    // silently dropped.
     const loafEntries: LoAFEntry[] = attribution.longAnimationFrames ?? [];
     const loafTotalMs = loafEntries.reduce((s, e) => s + e.duration, 0);
     const loafBlockingMs = loafEntries.reduce((s, e) => s + e.blockingDuration, 0);
@@ -231,15 +236,16 @@ async function main(): Promise<void> {
             ? loafEntries.reduce((a, b) => (b.duration > a.duration ? b : a))
             : null;
     console.log(
-        `\n## S1e — Long Animation Frames (LoAF) — the Goal's prod slow_frame signal class\n`,
+        `\n## S1e — Long Animation Frames (LoAF) — per-frame main-thread signal (third class beside longtask and the rAF-delta vital)\n`,
     );
     if (loafEntries.length === 0) {
         console.log(
             `0 LoAF entries — the engine does not support long-animation-frame (or no frame crossed ` +
                 `the 50ms rendering threshold this boot). The longtask total above (${r1(longTaskMs)}ms) ` +
-                `remains the only main-thread signal, and is NOT comparable to the Goal's prod ` +
-                `slow_frame numbers (sandbox 1100ms / roads 879ms) — longtask fires only on a single ` +
-                `task ≥50ms, while LoAF sums per-frame work including sub-50ms chunks.`,
+                `remains the only main-thread signal from the longtask/LoAF pair. Neither is comparable ` +
+                `to the Goal's prod slow_frame numbers (sandbox 1100ms / roads 879ms) — the Goal's ` +
+                `slow_frame is a rAF-delta vital, not a platform metric; see the S1f rAF-delta section ` +
+                `below for the Goal's own class.`,
         );
     } else {
         console.log(
@@ -268,29 +274,42 @@ async function main(): Promise<void> {
                 );
             });
     }
-    // the same-order-or-below verdict: is the local worst LoAF frame the same order as the Goal's prod
-    // worst frames (sandbox 1100ms / roads 879ms)? An order below means the local seat does not
-    // reproduce the prod stall's magnitude.
-    const ProdWorstSandbox = 1100;
-    const ProdWorstRoads = 879;
-    const prodWorst = args.dir.endsWith("roads") ? ProdWorstRoads : ProdWorstSandbox;
-    if (loafWorst) {
-        const ratio = loafWorst.duration / prodWorst;
-        const verdict =
-            ratio >= 0.5 ? "same order" : ratio >= 0.1 ? "within an order" : "an order below";
+    // S1e's LoAF-vs-prod verdict was dropped (S1f): it divided a LoAF duration by a rAF delta —
+    // two different signal classes — so it was not a reading of the Goal. The Goal's own class is
+    // the rAF-delta vital, reported in the S1f section below.
+
+    // S1f: rAF-delta sampler — the Goal's own signal class. `slow_frame` is shallot's rAF-delta
+    // duration vital (`site/rum-sampler.ts`'s `sampleFrame`: `delta = timestamp - lastTimestamp`,
+    // threshold 50ms, first frame never reports), not a platform metric and not LoAF. The
+    // `ATTRIBUTION_INIT_SCRIPT` installs a mirror of `sampleFrame` in-page on
+    // `window.__shallotRafDeltas`, recording every inter-callback gap >= 50ms with its rAF timestamp
+    // (which is `msSinceLoad` on the vital's own context axis). Run headed because a display-less
+    // frame clock undershoots real block durations (`rum-intake-driver.ts:31-36`).
+    const rafDeltas: { delta: number; timestamp: number }[] = attribution.rafDeltas ?? [];
+    const rafMax = rafDeltas.length > 0 ? Math.max(...rafDeltas.map((d) => d.delta)) : 0;
+    console.log(`\n## S1f — rAF-delta sampler (the Goal's own signal class, headed)\n`);
+    if (rafDeltas.length === 0) {
         console.log(
-            `\nLoAF-vs-prod verdict: local worst frame ${r1(loafWorst.duration)}ms vs prod worst ` +
-                `${prodWorst}ms (${args.dir.endsWith("roads") ? "roads" : "sandbox"}) — ratio ` +
-                // three decimals deliberately: the verdict's thresholds are 0.5 and 0.1, so a
-                // one-decimal ratio rounds 0.069 to "0.1" and reads as if it contradicted the
-                // "an order below" verdict it produced.
-                `${ratio.toFixed(3)}, ${verdict}.`,
+            `0 rAF deltas >= 50ms — no frame crossed the slow-frame threshold this boot. ` +
+                `This is the Goal's own signal class (mirrors \`site/rum-sampler.ts\`'s \`sampleFrame\`), ` +
+                `so a zero here means the local seat did not reproduce the prod stall in this metric.`,
         );
     } else {
         console.log(
-            `\nLoAF-vs-prod verdict: no LoAF entries to compare — the local instrument cannot ` +
-                `produce a number in the Goal's signal class for this run.`,
+            `${rafDeltas.length} rAF deltas >= 50ms, max delta ${r1(rafMax)}ms across the boot window.`,
         );
+        console.log(
+            `prod slow_frame cluster: 0.3–3.1s post-load, worst frames sandbox 1100ms / roads 879ms.`,
+        );
+        console.log("");
+        console.log("| # | timestamp (msSinceLoad) | delta (ms) |");
+        console.log("|---|---|---|");
+        rafDeltas
+            .slice()
+            .sort((a, b) => a.timestamp - b.timestamp)
+            .forEach((d, i) => {
+                console.log(`| ${i + 1} | ${r1(d.timestamp)} | ${r1(d.delta)} |`);
+            });
     }
 
     console.log("\n## Lazy-escape check (compile vs compileAfterIdle)\n");

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -70,6 +70,7 @@ export interface VerifyResult {
         compileAfterIdle: AttributionCompile | null;
         longTasks: { start: number; duration: number }[];
         longAnimationFrames: LoAFEntry[];
+        rafDeltas: { delta: number; timestamp: number }[];
     } | null;
     /** `--attribution` only (S1b): the CDP CPU-profile self-time breakdown, per
      *  `bin/verify.ts`'s `Result.cpuProfile` — null when CDP's `Profiler` domain wasn't reachable. */

--- a/scripts/verify.ts
+++ b/scripts/verify.ts
@@ -71,6 +71,7 @@ export interface VerifyResult {
         longTasks: { start: number; duration: number }[];
         longAnimationFrames: LoAFEntry[];
         rafDeltas: { delta: number; timestamp: number }[];
+        userAgent: string;
     } | null;
     /** `--attribution` only (S1b): the CDP CPU-profile self-time breakdown, per
      *  `bin/verify.ts`'s `Result.cpuProfile` — null when CDP's `Profiler` domain wasn't reachable. */
@@ -235,7 +236,15 @@ async function spawnVerify(
     quiet: boolean,
 ): Promise<{ stdout: string; exitCode: number }> {
     const cmd = isWSL ? await wslCmd(dir, extra) : ["bun", CLI, "verify", dir, "--json", ...extra];
-    const proc = Bun.spawn(cmd, { cwd: repoRoot, stdout: "pipe", stderr: "inherit" });
+    // `env: { ...process.env }` is required because Bun.spawn does NOT propagate runtime
+    // process.env changes (e.g. `process.env.SHALLOT_HEADED = "1"` set by stall-attribution.ts)
+    // to the child process — only pre-existing shell env vars are inherited by default.
+    const proc = Bun.spawn(cmd, {
+        cwd: repoRoot,
+        stdout: "pipe",
+        stderr: "inherit",
+        env: { ...process.env },
+    });
     const stdout = await new Response(proc.stdout).text();
     if (!quiet) process.stdout.write(stdout);
     const exitCode = await proc.exited;


### PR DESCRIPTION
## Problem

Five rounds of local attribution for the demo startup stall compared local numbers against prod's `slow_frame` RUM signal, and none of them measured that signal. PR #244 (S1e) shipped an explicit claim that Long Animation Frames *is* the class `slow_frame` derives from, across ~7 sites in `verify.ts` and `stall-attribution.ts`, plus a computed `LoAF-vs-prod verdict`.

## Cause

`slow_frame` is not a platform metric. It is shallot's **own** duration vital, defined 40 lines away in this same repo: `site/rum-sampler.ts`'s `sampleFrame` computes a raw `requestAnimationFrame` inter-callback delta (`delta = timestamp - state.lastTimestamp`, `SLOW_FRAME_THRESHOLD_MS = 50`) and `site/rum-runtime.ts` emits it via `DD_RUM.addDurationVital`. Its 50 ms threshold was picked *by analogy* to the platform's long-frame boundary, which is not the same thing as being that measurement. So LoAF was a third signal class beside longtask and the vital — not a match for either — and the `LoAF-vs-prod verdict` divided a LoAF duration by a rAF delta.

## Fix

- Corrected the false identity claim at every site, and **dropped** the cross-class verdict rather than re-deriving it.
- Installed a **mirror of `sampleFrame`** in `ATTRIBUTION_INIT_SCRIPT`, reporting max rAF delta and the post-load delta distribution on the vital's own `msSinceLoad` axis — the Goal's metric, measured locally for the first time.
- An `addInitScript` string cannot import, so the mirror is a hand copy and **drift is the exposure**: one arm evaluates the *shipped* init-script text and asserts the mirror and the real exported `sampleFrame` agree on a fixture sequence (first frame, sub-threshold, the `>=` boundary at exactly 50, and large deltas).
- Made the attribution run **headed**. A display-less frame clock measures this exact metric low — `scripts/rum-intake-driver.ts` records a probed sweep where 0/20/30/40/50/65 ms blocks never reported at all, 90 ms read as 66.7 ms and 120 ms as 100 ms — so a headless rAF delta is not a valid reading.
- Reconciled `bun.lock` with the `pngjs` optionalDependency `packages/shallot/package.json` already declared, so a fresh worktree no longer starts dirty.

## Evidence

The headed launch shipped **broken and green**, and the adversarial pass caught it: `Bun.spawn` does not propagate *runtime* `process.env` mutations to the child, so `SHALLOT_HEADED=1` set inside `main()` never reached the CLI and the run was silently headless (UA `HeadlessChrome/151.0.0.0`). Fixed with `env: { ...process.env }` in `spawnVerify`, and the gap is now **armed rather than reasoned about**: the run reads `navigator.userAgent` back and fails loud with a non-zero exit if it contains `HeadlessChrome`, printing the confirmed UA on success so a passing log carries positive evidence.

Headed readings, two independent agents plus the coordinator's own runs:

| demo | max rAF delta (headed) |
|---|---|
| sandbox | 59.2 / 67 ms |
| roads | 58.2 / 65 ms |

Against prod's worst frames of **1100 ms (sandbox) / 879 ms (roads)** and its 0.3–3.1 s post-load cluster. The single local delta lands at ~180–230 ms `msSinceLoad`, *before* prod's cluster even opens.

Gates: `bun run test` 2835 pass / 0 fail, `bun run check` exit 0, and `PASSED: no contaminating verify-harness call frames` on every attribution run. That absence claim is now qualified rather than overstated — the instrument's own `__shallotRafTick` rAF callback (~0.6–2.6 ms self time) is named as a deliberate exception instead of being silently outside the arm's reach.

LoAF and longtask reporting are untouched, so S1d's and S1e's readings stay re-readable off this instrument.
