### PR TITLE
shallot demo startup stall/s2p

### DIFF
--- a/scripts/rum-intake-check.ts
+++ b/scripts/rum-intake-check.ts
@@ -120,6 +120,7 @@ async function main(): Promise<void> {
             called: boolean;
             callDuration: number | null;
             reportedOnWire: boolean;
+            loafEntryCount: number | null;
         }
         const result = JSON.parse(line) as { below: ScenarioResult; above: ScenarioResult };
 
@@ -150,6 +151,16 @@ async function main(): Promise<void> {
         // (this is what caught the raw-rAF-timestamp-as-epoch bug `site/rum-runtime.ts` fixes).
         if (!result.above.reportedOnWire) {
             fail("above-threshold run never sent an intake request carrying slow_frame");
+        }
+        // S2p: the busy-loop above threshold is a genuinely scripted stall — the LoAF correlator
+        // must see its own long-animation-frame entry and report non-zero overlap, or the
+        // attribution context is reading a false "idle main thread" for a stall this run knows is
+        // scripted (the exact defect a synchronous-read correlator produces).
+        console.log(`  above threshold: loafEntryCount=${result.above.loafEntryCount}`);
+        if (!result.above.loafEntryCount) {
+            fail(
+                `above-threshold run's slow_frame vital reported loafEntryCount=${result.above.loafEntryCount} for a known-scripted stall`,
+            );
         }
 
         console.log("✓ RUM slow-frame intake proof: both directions discriminate correctly");

--- a/scripts/rum-intake-driver.ts
+++ b/scripts/rum-intake-driver.ts
@@ -53,14 +53,22 @@ interface ScenarioResult {
     called: boolean;
     callDuration: number | null;
     reportedOnWire: boolean;
+    // S2p (`shallot-demo-startup-stall`): the LoAF attribution context attached to the vital, so
+    // the above-threshold direction can assert the correlator actually saw the busy-loop's own
+    // long-animation-frame entry rather than reading a false "idle main thread" (site/rum-loaf.ts,
+    // site/rum-runtime.ts's deferred read).
+    loafEntryCount: number | null;
 }
 
 type RumWindow = Window & {
     // biome-ignore lint/style/useNamingConvention: DD_RUM is the SDK's own global name
     DD_RUM?: {
-        addDurationVital: (name: string, opts: { duration: number }) => void;
+        addDurationVital: (
+            name: string,
+            opts: { duration: number; context?: Record<string, unknown> },
+        ) => void;
     };
-    __vitalCalls?: { name: string; duration: number }[];
+    __vitalCalls?: { name: string; duration: number; context?: Record<string, unknown> }[];
 };
 
 async function runScenario(
@@ -100,7 +108,7 @@ async function runScenario(
             const orig = w.DD_RUM?.addDurationVital.bind(w.DD_RUM);
             if (w.DD_RUM && orig) {
                 w.DD_RUM.addDurationVital = (name, opts) => {
-                    w.__vitalCalls?.push({ name, duration: opts.duration });
+                    w.__vitalCalls?.push({ name, duration: opts.duration, context: opts.context });
                     return orig(name, opts);
                 };
             }
@@ -118,8 +126,10 @@ async function runScenario(
             }
         }, busyMs);
 
-        // a couple more rAF ticks for the sampler to observe the delta and call addDurationVital.
-        await page.waitForTimeout(500);
+        // a couple more rAF ticks for the sampler to observe the delta, plus `rum-runtime.ts`'s
+        // own deferred LoAF read (`LOAF_ATTRIBUTION_DELAY_MS`) before it calls addDurationVital —
+        // margin above that deferral, not just above the sampler's own rAF cadence.
+        await page.waitForTimeout(1_500);
 
         const calls = await page.evaluate(
             () => (window as unknown as RumWindow).__vitalCalls ?? [],
@@ -127,6 +137,8 @@ async function runScenario(
         const slowFrameCalls = calls.filter((c) => c.name === "slow_frame");
         const called = slowFrameCalls.length > 0;
         const callDuration = slowFrameCalls[0]?.duration ?? null;
+        const loafEntryCount =
+            (slowFrameCalls[0]?.context?.loafEntryCount as number | undefined) ?? null;
 
         if (expectReport) {
             // wire proof required: poll for the periodic batch flush to reach the intake host,
@@ -145,6 +157,7 @@ async function runScenario(
             called,
             callDuration,
             reportedOnWire: bodies.some((b) => b.includes("slow_frame")),
+            loafEntryCount,
         };
     } finally {
         await browser.close();

--- a/site/rum-loaf.test.ts
+++ b/site/rum-loaf.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import {
+    attributeSlowFrame,
+    type LoAFEntry,
+    type LoAFScript,
+    unsupportedLoafAttribution,
+} from "./rum-loaf";
+
+// Red-first: an inclusive-boundary `overlaps` (`<=`/`>=`) failed both boundary-exclusion arms below
+// — "an entry ending exactly at the window's start does not overlap" and "...starting exactly at
+// the window's end..." each read `received loafEntryCount 1` against `expected 0` — before the
+// strict-inequality comparison (`<`/`>`) was restored.
+
+function script(overrides: Partial<LoAFScript> = {}): LoAFScript {
+    return {
+        sourceURL: "https://example.com/app.js",
+        sourceFunctionName: "warm",
+        invoker: "https://example.com/app.js",
+        duration: 10,
+        ...overrides,
+    };
+}
+
+function entry(overrides: Partial<LoAFEntry> = {}): LoAFEntry {
+    return {
+        startTime: 0,
+        duration: 60,
+        blockingDuration: 20,
+        scripts: [script()],
+        ...overrides,
+    };
+}
+
+describe("attributeSlowFrame", () => {
+    test("zero-overlap path: no entry overlapping the window reports an idle main thread", () => {
+        const attribution = attributeSlowFrame(1000, 80, [entry({ startTime: 0, duration: 60 })]);
+        expect(attribution.loafSupported).toBe(true);
+        expect(attribution.loafEntryCount).toBe(0);
+        expect(attribution.loafOverlapDurationMs).toBe(0);
+        expect(attribution.loafOverlapBlockingMs).toBe(0);
+        expect(attribution.topScript).toBeNull();
+    });
+
+    test("an entry ending exactly at the window's start does not overlap", () => {
+        // window [100, 180]; entry spans [20, 100]
+        const attribution = attributeSlowFrame(100, 80, [entry({ startTime: 20, duration: 80 })]);
+        expect(attribution.loafEntryCount).toBe(0);
+    });
+
+    test("an entry starting exactly at the window's end does not overlap", () => {
+        // window [100, 180]; entry spans [180, 220]
+        const attribution = attributeSlowFrame(100, 80, [entry({ startTime: 180, duration: 40 })]);
+        expect(attribution.loafEntryCount).toBe(0);
+    });
+
+    test("an entry starting exactly at the window's start overlaps", () => {
+        // window [100, 180]; entry spans [100, 130]
+        const attribution = attributeSlowFrame(100, 80, [entry({ startTime: 100, duration: 30 })]);
+        expect(attribution.loafEntryCount).toBe(1);
+    });
+
+    test("an entry ending exactly at the window's end overlaps", () => {
+        // window [100, 180]; entry spans [150, 180]
+        const attribution = attributeSlowFrame(100, 80, [entry({ startTime: 150, duration: 30 })]);
+        expect(attribution.loafEntryCount).toBe(1);
+    });
+
+    test("multiple overlapping entries: durations and blocking durations sum", () => {
+        const entries = [
+            entry({
+                startTime: 100,
+                duration: 40,
+                blockingDuration: 10,
+                scripts: [script({ duration: 5 })],
+            }),
+            entry({
+                startTime: 130,
+                duration: 50,
+                blockingDuration: 15,
+                scripts: [script({ duration: 30 })],
+            }),
+        ];
+        const attribution = attributeSlowFrame(100, 80, entries);
+        expect(attribution.loafEntryCount).toBe(2);
+        expect(attribution.loafOverlapDurationMs).toBe(90);
+        expect(attribution.loafOverlapBlockingMs).toBe(25);
+    });
+
+    test("top script is the longest-running script across every overlapping entry", () => {
+        const entries = [
+            entry({
+                startTime: 100,
+                duration: 40,
+                scripts: [script({ sourceFunctionName: "small", duration: 5 })],
+            }),
+            entry({
+                startTime: 130,
+                duration: 50,
+                scripts: [
+                    script({ sourceFunctionName: "medium", duration: 12 }),
+                    script({ sourceFunctionName: "biggest", duration: 30 }),
+                ],
+            }),
+        ];
+        const attribution = attributeSlowFrame(100, 80, entries);
+        expect(attribution.topScript?.sourceFunctionName).toBe("biggest");
+        expect(attribution.topScript?.duration).toBe(30);
+    });
+
+    test("an overlapping entry with an empty scripts array leaves topScript null when no other entry has scripts", () => {
+        const attribution = attributeSlowFrame(100, 80, [
+            entry({ startTime: 100, duration: 40, scripts: [] }),
+        ]);
+        expect(attribution.loafEntryCount).toBe(1);
+        expect(attribution.topScript).toBeNull();
+    });
+
+    test("an empty entries list is the same as no overlap", () => {
+        const attribution = attributeSlowFrame(100, 80, []);
+        expect(attribution.loafEntryCount).toBe(0);
+        expect(attribution.topScript).toBeNull();
+    });
+
+    test("unsupportedLoafAttribution carries loafSupported: false and no attribution fields", () => {
+        const attribution = unsupportedLoafAttribution();
+        expect(attribution.loafSupported).toBe(false);
+        expect(attribution.loafEntryCount).toBe(0);
+        expect(attribution.loafOverlapDurationMs).toBe(0);
+        expect(attribution.loafOverlapBlockingMs).toBe(0);
+        expect(attribution.topScript).toBeNull();
+    });
+});

--- a/site/rum-loaf.ts
+++ b/site/rum-loaf.ts
@@ -1,0 +1,94 @@
+// Pure slow-frame/LoAF correlation logic — no DOM, no observer. `rum-runtime.ts` drives this with
+// buffered `long-animation-frame` PerformanceObserver entries; unit-testable on its own
+// (`rum-loaf.test.ts`).
+
+/** A single `long-animation-frame` entry's script attribution, reduced to the fields the vital
+ * surfaces. `sourceURL`/`sourceFunctionName`/`invoker` come straight off the PerformanceScriptTiming
+ * spec shape. */
+export interface LoAFScript {
+    sourceURL: string;
+    sourceFunctionName: string;
+    invoker: string;
+    duration: number;
+}
+
+/** A single `long-animation-frame` PerformanceObserver entry, rAF-relative (same clock as
+ * `performance.now()`) — the clock a slow frame's `startTime`/`duration` are already reported on. */
+export interface LoAFEntry {
+    startTime: number;
+    duration: number;
+    blockingDuration: number;
+    scripts: LoAFScript[];
+}
+
+export interface SlowFrameAttribution {
+    /** False on an engine without LoAF (Safari) — every other field is a zero/empty placeholder. */
+    loafSupported: boolean;
+    /** How many LoAF entries overlap the slow frame's window. */
+    loafEntryCount: number;
+    /** Summed `duration` of the overlapping entries. */
+    loafOverlapDurationMs: number;
+    /** Summed `blockingDuration` of the overlapping entries. */
+    loafOverlapBlockingMs: number;
+    /** The longest-running script across every overlapping entry, or null when none overlap —
+     * an idle main thread during a slow frame is a legitimate reading (GPU-present backpressure),
+     * not a missing measurement. */
+    topScript: LoAFScript | null;
+}
+
+const UNSUPPORTED_ATTRIBUTION: SlowFrameAttribution = {
+    loafSupported: false,
+    loafEntryCount: 0,
+    loafOverlapDurationMs: 0,
+    loafOverlapBlockingMs: 0,
+    topScript: null,
+};
+
+/** The attribution context to attach when LoAF is unsupported on this engine. */
+export function unsupportedLoafAttribution(): SlowFrameAttribution {
+    return UNSUPPORTED_ATTRIBUTION;
+}
+
+/** An entry overlaps `[start, end)` when their spans share more than a single instant — an entry
+ * ending exactly at `start`, or starting exactly at `end`, touches the window at one point and does
+ * not overlap it; an entry starting at `start` or ending at `end` does. */
+function overlaps(entry: LoAFEntry, start: number, end: number): boolean {
+    return entry.startTime < end && entry.startTime + entry.duration > start;
+}
+
+/**
+ * Correlates a reported slow frame's window (`[start, start + duration]`, rAF-relative ms) against
+ * buffered `long-animation-frame` entries, returning the attribution context to attach to the
+ * `slow_frame` vital.
+ *
+ * @example
+ * const attribution = attributeSlowFrame(1000, 80, loafEntries);
+ */
+export function attributeSlowFrame(
+    start: number,
+    duration: number,
+    entries: LoAFEntry[],
+): SlowFrameAttribution {
+    const end = start + duration;
+    const overlapping = entries.filter((entry) => overlaps(entry, start, end));
+
+    let loafOverlapDurationMs = 0;
+    let loafOverlapBlockingMs = 0;
+    let topScript: LoAFScript | null = null;
+
+    for (const entry of overlapping) {
+        loafOverlapDurationMs += entry.duration;
+        loafOverlapBlockingMs += entry.blockingDuration;
+        for (const script of entry.scripts) {
+            if (!topScript || script.duration > topScript.duration) topScript = script;
+        }
+    }
+
+    return {
+        loafSupported: true,
+        loafEntryCount: overlapping.length,
+        loafOverlapDurationMs,
+        loafOverlapBlockingMs,
+        topScript,
+    };
+}

--- a/site/rum-runtime.ts
+++ b/site/rum-runtime.ts
@@ -4,7 +4,12 @@
 // page; never imported by anything else, so it has no test of its own — the logic it drives is
 // tested in `rum-sampler.test.ts`.
 
-import { attributeSlowFrame, type LoAFEntry, unsupportedLoafAttribution } from "./rum-loaf";
+import {
+    attributeSlowFrame,
+    type LoAFEntry,
+    type SlowFrameAttribution,
+    unsupportedLoafAttribution,
+} from "./rum-loaf";
 import { initialFrameSamplerState, resetFrameSampler, sampleFrame } from "./rum-sampler";
 
 declare global {
@@ -25,39 +30,66 @@ let state = initialFrameSamplerState;
 // several minutes of steady-state jank without growing unbounded on a long-lived page.
 const LOAF_BUFFER_LIMIT = 200;
 
-let loafSupported = true;
+// `.observe({ type: "long-animation-frame" })` does NOT throw on an engine that lacks the entry
+// type (measured: Chromium's own `.observe()` with a made-up type string is a silent no-op, and
+// the Performance Timeline spec's `observe()` algorithm aborts without throwing for both the
+// `type` and `entryTypes` forms when the type is unsupported) — a `try/catch` around the observer
+// alone stays `loafSupported: true` forever on Safari with `loafEntries` permanently empty,
+// indistinguishable from a genuinely idle main thread on every single slow frame. The reliable
+// feature check is `PerformanceObserver.supportedEntryTypes`, read before ever calling `.observe`.
+let loafSupported =
+    typeof PerformanceObserver !== "undefined" &&
+    (PerformanceObserver.supportedEntryTypes?.includes("long-animation-frame") ?? false);
 let loafEntries: LoAFEntry[] = [];
 
-try {
-    // `long-animation-frame` entries (`scripts`, `blockingDuration`) aren't in lib.dom's
-    // `PerformanceEntry` yet — same shape as `packages/shallot/bin/verify.ts`'s own LoAF observer.
-    new PerformanceObserver((list) => {
-        for (const e of list.getEntries() as any[]) {
-            loafEntries.push({
-                startTime: e.startTime,
-                duration: e.duration,
-                blockingDuration: e.blockingDuration,
-                scripts: (e.scripts ?? []).map((s: any) => ({
-                    sourceURL: s.sourceURL ?? "",
-                    sourceFunctionName: s.sourceFunctionName ?? "",
-                    invoker: s.invoker ?? "",
-                    duration: s.duration,
-                })),
-            });
-        }
-        if (loafEntries.length > LOAF_BUFFER_LIMIT) {
-            loafEntries = loafEntries.slice(-LOAF_BUFFER_LIMIT);
-        }
-    }).observe({ type: "long-animation-frame", buffered: true });
-} catch {
-    // Engine lacks LoAF (Safari) — `attributeContext` degrades to `loafSupported: false` below.
-    loafSupported = false;
+if (loafSupported) {
+    try {
+        // `long-animation-frame` entries (`scripts`, `blockingDuration`) aren't in lib.dom's
+        // `PerformanceEntry` yet — same shape as `packages/shallot/bin/verify.ts`'s own LoAF observer.
+        new PerformanceObserver((list) => {
+            for (const e of list.getEntries() as any[]) {
+                loafEntries.push({
+                    startTime: e.startTime,
+                    duration: e.duration,
+                    blockingDuration: e.blockingDuration,
+                    scripts: (e.scripts ?? []).map((s: any) => ({
+                        sourceURL: s.sourceURL ?? "",
+                        sourceFunctionName: s.sourceFunctionName ?? "",
+                        invoker: s.invoker ?? "",
+                        duration: s.duration,
+                    })),
+                });
+            }
+            if (loafEntries.length > LOAF_BUFFER_LIMIT) {
+                loafEntries = loafEntries.slice(-LOAF_BUFFER_LIMIT);
+            }
+        }).observe({ type: "long-animation-frame", buffered: true });
+    } catch {
+        // Belt-and-suspenders — `supportedEntryTypes` said yes but construction/`observe` still
+        // threw (a real engine quirk, not the expected path); degrade rather than break the page.
+        loafSupported = false;
+    }
 }
 
-function attributeContext(startTime: number, duration: number) {
-    return loafSupported
-        ? attributeSlowFrame(startTime, duration, loafEntries)
-        : unsupportedLoafAttribution();
+// `long-animation-frame` entries are delivered to the PerformanceObserver asynchronously, in a
+// task separate from the frame whose work they describe — measured (a standalone Playwright probe,
+// 2026-08-27) at two animation frames / ~130ms after the busy frame completes, never on the same
+// task. A slow frame's own LoAF entry is therefore never in `loafEntries` yet at the moment `tick`
+// detects the gap: a synchronous read at that point always sees `loafEntryCount: 0` for exactly the
+// frame being attributed — the worst possible wrong reading, since every genuinely scripted stall
+// would read as "idle main thread". Give the observer time to deliver the entry before correlating.
+const LOAF_ATTRIBUTION_DELAY_MS = 500;
+
+function attributeContext(startTime: number, duration: number): Promise<SlowFrameAttribution> {
+    return new Promise((resolve) => {
+        setTimeout(() => {
+            resolve(
+                loafSupported
+                    ? attributeSlowFrame(startTime, duration, loafEntries)
+                    : unsupportedLoafAttribution(),
+            );
+        }, LOAF_ATTRIBUTION_DELAY_MS);
+    });
 }
 
 // `wasHidden` has two setters, for two different failure modes, and one consumer:
@@ -109,13 +141,17 @@ function tick(timestamp: number): void {
             // startTime reads as ~1970 to the SDK's own event-time bookkeeping).
             const epochStartTime = performance.timeOrigin + startTime;
             // `startTime`/`duration` here are still rAF-relative, the same clock LoAF entries
-            // report on — the attribution runs before the epoch conversion above, never after.
-            const attribution = attributeContext(startTime, duration);
-            window.DD_RUM?.onReady(() => {
-                window.DD_RUM?.addDurationVital("slow_frame", {
-                    startTime: epochStartTime,
-                    duration,
-                    context: { ...context, ...attribution },
+            // report on — the attribution reads them before the epoch conversion above, never
+            // after. The read itself is deferred (`attributeContext`'s `LOAF_ATTRIBUTION_DELAY_MS`)
+            // so the frame's own LoAF entry has had time to arrive; `epochStartTime`/`duration` are
+            // captured synchronously here, so the deferral doesn't skew the vital's own timing.
+            attributeContext(startTime, duration).then((attribution) => {
+                window.DD_RUM?.onReady(() => {
+                    window.DD_RUM?.addDurationVital("slow_frame", {
+                        startTime: epochStartTime,
+                        duration,
+                        context: { ...context, ...attribution },
+                    });
                 });
             });
         }

--- a/site/rum-runtime.ts
+++ b/site/rum-runtime.ts
@@ -4,6 +4,7 @@
 // page; never imported by anything else, so it has no test of its own — the logic it drives is
 // tested in `rum-sampler.test.ts`.
 
+import { attributeSlowFrame, type LoAFEntry, unsupportedLoafAttribution } from "./rum-loaf";
 import { initialFrameSamplerState, resetFrameSampler, sampleFrame } from "./rum-sampler";
 
 declare global {
@@ -19,6 +20,45 @@ declare global {
 }
 
 let state = initialFrameSamplerState;
+
+// Bound on buffered `long-animation-frame` entries — one entry per delayed frame, so this covers
+// several minutes of steady-state jank without growing unbounded on a long-lived page.
+const LOAF_BUFFER_LIMIT = 200;
+
+let loafSupported = true;
+let loafEntries: LoAFEntry[] = [];
+
+try {
+    // `long-animation-frame` entries (`scripts`, `blockingDuration`) aren't in lib.dom's
+    // `PerformanceEntry` yet — same shape as `packages/shallot/bin/verify.ts`'s own LoAF observer.
+    new PerformanceObserver((list) => {
+        for (const e of list.getEntries() as any[]) {
+            loafEntries.push({
+                startTime: e.startTime,
+                duration: e.duration,
+                blockingDuration: e.blockingDuration,
+                scripts: (e.scripts ?? []).map((s: any) => ({
+                    sourceURL: s.sourceURL ?? "",
+                    sourceFunctionName: s.sourceFunctionName ?? "",
+                    invoker: s.invoker ?? "",
+                    duration: s.duration,
+                })),
+            });
+        }
+        if (loafEntries.length > LOAF_BUFFER_LIMIT) {
+            loafEntries = loafEntries.slice(-LOAF_BUFFER_LIMIT);
+        }
+    }).observe({ type: "long-animation-frame", buffered: true });
+} catch {
+    // Engine lacks LoAF (Safari) — `attributeContext` degrades to `loafSupported: false` below.
+    loafSupported = false;
+}
+
+function attributeContext(startTime: number, duration: number) {
+    return loafSupported
+        ? attributeSlowFrame(startTime, duration, loafEntries)
+        : unsupportedLoafAttribution();
+}
 
 // `wasHidden` has two setters, for two different failure modes, and one consumer:
 //
@@ -68,11 +108,14 @@ function tick(timestamp: number): void {
             // console error, no exception (found 2026-08-26, S2's wire proof — a raw relative
             // startTime reads as ~1970 to the SDK's own event-time bookkeeping).
             const epochStartTime = performance.timeOrigin + startTime;
+            // `startTime`/`duration` here are still rAF-relative, the same clock LoAF entries
+            // report on — the attribution runs before the epoch conversion above, never after.
+            const attribution = attributeContext(startTime, duration);
             window.DD_RUM?.onReady(() => {
                 window.DD_RUM?.addDurationVital("slow_frame", {
                     startTime: epochStartTime,
                     duration,
-                    context,
+                    context: { ...context, ...attribution },
                 });
             });
         }


### PR DESCRIPTION
- **shallot-demo-startup-stall: attribution context on the slow_frame vital (S2p)**
- **shallot-demo-startup-stall: fix S2p's LoAF attribution reading its own stall as idle**
