### PR TITLE
shallot-compile-vitals: s2 — site observer + wire proof

### DIFF
--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -10,6 +10,16 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { Glob } from "bun";
+// `PIPELINE_COMPILE_MEASURE_PREFIX` is imported here — a Node-side build script, never bundled
+// for the browser — and threaded into `buildRumRuntimeBundle`'s `Bun.build` call via `define`,
+// never via a plain `import` inside `site/rum-runtime.ts` itself. `gpu.ts` has a top-level
+// `tgpu.fn(...)` call, a real side effect no bundler can tree-shake away, so importing anything
+// from it — even a single string constant — pulls TypeGPU's whole module graph into the bundle
+// (measured: a probe entry point importing only the prefix constant bundled to 0.56 MB / 170
+// modules for `--target browser`). `define` inlines the literal at build time instead, so the
+// browser bundle carries the string and nothing else — `site/rum-compile-vitals.ts`'s own
+// docblock records the same measurement for the reader who only sees the pure module.
+import { PIPELINE_COMPILE_MEASURE_PREFIX } from "../packages/shallot/src/engine/runtime/gpu";
 import { type DemoEntry, ROSTER } from "../site/roster";
 import {
     RUM_CONFIG,
@@ -71,12 +81,18 @@ window.DD_RUM.onReady(function() {
 
 /** Bundles `site/rum-runtime.ts` (which imports the pure sampler) to a single browser-target ESM
  * script — inlined so every demo page, at any output depth (`visualization/demos/*.html`
- * included), carries it with no relative-path plumbing. */
+ * included), carries it with no relative-path plumbing. `define` inlines
+ * `PIPELINE_COMPILE_MEASURE_PREFIX` as a literal (see the import comment above) — `rum-runtime.ts`
+ * references it as the ambient `__PIPELINE_COMPILE_MEASURE_PREFIX__` global, never imported. */
 async function buildRumRuntimeBundle(): Promise<string> {
     const result = await Bun.build({
         entrypoints: [resolve(root, "site/rum-runtime.ts")],
         target: "browser",
         minify: false,
+        define: {
+            // biome-ignore lint/style/useNamingConvention: mirrors the ambient global rum-runtime.ts declares — a `define` key must match the identifier verbatim.
+            __PIPELINE_COMPILE_MEASURE_PREFIX__: JSON.stringify(PIPELINE_COMPILE_MEASURE_PREFIX),
+        },
     });
     if (!result.success) {
         for (const log of result.logs) console.error(log);

--- a/scripts/rum-intake-check.ts
+++ b/scripts/rum-intake-check.ts
@@ -2,11 +2,16 @@ import { existsSync, mkdirSync } from "node:fs";
 import { extname, resolve } from "node:path";
 
 // `bun run scripts/rum-intake-check.ts [--demo <slug>]` — the RUM slow-frame intake proof (spec
-// `shallot-rum-slow-frame-vitals` S2). Serves `out/site/<slug>/` statically, drives it through a
-// real (headless) browser, forces a deterministic main-thread busy-loop above and below the
-// sampler's 50ms threshold (`site/rum-sampler.ts`'s `SLOW_FRAME_THRESHOLD_MS`), intercepts every
-// request to the Datadog intake host, and asserts both directions: the above-threshold run's
-// intercepted body carries a `slow_frame` vital, the below-threshold run's doesn't. Nothing this
+// `shallot-rum-slow-frame-vitals` S2), plus (spec `shallot-compile-vitals` S2) the
+// `pipeline_compile` wire proof. Serves `out/site/<slug>/` statically, drives it through a real
+// (headless) browser, forces a deterministic main-thread busy-loop above and below the sampler's
+// 50ms threshold (`site/rum-sampler.ts`'s `SLOW_FRAME_THRESHOLD_MS`), intercepts every request to
+// the Datadog intake host, and asserts both directions: the above-threshold run's intercepted
+// body carries a `slow_frame` vital, the below-threshold run's doesn't. A second, independent
+// two-sided arm does the same for `pipeline_compile`: a synthetic prefixed `performance.measure`
+// emitted in-page drives `site/rum-runtime.ts`'s own `PerformanceObserver`, and the intercepted
+// body must carry `pipeline_compile`; a non-prefixed synthetic measure must forward nothing. This
+// proves the site half end to end with no engine release and no real GPU device. Nothing this
 // check does reaches the real Datadog intake — every matching request is intercepted and never
 // forwarded (`scripts/rum-intake-driver.ts`).
 //
@@ -122,7 +127,16 @@ async function main(): Promise<void> {
             reportedOnWire: boolean;
             loafEntryCount: number | null;
         }
-        const result = JSON.parse(line) as { below: ScenarioResult; above: ScenarioResult };
+        interface CompileVitalScenarioResult {
+            called: boolean;
+            reportedOnWire: boolean;
+        }
+        const result = JSON.parse(line) as {
+            below: ScenarioResult;
+            above: ScenarioResult;
+            compileVitalPrefixed: CompileVitalScenarioResult;
+            compileVitalUnprefixed: CompileVitalScenarioResult;
+        };
 
         console.log(
             `  below threshold (${result.below.busyMs}ms busy-loop): addDurationVital ${
@@ -163,7 +177,43 @@ async function main(): Promise<void> {
             );
         }
 
-        console.log("✓ RUM slow-frame intake proof: both directions discriminate correctly");
+        // the `pipeline_compile` two-sided wire proof (spec `shallot-compile-vitals` S2) — a
+        // synthetic prefixed measure must forward, a non-prefixed one must not. `called` is the
+        // structural, primary verdict for both directions (`rum-intake-driver.ts`'s docblock:
+        // a wire-only negative check bounded by a sanity window can't distinguish a working
+        // filter from a disabled one when the SDK's flush cadence outlasts the window either
+        // way); `reportedOnWire` stays required for the positive direction.
+        console.log(
+            `  pipeline_compile (prefixed synthetic measure): addDurationVital ${
+                result.compileVitalPrefixed.called ? "called" : "not called (unexpected)"
+            }; wire: ${
+                result.compileVitalPrefixed.reportedOnWire
+                    ? "pipeline_compile seen"
+                    : "no pipeline_compile seen (unexpected)"
+            }`,
+        );
+        console.log(
+            `  pipeline_compile (non-prefixed synthetic measure): addDurationVital ${
+                result.compileVitalUnprefixed.called ? "called (unexpected)" : "not called"
+            }`,
+        );
+        if (!result.compileVitalPrefixed.called) {
+            fail(
+                "a prefixed synthetic measure never called addDurationVital with pipeline_compile",
+            );
+        }
+        if (!result.compileVitalPrefixed.reportedOnWire) {
+            fail(
+                "a prefixed synthetic measure never sent an intake request carrying pipeline_compile",
+            );
+        }
+        if (result.compileVitalUnprefixed.called) {
+            fail("a non-prefixed synthetic measure called addDurationVital with pipeline_compile");
+        }
+
+        console.log(
+            "✓ RUM slow-frame + pipeline_compile intake proof: all directions discriminate correctly",
+        );
         process.exit(0);
     } finally {
         server.stop();

--- a/scripts/rum-intake-driver.ts
+++ b/scripts/rum-intake-driver.ts
@@ -1,4 +1,5 @@
-// Node-runnable driver for the RUM slow-frame intake proof (`scripts/rum-intake-check.ts`).
+// Node-runnable driver for the RUM slow-frame intake proof, and (spec `shallot-compile-vitals`
+// S2) the `pipeline_compile` two-sided wire proof — both in `scripts/rum-intake-check.ts`.
 // Bundled to a node target and spawned with `node` — `scripts/wsl-bridge.ts`'s documented fact 2:
 // Bun's Playwright client hangs on this platform (`chromium.launch`/`chromium.connect` never
 // resolve), Node's client doesn't. No real GPU is needed here: the RUM sampler
@@ -18,13 +19,23 @@
 // entailed by `called === false` (the SDK cannot batch a vital it was never told about) rather than
 // a bounded wait proving a negative over a shared, noisy machine.
 //
+// `runCompileVitalScenario` (below) runs the analogous two-sided proof for `pipeline_compile`:
+// a synthetic `performance.measure` emitted in-page, prefixed or not, is real enough to drive
+// `site/rum-runtime.ts`'s `PerformanceObserver` without a real GPU device or a forced compile.
+//
 // argv: [baseUrl, slug]. Every request to the Datadog RUM intake host
 // (`browser-intake-datadoghq.com`, confirmed 2026-08-25 against the served CDN bundle) is
 // intercepted and fulfilled locally — never forwarded, so nothing this check does reaches the
 // real Datadog org. Prints one JSON line to stdout:
-//   { below: ScenarioResult, above: ScenarioResult }
+//   { below: ScenarioResult, above: ScenarioResult,
+//     compileVitalPrefixed: CompileVitalScenarioResult, compileVitalUnprefixed: CompileVitalScenarioResult }
 
 import { chromium } from "playwright";
+// This driver is bundled `--target node` (never browser) and runs in a Node subprocess — the
+// same bundle-graph concern `site/rum-compile-vitals.ts`'s docblock records for the *browser*
+// bundle doesn't apply here, so importing the real constant is fine and is the wire's own source
+// of truth rather than a second hand-copied string.
+import { PIPELINE_COMPILE_MEASURE_PREFIX } from "../packages/shallot/src/engine/runtime/gpu";
 
 const INTAKE_HOST_RE = /browser-intake-datadoghq\.com/;
 const BELOW_THRESHOLD_MS = 20;
@@ -164,6 +175,111 @@ async function runScenario(
     }
 }
 
+interface CompileVitalScenarioResult {
+    /** Whether `DD_RUM.addDurationVital` was called with `"pipeline_compile"` — the structural
+     * proof, read back immediately (no flush wait), same shape as `runScenario`'s `called`. */
+    called: boolean;
+    /** Whether the intercepted intake body carried a `pipeline_compile` vital — the wire proof,
+     * required for the positive direction (this is what caught S1's own
+     * raw-rAF-timestamp-as-epoch bug for `slow_frame`, the analogous bug this arm exists to catch
+     * for `pipeline_compile`). */
+    reportedOnWire: boolean;
+}
+
+// The `pipeline_compile` two-sided wire proof (spec `shallot-compile-vitals` S2): a synthetic
+// `performance.measure` emitted in-page, prefixed or not, drives `site/rum-runtime.ts`'s own
+// `PerformanceObserver({ type: "measure", buffered: true })` — this is the same mechanism a real
+// forced compile drives (`gpu.ts`'s `compileValidated`), just without needing a real GPU device.
+// Two instruments, same reason `runScenario` above carries two: `called` is read back
+// immediately after the synthetic measure with no flush wait, so it's the primary verdict for
+// the negative direction — a wire-only negative check bounded by a *sanity* window (not a full
+// flush wait, since "no request" can't be proven by a bounded wait ending early) passed with the
+// prefix filter itself deleted, discovered by mutation-testing this arm: the SDK's flush cadence
+// in this environment outlasted the sanity window either way, so the wire read never distinguished
+// a working filter from a disabled one. `reportedOnWire` stays the required check for the
+// positive direction, which does cross the network boundary.
+async function runCompileVitalScenario(
+    url: string,
+    prefixed: boolean,
+): Promise<CompileVitalScenarioResult> {
+    const browser = await chromium.launch({ headless: true });
+    try {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        const bodies: string[] = [];
+
+        await page.route("**/*", async (route) => {
+            const req = route.request();
+            if (INTAKE_HOST_RE.test(req.url())) {
+                bodies.push(req.postData() ?? "");
+                await route.fulfill({ status: 202, body: "" });
+            } else {
+                await route.continue();
+            }
+        });
+
+        await page.goto(url, { waitUntil: "load" });
+        await page.waitForFunction(
+            () => typeof (window as unknown as RumWindow).DD_RUM?.addDurationVital === "function",
+            null,
+            { timeout: 30_000 },
+        );
+
+        // monkey-patch the real call so we can read back what the observer actually told the
+        // SDK, immediately — no dependency on the SDK's own batch/flush timing (same shape as
+        // `runScenario` above).
+        await page.evaluate(() => {
+            const w = window as unknown as RumWindow;
+            w.__vitalCalls = [];
+            const orig = w.DD_RUM?.addDurationVital.bind(w.DD_RUM);
+            if (w.DD_RUM && orig) {
+                w.DD_RUM.addDurationVital = (name, opts) => {
+                    w.__vitalCalls?.push({ name, duration: opts.duration, context: opts.context });
+                    return orig(name, opts);
+                };
+            }
+        });
+
+        // a couple of natural frames first — `rum-runtime.ts`'s own observer is constructed at
+        // module top level, before this, so by the time the page has loaded it's already
+        // observing; this margin is just to let the page settle, not to wait for the observer.
+        await page.waitForTimeout(300);
+
+        const measureName = prefixed
+            ? `${PIPELINE_COMPILE_MEASURE_PREFIX}intake-check-synthetic`
+            : "intake-check-synthetic-unprefixed";
+        await page.evaluate((name) => {
+            const start = performance.now();
+            performance.measure(name, { start, end: start + 5 });
+        }, measureName);
+
+        // the observer's callback is synchronous on `measure` (no `LOAF_ATTRIBUTION_DELAY_MS`
+        // deferral the slow_frame path has), so a short margin is enough for `called`.
+        await page.waitForTimeout(500);
+
+        const calls = await page.evaluate(
+            () => (window as unknown as RumWindow).__vitalCalls ?? [],
+        );
+        const called = calls.some((c) => c.name === "pipeline_compile");
+
+        if (prefixed) {
+            // wire proof required for the positive direction — poll for the periodic batch flush
+            // to reach the intake host, stopping the moment a match lands.
+            const deadline = Date.now() + FLUSH_CEILING_MS;
+            while (Date.now() < deadline && !bodies.some((b) => b.includes("pipeline_compile"))) {
+                await page.waitForTimeout(FLUSH_POLL_MS);
+            }
+        } else {
+            // negative direction: `called === false` is the whole proof (the SDK cannot batch a
+            // vital it was never told about), so no flush wait is owed here at all.
+        }
+
+        return { called, reportedOnWire: bodies.some((b) => b.includes("pipeline_compile")) };
+    } finally {
+        await browser.close();
+    }
+}
+
 async function main(): Promise<void> {
     const [baseUrl, slug] = process.argv.slice(2);
     if (!baseUrl || !slug) {
@@ -173,7 +289,16 @@ async function main(): Promise<void> {
     const url = `${baseUrl}/${slug}/`;
     const below = await runScenario(url, BELOW_THRESHOLD_MS, false);
     const above = await runScenario(url, ABOVE_THRESHOLD_MS, true);
-    console.log(JSON.stringify({ below, above }));
+    const compileVitalPrefixed = await runCompileVitalScenario(url, true);
+    const compileVitalUnprefixed = await runCompileVitalScenario(url, false);
+    console.log(
+        JSON.stringify({
+            below,
+            above,
+            compileVitalPrefixed,
+            compileVitalUnprefixed,
+        }),
+    );
 }
 
 if (import.meta.main) {

--- a/site/rum-compile-vitals.test.ts
+++ b/site/rum-compile-vitals.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { compileVitalReports } from "./rum-compile-vitals";
+
+// Red-first: witnessed red with `compileVitalReports` stubbed to `return []` unconditionally —
+// 6 of 8 tests failed (`received length 0`, `TypeError: undefined is not an object (evaluating
+// 'reports[0].duration')`), leaving only the two negative-direction tests ("no report when
+// nothing matches", the substring-vs-startsWith test) green, confirming the stub stubbed to the
+// wrong side of the filter before the real prefix match and epoch conversion were restored.
+
+const PREFIX = "shallot:pipeline-compile:";
+
+describe("compileVitalReports", () => {
+    test("filters to prefixed entries only", () => {
+        const reports = compileVitalReports(
+            [
+                { name: `${PREFIX}sear-forward`, startTime: 100, duration: 40 },
+                { name: "some-other-measure", startTime: 200, duration: 10 },
+            ],
+            PREFIX,
+            0,
+        );
+        expect(reports).toHaveLength(1);
+        expect(reports[0].name).toBe(`${PREFIX}sear-forward`);
+    });
+
+    test("no report when nothing matches the prefix", () => {
+        const reports = compileVitalReports(
+            [{ name: "unrelated", startTime: 0, duration: 5 }],
+            PREFIX,
+            0,
+        );
+        expect(reports).toHaveLength(0);
+    });
+
+    test("label is the measure name with the prefix stripped", () => {
+        const reports = compileVitalReports(
+            [{ name: `${PREFIX}slab-warm`, startTime: 0, duration: 1 }],
+            PREFIX,
+            0,
+        );
+        expect(reports[0].context.label).toBe("slab-warm");
+    });
+
+    test("startTime is converted to an epoch timestamp via timeOrigin", () => {
+        const reports = compileVitalReports(
+            [{ name: `${PREFIX}x`, startTime: 500, duration: 1 }],
+            PREFIX,
+            1_000_000,
+        );
+        expect(reports[0].startTime).toBe(1_000_500);
+    });
+
+    test("duration passes through unchanged", () => {
+        const reports = compileVitalReports(
+            [{ name: `${PREFIX}x`, startTime: 0, duration: 73.5 }],
+            PREFIX,
+            0,
+        );
+        expect(reports[0].duration).toBe(73.5);
+    });
+
+    test("multiple matching entries each produce their own report", () => {
+        const reports = compileVitalReports(
+            [
+                { name: `${PREFIX}a`, startTime: 0, duration: 1 },
+                { name: `${PREFIX}b`, startTime: 10, duration: 2 },
+            ],
+            PREFIX,
+            0,
+        );
+        expect(reports.map((r) => r.context.label)).toEqual(["a", "b"]);
+    });
+
+    test("a non-prefixed entry that merely contains the prefix substring mid-string is not a match", () => {
+        // the filter is startsWith, not includes — a measure named unrelated to compiles that
+        // happens to carry the prefix text later in its name must not forward.
+        const reports = compileVitalReports(
+            [{ name: `noise-${PREFIX}x`, startTime: 0, duration: 1 }],
+            PREFIX,
+            0,
+        );
+        expect(reports).toHaveLength(0);
+    });
+
+    test("report.name carries the original entry name, for the caller to clear by", () => {
+        const reports = compileVitalReports(
+            [{ name: `${PREFIX}clear-me`, startTime: 0, duration: 1 }],
+            PREFIX,
+            0,
+        );
+        expect(reports[0].name).toBe(`${PREFIX}clear-me`);
+    });
+});

--- a/site/rum-compile-vitals.ts
+++ b/site/rum-compile-vitals.ts
@@ -1,0 +1,70 @@
+// Pure decision logic for the `pipeline_compile` RUM vital — no DOM, no `PerformanceObserver`, no
+// SDK. `rum-runtime.ts` drives this with real `PerformanceObserver({ type: "measure" })` entries
+// and reports through `DD_RUM.addDurationVital`; this module is unit-testable on its own
+// (`rum-compile-vitals.test.ts`).
+//
+// The wire: `packages/shallot/src/engine/runtime/gpu.ts`'s `compileValidated` emits
+// `performance.measure("<prefix><forcer.label>", { start, end })` beside the existing
+// `Compute.precompiled?.(...)` call — a page-side RUM script can't reach a demo bundle's
+// `Compute` singleton (each demo bundles the engine itself), so User Timing is the cross-bundle
+// wire. `<prefix>` is `PIPELINE_COMPILE_MEASURE_PREFIX`, imported build-side only (see the
+// module docblock on `../scripts/build-site.ts`'s `buildRumRuntimeBundle`) — never imported
+// here, since a plain `import` of anything from `gpu.ts` pulls TypeGPU's whole module graph into
+// a browser bundle through `gpu.ts`'s own top-level `tgpu.fn(...)` call (measured: 0.56 MB / 170
+// modules for a probe importing nothing but the string constant). This module takes the prefix
+// as a parameter instead, so it carries no import of its own.
+
+export interface CompileVitalContext {
+    /** The part of the measure entry's name after the prefix — the forcer's own label. */
+    label: string;
+}
+
+export interface CompileVitalReport {
+    /** The source measure entry's own name — the caller clears the shared `performance` timeline
+     * by this name once the report has been forwarded, bounding the buffer that grows one entry
+     * per `build()` call against a device (S1's review finding, owned by this stage). */
+    name: string;
+    /** Epoch ms (`performance.timeOrigin + startTime`) — `DD_RUM.addDurationVital`'s `startTime`
+     * is a Unix epoch timestamp, not a `performance.now()`/rAF-relative one
+     * (`@datadog/browser-rum-core`'s own `AddDurationVitalOptions.startTime` doc: "expects a
+     * UNIX timestamp in milliseconds", the same lesson `rum-runtime.ts`'s `tick` already
+     * documents for `slow_frame`). A raw relative `startTime` silently drops the vital — it never
+     * reaches the intake batch, no console error, no exception; the SDK's own event-time
+     * bookkeeping just reads it as ~1970. */
+    startTime: number;
+    duration: number;
+    context: CompileVitalContext;
+}
+
+interface MeasureEntryLike {
+    name: string;
+    startTime: number;
+    duration: number;
+}
+
+/**
+ * Filters a batch of `performance` `measure` entries down to the ones carrying `prefix`,
+ * converting each to an epoch-timed `pipeline_compile` vital report. A non-matching entry is
+ * silently skipped — the shared `performance` timeline can carry `measure` entries from other
+ * observers, so this is a filter, never an assertion that every entry matches.
+ *
+ * @example
+ * const reports = compileVitalReports(list.getEntries(), PIPELINE_COMPILE_MEASURE_PREFIX, performance.timeOrigin);
+ */
+export function compileVitalReports(
+    entries: readonly MeasureEntryLike[],
+    prefix: string,
+    timeOrigin: number,
+): CompileVitalReport[] {
+    const reports: CompileVitalReport[] = [];
+    for (const entry of entries) {
+        if (!entry.name.startsWith(prefix)) continue;
+        reports.push({
+            name: entry.name,
+            startTime: timeOrigin + entry.startTime,
+            duration: entry.duration,
+            context: { label: entry.name.slice(prefix.length) },
+        });
+    }
+    return reports;
+}

--- a/site/rum-runtime.ts
+++ b/site/rum-runtime.ts
@@ -1,9 +1,11 @@
-// Browser-only rAF/SDK glue — drives `rum-sampler.ts`'s pure decision logic with real
-// `requestAnimationFrame` timestamps and reports through the Datadog RUM CDN snippet's global.
-// Bundled by `scripts/build-site.ts` (`Bun.build`, target "browser") and inlined into every demo
-// page; never imported by anything else, so it has no test of its own — the logic it drives is
-// tested in `rum-sampler.test.ts`.
+// Browser-only rAF/SDK glue — drives `rum-sampler.ts`'s and `rum-compile-vitals.ts`'s pure
+// decision logic with real `requestAnimationFrame` timestamps and `PerformanceObserver` entries,
+// reporting through the Datadog RUM CDN snippet's global. Bundled by `scripts/build-site.ts`
+// (`Bun.build`, target "browser") and inlined into every demo page; never imported by anything
+// else, so it has no test of its own — the logic it drives is tested in `rum-sampler.test.ts` and
+// `rum-compile-vitals.test.ts`.
 
+import { compileVitalReports } from "./rum-compile-vitals";
 import {
     attributeSlowFrame,
     type LoAFEntry,
@@ -21,6 +23,53 @@ declare global {
                 options: { startTime: number; duration: number; context: Record<string, unknown> },
             ) => void;
         };
+    }
+}
+
+// Inlined at build time (`scripts/build-site.ts`'s `buildRumRuntimeBundle`, `Bun.build`'s
+// `define`) — never imported. `packages/shallot/src/engine/runtime/gpu.ts`'s
+// `PIPELINE_COMPILE_MEASURE_PREFIX` can't be imported directly into this browser bundle: `gpu.ts`
+// has a top-level `tgpu.fn(...)` call, a real side effect no bundler can tree-shake, so any import
+// from it pulls TypeGPU's whole module graph in (measured 0.56 MB / 170 modules for a probe
+// importing only the constant — `rum-compile-vitals.ts`'s own docblock records the same fact).
+declare const __PIPELINE_COMPILE_MEASURE_PREFIX__: string;
+
+// `PerformanceObserver({ type: "measure", buffered: true })` — `buffered: true` is load-bearing:
+// a compile forced during boot (the sear/slab forcers `precompileAll` warms before the page is
+// interactive) finishes and calls `performance.measure` well before this script's own
+// `DD_RUM.onReady` fires, let alone before an observer constructed here would otherwise see it.
+// `buffered` replays every matching entry already on the timeline at `observe()` time, so a
+// compile finished during boot is still reported.
+if (typeof PerformanceObserver !== "undefined") {
+    try {
+        new PerformanceObserver((list) => {
+            const reports = compileVitalReports(
+                list.getEntries(),
+                __PIPELINE_COMPILE_MEASURE_PREFIX__,
+                performance.timeOrigin,
+            );
+            for (const report of reports) {
+                window.DD_RUM?.onReady(() => {
+                    window.DD_RUM?.addDurationVital("pipeline_compile", {
+                        startTime: report.startTime,
+                        duration: report.duration,
+                        context: report.context,
+                    });
+                });
+                // Bound the shared `performance` timeline: `compileValidated` writes one `measure`
+                // entry per forcer per `build()` call against a device, so a page that rebuilds
+                // scenes (a demo switcher, a hot-reloaded editor) grows the timeline unboundedly
+                // if nothing ever clears it (S1's review finding, owned here). Clear only what
+                // this callback just forwarded — `clearMeasures(name)` removes every entry sharing
+                // that name, never the whole timeline, so an unrelated `measure` entry (there are
+                // none today, but the API is shared) is untouched.
+                performance.clearMeasures(report.name);
+            }
+        }).observe({ type: "measure", buffered: true });
+    } catch {
+        // Telemetry never breaks the page — an older runtime or a locked-down embedder that
+        // throws on `observe` degrades silently, same posture as the engine-side emitter's own
+        // guard (`gpu.ts`'s `compileValidated`).
     }
 }
 


### PR DESCRIPTION
PerformanceObserver({ type: "measure", buffered: true }) in rum-runtime.ts
forwards pipeline_compile duration vitals, bounding the shared performance
timeline by clearing each entry it forwards (S1's review finding). The pure
filter/epoch-conversion logic lives in the new rum-compile-vitals.ts, tested
in rum-compile-vitals.test.ts.

A naive `import { PIPELINE_COMPILE_MEASURE_PREFIX } from gpu.ts` in the
browser-bundled rum-runtime.ts pulls TypeGPU's whole module graph in (gpu.ts
has a top-level tgpu.fn() call, measured at 0.56 MB / 170 modules) —
build-site.ts now imports the constant Node-side and threads it through
Bun.build's `define`, so rum-runtime.ts references it as an inlined
ambient global instead of importing gpu.ts directly.

rum-intake-check.ts / rum-intake-driver.ts gain a two-sided
pipeline_compile arm: a synthetic prefixed performance.measure drives the
observer and must call addDurationVital + reach the intercepted intake; a
non-prefixed one must not call it. Mutation-tested (disabling the prefix
filter) — the wire-only reading for the negative direction passed
regardless (the SDK's flush cadence outlasted the sanity window either
way), so the negative direction reads the structural `called` proof
instead, same shape runScenario already uses for slow_frame.
