### PR TITLE
shallot-site-staging: add --staging build mode to the demo-site build

### DIFF
--- a/scripts/build-site.test.ts
+++ b/scripts/build-site.test.ts
@@ -17,8 +17,35 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { RUM_ENV_SNIPPET, RUM_ENV_SNIPPET_STAGING } from "../site/rum-config";
+import { datadogInitSnippet } from "./build-site";
 
 const src = readFileSync(resolve(import.meta.dir, "build-site.ts"), "utf8");
+
+// S1 (staging build mode) — datadogInitSnippet is a pure function, so its mode selection is
+// armed behaviorally rather than by source-text match, unlike the arms below.
+test("build-site — datadogInitSnippet selects the env constant by mode, mutually exclusive", () => {
+    const prod = datadogInitSnippet("prod");
+    const staging = datadogInitSnippet("staging");
+    expect(prod).toContain(RUM_ENV_SNIPPET);
+    expect(prod).not.toContain(RUM_ENV_SNIPPET_STAGING);
+    expect(staging).toContain(RUM_ENV_SNIPPET_STAGING);
+    expect(staging).not.toContain(RUM_ENV_SNIPPET);
+    // no mode arg defaults to prod — the prod build path stays byte-unchanged for a caller that
+    // never learns about `--staging`
+    expect(datadogInitSnippet()).toBe(prod);
+});
+
+// The staging pack-and-`file:`-pin mechanism itself needs a real `bun pm pack` + `bun install`,
+// which this file's other arms already document as too slow/non-hermetic for a source-text
+// match (see the file header). Structural pins only, same discipline and the same caveat: a
+// source-text match cannot tell a live guard from a commented-out one.
+test("build-site --staging — packs the engine once and pins every demo to the tarball, not the version", () => {
+    expect(src).toMatch(/bun pm pack/);
+    // the per-demo rewrite must use the mode-selected `enginePin`, not the bare release `version`
+    // — this is the line staging mode depends on to avoid ever pinning a prod release
+    expect(src).toMatch(/@dylanebert\/shallot["']\]\s*=\s*enginePin/);
+});
 
 test("build-site --demo — only clears that demo's slot, not all of out/site", () => {
     // The fix: when `only` is set, rmSync targets `resolve(outDir, only)` (that demo's slot),

--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -3,6 +3,7 @@ import {
     existsSync,
     mkdirSync,
     mkdtempSync,
+    readdirSync,
     readFileSync,
     rmSync,
     writeFileSync,
@@ -24,10 +25,11 @@ import { type DemoEntry, ROSTER } from "../site/roster";
 import {
     RUM_CONFIG,
     RUM_ENV_SNIPPET,
+    RUM_ENV_SNIPPET_STAGING,
     RUM_ENV_USAGE,
     RUM_INJECTION_MARKER,
 } from "../site/rum-config";
-import { demoFingerprints, writeStamp } from "../site/site-stamp";
+import { demoFingerprints, type SiteMode, writeStamp } from "../site/site-stamp";
 
 // `bun run site` — build every showcase demo as an ejected consumer of the *published* package,
 // then assemble the site index. Each demo is copied out of the workspace to a scratch tree under
@@ -38,9 +40,19 @@ import { demoFingerprints, writeStamp } from "../site/site-stamp";
 // so the artifact is a real published-consumer build — not a workspace build that silently carries
 // gitignored wasm the clean path does not (the Locked decision's measured fact).
 //
+// `--staging` is the same pipeline with one pin swapped: `bun pm pack` packs the engine once,
+// ahead of the demo loop, and every demo's `@dylanebert/shallot` dependency is rewritten to
+// `file:<tgz>` instead of the release version — a workspace-source build with no other machinery
+// forked (`scripts/install-test.ts` is the in-repo reference for the pack-and-`file:`-install
+// mechanism). The RUM env constant and the index label switch with it (`datadogInitSnippet`,
+// `siteIndex`); everything else — eject, install, `bunx shallot build`, RUM injection, artifact
+// assembly — is shared verbatim between modes.
+//
 // The page itself is static HTML: system monospace, no web fonts, no JS, one small style block,
 // readable at 360px. Each row carries a play link to the built demo and a code link to the
-// version-pinned tag path on GitHub. The page labels what it was built from (version plus ref).
+// version-pinned tag path on GitHub (staging: the built ref, since a staging build's version may
+// have no matching tag yet). The page labels what it was built from (version plus ref, or the ref
+// alone in staging mode).
 
 const root = resolve(import.meta.dir, "..");
 const showcaseDir = resolve(root, "examples/showcase");
@@ -63,7 +75,8 @@ const DATADOG_RUM_CDN_URL = `https://www.datadoghq-browser-agent.com/us1/v${DATA
 // CORS-mode load is exempt from the CORP check entirely — so `crossOrigin` fixes the verify-only failure
 // without needing a header change in `packages/shallot` (out of scope) or the deployed site, which never
 // sets COEP (a static host can't set headers, the doc comment above `CROSS_ORIGIN_ISOLATION` already notes).
-export function datadogInitSnippet(): string {
+export function datadogInitSnippet(mode: "prod" | "staging" = "prod"): string {
+    const envSnippet = mode === "staging" ? RUM_ENV_SNIPPET_STAGING : RUM_ENV_SNIPPET;
     return `${RUM_INJECTION_MARKER}
 <script>
 (function(h,o,u,n,d) {
@@ -72,7 +85,7 @@ export function datadogInitSnippet(): string {
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
 })(window,document,'script','${DATADOG_RUM_CDN_URL}','DD_RUM')
 window.DD_RUM.onReady(function() {
-    ${RUM_ENV_SNIPPET}
+    ${envSnippet}
     window.DD_RUM.init(${RUM_ENV_USAGE}${JSON.stringify(RUM_CONFIG)}));
 });
 </script>
@@ -106,8 +119,8 @@ async function buildRumRuntimeBundle(): Promise<string> {
 /** Injects the Datadog init snippet plus the bundled sampler into every `*.html` file under
  * `dir` (recursive — a demo like `visualization` emits nested pages under `demos/`), right
  * before `</body>`. */
-function injectRum(dir: string, runtimeBundle: string): void {
-    const snippet = `${datadogInitSnippet()}<script type="module">\n${runtimeBundle}</script>\n`;
+function injectRum(dir: string, runtimeBundle: string, mode: "prod" | "staging"): void {
+    const snippet = `${datadogInitSnippet(mode)}<script type="module">\n${runtimeBundle}</script>\n`;
     const glob = new Glob("**/*.html");
     for (const path of glob.scanSync({ cwd: dir })) {
         const full = resolve(dir, path);
@@ -124,13 +137,15 @@ function injectRum(dir: string, runtimeBundle: string): void {
 async function main(): Promise<void> {
     const args = process.argv.slice(2);
     if (args.includes("--help") || args.includes("-h")) {
-        console.log(`Usage: bun run site [--demo <slug>]
+        console.log(`Usage: bun run site [--demo <slug>] [--staging]
 
 Builds every showcase demo as an ejected consumer of the published @dylanebert/shallot,
 assembles out/site/<slug>/ per demo, and emits out/site/index.html.
 
 Options:
-  --demo <slug>   Build a single demo by its roster slug`);
+  --demo <slug>   Build a single demo by its roster slug
+  --staging       Pin @dylanebert/shallot to a packed workspace tarball instead of the
+                   release version, and tag the RUM env + index label "staging"`);
         process.exit(0);
     }
 
@@ -140,6 +155,9 @@ Options:
         console.error(`no demo "${only}" — one of: ${ROSTER.map((d) => d.slug).join(", ")}`);
         process.exit(2);
     }
+
+    const staging = args.includes("--staging");
+    const mode: "prod" | "staging" = staging ? "staging" : "prod";
 
     const pkg = (await Bun.file(resolve(root, "packages/shallot/package.json")).json()) as {
         version: string;
@@ -162,114 +180,149 @@ Options:
 
     const rumRuntimeBundle = await buildRumRuntimeBundle();
 
-    const sizes: { slug: string; size: string }[] = [];
-
-    for (const demo of demos) {
-        const slug = demo.slug;
-        const srcDir = resolve(showcaseDir, slug);
-        if (!existsSync(srcDir)) {
-            console.error(`✗ showcase dir not found: ${srcDir}`);
+    // `--staging`: pack the engine once, ahead of the demo loop, into a scratch dir that outlives
+    // every demo's own ejection — every demo pins the same tarball, so it must still exist when the
+    // last demo installs. `scripts/install-test.ts`'s `pack()` is the in-repo reference for this
+    // exact `bun pm pack --destination` shape.
+    let enginePin = version;
+    let packDest: string | undefined;
+    if (staging) {
+        packDest = mkdtempSync(join(tmpdir(), "shallot-site-pack-"));
+        console.log(`\npacking @dylanebert/shallot for staging...`);
+        const packResult = Bun.spawnSync(["bun", "pm", "pack", "--destination", packDest], {
+            cwd: resolve(root, "packages/shallot"),
+            stdout: "inherit",
+            stderr: "inherit",
+        });
+        if (packResult.exitCode !== 0) {
+            console.error(`✗ \`bun pm pack\` failed for packages/shallot`);
             process.exit(1);
         }
-
-        // scratch tree under /tmp — the eject/install/build happens outside the workspace.
-        // the demo dir's basename must be the slug: `shallot build` synthesizes the page
-        // <title> from it, so a unique parent carries the uniqueness and the leaf stays clean
-        const scratchParent = mkdtempSync(join(tmpdir(), `shallot-site-${slug}-`));
-        const scratch = join(scratchParent, slug);
-        mkdirSync(scratch, { recursive: true });
-
-        try {
-            console.log(`\n=== ${slug} ===`);
-
-            // copy the showcase dir verbatim (node_modules/dist excluded by the dir's own .gitignore
-            // patterns — but a fresh worktree has none, so just copy everything except those)
-            const nodeModulesDir = resolve(srcDir, "node_modules");
-            const distDir = resolve(srcDir, "dist");
-            cpSync(srcDir, scratch, {
-                recursive: true,
-                filter: (s) =>
-                    s !== nodeModulesDir &&
-                    !s.startsWith(nodeModulesDir + sep) &&
-                    s !== distDir &&
-                    !s.startsWith(distDir + sep),
-            });
-
-            // rewrite package.json: pin @dylanebert/shallot to the release version, carry every
-            // other dep over as authored
-            const demoPkg = (await Bun.file(resolve(scratch, "package.json")).json()) as {
-                dependencies?: Record<string, string>;
-                devDependencies?: Record<string, string>;
-                [key: string]: unknown;
-            };
-            if (demoPkg.dependencies?.["@dylanebert/shallot"]) {
-                demoPkg.dependencies["@dylanebert/shallot"] = version;
-            }
-            writeFileSync(
-                resolve(scratch, "package.json"),
-                `${JSON.stringify(demoPkg, null, 4)}\n`,
-            );
-
-            // rewrite tsconfig.json: standalone (the in-repo one extends a repo-root path that
-            // doesn't exist outside the workspace). Inline the compilerOptions from the root
-            // tsconfig.json, minus the workspace-only `paths` mapping.
-            writeFileSync(resolve(scratch, "tsconfig.json"), `${standaloneTsconfig()}\n`);
-
-            // install against the published package from npm
-            console.log(`  installing...`);
-            const install = Bun.spawnSync(["bun", "install"], {
-                cwd: scratch,
-                stdout: "inherit",
-                stderr: "inherit",
-            });
-            if (install.exitCode !== 0) {
-                console.error(`✗ install failed for ${slug}`);
-                process.exit(1);
-            }
-
-            // build with the published CLI
-            console.log(`  building...`);
-            const build = Bun.spawnSync(["bunx", "shallot", "build"], {
-                cwd: scratch,
-                stdout: "inherit",
-                stderr: "inherit",
-            });
-            if (build.exitCode !== 0) {
-                console.error(`✗ build failed for ${slug}`);
-                process.exit(1);
-            }
-
-            // assemble out/site/<slug>/ from dist/
-            const dist = resolve(scratch, "dist");
-            if (!existsSync(dist)) {
-                console.error(`✗ no dist/ produced for ${slug}`);
-                process.exit(1);
-            }
-            const demoOut = resolve(outDir, slug);
-            cpSync(dist, demoOut, { recursive: true });
-            injectRum(demoOut, rumRuntimeBundle);
-
-            const sizeBytes = dirSize(demoOut);
-            sizes.push({ slug, size: formatSize(sizeBytes) });
-            console.log(`  done — ${formatSize(sizeBytes)}`);
-        } finally {
-            rmSync(scratchParent, { recursive: true, force: true });
+        const tgz = readdirSync(packDest).find((f) => f.endsWith(".tgz") && !f.startsWith("."));
+        if (!tgz) {
+            console.error(`✗ no tarball produced in ${packDest}`);
+            process.exit(1);
         }
+        enginePin = `file:${resolve(packDest, tgz)}`;
+    }
+
+    const sizes: { slug: string; size: string }[] = [];
+
+    try {
+        for (const demo of demos) {
+            const slug = demo.slug;
+            const srcDir = resolve(showcaseDir, slug);
+            if (!existsSync(srcDir)) {
+                console.error(`✗ showcase dir not found: ${srcDir}`);
+                process.exit(1);
+            }
+
+            // scratch tree under /tmp — the eject/install/build happens outside the workspace.
+            // the demo dir's basename must be the slug: `shallot build` synthesizes the page
+            // <title> from it, so a unique parent carries the uniqueness and the leaf stays clean
+            const scratchParent = mkdtempSync(join(tmpdir(), `shallot-site-${slug}-`));
+            const scratch = join(scratchParent, slug);
+            mkdirSync(scratch, { recursive: true });
+
+            try {
+                console.log(`\n=== ${slug} ===`);
+
+                // copy the showcase dir verbatim (node_modules/dist excluded by the dir's own .gitignore
+                // patterns — but a fresh worktree has none, so just copy everything except those)
+                const nodeModulesDir = resolve(srcDir, "node_modules");
+                const distDir = resolve(srcDir, "dist");
+                cpSync(srcDir, scratch, {
+                    recursive: true,
+                    filter: (s) =>
+                        s !== nodeModulesDir &&
+                        !s.startsWith(nodeModulesDir + sep) &&
+                        s !== distDir &&
+                        !s.startsWith(distDir + sep),
+                });
+
+                // rewrite package.json: pin @dylanebert/shallot to the release version (prod) or the
+                // packed workspace tarball (staging), carry every other dep over as authored
+                const demoPkg = (await Bun.file(resolve(scratch, "package.json")).json()) as {
+                    dependencies?: Record<string, string>;
+                    devDependencies?: Record<string, string>;
+                    [key: string]: unknown;
+                };
+                if (demoPkg.dependencies?.["@dylanebert/shallot"]) {
+                    demoPkg.dependencies["@dylanebert/shallot"] = enginePin;
+                }
+                writeFileSync(
+                    resolve(scratch, "package.json"),
+                    `${JSON.stringify(demoPkg, null, 4)}\n`,
+                );
+
+                // rewrite tsconfig.json: standalone (the in-repo one extends a repo-root path that
+                // doesn't exist outside the workspace). Inline the compilerOptions from the root
+                // tsconfig.json, minus the workspace-only `paths` mapping.
+                writeFileSync(resolve(scratch, "tsconfig.json"), `${standaloneTsconfig()}\n`);
+
+                // install against the published package from npm
+                console.log(`  installing...`);
+                const install = Bun.spawnSync(["bun", "install"], {
+                    cwd: scratch,
+                    stdout: "inherit",
+                    stderr: "inherit",
+                });
+                if (install.exitCode !== 0) {
+                    console.error(`✗ install failed for ${slug}`);
+                    process.exit(1);
+                }
+
+                // build with the published CLI
+                console.log(`  building...`);
+                const build = Bun.spawnSync(["bunx", "shallot", "build"], {
+                    cwd: scratch,
+                    stdout: "inherit",
+                    stderr: "inherit",
+                });
+                if (build.exitCode !== 0) {
+                    console.error(`✗ build failed for ${slug}`);
+                    process.exit(1);
+                }
+
+                // assemble out/site/<slug>/ from dist/
+                const dist = resolve(scratch, "dist");
+                if (!existsSync(dist)) {
+                    console.error(`✗ no dist/ produced for ${slug}`);
+                    process.exit(1);
+                }
+                const demoOut = resolve(outDir, slug);
+                cpSync(dist, demoOut, { recursive: true });
+                injectRum(demoOut, rumRuntimeBundle, mode);
+
+                const sizeBytes = dirSize(demoOut);
+                sizes.push({ slug, size: formatSize(sizeBytes) });
+                console.log(`  done — ${formatSize(sizeBytes)}`);
+            } finally {
+                rmSync(scratchParent, { recursive: true, force: true });
+            }
+        }
+    } finally {
+        if (packDest) rmSync(packDest, { recursive: true, force: true });
     }
 
     // emit the site index — always lists the full roster so a single-demo build's index
     // still references the other demos from a prior full build
-    writeFileSync(resolve(outDir, "index.html"), siteIndex(ROSTER, version, refShort));
+    writeFileSync(resolve(outDir, "index.html"), siteIndex(ROSTER, version, refShort, mode));
 
     // record what each demo was built from, so `check-site.ts` can tell an artifact of *these*
     // sources from an artifact of some other sources before it judges the artifact
     // (`site/site-stamp.ts`). Merging, not overwriting: a `--demo` build only rebuilt one slot.
+    // `mode` is not merged — it names the mode this run built in.
+    const siteMode: SiteMode = staging
+        ? { kind: "staging", pin: enginePin }
+        : { kind: "prod", version };
     writeStamp(
         outDir,
         demoFingerprints(
             root,
             demos.map((d) => d.slug),
         ),
+        siteMode,
     );
 
     const total = sizes.reduce((sum, s) => sum + parseSize(s.size), 0);
@@ -279,7 +332,9 @@ Options:
     }
     console.log(`  total: ${formatSize(total)}`);
     console.log(`\n  index: ${resolve(outDir, "index.html")}`);
-    console.log(`  built from: v${version} (${refShort})`);
+    console.log(
+        `  built from: ${staging ? `staging (${enginePin})` : `v${version}`} (${refShort})`,
+    );
 }
 
 // The standalone tsconfig — the root tsconfig.json's compilerOptions inlined, minus the
@@ -339,9 +394,18 @@ function parseSize(s: string): number {
     return n;
 }
 
-function siteIndex(demos: DemoEntry[], version: string, ref: string): string {
+function siteIndex(
+    demos: DemoEntry[],
+    version: string,
+    ref: string,
+    mode: "prod" | "staging",
+): string {
+    // staging labels by ref, never by version tag — a staging build routinely runs ahead of the
+    // last release, so `v${version}` may name a GitHub tag that doesn't exist yet.
     const codeUrl = (slug: string) =>
-        `https://github.com/dylanebert/shallot/tree/v${version}/examples/showcase/${slug}`;
+        mode === "staging"
+            ? `https://github.com/dylanebert/shallot/tree/${ref}/examples/showcase/${slug}`
+            : `https://github.com/dylanebert/shallot/tree/v${version}/examples/showcase/${slug}`;
 
     const rows = demos
         .map((d) => {
@@ -388,7 +452,7 @@ function siteIndex(demos: DemoEntry[], version: string, ref: string): string {
     </head>
     <body>
         <h1>shallot</h1>
-        <p class="meta">v${version} · ${ref}</p>
+        <p class="meta">${mode === "staging" ? `staging · ${ref}` : `v${version} · ${ref}`}</p>
         <p class="warn">WebGPU required — Chrome, Edge, or Safari 26+ on desktop.</p>
         <table>
             <tbody>

--- a/scripts/check-site.test.ts
+++ b/scripts/check-site.test.ts
@@ -22,15 +22,32 @@
 // default, exit 1 naming staleness under `SITE_OUT_REQUIRED=1`.
 
 import { expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { ROSTER } from "../site/roster";
-import { demoFingerprints, readStamp, staleDemos, writeStamp } from "../site/site-stamp";
+import {
+    demoFingerprints,
+    readStamp,
+    type SiteMode,
+    staleDemos,
+    writeStamp,
+} from "../site/site-stamp";
 import { datadogInitSnippet } from "./build-site";
 
 const repoRoot = resolve(import.meta.dir, "..");
 const checkSite = resolve(repoRoot, "scripts/check-site.ts");
+
+// the real repo's release version — the fixtures below stamp `prod` mode with it so clause 2's
+// mode-branched pin check (new in the staging build mode) reads a matching version rather than
+// failing ahead of the clause each fixture actually exercises.
+const releaseVersion = (
+    JSON.parse(readFileSync(resolve(repoRoot, "packages/shallot/package.json"), "utf8")) as {
+        version: string;
+    }
+).version;
+const PROD_MODE: SiteMode = { kind: "prod", version: releaseVersion };
+const STAGING_MODE: SiteMode = { kind: "staging", pin: "file:/tmp/dylanebert-shallot-0.0.0.tgz" };
 
 /** A built-site fixture that clears clauses 4 and 5 and fails clause 6 — every demo root page
  * carries the pre-fix scratch-shaped <title> the site build used to synthesize. */
@@ -86,7 +103,11 @@ test("check-site — a stale artifact on the deploy path reds on staleness, not 
     try {
         // a stamp naming fingerprints that are not this tree's — the artifact is a build of some
         // other sources, which is exactly the founding defect's state
-        writeStamp(fixture, Object.fromEntries(ROSTER.map(({ slug }) => [slug, "0".repeat(32)])));
+        writeStamp(
+            fixture,
+            Object.fromEntries(ROSTER.map(({ slug }) => [slug, "0".repeat(32)])),
+            PROD_MODE,
+        );
         const { exitCode, out } = runCheck(fixture, { SITE_OUT_REQUIRED: "1" });
         expect(out).toContain("stale");
         expect(out).not.toContain("non-human-readable");
@@ -105,6 +126,7 @@ test("check-site — a fresh artifact is judged: clause 6 reds on the pre-fix ti
                 repoRoot,
                 ROSTER.map((d) => d.slug),
             ),
+            PROD_MODE,
         );
         const { exitCode, out } = runCheck(fixture);
         expect(out).toContain("non-human-readable");
@@ -186,7 +208,7 @@ test("site-stamp — staleness is per demo dir, and an absent dir is not stale",
         // present but unstamped
         expect(staleDemos(dir, out, ["demo"]).map((s) => s.slug)).toEqual(["demo"]);
 
-        writeStamp(out, demoFingerprints(dir, ["demo"]));
+        writeStamp(out, demoFingerprints(dir, ["demo"]), PROD_MODE);
         expect(staleDemos(dir, out, ["demo"])).toEqual([]);
 
         // sources move under a stamped artifact
@@ -201,10 +223,157 @@ test("site-stamp — staleness is per demo dir, and an absent dir is not stale",
 test("site-stamp — a stamp write merges over a prior build's other slots", () => {
     const out = mkdtempSync(join(tmpdir(), "site-stamp-merge-"));
     try {
-        writeStamp(out, { a: "aaa", b: "bbb" });
-        writeStamp(out, { b: "ccc" }); // a `--demo b` rebuild
+        writeStamp(out, { a: "aaa", b: "bbb" }, PROD_MODE);
+        writeStamp(out, { b: "ccc" }, PROD_MODE); // a `--demo b` rebuild
         expect(readStamp(out)?.demos).toEqual({ a: "aaa", b: "ccc" });
     } finally {
         rmSync(out, { recursive: true, force: true });
+    }
+});
+
+// --- S1 (staging build mode): the stamp's mode branches clause 2's pin check and clause 5's
+// env check two-sided ------------------------------------------------------------------------
+
+/** A built-site fixture that clears every clause: relative paths, correct <title>, and the
+ * given mode's RUM injection (`datadogInitSnippet(mode)`, `build-site.ts`'s own emitter — so
+ * the fixture is byte-identical to what a real build of that mode would inject). */
+function modeFixture(mode: "prod" | "staging"): string {
+    const out = mkdtempSync(join(tmpdir(), `check-site-fixture-${mode}-`));
+    for (const { slug } of ROSTER) {
+        mkdirSync(resolve(out, slug), { recursive: true });
+        writeFileSync(
+            resolve(out, slug, "index.html"),
+            `<!doctype html>
+<html lang="en">
+    <head>
+        <title>${slug}</title>
+        <link rel="stylesheet" href="./assets/index.css" />
+    </head>
+    <body>
+        <script type="module" src="./assets/index.js"></script>
+${datadogInitSnippet(mode)}    </body>
+</html>
+`,
+        );
+    }
+    writeFileSync(resolve(out, "index.html"), `<!doctype html>\n<html><body></body></html>\n`);
+    return out;
+}
+
+function stampFresh(fixture: string, mode: SiteMode) {
+    writeStamp(
+        fixture,
+        demoFingerprints(
+            repoRoot,
+            ROSTER.map((d) => d.slug),
+        ),
+        mode,
+    );
+}
+
+test("check-site — a staging artifact stamped staging passes clean", () => {
+    const fixture = modeFixture("staging");
+    try {
+        stampFresh(fixture, STAGING_MODE);
+        const { exitCode, out } = runCheck(fixture, { SITE_OUT_REQUIRED: "1" });
+        expect(exitCode).toBe(0);
+        expect(out).toContain("✓");
+    } finally {
+        rmSync(fixture, { recursive: true, force: true });
+    }
+});
+
+test("check-site — a prod artifact stamped prod passes clean", () => {
+    const fixture = modeFixture("prod");
+    try {
+        stampFresh(fixture, PROD_MODE);
+        const { exitCode, out } = runCheck(fixture, { SITE_OUT_REQUIRED: "1" });
+        expect(exitCode).toBe(0);
+        expect(out).toContain("✓");
+    } finally {
+        rmSync(fixture, { recursive: true, force: true });
+    }
+});
+
+// The two-sided mutation check the spec's Validation names directly: a staging artifact judged
+// with the prod clause set must red, and vice versa — never pass on the union of both literals.
+test("check-site — a staging artifact judged with the prod clause set reds", () => {
+    const fixture = modeFixture("staging");
+    try {
+        stampFresh(fixture, PROD_MODE); // wrong clause set: mode says prod, content is staging
+        const { exitCode, out } = runCheck(fixture, { SITE_OUT_REQUIRED: "1" });
+        expect(exitCode).toBe(1);
+        expect(out).toContain("missing the RUM env-derivation snippet for prod mode");
+    } finally {
+        rmSync(fixture, { recursive: true, force: true });
+    }
+});
+
+test("check-site — a prod artifact judged with the staging clause set reds", () => {
+    const fixture = modeFixture("prod");
+    try {
+        stampFresh(fixture, STAGING_MODE); // wrong clause set: mode says staging, content is prod
+        const { exitCode, out } = runCheck(fixture, { SITE_OUT_REQUIRED: "1" });
+        expect(exitCode).toBe(1);
+        expect(out).toContain("missing the RUM env-derivation snippet for staging mode");
+    } finally {
+        rmSync(fixture, { recursive: true, force: true });
+    }
+});
+
+test("check-site — a page carrying both mode's env literals reds on the two-sided check", () => {
+    const out = mkdtempSync(join(tmpdir(), "check-site-fixture-bothmodes-"));
+    try {
+        for (const { slug } of ROSTER) {
+            mkdirSync(resolve(out, slug), { recursive: true });
+            writeFileSync(
+                resolve(out, slug, "index.html"),
+                `<!doctype html>
+<html lang="en">
+    <head>
+        <title>${slug}</title>
+        <link rel="stylesheet" href="./assets/index.css" />
+    </head>
+    <body>
+        <script type="module" src="./assets/index.js"></script>
+${datadogInitSnippet("prod")}    <!-- var ddEnv='staging'; -->
+    </body>
+</html>
+`,
+            );
+        }
+        writeFileSync(resolve(out, "index.html"), `<!doctype html>\n<html><body></body></html>\n`);
+        stampFresh(out, PROD_MODE);
+        const { exitCode, out: log } = runCheck(out, { SITE_OUT_REQUIRED: "1" });
+        expect(exitCode).toBe(1);
+        expect(log).toContain("carry the other mode's env");
+    } finally {
+        rmSync(out, { recursive: true, force: true });
+    }
+});
+
+test("check-site — clause 2's artifact leg: a prod stamp naming a stale version reds", () => {
+    const fixture = modeFixture("prod");
+    try {
+        stampFresh(fixture, { kind: "prod", version: "0.0.0-not-the-real-version" });
+        const { exitCode, out } = runCheck(fixture, { SITE_OUT_REQUIRED: "1" });
+        expect(exitCode).toBe(1);
+        expect(out).toContain(
+            "build stamp records prod mode pinned to v0.0.0-not-the-real-version",
+        );
+    } finally {
+        rmSync(fixture, { recursive: true, force: true });
+    }
+});
+
+test("check-site — clause 2's artifact leg: a staging stamp naming a non-tarball pin reds", () => {
+    const fixture = modeFixture("staging");
+    try {
+        stampFresh(fixture, { kind: "staging", pin: "not-a-file-pin" });
+        const { exitCode, out } = runCheck(fixture, { SITE_OUT_REQUIRED: "1" });
+        expect(exitCode).toBe(1);
+        expect(out).toContain('build stamp records staging mode with pin "not-a-file-pin"');
+    } finally {
+        rmSync(fixture, { recursive: true, force: true });
     }
 });

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -2,8 +2,13 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve, sep } from "node:path";
 import { Glob } from "bun";
 import { ROSTER } from "../site/roster";
-import { RUM_ENV_SNIPPET, RUM_ENV_USAGE, RUM_INJECTION_MARKER } from "../site/rum-config";
-import { STAMP_FILE, staleDemos } from "../site/site-stamp";
+import {
+    RUM_ENV_SNIPPET,
+    RUM_ENV_SNIPPET_STAGING,
+    RUM_ENV_USAGE,
+    RUM_INJECTION_MARKER,
+} from "../site/rum-config";
+import { readStamp, STAMP_FILE, staleDemos } from "../site/site-stamp";
 
 // `bun run scripts/check-site.ts` — the site membership gate, wired into `bun check`. Seven
 // clauses, and a freshness precondition standing in front of the four (4-7) that read the built
@@ -218,6 +223,37 @@ if (stale.length > 0) {
     process.exit(0);
 }
 
+// --- clause 2 (artifact leg): the ejected pin actually used matches the declared mode -----
+//
+// The source-side half of clause 2 (above) can only assert the in-repo form (`workspace:*`) and
+// that the release version is a real semver — the pin actually written into each demo's ejected
+// `package.json` exists only in a scratch tree that `scripts/build-site.ts` deletes before this
+// script ever runs. So the build stamp records which pin the run used
+// (`site/site-stamp.ts`'s `SiteMode`), and this leg reads it back: a prod-mode stamp must have
+// pinned the current release version, a staging-mode stamp must have pinned a `file:`-form
+// workspace tarball — never the other way, so a mode mix-up reds here instead of the built
+// artifact silently carrying the wrong pin.
+const stamp = readStamp(outDir);
+if (stamp) {
+    if (stamp.mode.kind === "prod") {
+        if (stamp.mode.version !== version) {
+            fail(
+                `✗ build stamp records prod mode pinned to v${stamp.mode.version}, but ` +
+                    `packages/shallot/package.json now names v${version} — rebuild with ` +
+                    "`bun run site`",
+            );
+        }
+    } else {
+        if (!stamp.mode.pin.startsWith("file:") || !stamp.mode.pin.endsWith(".tgz")) {
+            fail(
+                `✗ build stamp records staging mode with pin "${stamp.mode.pin}" — expected a ` +
+                    "`file:<tgz>` workspace pin (`scripts/build-site.ts`'s `bun pm pack` step)",
+            );
+        }
+    }
+}
+const mode: "prod" | "staging" = stamp?.mode.kind ?? "prod";
+
 // scan every generated HTML/JS/CSS file for root-absolute paths: `href="/..."` or `src="/..."`
 // HTML attributes. A root-absolute path would break at a non-root base path (GitHub Pages
 // serves at /shallot/).
@@ -249,9 +285,19 @@ if (rootAbsFiles.length > 0) {
 }
 
 // --- clause 5: the RUM slow-frame injection reaches every demo page, and skips the index --
+//
+// The env check is two-sided: a page must carry the *mode's own* env literal and must not carry
+// the *other* mode's. A one-sided check (present-only) passes a mode mix-up — a prod build that
+// somehow injected the staging literal instead would still clear "prod snippet missing? no" if
+// nothing ever checked for staging's literal being there — so `wrongModeEnv` reds that shape
+// explicitly rather than relying on the two literals happening to differ enough in practice.
+
+const ownEnvSnippet = mode === "staging" ? RUM_ENV_SNIPPET_STAGING : RUM_ENV_SNIPPET;
+const otherEnvSnippet = mode === "staging" ? RUM_ENV_SNIPPET : RUM_ENV_SNIPPET_STAGING;
 
 const noInjection: string[] = [];
 const noEnv: string[] = [];
+const wrongModeEnv: string[] = [];
 const noEnvUsage: string[] = [];
 const noParse: { file: string; error: string }[] = [];
 for (const { slug } of ROSTER) {
@@ -264,8 +310,11 @@ for (const { slug } of ROSTER) {
         if (!html.includes(RUM_INJECTION_MARKER)) {
             noInjection.push(`${slug}/${path}`);
         }
-        if (!html.includes(RUM_ENV_SNIPPET)) {
+        if (!html.includes(ownEnvSnippet)) {
             noEnv.push(`${slug}/${path}`);
+        }
+        if (html.includes(otherEnvSnippet)) {
+            wrongModeEnv.push(`${slug}/${path}`);
         }
         if (!html.includes(RUM_ENV_USAGE)) {
             noEnvUsage.push(`${slug}/${path}`);
@@ -314,12 +363,27 @@ if (noInjection.length > 0) {
 }
 
 if (noEnv.length > 0) {
-    console.error(`✗ ${noEnv.length} demo page(s) missing the RUM env-derivation snippet:\n`);
+    console.error(
+        `✗ ${noEnv.length} demo page(s) missing the RUM env-derivation snippet for ${mode} mode:\n`,
+    );
     for (const f of noEnv) console.error(`  ${f}`);
     console.error(
-        '\nEvery built demo page must carry the hostname-derived `env: "prod" | "local"`' +
-            " snippet (`site/rum-config.ts`'s `RUM_ENV_SNIPPET`, injected by" +
-            " `scripts/build-site.ts`).",
+        `\nEvery built demo page must carry the ${mode} env snippet` +
+            ` (\`site/rum-config.ts\`'s \`${mode === "staging" ? "RUM_ENV_SNIPPET_STAGING" : "RUM_ENV_SNIPPET"}\`,` +
+            " injected by `scripts/build-site.ts`).",
+    );
+    process.exit(1);
+}
+
+if (wrongModeEnv.length > 0) {
+    console.error(
+        `✗ ${wrongModeEnv.length} demo page(s) built in ${mode} mode carry the other mode's env` +
+            " snippet:\n",
+    );
+    for (const f of wrongModeEnv) console.error(`  ${f}`);
+    console.error(
+        `\nA ${mode}-mode build must carry only the ${mode} env snippet — a page carrying both` +
+            " reads as a mode mix-up in the build itself, not the check.",
     );
     process.exit(1);
 }

--- a/site/rum-config.ts
+++ b/site/rum-config.ts
@@ -27,6 +27,16 @@ export const RUM_INJECTION_MARKER = "<!-- shallot: datadog rum slow-frame vitals
 export const RUM_ENV_SNIPPET =
     "var ddEnv=/(^|\\.)dylanebert\\.com$/.test(location.hostname)?'prod':'local';";
 
+// The staging build's env sibling — a constant `ddEnv`, no hostname derivation. Staging deploys
+// to a Cloudflare `pages.dev` URL that shares no host-suffix rule with `dylanebert.com`, so
+// `RUM_ENV_SNIPPET`'s regex has nothing to key on there; rather than generalize that regex (which
+// would put the prod path at risk for staging's sake), `scripts/build-site.ts` selects between the
+// two sibling constants by build mode. Same shared-literal discipline as `RUM_ENV_SNIPPET`:
+// `build-site.ts` injects this verbatim in `--staging` mode and `check-site.ts`'s clause-5 env
+// check matches on the same literal, so the two never drift apart. `RUM_ENV_USAGE` below is
+// shared unchanged — it wires whichever of the two derivations ran into `DD_RUM.init`.
+export const RUM_ENV_SNIPPET_STAGING = "var ddEnv='staging';";
+
 // The `env` wiring into `DD_RUM.init` — the derivation line above (`RUM_ENV_SNIPPET`) computes
 // `ddEnv` but does nothing until it's spread into the init call. `scripts/build-site.ts` opens
 // its `Object.assign(...)` call with this exact literal; `scripts/check-site.ts`'s clause 5

--- a/site/site-stamp.ts
+++ b/site/site-stamp.ts
@@ -40,15 +40,37 @@ import { resolve } from "node:path";
  * dotfile) so no static host's filter drops it and the artifact carries its own provenance. */
 export const STAMP_FILE = "build-stamp.json";
 
+/** Which build mode produced the artifact, and the `@dylanebert/shallot` pin that mode wrote into
+ * every demo's ejected `package.json` — recorded because the pin itself never survives to be read
+ * back: each demo is ejected into a scratch tree under /tmp and that tree is deleted once the demo
+ * is built, so `check-site.ts`'s clause 2 has nothing else to read the actual pin from. Prod
+ * carries the release version it pinned; staging carries the `file:<tgz>` pin `bun pm pack`
+ * produced, so a mode mix-up (prod artifact stamped staging, or vice versa) reds on the pin shape
+ * instead of passing silently. */
+export type SiteMode = { kind: "prod"; version: string } | { kind: "staging"; pin: string };
+
+function isSiteMode(v: unknown): v is SiteMode {
+    if (typeof v !== "object" || v === null) return false;
+    const m = v as Record<string, unknown>;
+    if (m.kind === "prod") return typeof m.version === "string";
+    if (m.kind === "staging") return typeof m.pin === "string";
+    return false;
+}
+
 export interface SiteStamp {
     /** Bumped when the fingerprint recipe below changes: an old stamp then reads stale, which is
-     * the correct answer — a fingerprint computed by a different recipe is not comparable. */
-    recipe: 1;
+     * the correct answer — a fingerprint computed by a different recipe is not comparable. Bumped
+     * 1 → 2 to add `mode` — a recipe-1 stamp predates mode recording and reads stale rather than
+     * being read with a mode it never carried. */
+    recipe: 2;
+    /** The mode this build ran in, and the engine pin it used — see `SiteMode` above. Overwritten
+     * on every write (unlike `demos`, which merges) since a build run has exactly one mode. */
+    mode: SiteMode;
     /** slug → fingerprint of the sources that demo was built from. */
     demos: Record<string, string>;
 }
 
-const RECIPE: SiteStamp["recipe"] = 1;
+const RECIPE: SiteStamp["recipe"] = 2;
 
 /** The builder files whose contents reach every built page regardless of demo. */
 const BUILDER_FILES = [
@@ -123,21 +145,32 @@ export function readStamp(outDirPath: string): SiteStamp | null {
     if (!existsSync(path)) return null;
     try {
         const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<SiteStamp>;
-        if (parsed.recipe !== RECIPE || typeof parsed.demos !== "object" || parsed.demos === null) {
+        if (
+            parsed.recipe !== RECIPE ||
+            typeof parsed.demos !== "object" ||
+            parsed.demos === null ||
+            !isSiteMode(parsed.mode)
+        ) {
             return null;
         }
-        return { recipe: RECIPE, demos: parsed.demos as Record<string, string> };
+        return { recipe: RECIPE, mode: parsed.mode, demos: parsed.demos as Record<string, string> };
     } catch {
         return null; // an unparseable stamp is no stamp — the artifact reads stale
     }
 }
 
 /** Records the fingerprints of the demos this build wrote, merging over any prior stamp — a
- * `--demo <slug>` build only rebuilt one slot, so the other slots keep the stamp they earned. */
-export function writeStamp(outDirPath: string, entries: Record<string, string>): void {
+ * `--demo <slug>` build only rebuilt one slot, so the other slots keep the stamp they earned.
+ * `mode` is not merged — it names the mode this build ran in, and a build run has one mode. */
+export function writeStamp(
+    outDirPath: string,
+    entries: Record<string, string>,
+    mode: SiteMode,
+): void {
     const prior = readStamp(outDirPath);
     const stamp: SiteStamp = {
         recipe: RECIPE,
+        mode,
         demos: { ...(prior?.demos ?? {}), ...entries },
     };
     writeFileSync(resolve(outDirPath, STAMP_FILE), `${JSON.stringify(stamp, null, 4)}\n`);


### PR DESCRIPTION
Ejected demos pin the workspace-packed engine (file:<tgz> via bun pm
pack) instead of the release version, the RUM snippet injects a
staging env constant, the site stamp records the build mode, and
check-site.ts branches its mode-sensitive clauses two-sided so a mode
mix-up reds instead of passing on the union of both literals.
