### PR TITLE
audit shallot app lifecycle robustness/S1

### DIFF
--- a/packages/shallot/src/engine/app/index.ts
+++ b/packages/shallot/src/engine/app/index.ts
@@ -132,24 +132,33 @@ export async function warmPlugins(
     device: GPUDevice,
     state: State,
     plugins: readonly Plugin[],
-    onProgress?: (completed: number, progress?: number) => void,
+    onProgress?: (progress: number) => void,
 ): Promise<void> {
     await validateGpu(device, "pipeline warm", async () => {
-        let completed = 0;
+        const perPlugin = new Array(plugins.length).fill(0);
+        const report = () => onProgress?.(perPlugin.reduce((a, b) => a + b, 0));
         const results = await Promise.allSettled(
-            plugins.map(async (plugin) => {
+            plugins.map(async (plugin, i) => {
                 try {
-                    await plugin.warm!(state, (progress) => onProgress?.(completed, progress));
+                    await plugin.warm!(state, (p) => {
+                        perPlugin[i] = Math.max(perPlugin[i], p);
+                        report();
+                    });
                 } finally {
-                    completed++;
-                    onProgress?.(completed);
+                    perPlugin[i] = 1;
+                    report();
                 }
             }),
         );
-        const rejected = results.find(
+        const rejected = results.filter(
             (result): result is PromiseRejectedResult => result.status === "rejected",
         );
-        if (rejected) throw rejected.reason;
+        if (rejected.length > 0) {
+            throw new AggregateError(
+                rejected.map((r) => r.reason),
+                "plugin warm failed",
+            );
+        }
 
         // typegpu creates pipelines synchronously and Dawn defers that compile to the first dispatch,
         // so every registered pipeline is forced here — under the loading screen, not on frame one.
@@ -263,7 +272,8 @@ export async function build(config: Config): Promise<App> {
                 : [config.scene]
             : [];
 
-        const total = sorted.length * 2 + scenes.length;
+        const warmable = sorted.filter((p) => p.warm);
+        const total = sorted.length + warmable.length + scenes.length;
 
         config.setup?.(state);
 
@@ -271,8 +281,8 @@ export async function build(config: Config): Promise<App> {
             const onProgress = loading
                 ? (progress: number) => loading.update((i + progress) / total)
                 : undefined;
-            await sorted[i].initialize?.(state, onProgress);
             initialized.push(sorted[i]);
+            await sorted[i].initialize?.(state, onProgress);
             loading?.update((i + 1) / total);
         }
 
@@ -288,7 +298,6 @@ export async function build(config: Config): Promise<App> {
             loading?.update((sorted.length + i + 1) / total);
         }
 
-        const warmable = sorted.filter((p) => p.warm);
         const warmBase = sorted.length + scenes.length;
         // freeze the membership generation count before any plugin's `warm` runs:
         // `allocMembership` (SlabPlugin.warm) sizes the GPU mirror from it, and the
@@ -296,8 +305,8 @@ export async function build(config: Config): Promise<App> {
         // plugin can build against it. Owned here, not in a standard plugin, so it
         // holds for every State regardless of which plugins are loaded.
         state.membership.freeze();
-        await warmPlugins(Compute.device, state, warmable, (completed, progress) => {
-            loading?.update((warmBase + completed + (progress ?? 0)) / total);
+        await warmPlugins(Compute.device, state, warmable, (progress) => {
+            loading?.update((warmBase + progress) / total);
         });
 
         if (cleanup) {
@@ -306,18 +315,29 @@ export async function build(config: Config): Promise<App> {
             cleanup();
         }
 
+        let disposed = false;
         return {
             state,
             skipped: [...skipped].map((p) => p.name),
             dispose() {
+                if (disposed) return;
+                disposed = true;
                 for (let i = sorted.length - 1; i >= 0; i--) {
-                    sorted[i].dispose?.(state);
+                    try {
+                        sorted[i].dispose?.(state);
+                    } catch (err) {
+                        console.error(`Plugin "${sorted[i].name}" threw during dispose:`, err);
+                    }
                 }
-                state.dispose();
+                try {
+                    state.dispose();
+                } catch (err) {
+                    console.error("State dispose threw:", err);
+                }
             },
         };
     } catch (e) {
-        // a failed build leaves nothing live: plugins that completed initialize dispose in
+        // a failed build leaves nothing live: plugins that started initialize dispose in
         // reverse, then the State, so a retry builds against clean module singletons. A dispose
         // throw here is reported, never allowed to mask the build error.
         for (let i = initialized.length - 1; i >= 0; i--) {
@@ -332,7 +352,8 @@ export async function build(config: Config): Promise<App> {
         } catch (err) {
             console.error("State dispose threw during cleanup:", err);
         }
-        loading?.error?.(e);
+        if (loading?.error) loading.error(e);
+        else cleanup?.();
         throw e;
     }
 }
@@ -380,12 +401,16 @@ function sortPlugins(nodes: Plugin[], edges: [Plugin, Plugin][]): Plugin[] {
  */
 export function mountOverlay(canvas: HTMLElement | null, state?: State): HTMLDivElement {
     const parent = canvas?.parentElement ?? document.body;
+    const prior = parent.style.position;
     parent.style.position = "relative";
     const overlay = document.createElement("div");
     overlay.style.cssText =
         "position:absolute;inset:0;pointer-events:none;z-index:1;contain:layout paint;overflow:hidden";
     parent.appendChild(overlay);
-    state?.onDispose(() => overlay.remove());
+    state?.onDispose(() => {
+        overlay.remove();
+        parent.style.position = prior;
+    });
     return overlay;
 }
 
@@ -463,9 +488,12 @@ export async function run(config: Config): Promise<App> {
         const fence = Compute.sync?.();
         if (fence) {
             const waitStart = now();
-            fence.then(() => {
-                pendingFenceWaitMs = now() - waitStart;
-            });
+            fence.then(
+                () => {
+                    pendingFenceWaitMs = now() - waitStart;
+                },
+                () => {},
+            );
         }
     }
 

--- a/packages/shallot/src/engine/app/index.ts
+++ b/packages/shallot/src/engine/app/index.ts
@@ -493,6 +493,12 @@ export async function run(config: Config): Promise<App> {
                 () => {
                     pendingFenceWaitMs = now() - waitStart;
                 },
+                // a rejected fence is device loss, and this continuation carries nothing but a timing
+                // sample — drop it rather than reporting a bogus wait. The handler exists only so the
+                // rejection isn't unhandled; the loss itself is reported by `observeDevice`, and the
+                // loop deliberately keeps running (report-only device-loss policy). Don't delete this
+                // as dead code: `Compute.sync`'s own `inFlight` accounting is what must not wedge, and
+                // it is guarded at the fence in `runtime/gpu.ts`, not here.
                 () => {},
             );
         }

--- a/packages/shallot/src/engine/app/index.ts
+++ b/packages/shallot/src/engine/app/index.ts
@@ -154,9 +154,10 @@ export async function warmPlugins(
             (result): result is PromiseRejectedResult => result.status === "rejected",
         );
         if (rejected.length > 0) {
+            const reasons = rejected.map((r) => r.reason);
             throw new AggregateError(
-                rejected.map((r) => r.reason),
-                "plugin warm failed",
+                reasons,
+                reasons.map((r) => (r instanceof Error ? r.message : String(r))).join(", "),
             );
         }
 
@@ -309,8 +310,8 @@ export async function build(config: Config): Promise<App> {
             loading?.update((warmBase + progress) / total);
         });
 
+        loading?.update(1);
         if (cleanup) {
-            loading?.update(1);
             await new Promise<void>((r) => requestFrame(() => r()));
             cleanup();
         }

--- a/packages/shallot/src/engine/app/overlay.test.ts
+++ b/packages/shallot/src/engine/app/overlay.test.ts
@@ -9,6 +9,7 @@ function mockElement() {
         style: {} as Record<string, string>,
         children: [] as unknown[],
         removed: false,
+        parentElement: null as unknown,
         appendChild(child: unknown) {
             this.children.push(child);
             return child;
@@ -54,5 +55,29 @@ describe("mountOverlay", () => {
         const overlay = mountOverlay(null) as unknown as ReturnType<typeof mockElement>;
         state.dispose();
         expect(overlay.removed).toBe(false);
+    });
+
+    test("restores the host element's prior inline position on dispose", () => {
+        const parent = mockElement();
+        parent.style.position = "absolute";
+        const canvas = mockElement();
+        canvas.parentElement = parent;
+        const state = new State();
+        mountOverlay(canvas as unknown as HTMLElement, state);
+        expect(parent.style.position).toBe("relative");
+        state.dispose();
+        expect(parent.style.position).toBe("absolute");
+    });
+
+    test("restores the prior position when there was no inline position", () => {
+        const parent = mockElement();
+        const prior = parent.style.position;
+        const canvas = mockElement();
+        canvas.parentElement = parent;
+        const state = new State();
+        mountOverlay(canvas as unknown as HTMLElement, state);
+        expect(parent.style.position).toBe("relative");
+        state.dispose();
+        expect(parent.style.position).toBe(prior);
     });
 });

--- a/packages/shallot/src/engine/app/plugin.test.ts
+++ b/packages/shallot/src/engine/app/plugin.test.ts
@@ -1011,5 +1011,144 @@ describe("Plugin", () => {
             );
             expect(cleanupCalled).toBe(true);
         });
+
+        // the AggregateError's message must name the actual reason(s), not a fixed string —
+        // validateGpu wraps it as a cause whose own message is built from cause.message alone,
+        // and the startup screen renders `${error.name}: ${error.message}`, so a fixed message
+        // loses the one piece a human reads. Assert on the thrown text a caller would log.
+        test("a single warm rejection's thrown error text names the plugin's own reason", async () => {
+            const saved = { ...Compute };
+            const device = {
+                queue: { onSubmittedWorkDone: async () => {} },
+                features: new Set(),
+                limits: {},
+                lost: new Promise(() => {}),
+                pushErrorScope: () => {},
+                popErrorScope: async () => null,
+            } as unknown as GPUDevice;
+            const plugins: Plugin[] = [
+                {
+                    name: "solo",
+                    warm: async () => {
+                        throw new Error("solo pipeline kaboom");
+                    },
+                },
+            ];
+            try {
+                await requestGPU(device);
+                try {
+                    await warmPlugins(device, {} as never, plugins);
+                    expect.unreachable("should have rejected");
+                } catch (e) {
+                    expect((e as Error).message).toContain("solo pipeline kaboom");
+                    const errors = (e as { cause?: AggregateError }).cause?.errors as Error[];
+                    expect(errors).toBeDefined();
+                    expect(errors.some((err) => err.message.includes("solo pipeline kaboom"))).toBe(
+                        true,
+                    );
+                }
+            } finally {
+                Object.assign(Compute, saved);
+            }
+        });
+
+        test("multiple warm rejections' thrown error text names every reason", async () => {
+            const saved = { ...Compute };
+            const device = {
+                queue: { onSubmittedWorkDone: async () => {} },
+                features: new Set(),
+                limits: {},
+                lost: new Promise(() => {}),
+                pushErrorScope: () => {},
+                popErrorScope: async () => null,
+            } as unknown as GPUDevice;
+            const plugins: Plugin[] = [
+                {
+                    name: "a",
+                    warm: async () => {
+                        throw new Error("a pipeline kaboom");
+                    },
+                },
+                {
+                    name: "b",
+                    warm: async () => {
+                        throw new Error("b pipeline kaboom");
+                    },
+                },
+            ];
+            try {
+                await requestGPU(device);
+                try {
+                    await warmPlugins(device, {} as never, plugins);
+                    expect.unreachable("should have rejected");
+                } catch (e) {
+                    expect((e as Error).message).toContain("a pipeline kaboom");
+                    expect((e as Error).message).toContain("b pipeline kaboom");
+                    const errors = (e as { cause?: AggregateError }).cause?.errors as Error[];
+                    expect(errors).toBeDefined();
+                    expect(errors.some((err) => err.message.includes("a pipeline kaboom"))).toBe(
+                        true,
+                    );
+                    expect(errors.some((err) => err.message.includes("b pipeline kaboom"))).toBe(
+                        true,
+                    );
+                }
+            } finally {
+                Object.assign(Compute, saved);
+            }
+        });
+
+        // a non-Error throw still surfaces its text in the AggregateError message
+        test("a non-Error warm throw's message falls back to String(reason)", async () => {
+            const saved = { ...Compute };
+            const device = {
+                queue: { onSubmittedWorkDone: async () => {} },
+                features: new Set(),
+                limits: {},
+                lost: new Promise(() => {}),
+                pushErrorScope: () => {},
+                popErrorScope: async () => null,
+            } as unknown as GPUDevice;
+            const plugins: Plugin[] = [
+                {
+                    name: "str",
+                    warm: async () => {
+                        throw "string-reason-kaboom";
+                    },
+                },
+            ];
+            try {
+                await requestGPU(device);
+                try {
+                    await warmPlugins(device, {} as never, plugins);
+                    expect.unreachable("should have rejected");
+                } catch (e) {
+                    expect((e as Error).message).toContain("string-reason-kaboom");
+                    const errors = (e as { cause?: AggregateError }).cause?.errors as unknown[];
+                    expect(errors).toBeDefined();
+                    expect(errors.some((r) => String(r).includes("string-reason-kaboom"))).toBe(
+                        true,
+                    );
+                }
+            } finally {
+                Object.assign(Compute, saved);
+            }
+        });
+
+        // the 0–1 progress contract this unit enforces must hold in its own degenerate case:
+        // a build with zero plugins and zero scenes still reports update reaching 1, even when
+        // Loading.show() returns no cleanup (warmPlugins([]) never invokes its progress callback)
+        test("a zero-plugin zero-scene build with no cleanup still reports progress reaching 1", async () => {
+            clear();
+            const trace: number[] = [];
+            const loading: Loading = {
+                show() {},
+                update(progress) {
+                    trace.push(progress);
+                },
+            };
+            await build({ plugins: [], defaults: false, loading });
+            expect(trace.at(-1)).toBe(1);
+        });
     });
 });

--- a/packages/shallot/src/engine/app/plugin.test.ts
+++ b/packages/shallot/src/engine/app/plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
     build,
     f32,
+    type Loading,
     type Plugin,
     type System,
     serialize,
@@ -781,7 +782,16 @@ describe("Plugin", () => {
             };
 
             await expect(build({ plugins: [A, B, C], defaults: false })).rejects.toThrow("c boom");
-            expect(log).toEqual(["a-init", "b-init", "b-dispose", "a-dispose", "sys-dispose"]);
+            // C is pushed to initialized before its initialize runs, so a mid-initialize throw
+            // still gets its dispose — the plugin that caused the failure is cleaned up too
+            expect(log).toEqual([
+                "a-init",
+                "b-init",
+                "c-dispose",
+                "b-dispose",
+                "a-dispose",
+                "sys-dispose",
+            ]);
         });
 
         test("a dispose throw during cleanup is reported, never masks the build error", async () => {
@@ -839,6 +849,167 @@ describe("Plugin", () => {
 
             state.step();
             expect(systemRan).toBe(true);
+        });
+    });
+
+    // lifecycle robustness: the dispose/initialize/warm contracts the engine's own comments state
+    describe("lifecycle robustness", () => {
+        test("a throwing plugin dispose does not skip later disposes or state teardown", async () => {
+            clear();
+            const log: string[] = [];
+            const A: Plugin = {
+                name: "a",
+                dispose: () => {
+                    throw new Error("dispose boom");
+                },
+            };
+            const B: Plugin = {
+                name: "b",
+                dispose: () => log.push("b-dispose"),
+            };
+            const app = await build({ plugins: [A, B], defaults: false });
+            const origError = console.error;
+            console.error = () => {};
+            try {
+                app.dispose();
+            } finally {
+                console.error = origError;
+            }
+            expect(log).toContain("b-dispose");
+            expect(app.state.disposed).toBe(true);
+        });
+
+        test("App.dispose is idempotent", async () => {
+            clear();
+            let disposeCount = 0;
+            const A: Plugin = {
+                name: "a",
+                dispose: () => {
+                    disposeCount++;
+                },
+            };
+            const app = await build({ plugins: [A], defaults: false });
+            app.dispose();
+            app.dispose();
+            expect(disposeCount).toBe(1);
+        });
+
+        test("a plugin that throws mid-initialize gets its dispose cleanup", async () => {
+            clear();
+            const log: string[] = [];
+            const A: Plugin = {
+                name: "a",
+                initialize: () => {
+                    log.push("a-init");
+                },
+                dispose: () => log.push("a-dispose"),
+            };
+            const B: Plugin = {
+                name: "b",
+                initialize: () => {
+                    log.push("b-init");
+                    throw new Error("b boom");
+                },
+                dispose: () => log.push("b-dispose"),
+            };
+            await expect(build({ plugins: [A, B], defaults: false })).rejects.toThrow("b boom");
+            expect(log).toContain("b-dispose");
+        });
+
+        test("sibling warm rejections are all reported, not just the first", async () => {
+            const saved = { ...Compute };
+            const device = {
+                queue: { onSubmittedWorkDone: async () => {} },
+                features: new Set(),
+                limits: {},
+                lost: new Promise(() => {}),
+                pushErrorScope: () => {},
+                popErrorScope: async () => null,
+            } as unknown as GPUDevice;
+            const plugins: Plugin[] = [
+                {
+                    name: "a",
+                    warm: async () => {
+                        throw new Error("a failed");
+                    },
+                },
+                {
+                    name: "b",
+                    warm: async () => {
+                        throw new Error("b failed");
+                    },
+                },
+            ];
+            try {
+                await requestGPU(device);
+                const warming = warmPlugins(device, {} as never, plugins);
+                try {
+                    await warming;
+                    expect.unreachable("should have rejected");
+                } catch (e) {
+                    const cause = (e as { cause?: AggregateError }).cause;
+                    const errors = cause?.errors as Error[];
+                    expect(errors).toBeDefined();
+                    expect(errors.some((err) => err.message.includes("a failed"))).toBe(true);
+                    expect(errors.some((err) => err.message.includes("b failed"))).toBe(true);
+                }
+            } finally {
+                Object.assign(Compute, saved);
+            }
+        });
+
+        test("a non-warming plugin's progress reaches 1 and concurrent warm progress is monotonic", async () => {
+            clear();
+            const trace: number[] = [];
+            const loading: Loading = {
+                show() {},
+                update(progress) {
+                    trace.push(progress);
+                },
+            };
+            const A: Plugin = {
+                name: "a",
+                warm: async (_s, onProgress) => {
+                    onProgress?.(0.9);
+                    await Promise.resolve();
+                    onProgress?.(0.3);
+                },
+            };
+            const B: Plugin = {
+                name: "b",
+                warm: async (_s, onProgress) => {
+                    onProgress?.(0.1);
+                },
+            };
+            const C: Plugin = { name: "c" };
+            await build({ plugins: [A, B, C], defaults: false, loading });
+            expect(trace.at(-1)).toBe(1);
+            for (let i = 1; i < trace.length; i++) {
+                expect(trace[i]).toBeGreaterThanOrEqual(trace[i - 1]);
+            }
+        });
+
+        test("a failed build calls cleanup when Loading has no error method", async () => {
+            clear();
+            let cleanupCalled = false;
+            const loading: Loading = {
+                show() {
+                    return () => {
+                        cleanupCalled = true;
+                    };
+                },
+                update() {},
+            };
+            const A: Plugin = {
+                name: "a",
+                initialize: () => {
+                    throw new Error("build boom");
+                },
+            };
+            await expect(build({ plugins: [A], defaults: false, loading })).rejects.toThrow(
+                "build boom",
+            );
+            expect(cleanupCalled).toBe(true);
         });
     });
 });

--- a/packages/shallot/src/engine/ecs/scheduler.test.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.test.ts
@@ -705,4 +705,34 @@ describe("Scheduler", () => {
             expect(Number.isFinite(state.time.scale)).toBe(true);
         });
     });
