### PR TITLE
audit shallot nan guard sweep/s1

### DIFF
--- a/packages/shallot/src/engine/ecs/scheduler.test.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.test.ts
@@ -688,4 +688,21 @@ describe("Scheduler", () => {
             expect(executionOrder).toEqual(["setup-new", "update-new"]);
         });
     });
+
+    // NaN dt poisons _accumulator permanently (NaN >= fixedDt is false forever), so step must reject it
+    describe("NaN guard", () => {
+        test("step(NaN) throws rather than poisoning the accumulator", () => {
+            expect(() => state.step(NaN)).toThrow(/NaN/);
+            expect(Number.isFinite(state.time.elapsed)).toBe(true);
+        });
+
+        test("step(-1) throws — negative dt drives the accumulator permanently negative", () => {
+            expect(() => state.step(-1)).toThrow();
+        });
+
+        test("timescale(NaN) throws — NaN scale poisons every subsequent step", () => {
+            expect(() => state.timescale(NaN)).toThrow(/NaN/);
+            expect(Number.isFinite(state.time.scale)).toBe(true);
+        });
+    });
 });

--- a/packages/shallot/src/engine/ecs/scheduler.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.ts
@@ -99,6 +99,8 @@ export class Scheduler {
     }
 
     setScale(scale: number): void {
+        if (!Number.isFinite(scale))
+            throw new Error(`timescale received ${scale} (must be a finite number)`);
         this._time.scale = Math.max(0, scale);
     }
 
@@ -158,6 +160,9 @@ export class Scheduler {
     }
 
     step(state: State, deltaTime = Time.DEFAULT_DT): void {
+        if (!Number.isFinite(deltaTime) || deltaTime < 0) {
+            throw new Error(`step received ${deltaTime} (must be a finite, non-negative number)`);
+        }
         const fixedDt = Time.FIXED_DT;
         const maxDt = fixedDt * Time.MAX_FIXED_STEPS;
 

--- a/packages/shallot/src/engine/ecs/state.test.ts
+++ b/packages/shallot/src/engine/ecs/state.test.ts
@@ -347,6 +347,19 @@ describe("State", () => {
                 r.dispose();
             }
         });
+
+        // NaN capacity passes the `!== capacity` guard (NaN !== anything is true) and assigns NaN to
+        // the module global, defeating create()'s check (eid + 1 > NaN is always false)
+        test("NaN capacity throws rather than poisoning the module global", () => {
+            const restore = sharedCapacity;
+            try {
+                expect(() => new State({ capacity: NaN }).dispose()).toThrow();
+                expect(Number.isFinite(sharedCapacity)).toBe(true);
+            } finally {
+                const r = new State({ capacity: restore });
+                r.dispose();
+            }
+        });
     });
 });
 

