### PR TITLE
shallot tui/close

### DIFF
--- a/examples/gym/src/scenarios/cells.ts
+++ b/examples/gym/src/scenarios/cells.ts
@@ -583,14 +583,18 @@ async function assertDrawDispatch(): Promise<Check> {
 //      resolution effect (fine high-frequency detail in a dense glyph's outline doesn't fully survive a
 //      24px cell) rather than a defect, confirmed by banding: even restricted to the ramp's clean lower
 //      60%, a 3-way split's middle third out-renders its own top third.
-//   2. `extras/text/sdf.ts`'s per-glyph SDF-generation render pass renders some of the ramp's highest-
-//      coverage (densest/most complex) glyphs as exactly zero ink — a genuine, pre-existing, reproducible
-//      defect this arm's own construction surfaced (not a regression from this item's draw.ts fix): the
-//      failure reproduces bit-for-bit identically whether `ensureString` is called once with the whole
-//      ramp or split down to one glyph per call, so it is not a batch-size or resource-accumulation
-//      artifact, and the affected characters (`M`, `Q`, `@`, `W`, …) are simple, non-composite outlines
-//      that parse correctly at the font layer — the defect sits in the GPU rasterization/finalize pass,
-//      root cause undetermined. Out of this item's footprint (`extras/text`, not `extras/cells`) to fix.
+//   2. `extras/text/sdf.ts`'s per-glyph SDF-generation render pass has been observed rendering some of
+//      the ramp's highest-coverage (densest/most complex) glyphs as exactly zero ink — a genuine,
+//      reproducible defect this arm's own construction surfaced (not a regression from this item's
+//      draw.ts fix): the failure reproduced bit-for-bit identically whether `ensureString` is called
+//      once with the whole ramp or split down to one glyph per call, so it is not a batch-size or
+//      resource-accumulation artifact. That reading, and the specific glyphs it named, were taken
+//      against the retired 91-glyph undilated ramp, which no longer exists — which glyphs (if any)
+//      render exactly zero ink on the current 87-glyph ramp is unmeasured; see the re-measurement note
+//      below (`MONO_CHECKED_COUNT`) for the reading that stands on this ramp (first dip at index 71,
+//      `m`; the current densest glyph, index 86 `W`, measures nonzero ink per `assertFacadeInk`'s own
+//      densest-glyph control, ~10.9% on nvidia/lovelace). Out of this item's footprint (`extras/text`,
+//      not `extras/cells`) to fix.
 //
 // So the checked claim is the one the ramp's own contract actually promises and this fix actually needs
 // to hold — "bands, not a strict total order" (`ramp.ts`'s own module doc) — restricted to a population

--- a/examples/showcase/ascii/test/pixel-probe.playwright.ts
+++ b/examples/showcase/ascii/test/pixel-probe.playwright.ts
@@ -76,10 +76,49 @@ test("ascii showcase — the cell grid reaches the compositor", async ({ page })
         const c = document.querySelector("canvas");
         return c instanceof HTMLCanvasElement && c.width > 0 && c.height > 0;
     });
-    // the atlas font load (`CellsPlugin.warm`) is async and gates the first cell draw — a fixed settle
-    // rather than a harness hook, since this project ships no `window.__harness` (no smoke concept to
-    // assert, only that the sink painted)
-    await page.waitForTimeout(1000);
+
+    // the cells-only signal (module doc above): grayscale glyph ink, which the scene's own chromatic
+    // colors (warm box, dark background) cannot produce — a probe `boxSwatch` alone can't discriminate,
+    // since deleting `"Cells": true` from `shallot.json` still leaves the box's own warm swatch on screen.
+    const glyphInk = {
+        name: "cell glyph ink reaches the compositor",
+        minPixels: 80,
+        minSpan: 20,
+        r: [210, 255] as [number, number],
+        g: [210, 255] as [number, number],
+        b: [210, 255] as [number, number],
+    };
+
+    // the atlas font load (`CellsPlugin.warm`) is async and gates the first cell draw. This project ships
+    // no `window.__harness` readiness hook, so wait on the derived value the assertion below is about to
+    // read — real ink on the composited canvas — rather than a frame count or a fixed sleep (`checks.md`'s
+    // Measurement discipline: a property that recalculates promptly still reads the previous state's
+    // values if you poll the wrong thing, so poll what the read will see). `page.waitForFunction` can't do
+    // that read here: this canvas presents through `RenderPlugin`'s `GPUTextureUsage.RENDER_ATTACHMENT |
+    // GPUTextureUsage.STORAGE_BINDING` WebGPU context (`view.ts`'s `attachCanvas`, no `COPY_SRC`), and
+    // measured directly against this real page (a same-page `drawImage`+`getImageData` probe run after a
+    // fixed settle, both channels and error state logged) — the in-page readback reads every channel 0
+    // even though the same frame's real pixels are present, so it cannot see the signal it would need to
+    // poll. `canvas.screenshot()` (Playwright's own CDP capture, reading the compositor rather than the
+    // page's JS realm) *does* see them, which is why the assertions below already use it and why this
+    // repo's other touch-driven gate (`examples/showcase/roads/test/touch-smoke.playwright.ts`) polls the
+    // same way. So this waits on `canvas.screenshot()` through `expect.poll`, driven by the exact
+    // `probePixels`/`pixelProbePass` classifier and `glyphInk` swatch the real assertion reads below — the
+    // derived value, read the only way this canvas lets it be read.
+    await expect
+        .poll(
+            async () => {
+                const shot = await canvas.screenshot({ timeout: 5_000 });
+                const png = PNG.sync.read(shot);
+                const result = probePixels(png.data, png.width, png.height, glyphInk);
+                return pixelProbePass(result, glyphInk);
+            },
+            {
+                message: "cells glyph ink should reach the compositor before probing",
+                timeout: 15_000,
+            },
+        )
+        .toBe(true);
 
     const shot = await canvas.screenshot({ timeout: 5_000 });
     const png = PNG.sync.read(shot);
