### PR TITLE
agentic-engineering: prepare Shallot 0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Newest first. **Breaking:** marks a change that needs consumer action; [`packages/shallot/MIGRATION.md`](packages/shallot/MIGRATION.md) is the 0.8→0.9 port. Versions follow [semver](https://semver.org).
 
-## Unreleased — next minor
+## 0.10.0 — 2026-09-03
 
 - **animation (fix)** — `Animator.clip` interns the authored clip name independently of `Playables` registration, so a scene round-trips its `clip:` with no plugin initialized. Before, the scene formatter (`bun run format`) normalized every animator with no playable registered, the id formatted back to "" and the attribute vanished — which is how the visualization showcase's animation and text scenes and the `animate-with-clips` recipe all shipped animators with no `clip:`, parked on a green gate. An animator whose clip resolves to nothing now warns once at its first step (`names no clip`, or `clip "x" is not registered`), both forms `shallot verify` promotes to errors; the scenes name their clips again, the recipe carries a motion smoke, and the showcase gate asserts the animated demos' frames actually change.
 - **format** — `bun run format` / `--check` refuses to write a scene when normalizing an attribute would drop one of its keys, naming the file, attribute and key, instead of silently deleting authored state.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Five demos are built and served at [dylanebert.com/shallot](https://dylanebert.c
 
 | demo | play | code |
 |---|---|---|
-| Collapse | [play](https://dylanebert.com/shallot/collapse/) | [code](https://github.com/dylanebert/shallot/tree/v0.9.5/examples/showcase/collapse) |
-| Roads | [play](https://dylanebert.com/shallot/roads/) | [code](https://github.com/dylanebert/shallot/tree/v0.9.5/examples/showcase/roads) |
-| Sandbox | [play](https://dylanebert.com/shallot/sandbox/) | [code](https://github.com/dylanebert/shallot/tree/v0.9.5/examples/showcase/sandbox) |
-| Visualization | [play](https://dylanebert.com/shallot/visualization/) | [code](https://github.com/dylanebert/shallot/tree/v0.9.5/examples/showcase/visualization) |
-| Voxel | [play](https://dylanebert.com/shallot/voxel/) | [code](https://github.com/dylanebert/shallot/tree/v0.9.5/examples/showcase/voxel) |
+| Collapse | [play](https://dylanebert.com/shallot/collapse/) | [code](https://github.com/dylanebert/shallot/tree/v0.10.0/examples/showcase/collapse) |
+| Roads | [play](https://dylanebert.com/shallot/roads/) | [code](https://github.com/dylanebert/shallot/tree/v0.10.0/examples/showcase/roads) |
+| Sandbox | [play](https://dylanebert.com/shallot/sandbox/) | [code](https://github.com/dylanebert/shallot/tree/v0.10.0/examples/showcase/sandbox) |
+| Visualization | [play](https://dylanebert.com/shallot/visualization/) | [code](https://github.com/dylanebert/shallot/tree/v0.10.0/examples/showcase/visualization) |
+| Voxel | [play](https://dylanebert.com/shallot/voxel/) | [code](https://github.com/dylanebert/shallot/tree/v0.10.0/examples/showcase/voxel) |
 
 ## quick start
 

--- a/bun.lock
+++ b/bun.lock
@@ -344,12 +344,12 @@
     },
     "packages/create-shallot": {
       "name": "create-shallot",
-      "version": "0.9.5",
+      "version": "0.10.0",
       "bin": "./index.ts",
     },
     "packages/shallot": {
       "name": "@dylanebert/shallot",
-      "version": "0.9.5",
+      "version": "0.10.0",
       "bin": {
         "shallot": "./bin/cli.ts",
       },

--- a/packages/create-shallot/package.json
+++ b/packages/create-shallot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-shallot",
-    "version": "0.9.5",
+    "version": "0.10.0",
     "type": "module",
     "bin": "./index.ts",
     "files": ["index.ts"],

--- a/packages/shallot/package.json
+++ b/packages/shallot/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dylanebert/shallot",
-    "version": "0.9.5",
+    "version": "0.10.0",
     "description": "WebGPU game engine. Procedural-first, ECS, declarative scenes. In development.",
     "sideEffects": [
         "./src/standard/index.ts",

--- a/packages/shallot/rust/audio/Cargo.toml
+++ b/packages/shallot/rust/audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shallot-audio"
-version = "0.9.5"
+version = "0.10.0"
 edition = "2021"
 
 [lib]

--- a/packages/shallot/rust/window/Cargo.lock
+++ b/packages/shallot/rust/window/Cargo.lock
@@ -2909,7 +2909,7 @@ dependencies = [
 
 [[package]]
 name = "shallot-window"
-version = "0.9.5"
+version = "0.10.0"
 dependencies = [
  "cef",
  "image",

--- a/packages/shallot/rust/window/Cargo.toml
+++ b/packages/shallot/rust/window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shallot-window"
-version = "0.9.5"
+version = "0.10.0"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Prepare the 0.10.0 release across package, Rust, lockfile, changelog, and README version surfaces. No registry publication.