--- a/packages/shallot/src/engine/ecs/state.ts
+++ b/packages/shallot/src/engine/ecs/state.ts
@@ -69,6 +69,11 @@ export class State {
         mode?: "edit" | "play";
     }) {
         if (opts?.capacity !== undefined && opts.capacity !== capacity) {
+            if (!Number.isFinite(opts.capacity) || opts.capacity < 1) {
+                throw new Error(
+                    `State: capacity ${opts.capacity} is not a finite positive integer`,
+                );
+            }
             if (_liveStates.size > 0) {
                 console.warn(
                     `State: capacity retune from ${capacity} to ${opts.capacity} while ${_liveStates.size} State(s) are live — ` +

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -836,6 +836,20 @@ describe("checkTextureLimits", () => {
             checkTextureLimits("x", { width: 1, height: 1, layers: 257 }, limits(), "r"),
         ).toThrow(UnsupportedError);
     });
+
+    test("NaN byte count passes the single-sided > guard silently — must throw instead", () => {
+        expect(() => checkStorageBinding("x", NaN, 128 * MB, "r")).toThrow();
+    });
+
+    test("NaN width passes the single-sided > guard silently — must throw instead", () => {
+        expect(() => checkTextureLimits("x", { width: NaN, height: 4 }, limits(), "r")).toThrow();
+    });
+
+    test("NaN layers passes the single-sided > guard silently — must throw instead", () => {
+        expect(() =>
+            checkTextureLimits("x", { width: 256, height: 256, layers: NaN }, limits(), "r"),
+        ).toThrow();
+    });
 });
 
 describe("TGSL metadata", () => {

--- a/packages/shallot/src/engine/runtime/gpu.ts
+++ b/packages/shallot/src/engine/runtime/gpu.ts
@@ -66,6 +66,9 @@ export function checkStorageBinding(
     maxBinding: number,
     remedy: string,
 ): void {
+    if (!Number.isFinite(bytes)) {
+        throw new UnsupportedError(`${label} received a non-finite byte count (${bytes})`);
+    }
     if (bytes > maxBinding) {
         throw new UnsupportedError(
             `${label} needs ${mb(bytes)}, but the device's maxStorageBufferBindingSize is ` +
@@ -88,6 +91,11 @@ export function checkTextureLimits(
     limits: Pick<GPUSupportedLimits, "maxTextureDimension2D" | "maxTextureArrayLayers">,
     remedy: string,
 ): void {
+    if (!Number.isFinite(size.width) || !Number.isFinite(size.height)) {
+        throw new UnsupportedError(
+            `${label} received a non-finite extent (${size.width}×${size.height})`,
+        );
+    }
     const dim = Math.max(size.width, size.height);
     if (dim > limits.maxTextureDimension2D) {
         throw new UnsupportedError(
@@ -96,6 +104,9 @@ export function checkTextureLimits(
         );
     }
     const layers = size.layers ?? 1;
+    if (!Number.isFinite(layers)) {
+        throw new UnsupportedError(`${label} received a non-finite layer count (${layers})`);
+    }
     if (layers > limits.maxTextureArrayLayers) {
         throw new UnsupportedError(
             `${label} needs ${layers} array layers, but the device's maxTextureArrayLayers is ` +

--- a/packages/shallot/src/engine/utils/color.test.ts
+++ b/packages/shallot/src/engine/utils/color.test.ts
@@ -73,6 +73,10 @@ describe("packColor", () => {
         expect((packColor(0xffffff, 0.5) >>> 24) & 0xff).toBe(128);
         expect((packColor(0xffffff, 0) >>> 24) & 0xff).toBe(0);
     });
+
+    test("NaN opacity throws — not silently packing transparent (NaN << 24 === 0)", () => {
+        expect(() => packColor(0xffffff, NaN)).toThrow();
+    });
 });
 
 // Regression pin: linearToSrgb must not produce NaN for negative inputs. The CPU ternary's

--- a/packages/shallot/src/engine/utils/color.ts
+++ b/packages/shallot/src/engine/utils/color.ts
@@ -28,6 +28,8 @@ export function unpackColor(packed: number): { r: number; g: number; b: number }
  * const word = packColor(0xff8040, 0.5); // 0x80_40_80_ff, half alpha
  */
 export function packColor(hex: number, opacity: number): number {
+    if (!Number.isFinite(opacity))
+        throw new Error(`packColor received non-finite opacity: ${opacity}`);
     const r = (hex >> 16) & 0xff;
     const g = (hex >> 8) & 0xff;
     const b = hex & 0xff;

--- a/packages/shallot/src/engine/utils/math.test.ts
+++ b/packages/shallot/src/engine/utils/math.test.ts
@@ -105,6 +105,15 @@ describe("Math functions vs wgpu-matrix", () => {
                 expect(eulerEqual(e, angle, EulerRt)).toBe(true);
             }
         });
+
+        test("throws on NaN in any of the 4 quaternion components", () => {
+            // NaN makes m13 NaN, so `m13 > -0.9999999 && m13 < 0.9999999` is false →
+            // the else branch runs and NaN reaches the returned euler angles.
+            expect(() => math.euler(NaN, 0, 0, 1)).toThrow(/NaN/);
+            expect(() => math.euler(0, NaN, 0, 1)).toThrow(/NaN/);
+            expect(() => math.euler(0, 0, NaN, 1)).toThrow(/NaN/);
+            expect(() => math.euler(0, 0, 0, NaN)).toThrow(/NaN/);
+        });
     });
 
     describe("slerp", () => {
@@ -235,6 +244,20 @@ describe("Math functions vs wgpu-matrix", () => {
             const m = math.lookAt(0, 0, 0, 1e-7, 0, 0);
             // the forward vector is -X (normalized), not the fallback -Z
             expect(m[2]).toBeCloseTo(-1, 5);
+        });
+
+        test("throws on NaN in any of the 9 scalar params (eye, target, up)", () => {
+            // NaN param makes zLen/xLen NaN; `xLen < 1e-6` is false and
+            // `Math.abs(zy) > 0.9` is false, so NaN propagates into the matrix.
+            expect(() => math.lookAt(NaN, 0, 0, 0, 0, -1)).toThrow(/NaN/);
+            expect(() => math.lookAt(0, NaN, 0, 0, 0, -1)).toThrow(/NaN/);
+            expect(() => math.lookAt(0, 0, NaN, 0, 0, -1)).toThrow(/NaN/);
+            expect(() => math.lookAt(0, 0, 0, NaN, 0, -1)).toThrow(/NaN/);
+            expect(() => math.lookAt(0, 0, 0, 0, NaN, -1)).toThrow(/NaN/);
+            expect(() => math.lookAt(0, 0, 0, 0, 0, NaN)).toThrow(/NaN/);
+            expect(() => math.lookAt(0, 0, 0, 0, 0, -1, NaN, 1, 0)).toThrow(/NaN/);
+            expect(() => math.lookAt(0, 0, 0, 0, 0, -1, 0, NaN, 0)).toThrow(/NaN/);
+            expect(() => math.lookAt(0, 0, 0, 0, 0, -1, 0, 1, NaN)).toThrow(/NaN/);
         });
     });
 

--- a/packages/shallot/src/engine/utils/math.test.ts
+++ b/packages/shallot/src/engine/utils/math.test.ts
@@ -159,6 +159,19 @@ describe("Math functions vs wgpu-matrix", () => {
             const expected = quat.slerp(from, to, 0.5);
             expect(quatEqual(result, expected)).toBe(true);
         });
+
+        test("throws on NaN in any of the 8 quaternion components (guard checks all 8, not 3)", () => {
+            const from = quat.fromEuler(0, 0, 0, "xyz");
+            const to = quat.fromEuler(utils.degToRad(90), 0, 0, "xyz");
+            // fromX is NaN — the current guard only checks t, fromW, toW
+            expect(() =>
+                math.slerp(NaN, from[1], from[2], from[3], to[0], to[1], to[2], to[3], 0.5),
+            ).toThrow(/NaN/);
+            // toY is NaN
+            expect(() =>
+                math.slerp(from[0], from[1], from[2], from[3], to[0], NaN, to[2], to[3], 0.5),
+            ).toThrow(/NaN/);
+        });
     });
 
     describe("aim", () => {
@@ -211,6 +224,17 @@ describe("Math functions vs wgpu-matrix", () => {
             // forward (0,-1,0) is anti-parallel to up (0,1,0): the fallback yields
             // a 180° rotation (w=0) about the axis bisecting Y and Z
             expect(quatEqual(result, [0, Math.SQRT1_2, Math.SQRT1_2, 0])).toBe(true);
+        });
+    });
+
+    describe("lookAt degeneracy", () => {
+        // the derived bound (eps_f64 * max(|eye|, |target|)) replaces the old tuned 1e-6 in lookAt
+        // and the exact === 0 in aim. A direction of length 1e-7 at unit scale is above the derived
+        // threshold (~2.22e-16) so it must NOT trigger the fallback — the old < 1e-6 would have.
+        test("a small-but-legitimate direction (1e-7) does not trigger the lookAt fallback", () => {
+            const m = math.lookAt(0, 0, 0, 1e-7, 0, 0);
+            // the forward vector is -X (normalized), not the fallback -Z
+            expect(m[2]).toBeCloseTo(-1, 5);
         });
     });
 
@@ -270,6 +294,21 @@ describe("invert", () => {
         for (let i = 0; i < 16; i++) {
             expect(result[i]).toBe(0);
         }
+    });
+
+    // a ~2e-4-scale transform has det = (2e-4)^3 = 8e-12, below the old absolute 1e-10 threshold,
+    // so the old code silently zeroed a legitimate invertible matrix. The derived relative threshold
+    // (n * eps_f32 * Hadamard product) scales with the matrix's own magnitude, so it does not zero it.
+    test("a small-scale transform (det ~8e-12) is not silently zeroed by the threshold", () => {
+        const s = 2e-4;
+        const m = math.compose(0, 0, 0, 0, 0, 0, 1, s, s, s);
+        const inv = math.invert(m);
+        // not zeroed — the inverse exists and has scale 1/s = 5000
+        expect(inv[0]).not.toBe(0);
+        expect(inv[5]).not.toBe(0);
+        expect(inv[10]).not.toBe(0);
+        // compose is TRS, so the inverse scale is 1/s
+        expect(inv[0]).toBeCloseTo(1 / s, 5);
     });
 });
 
@@ -344,6 +383,13 @@ describe("orthographic", () => {
     test("throws on near === far", () => {
         expect(() => math.orthographic(5, 1, 100, 100)).toThrow("Invalid depth planes");
     });
+
+    test("throws on NaN fov/aspect/near/far (NaN <= 0 and NaN === far are both false)", () => {
+        expect(() => math.orthographic(NaN, 1, 0.1, 100)).toThrow();
+        expect(() => math.orthographic(5, NaN, 0.1, 100)).toThrow();
+        expect(() => math.orthographic(5, 1, NaN, 100)).toThrow();
+        expect(() => math.orthographic(5, 1, 0.1, NaN)).toThrow();
+    });
 });
 
 describe("perspective", () => {
@@ -388,6 +434,13 @@ describe("perspective", () => {
 
     test("throws on near === far", () => {
         expect(() => math.perspective(60, 1, 100, 100)).toThrow("Invalid depth planes");
+    });
+
+    test("throws on NaN fov/aspect/near/far (NaN <= 0 and NaN === far are both false)", () => {
+        expect(() => math.perspective(NaN, 1, 0.1, 100)).toThrow();
+        expect(() => math.perspective(60, NaN, 0.1, 100)).toThrow();
+        expect(() => math.perspective(60, 1, NaN, 100)).toThrow();
+        expect(() => math.perspective(60, 1, 0.1, NaN)).toThrow();
     });
 });
 

--- a/packages/shallot/src/engine/utils/math.ts
+++ b/packages/shallot/src/engine/utils/math.ts
@@ -101,6 +101,9 @@ export function euler(
     z: number,
     w: number,
 ): { x: number; y: number; z: number } {
+    if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z) || !Number.isFinite(w)) {
+        throw new Error(`euler received NaN: q=[${x},${y},${z},${w}]`);
+    }
     const x2 = x + x,
         y2 = y + y,
         z2 = z + z;
@@ -465,6 +468,21 @@ export function lookAt(
     upZ = 0,
     out?: Float32Array,
 ): Float32Array {
+    if (
+        !Number.isFinite(eyeX) ||
+        !Number.isFinite(eyeY) ||
+        !Number.isFinite(eyeZ) ||
+        !Number.isFinite(targetX) ||
+        !Number.isFinite(targetY) ||
+        !Number.isFinite(targetZ) ||
+        !Number.isFinite(upX) ||
+        !Number.isFinite(upY) ||
+        !Number.isFinite(upZ)
+    ) {
+        throw new Error(
+            `lookAt received NaN: eye=[${eyeX},${eyeY},${eyeZ}], target=[${targetX},${targetY},${targetZ}], up=[${upX},${upY},${upZ}]`,
+        );
+    }
     let zx = eyeX - targetX;
     let zy = eyeY - targetY;
     let zz = eyeZ - targetZ;

--- a/packages/shallot/src/engine/utils/math.ts
+++ b/packages/shallot/src/engine/utils/math.ts
@@ -23,7 +23,17 @@ export function slerp(
     toW: number,
     t: number,
 ): { x: number; y: number; z: number; w: number } {
-    if (!Number.isFinite(t) || !Number.isFinite(fromW) || !Number.isFinite(toW)) {
+    if (
+        !Number.isFinite(fromX) ||
+        !Number.isFinite(fromY) ||
+        !Number.isFinite(fromZ) ||
+        !Number.isFinite(fromW) ||
+        !Number.isFinite(toX) ||
+        !Number.isFinite(toY) ||
+        !Number.isFinite(toZ) ||
+        !Number.isFinite(toW) ||
+        !Number.isFinite(t)
+    ) {
         throw new Error(
             `slerp received NaN: from=[${fromX},${fromY},${fromZ},${fromW}], to=[${toX},${toY},${toZ},${toW}], t=${t}`,
         );
@@ -163,9 +173,11 @@ export function perspective(
     far: number,
     out?: Float32Array,
 ): Float32Array {
-    if (fov <= 0) throw new Error(`Invalid FOV: ${fov} (must be > 0)`);
-    if (aspect <= 0) throw new Error(`Invalid aspect ratio: ${aspect} (must be > 0)`);
-    if (near === far) throw new Error(`Invalid depth planes: near === far (${near})`);
+    if (!Number.isFinite(fov) || fov <= 0) throw new Error(`Invalid FOV: ${fov} (must be > 0)`);
+    if (!Number.isFinite(aspect) || aspect <= 0)
+        throw new Error(`Invalid aspect ratio: ${aspect} (must be > 0)`);
+    if (!Number.isFinite(near) || !Number.isFinite(far) || near === far)
+        throw new Error(`Invalid depth planes: near === far (${near})`);
     if (!out) out = new Float32Array(16);
     const f = 1 / Math.tan((fov * Math.PI) / 360);
     const nf = 1 / (near - far);
@@ -199,9 +211,12 @@ export function orthographic(
     far: number,
     out?: Float32Array,
 ): Float32Array {
-    if (size <= 0) throw new Error(`Invalid orthographic size: ${size} (must be > 0)`);
-    if (aspect <= 0) throw new Error(`Invalid aspect ratio: ${aspect} (must be > 0)`);
-    if (near === far) throw new Error(`Invalid depth planes: near === far (${near})`);
+    if (!Number.isFinite(size) || size <= 0)
+        throw new Error(`Invalid orthographic size: ${size} (must be > 0)`);
+    if (!Number.isFinite(aspect) || aspect <= 0)
+        throw new Error(`Invalid aspect ratio: ${aspect} (must be > 0)`);
+    if (!Number.isFinite(near) || !Number.isFinite(far) || near === far)
+        throw new Error(`Invalid depth planes: near === far (${near})`);
     if (!out) out = new Float32Array(16);
     const lr = 1 / (size * aspect);
     const bt = 1 / size;
@@ -351,7 +366,7 @@ export function decompose(m: Float32Array, out?: Float32Array): Float32Array {
     return out;
 }
 
-/** mat4 × mat4, column-major */
+/** mat4 × mat4, column-major. `out` must not alias `a` or `b` — the element-wise write-back corrupts the read. */
 export function multiply(a: Float32Array, b: Float32Array, out?: Float32Array): Float32Array {
     if (!out) out = new Float32Array(16);
     for (let i = 0; i < 4; i++) {
@@ -401,7 +416,17 @@ export function invert(m: Float32Array, out?: Float32Array): Float32Array {
     const b11 = a22 * a33 - a23 * a32;
 
     let det = b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
-    if (Math.abs(det) < 1e-10) {
+
+    // relative singularity threshold: Hadamard's inequality bounds |det| by the product of column
+    // norms, so |det| / Hadamard ∈ [0, 1] measures relative volume. A matrix is numerically singular
+    // when that ratio falls to the f32 rounding level (inputs are Float32Array, eps = 2^-23). The n
+    // factor (dimension = 4) accounts for the O(n) multiplications in the determinant expansion.
+    const col0 = Math.hypot(m[0], m[1], m[2], m[3]);
+    const col1 = Math.hypot(m[4], m[5], m[6], m[7]);
+    const col2 = Math.hypot(m[8], m[9], m[10], m[11]);
+    const col3 = Math.hypot(m[12], m[13], m[14], m[15]);
+    const hadamard = col0 * col1 * col2 * col3;
+    if (hadamard === 0 || Math.abs(det) < 4 * 2 ** -23 * hadamard) {
         out.fill(0);
         return out;
     }
@@ -445,7 +470,19 @@ export function lookAt(
     let zz = eyeZ - targetZ;
     let zLen = Math.sqrt(zx * zx + zy * zy + zz * zz);
 
-    if (zLen < 1e-6) {
+    // degeneracy: the eye-minus-target direction is garbage when |z| falls to the f64 rounding
+    // level of the subtraction (eps * max(|eye|, |target|)). The 1 floor avoids a zero threshold
+    // for origin-coincident coordinates. Unifies the old tuned 1e-6 (lookAt) and exact === 0 (aim).
+    const _zScale = Math.max(
+        Math.abs(eyeX),
+        Math.abs(eyeY),
+        Math.abs(eyeZ),
+        Math.abs(targetX),
+        Math.abs(targetY),
+        Math.abs(targetZ),
+        1,
+    );
+    if (zLen < Number.EPSILON * _zScale) {
         zx = 0;
         zy = 0;
         zz = 1;
@@ -537,7 +574,16 @@ export function aim(
     let zz = eyeZ - targetZ;
     let zLen = Math.sqrt(zx * zx + zy * zy + zz * zz);
 
-    if (zLen === 0) {
+    const _zScale = Math.max(
+        Math.abs(eyeX),
+        Math.abs(eyeY),
+        Math.abs(eyeZ),
+        Math.abs(targetX),
+        Math.abs(targetY),
+        Math.abs(targetZ),
+        1,
+    );
+    if (zLen < Number.EPSILON * _zScale) {
         zz = 1;
     } else {
         zLen = 1 / zLen;


### PR DESCRIPTION
- **audit-shallot-nan-guard-sweep: guard step(dt) and setScale against NaN**
- **audit-shallot-nan-guard-sweep: guard State capacity against NaN**
- **audit-shallot-nan-guard-sweep: guard GPU pre-flight checks against NaN**
- **audit-shallot-nan-guard-sweep: guard perspective/orthographic/slerp against NaN**
- **audit-shallot-nan-guard-sweep: guard packColor against NaN opacity**
- **audit-shallot-nan-guard-sweep: guard euler and lookAt against NaN**
