### PR TITLE
audit shallot engine test integrity/S1

### DIFF
--- a/packages/shallot/src/engine/ecs/scheduler.test.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.test.ts
@@ -476,8 +476,10 @@ describe("Scheduler", () => {
         });
     });
 
-    // unregister clears _errored/_names but not the _initialized WeakSet, so an unregistered-then-
-    // re-added system never re-runs setup — the scheduler thinks it already initialized.
+    // RED witnessed: before 91f8a29, unregister cleared _errored/_names but not the _initialized
+    // WeakSet, so an unregistered-then-re-added system never re-ran setup — the scheduler thought it
+    // already initialized. 91f8a29 added this._initialized.delete(system) to unregister; today a
+    // re-registered system re-runs setup.
     test("unregister then re-register re-runs setup", () => {
         let setupCount = 0;
         const sys: System = {
@@ -492,7 +494,7 @@ describe("Scheduler", () => {
         state.removeSystem(sys);
         state.addSystem(sys);
         state.step();
-        expect(setupCount).toBe(2); // fails: _initialized still has the system
+        expect(setupCount).toBe(2); // unregister cleared _initialized, so the re-registered system re-runs setup
     });
 
     describe("Cache Invalidation", () => {

--- a/packages/shallot/src/engine/ecs/state.test.ts
+++ b/packages/shallot/src/engine/ecs/state.test.ts
@@ -218,9 +218,11 @@ describe("State", () => {
             expect(state.identity.id(b)).toBeUndefined();
         });
 
-        // RED witnessed: author(eid) then author(eid, "x") then author(eid) leaves "x" in _ids
-        // because the else-branch is missing. Witnessed red: expected id(eid) to be undefined,
-        // received "x" — the stale id makes the doc's "undefined if anonymous" false.
+        // RED witnessed: before b9dafde, author(eid) then author(eid, "x") then author(eid) left
+        // "x" in _ids because the else-branch was missing. Witnessed red: expected id(eid) to be
+        // undefined, received "x" — the stale id made the doc's "undefined if anonymous" false.
+        // b9dafde added the else-branch in identity.ts (author deletes _ids when id is undefined),
+        // so today re-authoring anonymously clears the stale recorded id.
         test("re-authoring anonymously clears the stale recorded id", () => {
             const a = state.create();
             state.identity.author(a, "cube");

--- a/packages/shallot/src/engine/ecs/state.ts
+++ b/packages/shallot/src/engine/ecs/state.ts
@@ -236,7 +236,7 @@ export class State {
     }
 
     /**
-     * find exactly one entity, warns if multiple match
+     * find exactly one entity, warns if multiple match, returns -1 when nothing matches
      * @example
      * const player = state.only([Player]);
      */

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -855,9 +855,11 @@ describe("TGSL metadata", () => {
 
     // the other failure checkTgsl guards: a second typegpu copy loaded after the engine's. The key is
     // redefined as a write-counting accessor (gpu.ts), so mutating it at check time exercises the real
-    // production path; restore both the version and the counter in `finally` (the counter, not just
-    // the version, since a later test would otherwise inherit an elevated count from this one).
-    test("checkTgsl throws when a second typegpu copy's version differs from the engine's", () => {
+    // production path; the throw comes from the write counter, not the version value, so this arm pins
+    // the same mechanism as its same-version sibling below. Restore both the version and the counter
+    // in `finally` (the counter, not just the version, since a later test would otherwise inherit an
+    // elevated count from this one).
+    test("checkTgsl throws when a second typegpu copy writes a differing version (the write-count trips on any distinct evaluation, version-independent)", () => {
         const globals = globalThis as unknown as Record<string, unknown>;
         const priorVersion = globals.__TYPEGPU_VERSION__;
         const priorWrites = globals.__SHALLOT_TYPEGPU_WRITES__;

--- a/packages/shallot/src/engine/runtime/probe.ts
+++ b/packages/shallot/src/engine/runtime/probe.ts
@@ -24,7 +24,7 @@ export interface TextureProbe {
 
 /** buffer range and trigger captured by {@link probeBuffer}. */
 export interface BufferProbeOptions {
-    /** byte offset in `source`; an unaligned range is copied through an aligned enclosing range. */
+    /** byte offset in `source`; an unaligned range is copied through an aligned enclosing range when that aligned range fits in `source`, but a trailing unaligned tail with no aligned copy range in the source throws. */
     offset?: number;
     /** bytes to return. Defaults to the rest of `source`. */
     size?: number;

--- a/packages/shallot/src/engine/scene/roundtrip.test.ts
+++ b/packages/shallot/src/engine/scene/roundtrip.test.ts
@@ -296,9 +296,11 @@ describe("serialize(state)", () => {
 });
 
 describe("NaN-sentinel default elision", () => {
-    // RED witnessed: formatFields emits "roughness: NaN" on the alias-lane path because
-    // `value === defaults[dotKey]` is false for NaN. Witnessed red: expected not.toContain("NaN"),
-    // received "metallic: 0; roughness: NaN; emissive: 0; occlusion: 0".
+    // RED witnessed: before b9dafde, formatFields emitted "roughness: NaN" on the alias-lane path
+    // because `value === defaults[dotKey]` was false for NaN. Witnessed red: expected
+    // not.toContain("NaN"), received "metallic: 0; roughness: NaN; emissive: 0; occlusion: 0".
+    // b9dafde routed the comparison through atDefault (codec.ts), which treats a field at its NaN
+    // default as default, so today a NaN-sentinel lane elides on the alias-lane path.
     test("NaN-sentinel default elides on the alias-lane path", () => {
         clear();
         const Mat = { params: sparse(vec4) };
@@ -335,9 +337,11 @@ describe("NaN-sentinel default elision", () => {
         expect(restored["params.w"]).toBe(0);
     });
 
-    // RED witnessed: formatFields emits "pos: 0 0 0 NaN" on the positional Pair/Quad path because
-    // `v === defaultValues[i]` is false for NaN. Witnessed red: expected not.toContain("NaN"),
-    // received "pos: 0 0 0 NaN".
+    // RED witnessed: before b9dafde, formatFields emitted "pos: 0 0 0 NaN" on the positional
+    // Pair/Quad path because `v === defaultValues[i]` was false for NaN. Witnessed red: expected
+    // not.toContain("NaN"), received "pos: 0 0 0 NaN". b9dafde routed the comparison through
+    // atDefault (codec.ts), which treats a field at its NaN default as default, so today a
+    // NaN-sentinel lane elides on the positional Pair/Quad path.
     test("NaN-sentinel default elides on the positional Pair/Quad path", () => {
         clear();
         const Vec = { pos: sparse(vec4) };

--- a/packages/shallot/src/engine/scene/roundtrip.test.ts
+++ b/packages/shallot/src/engine/scene/roundtrip.test.ts
@@ -485,10 +485,12 @@ describe("serialize identity + refs", () => {
         expect(Mark.v.get(target2)).toBe(77);
     });
 
-    // RED witnessed: serialize(state, [a]) emits "to: 2" (raw eid) instead of "to: @b"
-    // because resolveRef returns undefined for a ref target outside the serialized subset.
-    // Witnessed red: expected to contain "to: @b", received `arrow="to: 2"` — the raw eid
+    // RED witnessed: before b9dafde, serialize(state, [a]) emitted "to: 2" (raw eid) instead of
+    // "to: @b" because resolveRef returned undefined for a ref target outside the serialized
+    // subset. Witnessed red: expected to contain "to: @b", received `arrow="to: 2"` — the raw eid
     // points at the wrong (recycled) entity on reload, breaking the round-trip-by-name contract.
+    // b9dafde made resolveRef resolve an out-of-set target to its scene id (codec.ts), so today a
+    // subset serialize emits `@name` for a target outside the serialized set.
     test("subset serialize emits @-ref for a target outside the serialized set", () => {
         clear();
         const Arrow = { to: sparse(entity) };
@@ -499,10 +501,12 @@ describe("serialize identity + refs", () => {
         expect(stringify(serialize(state, [a]))).toContain("to: @b");
     });
 
-    // RED witnessed: serialize(state, [a]) does not throw — resolveRef returns undefined for a
-    // ref target outside the serialized set with no scene id, leaving a raw eid in the output.
-    // Witnessed red: expected toThrow, received `arrow="to: 2"` — the raw eid points at the
-    // wrong (recycled) entity on reload, silently breaking the round-trip-by-name contract.
+    // RED witnessed: before b9dafde, serialize(state, [a]) did not throw — resolveRef returned
+    // undefined for a ref target outside the serialized set with no scene id, leaving a raw eid
+    // in the output. Witnessed red: expected toThrow, received `arrow="to: 2"` — the raw eid
+    // pointed at the wrong (recycled) entity on reload, silently breaking the round-trip-by-name
+    // contract. b9dafde made resolveRef throw for a destroyed or unnamed out-of-set target
+    // (codec.ts), so today serialize fails loud instead of emitting a raw eid.
     test("serialize throws on a ref to a destroyed entity (not a raw eid)", () => {
         clear();
         const Arrow = { to: sparse(entity) };

--- a/packages/shallot/src/engine/scene/roundtrip.test.ts
+++ b/packages/shallot/src/engine/scene/roundtrip.test.ts
@@ -489,12 +489,13 @@ describe("serialize identity + refs", () => {
         expect(Mark.v.get(target2)).toBe(77);
     });
 
-    // RED witnessed: before b9dafde, serialize(state, [a]) emitted "to: 2" (raw eid) instead of
+    // RED witnessed: before e200a63, serialize(state, [a]) emitted "to: 2" (raw eid) instead of
     // "to: @b" because resolveRef returned undefined for a ref target outside the serialized
     // subset. Witnessed red: expected to contain "to: @b", received `arrow="to: 2"` — the raw eid
     // points at the wrong (recycled) entity on reload, breaking the round-trip-by-name contract.
-    // b9dafde made resolveRef resolve an out-of-set target to its scene id (codec.ts), so today a
-    // subset serialize emits `@name` for a target outside the serialized set.
+    // e200a63 made resolveRef resolve an out-of-set target to its scene id (codec.ts), so today a
+    // subset serialize emits `@name` for a target outside the serialized set; b9dafde later made
+    // it throw when that target has no scene id (the sibling arm below).
     test("subset serialize emits @-ref for a target outside the serialized set", () => {
         clear();
         const Arrow = { to: sparse(entity) };

--- a/packages/shallot/src/engine/scene/xml.test.ts
+++ b/packages/shallot/src/engine/scene/xml.test.ts
@@ -344,17 +344,18 @@ describe("XML", () => {
             expect(parsed.color).toBe(0xff8800);
         });
 
-        // RED witnessed: parseNumber treats #fff as parseInt("fff", 16) = 4095 (a 12-bit int)
-        // instead of expanding to the 24-bit 0xffffff or rejecting as null. Witnessed red:
-        // expected 0xffffff or null, received 4095.
+        // RED witnessed: before e200a63, parseNumber treated #fff as parseInt("fff", 16) = 4095
+        // (a 12-bit int) instead of expanding to the 24-bit 0xffffff or rejecting as null.
+        // Witnessed red: expected 0xffffff or null, received 4095. e200a63 made #rgb expand to
+        // #rrggbb (each digit doubled, CSS convention); today parseNumber returns 0xffffff for
+        // #fff or null for a non-hex value, never the 12-bit integer.
         //
-        // The spec leaves expand-vs-reject to S2's executor, so this asserts the *disjunction*
-        // of the two acceptable answers rather than pinning one. It is deliberately not the
-        // weaker `not.toBe(4095)`: that form is satisfied by `undefined`, a thrown-and-swallowed
-        // parse, or any garbage value, so S2 could green it without expanding or rejecting
-        // anything (`checks.md`: a criterion a shipped commit can satisfy without fixing the
-        // defect is not a criterion). The matcher below can only go green on a real fix, and it
-        // discriminates *which* fix landed without caring which one S2 picks.
+        // The matcher asserts the *disjunction* of the two acceptable answers rather than pinning
+        // one. It is deliberately not the weaker `not.toBe(4095)`: that form is satisfied by
+        // `undefined`, a thrown-and-swallowed parse, or any garbage value, so it could go green
+        // without expanding or rejecting anything (a criterion a shipped commit can satisfy
+        // without fixing the defect is not a criterion). The matcher below can only go green on a
+        // real fix, and it discriminates *which* fix landed without caring which one is picked.
         test("#rgb shorthand expands to 24-bit or is rejected, never a 12-bit integer", () => {
             const Part = { color: [] as number[] };
             register("part", Part, { defaults: () => ({ color: 0 }) });
@@ -729,7 +730,9 @@ describe("XML", () => {
         // RED witnessed: the original fixture (three plain ids) could not construct the escape
         // asymmetry its name claims. Replaced with a fixture carrying an escaped id ("a&amp;b").
         // Witnessed red: expected `a&amp;amp;b` (once), received `a&amp;amp;amp;b` (twice) —
-        // escapeAttr has no parse-side inverse, so each round grows an escape layer.
+        // before e200a63 escapeAttr had no parse-side inverse, so each round grew an escape layer.
+        // e200a63 added decodeAttr in xml.ts (called in parseEntity on id and attribute values), so
+        // today stringify(parse(xml)) is a fixed point over escaped attribute text.
         test("stringify(parse(xml)) is idempotent", () => {
             const xml = `<scene>
     <a id="a&amp;b" />
@@ -741,9 +744,11 @@ describe("XML", () => {
             expect(twice).toBe(once);
         });
 
-        // RED witnessed: escapeAttr escapes & → &amp; but parse never decodes &amp; back to &.
-        // Witnessed red: expected `a&amp;b`, received `a&amp;amp;b` — one round grows an escape
-        // layer, so a formatter write-back (parse → stringify) corrupts well-formed scenes.
+        // RED witnessed: before e200a63, escapeAttr escaped & → &amp; but parse never decoded
+        // &amp; back to &. Witnessed red: expected `a&amp;b`, received `a&amp;amp;b` — one round
+        // grew an escape layer, so a formatter write-back (parse → stringify) corrupted
+        // well-formed scenes. e200a63 added decodeAttr in xml.ts (called in parseEntity), so today
+        // parse decodes &amp; back to & and stringify(parse(src)) preserves escaped attribute text.
         test("stringify(parse(xml)) preserves escaped attribute text", () => {
             const src = '<scene>\n    <a id="a&amp;b" />\n</scene>';
             expect(stringify(parse(src))).toBe(src);

--- a/packages/shallot/src/engine/utils/color.test.ts
+++ b/packages/shallot/src/engine/utils/color.test.ts
@@ -78,8 +78,8 @@ describe("packColor", () => {
 // Regression pin: linearToSrgb must not produce NaN for negative inputs. The CPU ternary's
 // condition (c <= 0.0031308) routes every negative value to the linear branch, so no negative
 // ever reaches the power branch — that is what makes the function correct as written, with no
-// max(c,0) guard needed. (The TGSL twin in encode.ts:345 does need max because WGSL `select`
-// evaluates both arms.) This test pins that already-correct behavior against future regressions.
+// max(c,0) guard needed. (The TGSL twin `linearToSrgb1` in encode.ts does need max because WGSL
+// `select` evaluates both arms.) This test pins that already-correct behavior against future regressions.
 describe("linearToSrgb", () => {
     test("does not produce NaN for a negative channel", () => {
         expect(Number.isNaN(linearToSrgb(-0.1))).toBe(false);


### PR DESCRIPTION
**Problem.** Eleven sites in `src/engine` narrated behaviour the code no longer has: comments asserting a pre-fix cause in the present tense (so a test passed while its own comment said it fails), a comment naming another unit's workflow stage, a claim pinned to a foreign file's line number, an arm named for version-difference causality it does not pin, and two JSDoc blocks overclaiming or omitting a return path.

**Cause.** Each was authored beside a red-first witness or a repair and never retensed when the fix shipped. Nothing gates a comment, and the next stage's brief is written from exactly these comments.

**Fix.** The witnessed-red record stays — it is the arm's discrimination evidence — but every pre-fix cause moves to past tense with the repairing commit named (`91f8a29`, `e200a63`, `b9dafde`), and the present-tense sentence states the invariant that holds today. The stage reference is gone; `encode.ts:345` became a symbol citation; the `checkTgsl` arm is renamed to the write-count property it pins; `probe.ts`'s `offset` docblock now states that the aligned enclosing copy holds only when it fits in `source` and that a trailing unaligned tail throws; `state.ts`'s `only` documents its `-1` no-match sentinel. No assertion, fixture or logic change — the only non-comment line in the diff is the renamed test.

**Evidence.** All gates from the shallot repo root (`bunfig.toml`'s preload is cwd-only, so a run from `packages/shallot` reds shader-reaching arms spuriously): touched files 233 pass / 0 fail; `bun run test` 2835 pass / 0 fail; `bun run check` exit 0. An adversarial pass briefed at the instrument descriptions rather than the file list found one blocker — the out-of-set ref resolution was attributed to `b9dafde` when `e200a63` introduced it and `b9dafde` only added the throw — verified by reading `resolveRef` at both refs and their parents, and fixed in `d9555d7`. Three of the eleven sites were not in the unit's enumerated list; a widened query over `RED witnessed` blocks naming no ref found them.