@@ -98,17 +137,6 @@ test("ascii showcase — the cell grid reaches the compositor", async ({ page })
         `matched ${boxResult.pixels} px, span ${boxResult.width}x${boxResult.height} (want >= ${boxSwatch.minPixels} px, >= ${boxSwatch.minSpan} px span)`,
     ).toBe(true);
 
-    // the cells-only signal (module doc above): grayscale glyph ink, which the scene's own chromatic
-    // colors (warm box, dark background) cannot produce — a probe `boxSwatch` alone can't discriminate,
-    // since deleting `"Cells": true` from `shallot.json` still leaves the box's own warm swatch on screen.
-    const glyphInk = {
-        name: "cell glyph ink reaches the compositor",
-        minPixels: 80,
-        minSpan: 20,
-        r: [210, 255] as [number, number],
-        g: [210, 255] as [number, number],
-        b: [210, 255] as [number, number],
-    };
     const inkResult = probePixels(png.data, png.width, png.height, glyphInk);
     expect(
         pixelProbePass(inkResult, glyphInk),

--- a/packages/shallot/bin/tui.test.ts
+++ b/packages/shallot/bin/tui.test.ts
@@ -348,9 +348,18 @@ describe("importShallotTui / runTui — missing @dylanebert/shallot-tui", () => 
 });
 
 describe("noShallotTuiMessage", () => {
-    test("names the install command and carries no stack-trace shape", () => {
+    // Two-sided: the message must name a command that actually resolves the package for the reader it
+    // can help (an in-repo dev — `bun install` from the shallot repo root links the workspace member,
+    // verified directly: `readlink node_modules/@dylanebert/shallot-tui` resolves to `packages/shallot-
+    // tui` after that command), and must NOT prescribe `bun add @dylanebert/shallot-tui` as the fix —
+    // that 404s against the public registry (measured: `bun add @dylanebert/shallot-tui` run from
+    // `packages/shallot` in this repo still hits `registry.npmjs.org` and 404s, since it isn't declared
+    // as a `workspace:*` dependency there).
+    test("names an install command that resolves the package, and carries no stack-trace shape", () => {
         const msg = noShallotTuiMessage();
-        expect(msg).toContain("bun add @dylanebert/shallot-tui");
+        expect(msg).toContain("bun install");
+        expect(msg).toContain("link the workspace package");
+        expect(msg).not.toContain("bun add @dylanebert/shallot-tui");
         expect(msg).not.toMatch(/\bat \S+\(.*:\d+:\d+\)/); // a "    at fn (file:line:col)" stack frame
         expect(msg).not.toContain("Cannot find module");
     });

--- a/packages/shallot/bin/tui.ts
+++ b/packages/shallot/bin/tui.ts
@@ -244,19 +244,26 @@ export async function importBunWebgpu(
 
 export const EXIT_NO_SHALLOT_TUI = 4; // @dylanebert/shallot-tui isn't installed (optionalDependencies)
 
-const INSTALL_SHALLOT_TUI = "bun add @dylanebert/shallot-tui";
+const INSTALL_SHALLOT_TUI = "bun install";
 
-/** the refusal diagnostic for a missing `@dylanebert/shallot-tui` — names the install command, never a
- *  stack trace, the same shape {@link noBunWebgpuMessage} uses. `@dylanebert/shallot-tui` is an
+/** the refusal diagnostic for a missing `@dylanebert/shallot-tui` — names an install command that works,
+ *  never a stack trace, the same shape {@link noBunWebgpuMessage} uses. `@dylanebert/shallot-tui` is an
  *  `optionalDependencies` entry on `@dylanebert/shallot` (`packages/shallot/package.json`), not a hard
  *  dependency: a real registry install tolerates it failing (unpublished, platform mismatch, `--omit=
  *  optional`), which is exactly the case this message exists to name instead of a raw module-resolution
- *  crash. */
+ *  crash. `@dylanebert/shallot-tui` isn't published to npm — this unit authors the package and its
+ *  release metadata but does not publish (`specs/shallot-tui.md`'s Out of scope) — so `bun add
+ *  @dylanebert/shallot-tui` 404s against the registry rather than fixing anything; the reader this
+ *  message can actually help today is a developer inside the shallot repo, where the package already
+ *  exists as a workspace member (`packages/shallot-tui`), and running {@link INSTALL_SHALLOT_TUI} from
+ *  the repo root links it (verified: `bun install` there resolves `node_modules/@dylanebert/shallot-tui`
+ *  to a symlink onto `packages/shallot-tui`). */
 export function noShallotTuiMessage(): string {
     return (
         `shallot tui needs @dylanebert/shallot-tui to encode the cell grid, but it isn't installed. ` +
-        `Install it: ${INSTALL_SHALLOT_TUI} (not published yet; this command 404s on the public ` +
-        `registry until a shallot-tui release ships)`
+        `It isn't published to the public npm registry yet, so \`bun add\` 404s against it — inside ` +
+        `the shallot repo, run \`${INSTALL_SHALLOT_TUI}\` from its root to link the workspace package ` +
+        `instead.`
     );
 }
 

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -354,10 +354,15 @@ function createShallotFlow(work: string, engineTgz: string, tuiTgz: string) {
         stderr: "pipe",
     });
     const noShallotTuiOut = `${noShallotTui.stdout.toString()}\n${noShallotTui.stderr.toString()}`;
+    // The prescribed command is `bun install` (an in-repo dev's fix — `bin/tui.ts`'s `noShallotTuiMessage`
+    // docblock has the verified reasoning), never `bun add @dylanebert/shallot-tui` — that 404s against
+    // the public registry, this scaffold's own `proj` included, since the package isn't published.
     check(
         "shallot tui exits with an install remedy when @dylanebert/shallot-tui is absent, not a stack trace",
         noShallotTui.exitCode === 4 &&
-            /bun add @dylanebert\/shallot-tui/.test(noShallotTuiOut) &&
+            /bun install/.test(noShallotTuiOut) &&
+            /link the workspace package/.test(noShallotTuiOut) &&
+            !/bun add @dylanebert\/shallot-tui/.test(noShallotTuiOut) &&
             !/Cannot find module/.test(noShallotTuiOut),
         `exit ${noShallotTui.exitCode}`,
     );


### PR DESCRIPTION
## Problem
Three findings from the shallot-tui close-stage architectural review, each a claim-outrunning-fixture defect:
1. `examples/gym/src/scenarios/cells.ts`'s item-2 comment named `M`, `Q`, `@`, `W` as glyphs the SDF-generation pass renders as exactly zero ink, contradicting a measured reading elsewhere in the same file.
2. `examples/showcase/ascii/test/pixel-probe.playwright.ts` used `waitForTimeout(1000)`, forbidden by `coding.md`.
3. `packages/shallot/bin/tui.ts`'s remedy for a missing `@dylanebert/shallot-tui` prescribed `bun add @dylanebert/shallot-tui`, which 404s (the package isn't published).

## Cause
1. The glyph list was measured against the retired 91-glyph undilated ramp and never re-measured after the ramp shrank to 87 and dilation was removed.
2. A fixed sleep stood in for a real readiness signal because the project ships no `window.__harness` hook.
3. The remedy assumed `bun add` would resolve the package, but it isn't declared `workspace:*` in `packages/shallot`, so `bun add` hits the public registry and 404s even run from inside the repo.

## Fix
1. Repaired the comment to state only what's measured: the named list belonged to the retired ramp, the current ramp's affected set is unmeasured, and the index-71 dip is the reading that stands. Verified `W` (index 86, current densest glyph) reads ~10.9% ink via `bun bench --scenario cells`.
2. Replaced the sleep with `expect.poll` over `canvas.screenshot()` (the same working idiom `roads/test/touch-smoke.playwright.ts` already uses for this exact problem) after measuring that in-page `drawImage`/`getImageData` reads all-zero on this WebGPU canvas (no `COPY_SRC` usage). Proved non-vacuous: poll attempt 1 reads 0 matching pixels, attempt 2 reads 4318 and passes.
3. Changed the remedy to prescribe `bun install` from the shallot repo root (verified: resolves `node_modules/@dylanebert/shallot-tui` to a symlink onto `packages/shallot-tui`), and updated both oracles (`bin/tui.test.ts`, `scripts/install-test.ts`) to assert the new command is present and the broken one is absent.

## Evidence
- `bun run format` — clean, no diff
- `bun check` — exit 0
- `bun run test` — 3129 pass / 0 fail (re-run after one unrelated per-file-cap load flake on `plugin.test.ts`, which passed clean in isolation)
- `bun run test:tui-probes` — 3 pass / 0 fail
- `bunx playwright test test/pixel-probe.playwright.ts` (ascii showcase) — 1 passed
- `bun run test:install` — real-subprocess install flow, all checks pass including the updated shallot-tui-absence remedy check
- `bun bench --scenario cells` — all 9 checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Me3TAv82oS1QZZSB4ykXJe