+
+    // a throwing system.dispose must not skip later disposes or the _queries.clear() that
+    // state.dispose() runs after the scheduler — one throw must not re-open the leak
+    describe("dispose", () => {
+        test("a throwing system.dispose does not skip later disposes", () => {
+            const log: string[] = [];
+            const sysA: System = {
+                update: () => {},
+                dispose: () => {
+                    throw new Error("dispose A boom");
+                },
+            };
+            const sysB: System = {
+                update: () => {},
+                dispose: () => log.push("b-dispose"),
+            };
+            state.addSystem(sysA);
+            state.addSystem(sysB);
+
+            const origError = console.error;
+            console.error = () => {};
+            try {
+                expect(() => state.dispose()).not.toThrow();
+            } finally {
+                console.error = origError;
+            }
+            expect(log).toContain("b-dispose");
+            expect(state.disposed).toBe(true);
+        });
+    });
 });

--- a/packages/shallot/src/engine/ecs/scheduler.ts
+++ b/packages/shallot/src/engine/ecs/scheduler.ts
@@ -106,7 +106,14 @@ export class Scheduler {
 
     dispose(state: State): void {
         for (const system of this._systems) {
-            system.dispose?.(state);
+            try {
+                system.dispose?.(state);
+            } catch (err) {
+                console.error(
+                    `System "${this._names.get(system) ?? system.name ?? "?"}" threw during dispose:`,
+                    err,
+                );
+            }
         }
     }
 

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -1205,3 +1205,26 @@ describe("precompile", () => {
         }
     });
 });
