### PR TITLE
gate scanners: mask regex literals, refuse an unlexable file

### DIFF
--- a/packages/shallot/tests/check-exports.test.ts
+++ b/packages/shallot/tests/check-exports.test.ts
@@ -91,6 +91,50 @@ export const TumblePlugin: Plugin = { name: "Tumble" };
     });
 });
 
+// Regex literals: `/["']/` carries a quote that the old scanner read as a string opener, and the
+// string then ran to end of file — every comment after it was copied through as code, so a
+// `@example export const ghost` inside a JSDoc block became a real export. The engine twin
+// (`maskTrivia`, `runtime/gpu-labels.test.ts`) was repaired first; these arms are that repair
+// here. Mutation: delete the regex branch in `maskTrivia` → `ghost` reappears and this reds.
+describe("stripComments — regex literals", () => {
+    const source = [
+        "const QUOTE = /[\"']/;",
+        "/**",
+        " * @example",
+        " * export const ghost = 1;",
+        " */",
+        "export const real = 2;",
+        "",
+    ].join("\n");
+
+    test("a quote inside a regex does not blind the scanner to the comments after it", () => {
+        const names = extractDirectExports(stripComments(source)).map((e) => e.name);
+        expect(names).toContain("real");
+        expect(names).not.toContain("ghost");
+    });
+
+    test("division is not read as a regex", () => {
+        const stripped = stripComments("const ratio = total / count; // note\nconst y = 2;");
+        expect(stripped).toContain("total / count");
+        expect(stripped).not.toContain("note");
+    });
+
+    test("a non-null assertion before a slash is division, not a regex start", () => {
+        const stripped = stripComments("const r = a.get(k)! / b.get(k)!;\nconst y = 2;");
+        expect(stripped).toContain("const y = 2;");
+    });
+
+    // The strict half: a scanner that runs an unterminated construct to end of file reports a
+    // clean pass over code it never read, so the reader every walk goes through refuses instead.
+    // Mutation: drop the `unparsed` check in `stripComments` → this arm reds.
+    test("throws on a region it could not close", () => {
+        expect(() => stripComments("const q = /unterminated\nconst y = 2;\n")).toThrow(
+            /unterminated regex literal/,
+        );
+        expect(() => stripComments("/* unterminated")).toThrow(/unterminated block comment/);
+    });
+});
+
 describe("extractDirectExports", () => {
     test("captures function, const, class, type, interface, enum", () => {
         const content = `

--- a/packages/shallot/tests/check-tumble-fp.test.ts
+++ b/packages/shallot/tests/check-tumble-fp.test.ts
@@ -168,6 +168,44 @@ describe("maskLiterals", () => {
     });
 });
 
+// Regex literals: a `/["']/` body carries characters that every other branch of the lexer treats
+// as an opener. Before the repair the quote started a string that ran to end of file, so every
+// `f32(...)` after it was invisible and the sweep reported a clean pass over code it never read
+// — the same defect repaired first in the engine twin (`maskTrivia`,
+// `runtime/gpu-labels.test.ts`). Mutation: delete the regex branch in `maskLiterals` → the
+// literal after the regex disappears from the sweep and these arms red.
+describe("maskLiterals — regex literals", () => {
+    test("masks a regex body carrying a quote, leaving the code after it visible", () => {
+        const { masked, unparsed } = maskLiterals(
+            "const q = /[\"']/;\nconst bad = f32(0.1 * mass);\n",
+        );
+        expect(unparsed).toEqual([]);
+        expect(masked).toContain("f32(0.1 * mass)");
+        expect(masked).not.toContain("[\"']");
+    });
+
+    test("masks a regex body carrying a comment opener", () => {
+        const { masked, unparsed } = maskLiterals("const c = /a\\/*b/;\nconst y = f32(0.1 * m);\n");
+        expect(unparsed).toEqual([]);
+        expect(masked).toContain("f32(0.1 * m)");
+    });
+
+    test("leaves division alone — a `/` after an operand is not a regex start", () => {
+        const { masked, unparsed } = maskLiterals(
+            "const r = a / b;\nconst bad = f32(0.1 * mass);\n",
+        );
+        expect(unparsed).toEqual([]);
+        expect(masked).toContain("a / b");
+        expect(masked).toContain("f32(0.1 * mass)");
+    });
+
+    test("reports an unterminated regex literal as an unparsed site", () => {
+        const { unparsed } = maskLiterals("const q = /unterminated\nconst y = 2;\n");
+        expect(unparsed).toHaveLength(1);
+        expect(unparsed[0].reason).toBe("unterminated regex literal");
+    });
+});
+
 // `stripComments` is a backward-compatible wrapper around `maskLiterals` — the masked text only,
 // without the unparsed-site list. The S1 tests checked that comment content is removed and string
 // content is preserved; the S1b rebuild masks string content too (so a `)` inside a string never
@@ -185,6 +223,16 @@ describe("stripComments", () => {
         expect(out).not.toContain("// not a comment");
         expect(out).toContain("const s = ");
         expect(out).toContain(";");
+    });
+
+    // The strict half: `sourceFiles` reports `maskLiterals`' unparsed sites as findings, and this
+    // wrapper used to drop them — a caller reading only the masked text cannot tell a fully-lexed
+    // file from one the lexer went blind partway through. Mutation: return `masked` without the
+    // check → this arm reds.
+    test("throws on a region the lexer could not decompose", () => {
+        expect(() => stripComments('const s = "unterminated')).toThrow(
+            /unterminated string literal/,
+        );
     });
 });
 
@@ -495,6 +543,11 @@ describe("sweep — F1: composition fixture exercising every structural leg", ()
         // Mutation: delete the recursion into parenthesized groups in `collectOffendingLiterals`
         // → `0.1` is invisible, this finding disappears, the assertion reds.
         "engine/nested-call.ts": "export const bad = f32(Math.sqrt(0.1 * a));\n",
+        // Regex literal: the quote inside `/["']/` must not open a string. `f32(0.1 * mass)`
+        // after it is real code and must be found.
+        // Mutation: delete the regex branch in `maskLiterals` → the quote opens a string that
+        // runs to end of file, the finding disappears, the assertion reds.
+        "engine/regex.ts": "const q = /[\"']/;\nexport const bad = f32(0.1 * mass);\n",
         // Undecomposable region: an unterminated string. Must be reported as unparsed, not
         // silently swallowed.
         // Mutation: delete the unterminated-string report in `maskLiterals` → the unparsed
@@ -503,13 +556,14 @@ describe("sweep — F1: composition fixture exercising every structural leg", ()
             'const s = "unterminated string\nconst bad = f32(0.1 * mass);\n',
     };
 
-    test("sweepLiterals finds the template-interpolation literal and the nested-call literal", async () => {
+    test("sweepLiterals finds the template-interpolation, nested-call and post-regex literals", async () => {
         const root = fixture(compositionFixture);
         const findings = await sweepLiterals(root);
-        // Two literal findings: one from the template interpolation, one from the nested call.
-        expect(findings).toHaveLength(2);
+        // Three literal findings: the template interpolation, the nested call, and the line
+        // after the regex literal (invisible before the regex branch existed).
+        expect(findings).toHaveLength(3);
         const files = findings.map((f) => f.file).sort();
-        expect(files).toEqual(["engine/nested-call.ts", "engine/template.ts"]);
+        expect(files).toEqual(["engine/nested-call.ts", "engine/regex.ts", "engine/template.ts"]);
         // The string and comment fixtures must NOT appear — they are masked.
         const allFiles = findings.map((f) => f.file);
         expect(allFiles).not.toContain("engine/string.ts");
@@ -527,11 +581,11 @@ describe("sweep — F1: composition fixture exercising every structural leg", ()
     test("sweep over the composition fixture exercises every leg through the real entry point", async () => {
         const root = fixture(compositionFixture);
         const findings = await sweep(root);
-        // 2 literal findings + 1 unparsed = 3 total. No trig findings.
-        expect(findings).toHaveLength(3);
+        // 3 literal findings + 1 unparsed = 4 total. No trig findings.
+        expect(findings).toHaveLength(4);
         const literalCount = findings.filter((f) => f.kind === "literal").length;
         const unparsedCount = findings.filter((f) => f.kind === "unparsed").length;
-        expect(literalCount).toBe(2);
+        expect(literalCount).toBe(3);
         expect(unparsedCount).toBe(1);
     });
 });

--- a/scripts/check-exports.ts
+++ b/scripts/check-exports.ts
@@ -20,6 +20,7 @@ import { existsSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { Glob } from "bun";
 import { TEST_TIER_SUFFIXES } from "../packages/shallot/tests/test-tiers";
+import { isRegexLiteralStart, scanRegexLiteral } from "./source-mask";
 
 const PKG = "@dylanebert/shallot";
 
@@ -57,10 +58,19 @@ function lineOf(content: string, offset: number): number {
     return content.slice(0, offset).split("\n").length;
 }
 
-// Strip line comments (`// ...`) and block comments (`/* ... */`, including JSDoc) while
-// preserving string literals and newlines (for line-number accuracy). A reference inside a
-// JSDoc `@example` block is not a consumer.
-export function stripComments(content: string): string {
+// A region the scanner could not close — an unterminated string, regex literal, or block
+// comment. A scanner that runs one of these to end of file reads the remainder as literal text
+// and reports a clean pass over code it never saw, so the callers refuse instead.
+export type UnparsedSite = { line: number; reason: string };
+
+// Mask comments (`// ...`, `/* ... */`, JSDoc included) and regex-literal bodies while preserving
+// string literals and newlines (for line-number accuracy). A reference inside a JSDoc `@example`
+// block is not a consumer. Regex literals are masked — not preserved — because a `/`, quote or
+// backtick inside one would otherwise open a comment or string and blind the rest of the file
+// (the same defect repaired in the engine twin, `maskTrivia` in `runtime/gpu-labels.test.ts`);
+// their contents are never an export, an import or a namespace access, so masking loses nothing.
+export function maskTrivia(content: string): { masked: string; unparsed: UnparsedSite[] } {
+    const unparsed: UnparsedSite[] = [];
     let result = "";
     let i = 0;
     const len = content.length;
@@ -69,6 +79,8 @@ export function stripComments(content: string): string {
         // String literals — copy through, don't treat // or /* inside them as comments
         if (content[i] === '"' || content[i] === "'" || content[i] === "`") {
             const quote = content[i];
+            const start = i;
+            let closed = false;
             result += content[i];
             i++;
             while (i < len) {
@@ -80,9 +92,19 @@ export function stripComments(content: string): string {
                 result += content[i];
                 if (content[i] === quote) {
                     i++;
+                    closed = true;
                     break;
                 }
                 i++;
+            }
+            if (!closed) {
+                unparsed.push({
+                    line: lineOf(content, start),
+                    reason:
+                        quote === "`"
+                            ? "unterminated template literal"
+                            : "unterminated string literal",
+                });
             }
             continue;
         }
@@ -96,14 +118,39 @@ export function stripComments(content: string): string {
 
         // Block comments (including JSDoc) — skip, but preserve newlines for line numbers
         if (content[i] === "/" && i + 1 < len && content[i + 1] === "*") {
+            const start = i;
             i += 2;
+            let closed = false;
             while (i < len) {
                 if (content[i] === "*" && i + 1 < len && content[i + 1] === "/") {
                     i += 2;
+                    closed = true;
                     break;
                 }
                 if (content[i] === "\n") result += "\n";
                 i++;
+            }
+            if (!closed) {
+                unparsed.push({
+                    line: lineOf(content, start),
+                    reason: "unterminated block comment",
+                });
+            }
+            continue;
+        }
+
+        // Regex literals — mask body, delimiters and flags. Checked after the two comment forms,
+        // so `//` and `/*` are already consumed, and gated on `isRegexLiteralStart` reading the
+        // masked output so a `/` that is division stays code.
+        if (content[i] === "/" && isRegexLiteralStart(result.slice(-32))) {
+            const start = i;
+            const { end, terminated } = scanRegexLiteral(content, i);
+            for (; i < end; i++) result += content[i] === "\n" ? "\n" : " ";
+            if (!terminated) {
+                unparsed.push({
+                    line: lineOf(content, start),
+                    reason: "unterminated regex literal",
+                });
             }
             continue;
         }
@@ -112,7 +159,29 @@ export function stripComments(content: string): string {
         i++;
     }
 
-    return result;
+    return { masked: result, unparsed };
+}
+
+// Strict reader over `maskTrivia`: the masked text, and a throw naming every region the scanner
+// could not close. Both walks in `findDeadExports` read through here — silently dropping the
+// unparsed list is what lets a blinded scan report a clean pass.
+export function stripComments(content: string): string {
+    const { masked, unparsed } = maskTrivia(content);
+    if (unparsed.length > 0) {
+        const sites = unparsed.map((u) => `line ${u.line}: ${u.reason}`).join("; ");
+        throw new Error(`source could not be fully lexed — ${sites}`);
+    }
+    return masked;
+}
+
+// The two source walks below read every file through here, so a refusal names the file it
+// could not lex rather than only the reason.
+async function readMasked(path: string, rel: string): Promise<string> {
+    try {
+        return stripComments(await Bun.file(path).text());
+    } catch (err) {
+        throw new Error(`${rel}: ${err instanceof Error ? err.message : String(err)}`);
+    }
 }
 
 // --- Export extraction ------------------------------------------------------
@@ -502,8 +571,8 @@ export async function findDeadExports(
     for await (const path of srcGlob.scan({ cwd: srcDir })) {
         if (isTestFile(path)) continue;
         const full = resolve(srcDir, path);
-        const content = stripComments(await Bun.file(full).text());
         const relPath = relative(rootDir, full).replace(/\\/g, "/");
+        const content = await readMasked(full, relPath);
         fileContents.set(relPath, content);
 
         const exports = extractDirectExports(content);
@@ -547,8 +616,8 @@ export async function findDeadExports(
             if (path.includes("node_modules") || path.includes("dist/")) continue;
 
             const fullPath = resolve(full, path);
-            const content = stripComments(await Bun.file(fullPath).text());
             const relPath = relative(rootDir, fullPath).replace(/\\/g, "/");
+            const content = await readMasked(fullPath, relPath);
             const isTest = isTestFile(relPath);
 
             const imports = extractImports(content);

--- a/scripts/check-tumble-fp.ts
+++ b/scripts/check-tumble-fp.ts
@@ -1,6 +1,7 @@
 import { join, resolve } from "node:path";
 import { Glob } from "bun";
 import { TEST_TIER_SUFFIXES } from "../packages/shallot/tests/test-tiers";
+import { isRegexLiteralStart, scanRegexLiteral } from "./source-mask";
 
 // The tumble engine's rule 1a (`.claude/rules/tumble.md` § "The contract: bit-exact f32
 // parity") says to `fround` a non-exact float literal before it enters `f32(...)` arithmetic:
@@ -106,8 +107,8 @@ function lineOf(text: string, pos: number): number {
 // Lexer: mask strings, comments, and template-literal text (preserve interpolations)
 // ---------------------------------------------------------------------------
 
-// A region the lexer could not fully decompose — an unterminated string, template literal, or
-// block comment, or an unbalanced template interpolation. The sweep reports these as `unparsed`
+// A region the lexer could not fully decompose — an unterminated string, template literal, regex
+// literal, or block comment, or an unbalanced template interpolation. The sweep reports these as `unparsed`
 // findings and exits non-zero, so safety rests on exhaustiveness plus a loud inconclusive.
 export type UnparsedSite = { line: number; reason: string; snippet: string };
 
@@ -117,6 +118,8 @@ export type UnparsedSite = { line: number; reason: string; snippet: string };
 //   - single- and double-quoted string content → spaces (quote delimiters → spaces too, so a `)`
 //     inside a string never confuses the paren depth counter in `findCalls`);
 //   - template-literal text portions → spaces (backtick delimiters → spaces);
+//   - regex-literal bodies and flags → spaces (delimiters too), so a quote or `/` inside a
+//     regex cannot open a string or comment and blind the rest of the file;
 //   - template-literal interpolation expressions (`${...}`) → **preserved as real code**, so a
 //     `f32(...)` inside an interpolation IS found by `findCalls` (it is a real call);
 //   - everything else → preserved verbatim.
@@ -150,6 +153,21 @@ export function maskLiterals(content: string): { masked: string; unparsed: Unpar
             i++;
         }
         return false;
+    }
+
+    // The last few emitted (masked) characters, enough for `isRegexLiteralStart`'s longest
+    // keyword. Joining the whole output at every `/` would be quadratic over a large file.
+    function maskedTail(): string {
+        return out.slice(Math.max(0, out.length - 32)).join("");
+    }
+
+    // Mask a regex literal opening at `i` (masking delimiters, body and flags to spaces, since
+    // none of it is code the sweep may read). Returns true if the closing `/` was found on the
+    // same line. Called only where `isRegexLiteralStart` says a `/` cannot be division.
+    function maskRegex(): boolean {
+        const { end, terminated } = scanRegexLiteral(content, i);
+        for (; i < end; i++) out.push(content[i] === "\n" ? "\n" : " ");
+        return terminated;
     }
 
     // Mask a template literal. Text portions and backtick delimiters → spaces; `${...}`
@@ -196,6 +214,10 @@ export function maskLiterals(content: string): { masked: string; unparsed: Unpar
                             out.push(content[i] === "\n" ? "\n" : " ");
                             i++;
                         }
+                        continue;
+                    }
+                    if (content[i] === "/" && isRegexLiteralStart(maskedTail())) {
+                        maskRegex(); // unterminated → reported by the outer loop's own scan
                         continue;
                     }
                     if (content[i] === '"' || content[i] === "'") {
@@ -274,6 +296,20 @@ export function maskLiterals(content: string): { masked: string; unparsed: Unpar
             continue;
         }
 
+        // Regex literal — must be masked before the string branch, because a quote inside a
+        // regex would otherwise open a string that swallows the rest of the file.
+        if (c === "/" && isRegexLiteralStart(maskedTail())) {
+            const start = i;
+            if (!maskRegex()) {
+                unparsed.push({
+                    line: lineOf(content, start),
+                    reason: "unterminated regex literal",
+                    snippet: content.slice(start, Math.min(start + 40, len)).trim(),
+                });
+            }
+            continue;
+        }
+
         // Single/double-quoted string
         if (c === '"' || c === "'") {
             const start = i;
@@ -307,12 +343,19 @@ export function maskLiterals(content: string): { masked: string; unparsed: Unpar
     return { masked: out.join(""), unparsed };
 }
 
-// Backward-compatible wrapper: returns just the masked text. Replaces the S1 `stripComments`
-// (which preserved string content and did not handle template-literal interpolations). String
-// and comment content is now masked so a `)` or `{` inside a string never confuses the depth
-// counters in `findCalls` / `splitTopLevelTokens`.
+// Strict reader: the masked text, and a throw on any region the lexer could not decompose.
+// Replaces the S1 `stripComments` (which preserved string content and did not handle
+// template-literal interpolations). String and comment content is now masked so a `)` or `{`
+// inside a string never confuses the depth counters in `findCalls` / `splitTopLevelTokens`.
+// `sourceFiles` reads `maskLiterals` directly and reports the unparsed sites as findings; every
+// other caller goes through here, where dropping the list would let a blind scan read as clean.
 export function stripComments(content: string): string {
-    return maskLiterals(content).masked;
+    const { masked, unparsed } = maskLiterals(content);
+    if (unparsed.length > 0) {
+        const sites = unparsed.map((u) => `line ${u.line}: ${u.reason}`).join("; ");
+        throw new Error(`source could not be fully lexed — ${sites}`);
+    }
+    return masked;
 }
 
 // ---------------------------------------------------------------------------
@@ -646,7 +689,7 @@ export async function sweepTrig(root: string): Promise<Finding[]> {
 }
 
 // The unparsed arm: any region the lexer could not fully decompose — an unterminated string,
-// template literal, or block comment from `maskLiterals`, or an `f32(` call whose parens don't
+// template literal, regex literal, or block comment from `maskLiterals`, or an `f32(` call whose parens don't
 // balance. Safety rests on exhaustiveness over the region set plus a loud inconclusive: the sweep
 // exits non-zero rather than silently swallowing the rest of the file and returning zero findings.
 export async function sweepUnparsed(root: string): Promise<Finding[]> {

--- a/scripts/source-mask.ts
+++ b/scripts/source-mask.ts
@@ -1,0 +1,78 @@
+// Regex-literal scanning, shared by the source maskers in `check-exports.ts` and
+// `check-tumble-fp.ts`.
+//
+// Both scanners mask comments and string literals so a `//`, a quote or a `)` inside one cannot
+// be read as code. Neither handled a **regex literal**, whose body may carry `/`, `"`, `'` or a
+// backtick — so `/["']/` opened a string that swallowed the rest of the file and the scanner went
+// blind past it while still reporting a clean pass. The engine twin (`maskTrivia`,
+// `runtime/gpu-labels.test.ts`) was repaired first and witnessed red under a regex-literal
+// fixture; this is that repair for `scripts/`, factored out rather than written twice.
+//
+// A regex literal cannot be recognized from the `/` alone — `a / b` is division. The
+// discriminator is what precedes it: a regex may start where an *operand* may not follow, i.e.
+// after punctuation/an operator, after one of the keywords below, or at the start of input.
+
+// `}` is deliberately absent: a regex may follow a block's closing brace, but division after one
+// (`${a}/b` in text a scanner preserved verbatim) is the commoner shape, and treating it as a
+// regex start swallows the rest of the line. Matches the engine twin's set.
+const REGEX_PRECEDING_PUNCTUATION = /[=(,:[!&|^~+\-*%<>?{;]/;
+
+// Keywords after which a `/` opens a regex rather than dividing (`return /x/.test(s)`). The
+// punctuation set alone misses these, and a missed regex is exactly the blind spot this file
+// exists to close.
+const REGEX_PRECEDING_KEYWORD =
+    /\b(return|typeof|instanceof|in|of|case|do|else|yield|await|delete|void|new|throw)$/;
+
+// True when a `/` at the current position opens a regex literal, given the code *already
+// emitted* (masked) before it. Reading the masked tail rather than the raw source is what makes
+// a `/` after a comment (`// note\n/re/`) resolve correctly — the comment is spaces by then.
+export function isRegexLiteralStart(maskedTail: string): boolean {
+    const trimmed = maskedTail.replace(/\s+$/, "");
+    if (trimmed === "") return true;
+    const prev = trimmed[trimmed.length - 1];
+    const before = trimmed[trimmed.length - 2] ?? "";
+    // Two punctuation members are ambiguous because they also *end* an operand: TypeScript's
+    // non-null assertion (`counts.get(k)! / n`) and a postfix increment (`i++ / n`). In both the
+    // `/` divides, so the operand-ending reading wins over the operator reading.
+    if (prev === "!" && /[\w$)\]]/.test(before)) return false;
+    if ((prev === "+" || prev === "-") && before === prev) return false;
+    if (REGEX_PRECEDING_PUNCTUATION.test(prev)) return true;
+    return REGEX_PRECEDING_KEYWORD.test(trimmed);
+}
+
+// Scan the regex literal opening at `start` (which must index a `/`). Returns the offset one past
+// the literal — closing `/` plus flags — and whether the literal was terminated. A regex literal
+// cannot span a newline, so an unterminated one ends at the line break and the caller reports it
+// as an unparsed site rather than masking to end of file.
+export function scanRegexLiteral(
+    content: string,
+    start: number,
+): { end: number; terminated: boolean } {
+    let i = start + 1;
+    let inClass = false;
+    while (i < content.length) {
+        const c = content[i];
+        if (c === "\n") return { end: i, terminated: false };
+        if (c === "\\") {
+            i += 2;
+            continue;
+        }
+        if (c === "[") {
+            inClass = true;
+            i++;
+            continue;
+        }
+        if (c === "]" && inClass) {
+            inClass = false;
+            i++;
+            continue;
+        }
+        if (c === "/" && !inClass) {
+            i++;
+            while (i < content.length && /[dgimsuvy]/.test(content[i])) i++;
+            return { end: i, terminated: true };
+        }
+        i++;
+    }
+    return { end: i, terminated: false };
+}


### PR DESCRIPTION
**Problem.** Three of shallot's own gate scanners went blind past a regex literal. `check-exports.ts`'s `stripComments`, and `check-tumble-fp.ts`'s `maskLiterals` / `stripComments`, masked strings, comments and template text but not regex bodies — so a `/["']/` opened a string or comment that swallowed the rest of the file while the gate still reported a clean pass. `check-tumble-fp` is the gate protecting bit-exact tumble f32 literals (an under-scan reaches users as replay desync); `check-exports` guards the published barrel.

**Cause.** A `/` cannot be classified from itself — `a / b` is division — so neither scanner had a regex branch at all. The engine twin (`maskTrivia`, `runtime/gpu-labels.test.ts`) was repaired earlier; `scripts/` was out of scope there. Second half: `check-tumble-fp`'s `sourceFiles` reads `maskLiterals`' `unparsed` list and refuses on it, while `stripComments` in the same file dropped it, so a caller could not tell a fully-lexed file from one the lexer went blind partway through.

**Fix.** New `scripts/source-mask.ts` carries the shared regex scan: `isRegexLiteralStart` (punctuation set matching the engine twin, plus the keyword forms `return /x/`, and two operand-ending exceptions — a TS non-null assertion and a postfix increment, both of which precede a division) and `scanRegexLiteral` (body, class, escapes, flags; a newline ends an unterminated literal). Both scanners gained a regex branch after their comment branches, gated on the *masked* output so a `/` after a comment resolves correctly. Both `stripComments` wrappers became strict readers that throw naming each unclosed region; `check-exports` wraps its two walks so a refusal names the file.

**Evidence.** Both scanners witnessed red under the new arms with the regex branch disabled (8 failures across the two test files), green with it. `check-exports.ts` output over the real tree is byte-identical to the pre-change baseline (343 advisory, 0 zero-consumer). `bun run check` exits 0; `bun run test` is 2891 pass / 0 fail — one unrelated red under host load (`scripts/verify.test.ts`'s per-file wall-clock cap) greens when re-run alone, which is what that cap's own message says discriminates load from artifact.
