### PR TITLE
shallot-document-removal: repair the close sweep's surviving dead referents

### DIFF
--- a/evals/harness/server.ts
+++ b/evals/harness/server.ts
@@ -21,7 +21,7 @@ async function answers(url: string): Promise<boolean> {
 // Boot a dev server on `port` and resolve once it answers. `cwd` + `cmd` is any project that serves a
 // page: by default `bun run dev` in `cwd` (a shallot example, or an external workspace driving the
 // window.__harness contract); pass `cmd` to run something else from `cwd`
-// (capture boots the standalone runtime via `shallot dev` against an in-repo fixture). `label` names it in
+// (the eval grader boots the graded project's installed CLI — `bun <cli> dev .`). `label` names it in
 // log + error lines. `BROWSER=none` suppresses vite's auto-open — a harness never wants a tab.
 //
 // A crash or a wedged-but-listening server throws (naming the server + port, killing the child) within

--- a/packages/shallot/src/engine/app/index.ts
+++ b/packages/shallot/src/engine/app/index.ts
@@ -529,7 +529,7 @@ export interface SwapResult {
  * preserved), and re-runs `initialize` to repopulate module singletons with the
  * reloaded code. A schema / system-set / ordering / dependency / feature change
  * it can't carry safely returns `{ ok: false, reason }`; the caller then rebuilds
- * from the document. A `warm`- or `setup`-body edit is undetectable (a closure body can't
+ * from the serialized scene. A `warm`- or `setup`-body edit is undetectable (a closure body can't
  * be diffed) and lands on the next rebuild rather than this swap. A live host
  * drives this from its HMR seam; `prev`/`next` are the project's own plugins
  * before and after the reload.

--- a/packages/shallot/tests/conformance-roster.ts
+++ b/packages/shallot/tests/conformance-roster.ts
@@ -165,7 +165,7 @@ export function signature(state: State, probe?: () => unknown): Record<string, u
     return {
         components: components.sort(),
         counts,
-        document: stringify(serialize(state)),
+        scene: stringify(serialize(state)),
         probe: probe?.(),
     };
 }
@@ -186,7 +186,7 @@ export const skinLayout = () => ({
 });
 
 // a custom project-style plugin — the user-authored shape a project boot builds from a manifest's local
-// plugins (the hot-reload capture fixture's `ticker`). Project plugins never ran the conformance loop
+// plugins (e.g. `examples/recipes/moving-platform`'s `Elevator`, loaded from `./src/elevator`). Project plugins never ran the conformance loop
 // before; this pins that a project warm spawns exactly once per build (a doubling warm shows as a
 // Counter count of 2 in the second pass) and rebuilds idempotently against the same module singletons.
 const Counter = { ticks: sparse(u32) };


### PR DESCRIPTION
The close stage's prose repair fixed the named dead referent per sentence
but left second dead referents beside them. Four:

- evals/harness/server.ts: startServer's cmd parenthetical cited the deleted
  capture harness; it now names the live caller (grade.ts boots the graded
  project's installed CLI via a `dev` command run from the project dir).
- app/index.ts swap() JSDoc: "rebuilds from the document" now names the
  serialized scene, the settled replacement noun.
- conformance-roster.ts: ProjectPlugin's parenthetical cited the deleted
  hot-reload capture fixture's ticker; it now cites a live local-specifier
  project plugin (moving-platform's Elevator).
- conformance-roster.ts signature(): the record key `document` renamed to
  `scene`, matching the comment above it; all readers iterate keys
  generically, so the rename reaches no further than this record.