+
+// a rejected onSubmittedWorkDone (device loss) must decrement inFlight so the
+// pending() >= MAX_FRAMES_IN_FLIGHT backpressure gate cannot wedge
+describe("fence rejection", () => {
+    test("a rejected fence decrements inFlight so the backpressure gate cannot wedge", async () => {
+        const saved = { ...Compute };
+        try {
+            const fence = Promise.reject(new Error("device lost"));
+            const device = {
+                ...fakeDevice(),
+                queue: { onSubmittedWorkDone: () => fence },
+            } as unknown as GPUDevice;
+            await requestGPU(device);
+            expect(Compute.pending!()).toBe(0);
+            const f = Compute.sync!();
+            expect(Compute.pending!()).toBe(1);
+            await expect(f).rejects.toThrow("device lost");
+            expect(Compute.pending!()).toBe(0);
+        } finally {
+            Object.assign(Compute, saved);
+        }
+    });
+});

--- a/packages/shallot/src/engine/runtime/gpu.ts
+++ b/packages/shallot/src/engine/runtime/gpu.ts
@@ -1021,7 +1021,10 @@ export async function requestGPU(
         sync: () => {
             inFlight++;
             const fence = d.queue.onSubmittedWorkDone();
-            fence.then(() => inFlight--);
+            fence.then(
+                () => inFlight--,
+                () => inFlight--,
+            );
             return fence;
         },
         buffers: new Map<string, GPUBuffer>(),


### PR DESCRIPTION
- **audit-shallot-app-lifecycle-robustness: guard dispose, fix warm progress, fence rejection**
- **audit-shallot-app-lifecycle-robustness: compose warm AggregateError message, unconditional update(1)**
- **audit-shallot-app-lifecycle-robustness: say why the app fence swallows**
