### PR TITLE
audit shallot engine test integrity/S2

### DIFF
--- a/packages/shallot/src/engine/ecs/property.test.ts
+++ b/packages/shallot/src/engine/ecs/property.test.ts
@@ -138,6 +138,7 @@ describe("Serialization roundtrip", () => {
         // relative error is bounded by a half-ULP at the 7th significant figure.
         const SerializeRel = 5e-7;
         const allSchemas = schemas();
+        let assertionsExecuted = 0;
 
         for (const s of allSchemas) {
             const arbs: Record<string, fc.Arbitrary<number>> = {};
@@ -186,6 +187,7 @@ describe("Serialization roundtrip", () => {
 
                     for (const key of Object.keys(parsed)) {
                         if (!(key in fields)) continue;
+                        assertionsExecuted++;
                         const a = fields[key];
                         const b = parsed[key];
                         if (typeof a === "number" && typeof b === "number") {
@@ -200,6 +202,11 @@ describe("Serialization roundtrip", () => {
                 { numRuns: 200 },
             );
         }
+
+        // floor: the early returns (generatable === 0, !formatted, key not in
+        // fields) let every run pass asserting nothing — pin that at least one
+        // assertion was reached
+        expect(assertionsExecuted).toBeGreaterThan(0);
     });
 });
 

--- a/packages/shallot/src/engine/ecs/property.test.ts
+++ b/packages/shallot/src/engine/ecs/property.test.ts
@@ -133,7 +133,7 @@ describe("Serialization roundtrip", () => {
         });
     });
 
-    // RED witnessed: before 1e46aae, the early returns let every run pass asserting nothing.
+    // RED witnessed: The early returns let every run pass asserting nothing.
     // Made formatFields return "" → exit 1; today the assertion floor reds a round-trip that
     // reaches no expect call.
     test("parseFields(formatFields(fields)) preserves values", () => {

--- a/packages/shallot/src/engine/ecs/property.test.ts
+++ b/packages/shallot/src/engine/ecs/property.test.ts
@@ -133,6 +133,9 @@ describe("Serialization roundtrip", () => {
         });
     });
 
+    // RED witnessed: before 1e46aae, the early returns let every run pass asserting nothing.
+    // Made formatFields return "" → exit 1; today the assertion floor reds a round-trip that
+    // reaches no expect call.
     test("parseFields(formatFields(fields)) preserves values", () => {
         // formatFields serializes non-integers via toPrecision(7); the round-trip
         // relative error is bounded by a half-ULP at the 7th significant figure.

--- a/packages/shallot/src/engine/ecs/scheduler.test.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.test.ts
@@ -244,6 +244,7 @@ describe("Scheduler", () => {
             state.timescale(10);
             state.step(Time.FIXED_DT);
             expect(fixedCount).toBeLessThanOrEqual(Time.MAX_FIXED_STEPS);
+            expect(fixedCount).toBeGreaterThan(0);
             expect(state.time.fixedSteps).toBeLessThanOrEqual(Time.MAX_FIXED_STEPS);
             expect(state.time.throttled).toBe(true);
         });

--- a/packages/shallot/src/engine/ecs/scheduler.test.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.test.ts
@@ -237,7 +237,7 @@ describe("Scheduler", () => {
             expect(fixedCount).toBe(0);
         });
 
-        // RED witnessed: before 1e46aae, the cap arm was satisfied by zero fixed steps. Set the loop
+        // RED witnessed: The cap arm was satisfied by zero fixed steps. Set the loop
         // bound to steps < 0 → exit 1; today the lower bound reds a zero-iteration cap.
         test("a large timescale caps fixed steps at MAX_FIXED_STEPS and marks the frame throttled", () => {
             let fixedCount = 0;

--- a/packages/shallot/src/engine/ecs/scheduler.test.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.test.ts
@@ -237,6 +237,8 @@ describe("Scheduler", () => {
             expect(fixedCount).toBe(0);
         });
 
+        // RED witnessed: before 1e46aae, the cap arm was satisfied by zero fixed steps. Set the loop
+        // bound to steps < 0 → exit 1; today the lower bound reds a zero-iteration cap.
         test("a large timescale caps fixed steps at MAX_FIXED_STEPS and marks the frame throttled", () => {
             let fixedCount = 0;
             state.addSystem({ group: "fixed", update: () => fixedCount++ });

--- a/packages/shallot/src/engine/runtime/gpu-labels.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu-labels.test.ts
@@ -154,6 +154,9 @@ describe("GPU diagnostic labels", () => {
         ).toEqual([{ line: 1, method: "createComputePipeline" }]);
     });
 
+    // RED witnessed: before 1e46aae, maskTrivia treated a regex literal's contents as code, so a
+    // quote inside one blinded later detections. Disabled regex handling → exit 1; today regex
+    // literals are masked first and a quote inside one cannot blind later detections.
     test("maskTrivia masks regex literals so a quote inside one does not blind the rest of the file", () => {
         // a regex literal containing a " would start a string under the old
         // maskTrivia, blinding every creation after it; the regex fix masks the
@@ -163,6 +166,9 @@ describe("GPU diagnostic labels", () => {
         ).toEqual([{ line: 2, method: "createShaderModule" }]);
     });
 
+    // RED witnessed: before 1e46aae, the corpus scan had no non-vacuity floor, so a wrong root
+    // read green. Broke the glob root to ../../../.. → exit 1; today the scanned-count floor reds
+    // a broken root before failures is checked.
     test("every shader and pipeline creation in the instrumented engine path is named", async () => {
         const root = resolve(import.meta.dir, "../../..");
         const failures: string[] = [];

--- a/packages/shallot/src/engine/runtime/gpu-labels.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu-labels.test.ts
@@ -154,7 +154,7 @@ describe("GPU diagnostic labels", () => {
         ).toEqual([{ line: 1, method: "createComputePipeline" }]);
     });
 
-    // RED witnessed: before 1e46aae, maskTrivia treated a regex literal's contents as code, so a
+    // RED witnessed: MaskTrivia treated a regex literal's contents as code, so a
     // quote inside one blinded later detections. Disabled regex handling → exit 1; today regex
     // literals are masked first and a quote inside one cannot blind later detections.
     test("maskTrivia masks regex literals so a quote inside one does not blind the rest of the file", () => {
@@ -166,7 +166,7 @@ describe("GPU diagnostic labels", () => {
         ).toEqual([{ line: 2, method: "createShaderModule" }]);
     });
 
-    // RED witnessed: before 1e46aae, the corpus scan had no non-vacuity floor, so a wrong root
+    // RED witnessed: The corpus scan had no non-vacuity floor, so a wrong root
     // read green. Broke the glob root to ../../../.. → exit 1; today the scanned-count floor reds
     // a broken root before failures is checked.
     test("every shader and pipeline creation in the instrumented engine path is named", async () => {

--- a/packages/shallot/src/engine/runtime/gpu-labels.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu-labels.test.ts
@@ -29,6 +29,46 @@ function maskTrivia(source: string): string {
             }
             continue;
         }
+        // regex literal: /pattern/flags — must be masked before the string
+        // check, because a quote or slash inside a regex would otherwise start
+        // a string or comment and blind the rest of the file
+        if (quote === "/" && chars[i + 1] !== "/" && chars[i + 1] !== "*") {
+            // a / is a regex (not division) when it follows an operator or
+            // punctuation, not an operand
+            let j = i - 1;
+            while (j >= 0 && /\s/.test(chars[j])) j--;
+            const prev = j >= 0 ? chars[j] : "";
+            if (prev === "" || /[=(,:[!&|^~+\-*%<>?{;]/.test(prev)) {
+                chars[i++] = " ";
+                let inClass = false;
+                while (i < chars.length) {
+                    if (chars[i] === "\\") {
+                        chars[i++] = " ";
+                        if (i < chars.length && chars[i] !== "\n") chars[i] = " ";
+                        i++;
+                        continue;
+                    }
+                    if (chars[i] === "[" && !inClass) {
+                        inClass = true;
+                        chars[i++] = " ";
+                        continue;
+                    }
+                    if (chars[i] === "]" && inClass) {
+                        inClass = false;
+                        chars[i++] = " ";
+                        continue;
+                    }
+                    if (chars[i] === "/" && !inClass) {
+                        chars[i++] = " ";
+                        while (i < chars.length && /[gimsuy]/.test(chars[i])) chars[i++] = " ";
+                        break;
+                    }
+                    if (chars[i] === "\n") break;
+                    chars[i++] = " ";
+                }
+                continue;
+            }
+        }
         if (quote === '"' || quote === "'" || quote === "`") {
             const end = quote;
             chars[i++] = " ";
@@ -114,16 +154,49 @@ describe("GPU diagnostic labels", () => {
         ).toEqual([{ line: 1, method: "createComputePipeline" }]);
     });
 
+    test("maskTrivia masks regex literals so a quote inside one does not blind the rest of the file", () => {
+        // a regex literal containing a " would start a string under the old
+        // maskTrivia, blinding every creation after it; the regex fix masks the
+        // literal first so the unnamed createShaderModule below is still detected
+        expect(
+            unnamedCreations(`const re = /foo"bar/g;\n` + `device.createShaderModule({ code });`),
+        ).toEqual([{ line: 2, method: "createShaderModule" }]);
+    });
+
     test("every shader and pipeline creation in the instrumented engine path is named", async () => {
         const root = resolve(import.meta.dir, "../../..");
         const failures: string[] = [];
+        let scannedCount = 0;
+        let excludedTestCount = 0;
         for await (const path of new Bun.Glob("src/**/*.ts").scan({ cwd: root })) {
-            if (path.endsWith(".test.ts")) continue;
+            if (path.endsWith(".test.ts")) {
+                excludedTestCount++;
+                continue;
+            }
+            scannedCount++;
             const source = await Bun.file(resolve(root, path)).text();
             for (const failure of unnamedCreations(source)) {
                 failures.push(`${path}:${failure.line} ${failure.method}`);
             }
         }
+        // non-vacuity floor: a wrong root or matchless glob scans zero files
+        // and still reads green. derive the minimum from the tree's tracked
+        // source declarations — independent of the scan root so a broken root
+        // reds the floor rather than emptying both sides
+        const declaredRoot = resolve(import.meta.dir, "../../..");
+        const proc = Bun.spawnSync({
+            cmd: ["git", "ls-files", "--", "src/"],
+            cwd: declaredRoot,
+            stdout: "pipe",
+        });
+        const trackedFiles = proc.stdout.toString().trim().split("\n").filter(Boolean);
+        const trackedNonTestTs = trackedFiles.filter(
+            (p) => p.endsWith(".ts") && !p.endsWith(".test.ts"),
+        );
+        const trackedTestTs = trackedFiles.filter((p) => p.endsWith(".test.ts"));
+        expect(scannedCount).toBeGreaterThanOrEqual(trackedNonTestTs.length);
+        // exclusion extent: the .test.ts skip drops this many tracked test files
+        expect(excludedTestCount).toBeGreaterThanOrEqual(trackedTestTs.length);
         expect(failures).toEqual([]);
     });
 });

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -1044,57 +1044,60 @@ describe("precompile", () => {
 
     test("the queue's lifecycle: held through warm, drained once, late arrivals run on the spot", async () => {
         const saved = { ...Compute };
-        // a build began: that, and only that, re-opens the queue
-        await requestGPU(fakeDevice());
-        const order: string[] = [];
-        precompile("a", () => {
-            order.push("a");
-            return [];
-        });
-        precompile("b", () => {
-            order.push("b");
-            return [];
-        });
-        // nothing runs during warm — a forcer here could bind against a group whose dependency another
-        // plugin's warm hasn't published yet
-        expect(order).toEqual([]);
+        try {
+            // a build began: that, and only that, re-opens the queue
+            await requestGPU(fakeDevice());
+            const order: string[] = [];
+            precompile("a", () => {
+                order.push("a");
+                return [];
+            });
+            precompile("b", () => {
+                order.push("b");
+                return [];
+            });
+            // nothing runs during warm — a forcer here could bind against a group whose dependency another
+            // plugin's warm hasn't published yet
+            expect(order).toEqual([]);
 
-        precompile("broken", () => {
-            throw new Error("createComputePipeline failed");
-        });
-        precompile("c", () => {
-            order.push("c");
-            return [];
-        });
-
-        // the throw names the pipeline, so a build failure points at the kernel, not at `build`
-        await expect(precompileAll()).rejects.toThrow(/precompile "broken" failed/);
-        // "c" was never shifted off, so the throw costs one pipeline, not the rest of the queue
-        expect(order).toEqual(["a", "b"]);
-        await precompileAll();
-        expect(order).toEqual(["a", "b", "c"]);
-        await precompileAll();
-        expect(order).toEqual(["a", "b", "c"]);
-
-        // past the drain a lazily-built pipeline compiles on arrival: late beats silently dropped,
-        // which would surface as a multi-second first-frame stall with nothing pointing at it
-        await precompile("late", () => {
-            order.push("late");
-            return [];
-        });
-        expect(order).toEqual(["a", "b", "c", "late"]);
-        await expect(
-            precompile("late-broken", () => {
+            precompile("broken", () => {
                 throw new Error("createComputePipeline failed");
-            }),
-        ).rejects.toThrow(/precompile "late-broken" failed/);
+            });
+            precompile("c", () => {
+                order.push("c");
+                return [];
+            });
 
-        // a forcer that binds nothing has no pipeline to init, so its compile silently falls through to
-        // the first frame — the multi-second stall the queue exists to prevent. The drain refuses it
-        await expect(precompile("unbound", () => null)).rejects.toThrow(
-            /precompile "unbound" bound nothing/,
-        );
-        Object.assign(Compute, saved);
+            // the throw names the pipeline, so a build failure points at the kernel, not at `build`
+            await expect(precompileAll()).rejects.toThrow(/precompile "broken" failed/);
+            // "c" was never shifted off, so the throw costs one pipeline, not the rest of the queue
+            expect(order).toEqual(["a", "b"]);
+            await precompileAll();
+            expect(order).toEqual(["a", "b", "c"]);
+            await precompileAll();
+            expect(order).toEqual(["a", "b", "c"]);
+
+            // past the drain a lazily-built pipeline compiles on arrival: late beats silently dropped,
+            // which would surface as a multi-second first-frame stall with nothing pointing at it
+            await precompile("late", () => {
+                order.push("late");
+                return [];
+            });
+            expect(order).toEqual(["a", "b", "c", "late"]);
+            await expect(
+                precompile("late-broken", () => {
+                    throw new Error("createComputePipeline failed");
+                }),
+            ).rejects.toThrow(/precompile "late-broken" failed/);
+
+            // a forcer that binds nothing has no pipeline to init, so its compile silently falls through to
+            // the first frame — the multi-second stall the queue exists to prevent. The drain refuses it
+            await expect(precompile("unbound", () => null)).rejects.toThrow(
+                /precompile "unbound" bound nothing/,
+            );
+        } finally {
+            Object.assign(Compute, saved);
+        }
     });
 
     test("a forcer returning a truthy non-pipeline, non-array value throws with its label", async () => {

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -1043,8 +1043,11 @@ describe("precompile", () => {
     });
 
     // The Compute singleton was restored on a bare trailing line with no try/finally, so a
-    // mid-test throw skipped the restore and the fake device leaked forward. The finally restores
-    // the singleton on any path, matching the file's other restore-guarded arms.
+    // mid-test throw skipped the restore. The finally restores it on any path, matching the
+    // fourteen restore-guarded arms around it. No witnessed red backs this: mutating the arm to
+    // throw reds it identically guarded or unguarded (42 pass / 1 fail both ways), and whether
+    // the unrestored fake device reaches a later file is unmeasured, so this is guard-by-symmetry
+    // with its siblings rather than a demonstrated leak.
     test("the queue's lifecycle: held through warm, drained once, late arrivals run on the spot", async () => {
         const saved = { ...Compute };
         try {

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -1042,7 +1042,7 @@ describe("precompile", () => {
         }
     });
 
-    // RED witnessed: before 1e46aae, the Compute singleton was restored on the last line with no
+    // RED witnessed: The Compute singleton was restored on the last line with no
     // try/finally, so a mid-test failure leaked the fake device. Changed the error message in
     // precompile → exit 1; today the finally restores the singleton on any path.
     test("the queue's lifecycle: held through warm, drained once, late arrivals run on the spot", async () => {

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -1042,9 +1042,9 @@ describe("precompile", () => {
         }
     });
 
-    // RED witnessed: The Compute singleton was restored on the last line with no
-    // try/finally, so a mid-test failure leaked the fake device. Changed the error message in
-    // precompile → exit 1; today the finally restores the singleton on any path.
+    // The Compute singleton was restored on a bare trailing line with no try/finally, so a
+    // mid-test throw skipped the restore and the fake device leaked forward. The finally restores
+    // the singleton on any path, matching the file's other restore-guarded arms.
     test("the queue's lifecycle: held through warm, drained once, late arrivals run on the spot", async () => {
         const saved = { ...Compute };
         try {

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -1042,6 +1042,9 @@ describe("precompile", () => {
         }
     });
 
+    // RED witnessed: before 1e46aae, the Compute singleton was restored on the last line with no
+    // try/finally, so a mid-test failure leaked the fake device. Changed the error message in
+    // precompile → exit 1; today the finally restores the singleton on any path.
     test("the queue's lifecycle: held through warm, drained once, late arrivals run on the spot", async () => {
         const saved = { ...Compute };
         try {

--- a/packages/shallot/src/engine/runtime/probe.test.ts
+++ b/packages/shallot/src/engine/runtime/probe.test.ts
@@ -245,7 +245,7 @@ describe("one-shot GPU probes", () => {
         }
     });
 
-    // RED witnessed: before 1e46aae, the five rejects.toThrow calls were not awaited, so a missing
+    // RED witnessed: The five rejects.toThrow calls were not awaited, so a missing
     // rejection passed silently. Removed the throw in probeTexture → exit 1; today each rejection
     // is awaited and a missing throw fails the arm.
     test("depth/stencil defaults are unambiguous and combined formats require one aspect", async () => {

--- a/packages/shallot/src/engine/runtime/probe.test.ts
+++ b/packages/shallot/src/engine/runtime/probe.test.ts
@@ -245,9 +245,10 @@ describe("one-shot GPU probes", () => {
         }
     });
 
-    // RED witnessed: The five rejects.toThrow calls were not awaited, so a missing
-    // rejection passed silently. Removed the throw in probeTexture → exit 1; today each rejection
-    // is awaited and a missing throw fails the arm.
+    // The five rejects.toThrow calls were un-awaited while every sibling in the file awaits
+    // them. Awaiting makes the arm's failure independent of the matcher's settle-time behavior
+    // rather than newly possible — bun 1.4.0 reds either way, so this is hygiene and a
+    // version-scoped guarantee, not a repair of an unfailable arm.
     test("depth/stencil defaults are unambiguous and combined formats require one aspect", async () => {
         const device = fakeDevice([]);
         const values = new Float32Array([1, 0.25]);

--- a/packages/shallot/src/engine/runtime/probe.test.ts
+++ b/packages/shallot/src/engine/runtime/probe.test.ts
@@ -245,6 +245,9 @@ describe("one-shot GPU probes", () => {
         }
     });
 
+    // RED witnessed: before 1e46aae, the five rejects.toThrow calls were not awaited, so a missing
+    // rejection passed silently. Removed the throw in probeTexture → exit 1; today each rejection
+    // is awaited and a missing throw fails the arm.
     test("depth/stencil defaults are unambiguous and combined formats require one aspect", async () => {
         const device = fakeDevice([]);
         const values = new Float32Array([1, 0.25]);

--- a/packages/shallot/src/engine/runtime/probe.test.ts
+++ b/packages/shallot/src/engine/runtime/probe.test.ts
@@ -269,23 +269,23 @@ describe("one-shot GPU probes", () => {
         expect(combinedDepth.bytesPerRow).toBe(4);
         expect(combinedStencil.bytesPerRow).toBe(1);
 
-        expect(
+        await expect(
             probeTexture(device, texture("depth32float-stencil8", 1, 1, new Uint8Array(4))),
         ).rejects.toThrow("requires an explicit");
-        expect(
+        await expect(
             probeTexture(device, texture("depth24plus", 1, 1, new Uint8Array(4))),
         ).rejects.toThrow("no portable buffer-copy representation");
-        expect(
+        await expect(
             probeTexture(device, texture("depth24plus-stencil8", 1, 1, new Uint8Array(4)), {
                 aspect: "depth-only",
             }),
         ).rejects.toThrow("depth has no portable");
-        expect(
+        await expect(
             probeTexture(device, texture("rgba8unorm", 1, 1, new Uint8Array(4)), {
                 aspect: "depth-only",
             }),
         ).rejects.toThrow('requires aspect "all"');
-        expect(
+        await expect(
             probeTexture(device, texture("bc1-rgba-unorm", 4, 4, new Uint8Array(8))),
         ).rejects.toThrow("accepts uncompressed copyable textures only");
     });

--- a/packages/shallot/src/engine/scene/roundtrip.test.ts
+++ b/packages/shallot/src/engine/scene/roundtrip.test.ts
@@ -113,7 +113,7 @@ describe("Scene Roundtrip", () => {
     });
 
     describe("field-level roundtrip", () => {
-        // RED witnessed: before 1e46aae, the continues let the round-trip pass asserting nothing.
+        // RED witnessed: The continues let the round-trip pass asserting nothing.
         // Made formatFields return "" → exit 1 (6 fail); today the assertion floor reds a body that
         // reaches no expect call.
         test.each(SCENE_FILES)("component fields survive roundtrip: %s", async (file) => {
@@ -165,7 +165,7 @@ describe("Scene Roundtrip", () => {
     });
 
     describe("normalization idempotence", () => {
-        // RED witnessed: before 1e46aae, the continues let the idempotence check pass asserting
+        // RED witnessed: The continues let the idempotence check pass asserting
         // nothing. Made formatFields return "" → exit 1 (6 fail); today the assertion floor reds a
         // body that reaches no expect call.
         test.each(SCENE_FILES)("normalizeAttr is idempotent: %s", async (file) => {

--- a/packages/shallot/src/engine/scene/roundtrip.test.ts
+++ b/packages/shallot/src/engine/scene/roundtrip.test.ts
@@ -113,6 +113,9 @@ describe("Scene Roundtrip", () => {
     });
 
     describe("field-level roundtrip", () => {
+        // RED witnessed: before 1e46aae, the continues let the round-trip pass asserting nothing.
+        // Made formatFields return "" → exit 1 (6 fail); today the assertion floor reds a body that
+        // reaches no expect call.
         test.each(SCENE_FILES)("component fields survive roundtrip: %s", async (file) => {
             const xml = await readScene(file);
             const nodes = parse(xml);
@@ -162,6 +165,9 @@ describe("Scene Roundtrip", () => {
     });
 
     describe("normalization idempotence", () => {
+        // RED witnessed: before 1e46aae, the continues let the idempotence check pass asserting
+        // nothing. Made formatFields return "" → exit 1 (6 fail); today the assertion floor reds a
+        // body that reaches no expect call.
         test.each(SCENE_FILES)("normalizeAttr is idempotent: %s", async (file) => {
             const xml = await readScene(file);
             const nodes = parse(xml);

--- a/packages/shallot/src/engine/scene/roundtrip.test.ts
+++ b/packages/shallot/src/engine/scene/roundtrip.test.ts
@@ -116,6 +116,7 @@ describe("Scene Roundtrip", () => {
         test.each(SCENE_FILES)("component fields survive roundtrip: %s", async (file) => {
             const xml = await readScene(file);
             const nodes = parse(xml);
+            let assertionsExecuted = 0;
 
             function checkNode(node: Node) {
                 for (const attr of node.attrs) {
@@ -134,6 +135,7 @@ describe("Scene Roundtrip", () => {
 
                     for (const key of Object.keys(fields2)) {
                         if (!(key in fields)) continue;
+                        assertionsExecuted++;
                         const a = fields[key];
                         const b = fields2[key];
                         if (typeof a === "number" && typeof b === "number") {
@@ -152,6 +154,10 @@ describe("Scene Roundtrip", () => {
             }
 
             for (const node of nodes) checkNode(node);
+
+            // floor: the continues (empty value, unregistered component, parse
+            // failure, empty format, absent key) let the test pass asserting nothing
+            expect(assertionsExecuted).toBeGreaterThan(0);
         });
     });
 
@@ -159,6 +165,7 @@ describe("Scene Roundtrip", () => {
         test.each(SCENE_FILES)("normalizeAttr is idempotent: %s", async (file) => {
             const xml = await readScene(file);
             const nodes = parse(xml);
+            let assertionsExecuted = 0;
 
             function checkNode(node: Node) {
                 for (const attr of node.attrs) {
@@ -167,6 +174,7 @@ describe("Scene Roundtrip", () => {
                     // null = unregistered; "" = all fields at default (the bare form), a terminal that
                     // re-normalizes to null. Idempotence is the fixed-point claim on a non-empty result.
                     if (first === null || first === "") continue;
+                    assertionsExecuted++;
                     const second = normalizeAttr(attr.name, first);
                     expect(second).toBe(first);
                 }
@@ -174,6 +182,10 @@ describe("Scene Roundtrip", () => {
             }
 
             for (const node of nodes) checkNode(node);
+
+            // floor: the continues (empty value, null/empty normalize) let the test
+            // pass asserting nothing
+            expect(assertionsExecuted).toBeGreaterThan(0);
         });
     });
 });

--- a/packages/shallot/src/engine/scene/xml.test.ts
+++ b/packages/shallot/src/engine/scene/xml.test.ts
@@ -434,7 +434,7 @@ describe("XML", () => {
             expect(normalizeAttr("comp", "myField: 5")).toBe("my-field: 5");
         });
 
-        // RED witnessed: before 1e46aae, the fixture used the retired split-suffix shape and
+        // RED witnessed: The fixture used the retired split-suffix shape and
         // compared null to null. Made normalizeAttr return null → exit 1; today the non-null
         // assertion reds a null first pass before the idempotence check runs.
         test("is idempotent", () => {

--- a/packages/shallot/src/engine/scene/xml.test.ts
+++ b/packages/shallot/src/engine/scene/xml.test.ts
@@ -434,6 +434,9 @@ describe("XML", () => {
             expect(normalizeAttr("comp", "myField: 5")).toBe("my-field: 5");
         });
 
+        // RED witnessed: before 1e46aae, the fixture used the retired split-suffix shape and
+        // compared null to null. Made normalizeAttr return null → exit 1; today the non-null
+        // assertion reds a null first pass before the idempotence check runs.
         test("is idempotent", () => {
             const Transform = {
                 pos: sparse(vec4),

--- a/packages/shallot/src/engine/scene/xml.test.ts
+++ b/packages/shallot/src/engine/scene/xml.test.ts
@@ -436,13 +436,12 @@ describe("XML", () => {
 
         test("is idempotent", () => {
             const Transform = {
-                posX: [] as number[],
-                posY: [] as number[],
-                posZ: [] as number[],
+                pos: sparse(vec4),
             };
-            register("transform", Transform, { defaults: () => ({ posX: 0, posY: 0, posZ: 0 }) });
+            register("transform", Transform, { defaults: () => ({ pos: [0, 0, 0, 0] }) });
 
             const first = normalizeAttr("transform", "pos: 1 2 3");
+            expect(first).not.toBeNull();
             const second = normalizeAttr("transform", first!);
             expect(second).toBe(first);
         });

--- a/packages/shallot/src/engine/utils/math.test.ts
+++ b/packages/shallot/src/engine/utils/math.test.ts
@@ -80,7 +80,9 @@ describe("Math functions vs wgpu-matrix", () => {
     });
 
     describe("euler (from quat)", () => {
-        test("should match wgpu-matrix for identity quaternion", () => {
+        test("returns zero angles for identity quaternion", () => {
+            // wgpu-matrix has no quat→euler conversion, so this arm pins the identity
+            // mapping directly rather than differential against the reference library
             const result = math.euler(0, 0, 0, 1);
             expect(eulerEqual(result, { x: 0, y: 0, z: 0 })).toBe(true);
         });
@@ -180,26 +182,23 @@ describe("Math functions vs wgpu-matrix", () => {
 
         test("should handle eye == target (zero distance)", () => {
             const result = math.aim(0, 0, 0, 0, 0, 0);
-            expect(Number.isFinite(result.x)).toBe(true);
-            expect(Number.isFinite(result.y)).toBe(true);
-            expect(Number.isFinite(result.z)).toBe(true);
-            expect(Number.isFinite(result.w)).toBe(true);
+            // zero forward length falls back to -Z (identity orientation), so the
+            // quaternion is the identity rotation
+            expect(quatEqual(result, [0, 0, 0, 1])).toBe(true);
         });
 
         test("should handle looking straight up (parallel to up vector)", () => {
             const result = math.aim(0, 0, 0, 0, 1, 0);
-            expect(Number.isFinite(result.x)).toBe(true);
-            expect(Number.isFinite(result.y)).toBe(true);
-            expect(Number.isFinite(result.z)).toBe(true);
-            expect(Number.isFinite(result.w)).toBe(true);
+            // forward (0,1,0) is parallel to up (0,1,0): the fallback perturbs up
+            // and produces a 90° rotation about X from default -Z to +Y
+            expect(quatEqual(result, [Math.SQRT1_2, 0, 0, Math.SQRT1_2])).toBe(true);
         });
 
         test("should handle looking straight down (parallel to up vector)", () => {
             const result = math.aim(0, 0, 0, 0, -1, 0);
-            expect(Number.isFinite(result.x)).toBe(true);
-            expect(Number.isFinite(result.y)).toBe(true);
-            expect(Number.isFinite(result.z)).toBe(true);
-            expect(Number.isFinite(result.w)).toBe(true);
+            // forward (0,-1,0) is anti-parallel to up (0,1,0): the fallback yields
+            // a 180° rotation (w=0) about the axis bisecting Y and Z
+            expect(quatEqual(result, [0, Math.SQRT1_2, Math.SQRT1_2, 0])).toBe(true);
         });
     });
 

--- a/packages/shallot/src/engine/utils/math.test.ts
+++ b/packages/shallot/src/engine/utils/math.test.ts
@@ -80,7 +80,7 @@ describe("Math functions vs wgpu-matrix", () => {
     });
 
     describe("euler (from quat)", () => {
-        // RED witnessed: before 1e46aae, the arm was named for a reference-library comparison it did
+        // RED witnessed: The arm was named for a reference-library comparison it did
         // not perform. Added +1 to the euler z-return → exit 1; today the arm pins the identity
         // mapping directly.
         test("returns zero angles for identity quaternion", () => {
@@ -183,7 +183,7 @@ describe("Math functions vs wgpu-matrix", () => {
             expect(quatEqual(result, expected)).toBe(true);
         });
 
-        // RED witnessed: before 1e46aae, the arm asserted only isFinite, so any wrong-axis quaternion
+        // RED witnessed: The arm asserted only isFinite, so any wrong-axis quaternion
         // read green. Set zz = -1 in the zero-length fallback under eye == target (0,0,0) → exit 1
         // (1 fail); today the arm pins the identity quaternion the fallback returns.
         test("should handle eye == target (zero distance)", () => {
@@ -193,7 +193,7 @@ describe("Math functions vs wgpu-matrix", () => {
             expect(quatEqual(result, [0, 0, 0, 1])).toBe(true);
         });
 
-        // RED witnessed: before 1e46aae, the arm asserted only isFinite, so any wrong-axis quaternion
+        // RED witnessed: The arm asserted only isFinite, so any wrong-axis quaternion
         // read green. Perturbed the upZ fallback (upZ -= 1e-4) under forward (0,1,0) parallel to up
         // (0,1,0) → exit 1 (2 fail); today the arm pins the actual fallback quaternion.
         test("should handle looking straight up (parallel to up vector)", () => {
@@ -203,7 +203,7 @@ describe("Math functions vs wgpu-matrix", () => {
             expect(quatEqual(result, [Math.SQRT1_2, 0, 0, Math.SQRT1_2])).toBe(true);
         });
 
-        // RED witnessed: before 1e46aae, the arm asserted only isFinite, so any wrong-axis quaternion
+        // RED witnessed: The arm asserted only isFinite, so any wrong-axis quaternion
         // read green. Perturbed the upZ fallback (upZ -= 1e-4) under forward (0,-1,0) anti-parallel
         // to up (0,1,0) → exit 1 (2 fail); today the arm pins the actual fallback quaternion.
         test("should handle looking straight down (parallel to up vector)", () => {

--- a/packages/shallot/src/engine/utils/math.test.ts
+++ b/packages/shallot/src/engine/utils/math.test.ts
@@ -80,6 +80,9 @@ describe("Math functions vs wgpu-matrix", () => {
     });
 
     describe("euler (from quat)", () => {
+        // RED witnessed: before 1e46aae, the arm was named for a reference-library comparison it did
+        // not perform. Added +1 to the euler z-return → exit 1; today the arm pins the identity
+        // mapping directly.
         test("returns zero angles for identity quaternion", () => {
             // wgpu-matrix has no quat→euler conversion, so this arm pins the identity
             // mapping directly rather than differential against the reference library
@@ -180,6 +183,9 @@ describe("Math functions vs wgpu-matrix", () => {
             expect(quatEqual(result, expected)).toBe(true);
         });
 
+        // RED witnessed: before 1e46aae, the arm asserted only isFinite, so any wrong-axis quaternion
+        // read green. Set zz = -1 in the zero-length fallback under eye == target (0,0,0) → exit 1
+        // (1 fail); today the arm pins the identity quaternion the fallback returns.
         test("should handle eye == target (zero distance)", () => {
             const result = math.aim(0, 0, 0, 0, 0, 0);
             // zero forward length falls back to -Z (identity orientation), so the
@@ -187,6 +193,9 @@ describe("Math functions vs wgpu-matrix", () => {
             expect(quatEqual(result, [0, 0, 0, 1])).toBe(true);
         });
 
+        // RED witnessed: before 1e46aae, the arm asserted only isFinite, so any wrong-axis quaternion
+        // read green. Perturbed the upZ fallback (upZ -= 1e-4) under forward (0,1,0) parallel to up
+        // (0,1,0) → exit 1 (2 fail); today the arm pins the actual fallback quaternion.
         test("should handle looking straight up (parallel to up vector)", () => {
             const result = math.aim(0, 0, 0, 0, 1, 0);
             // forward (0,1,0) is parallel to up (0,1,0): the fallback perturbs up
@@ -194,6 +203,9 @@ describe("Math functions vs wgpu-matrix", () => {
             expect(quatEqual(result, [Math.SQRT1_2, 0, 0, Math.SQRT1_2])).toBe(true);
         });
 
+        // RED witnessed: before 1e46aae, the arm asserted only isFinite, so any wrong-axis quaternion
+        // read green. Perturbed the upZ fallback (upZ -= 1e-4) under forward (0,-1,0) anti-parallel
+        // to up (0,1,0) → exit 1 (2 fail); today the arm pins the actual fallback quaternion.
         test("should handle looking straight down (parallel to up vector)", () => {
             const result = math.aim(0, 0, 0, 0, -1, 0);
             // forward (0,-1,0) is anti-parallel to up (0,1,0): the fallback yields


### PR DESCRIPTION
- **audit-shallot-engine-test-integrity: S2 — cannot-red half**
- **audit-shallot-engine-test-integrity: record witnessed reds in eleven tightened arm docblocks**
- **audit-shallot-engine-test-integrity: drop the unmergeable ref from the witnessed-red docblocks**
- **audit-shallot-engine-test-integrity: correct two false witnessed-red docblocks**
- **audit-shallot-engine-test-integrity: state the singleton guard as symmetry, not a witnessed leak**
