### PR TITLE
shallot-strip-back: restore standalone checks and ASCII gate

### DIFF
--- a/examples/gym/src/scenarios/budgets.ts
+++ b/examples/gym/src/scenarios/budgets.ts
@@ -82,13 +82,12 @@ export const SCENARIO_BUDGETS: Record<string, AxisBudget> = {
     "bodies-motion-locks": { pipelines: 30, pipelineCalls: 30, gpuBytes: 13_516_692 },
     "bodies-spinning-book": { pipelines: 30, pipelineCalls: 30, gpuBytes: 13_517_860 },
     // measured 2026-09-01, `--scenario cells` (WSL/NVIDIA bridge, lovelace), re-measured the same day
-    // after S3r item 2's ramp-monotonicity arm landed (`specs/shallot-tui.md`'s s3r item 2 — the owed
+    // after S3r item 2's ramp-monotonicity arm landed (the owed
     // regression guard driving `draw.ts`'s real pipeline against a real font atlas, not the synthetic
     // solid atlas the draw differential below uses), again after the s3r item-8 background-detection
     // repair, which grew `SelectParams` (`select.ts`) by one `bg: vec4f` reference (16 B), and again after
     // criterion 9's arm (`assertFrameIsGrid`, `FramePlugin` below `MonoPlugin` in this file) — the two-
-    // sided proof that `drawCells` replaces a target's prior contents rather than compositing over them
-    // (`specs/shallot-tui.md`'s s3r item 9). Nine compute/render pipelines: `cells-fill` (S1's synthetic
+    // sided proof that `drawCells` replaces a target's prior contents rather than compositing over them. Nine compute/render pipelines: `cells-fill` (S1's synthetic
     // producer), `cells-avg` + `cells-select` (S3's two-pass real content producer), `cells-draw` (the
     // draw differential's real render pipeline, shared by the mono-ramp arm and criterion 9's own
     // `FramePlugin` draw — reused under the same label three times over, which is why `pipelineCalls` (11)
@@ -120,7 +119,7 @@ export const SCENARIO_BUDGETS: Record<string, AxisBudget> = {
     // `cells-gym-frame-out` 8 (two 4 B atomic-u32 counters sharing that label) = 4_472_008, matching
     // `gpuBytes` below exactly.
     //
-    // Re-measured 2026-09-01, same day, after the s3r fill-treatment amendment (`specs/shallot-tui.md`):
+    // Re-measured 2026-09-01, same day, after the s3r fill-treatment amendment:
     // rule 2's curated curved-glyph exclusion (`ramp.ts`'s `CELL_FILL_EXCLUDED_GLYPHS`) shrinks
     // `CELL_FILL_GLYPHS` from 91 to 87 and `MONO_GLYPH_COUNT` (this file, `= CELL_FILL_GLYPHS.length`)
     // with it, moving five labels that scale off the fill-ramp length: `cells-grid` (-48 B, `MonoPlugin`'s
@@ -131,8 +130,7 @@ export const SCENARIO_BUDGETS: Record<string, AxisBudget> = {
     // now-retired `INK_DILATE_FRACTION` changed gpu *behavior*, not any allocation size, so neither moved
     // this row at that measurement. Two independent same-day confirming runs agreed exactly on `gpuBytes`.
     //
-    // Re-measured 2026-09-02, after the fill-treatment amendment's s3r review repair
-    // (`specs/shallot-tui.md`): `draw.ts`'s `INK_DILATE_FRACTION` is deleted outright (a behavior-only
+    // Re-measured 2026-09-02, after the fill-treatment amendment's s3r review repair: `draw.ts`'s `INK_DILATE_FRACTION` is deleted outright (a behavior-only
     // change, so it still moves nothing on its own) and the facade-ink measurement (rule 3) moves off the
     // old per-glyph-average sweep onto a real per-pixel device readback — `examples/gym/src/scenarios/
     // cells.ts`'s new `FacadePlugin`, added to this scenario's plugin list between `MonoPlugin` and

--- a/examples/gym/src/scenarios/cells.ts
+++ b/examples/gym/src/scenarios/cells.ts
@@ -658,8 +658,7 @@ async function assertDrawDispatch(): Promise<Check> {
 // S3r item 2's owed arm: render every coverage-ordered fill glyph through `draw.ts`'s own real pipeline
 // (not the synthetic solid atlas `DrawPlugin` above uses for its fg/bg-only check) and assert the
 // *rendered* ink rises with the ramp's own measured-coverage order — the property `draw.ts`'s
-// `cellFootprintPx`/`glyphFootprintT` fix exists to preserve at the point of use (`specs/shallot-tui.md`'s s3r item 2,
-// "the coverage-ordered ramp whose rendered order does not match its measured order is the defect class
+// `cellFootprintPx`/`glyphFootprintT` fix exists to preserve at the point of use ("the coverage-ordered ramp whose rendered order does not match its measured order is the defect class
 // here"). One cell per fill glyph, `CELL_FILL_GLYPHS[i]`'s glyph index `i` — `ramp.ts`'s own contract
 // keeps that array sorted ascending by measured coverage, so "monotone in the same direction as
 // RAMP_TABLE's measured coverage" reduces to "rendered ink at cell `i` rises with `i`".
@@ -1069,7 +1068,7 @@ const FacadePlugin: Plugin = {
     },
 };
 
-// rule 3's own real-device arm (`specs/shallot-tui.md`'s fill-treatment amendment: "facade ink is low…
+// rule 3's own real-device arm ("facade ink is low…
 // the target is the number"), reworked after criterion 8's round-1 rejection. The prior version averaged
 // `assertMonoRamp`'s per-glyph readback (a continuous per-glyph coverage fraction) over the whole fill
 // ramp's own `[0, 1]` luma domain — not a facade (a facade never selects the ramp's blank or densest

--- a/examples/gym/test/touch.playwright.ts
+++ b/examples/gym/test/touch.playwright.ts
@@ -178,8 +178,8 @@ test("orbit touch gate — pinch/drag/pan isolation, 2→1 finger transition (re
     ).toBeGreaterThan(MoveEps);
 
     // the survivor's one-finger rotate lands a few animation frames after the drag helper's own last
-    // dispatch — poll the observable (yaw's own delta from before4) rather than a fixed sleep (kex
-    // coding.md Testing → Forbidden: no waitForTimeout). A frozen handoff (the pre-fix defect) never
+    // dispatch — poll the observable (yaw's own delta from before4) rather than a fixed sleep.
+    // A frozen handoff (the pre-fix defect) never
     // clears this poll and times out rather than silently reading a stale pose.
     await expect
         .poll(async () => Math.abs((await readPose(page)).yaw - before4.yaw), {

--- a/examples/showcase/ascii/test/pixel-probe.playwright.ts
+++ b/examples/showcase/ascii/test/pixel-probe.playwright.ts
@@ -1,77 +1,335 @@
+import { createHash } from "node:crypto";
+import { readFileSync, realpathSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as harness from "@dylanebert/shallot/harness";
 import { assertMotion, isDegradedBootMessage } from "@dylanebert/shallot/harness";
 import { pixelProbePass, probePixels } from "@dylanebert/shallot/harness/pixels";
-import { expect, test } from "@playwright/test";
+import { expect, type Locator, type Page, test } from "@playwright/test";
 import { PNG } from "pngjs";
 import { adapterName, SOFTWARE } from "./gpu-adapter";
 
 const KNOWN_PREEXISTING_WARNING = /\[implicit-conversion\][\s\S]*struct:vertexVsOut/;
+const EXCLUDE_DOM =
+    "body * { visibility: hidden !important; } canvas { visibility: visible !important; }";
+const PARKED = /^samples are parked \(mean absolute difference [\d.]+, need > 0\.1\)$/;
+const SWATCH_MESSAGE = "the composited cell grid should contain the cube swatch";
+const swatch = {
+    name: "glyph-colored cube reaches the compositor",
+    minPixels: 500,
+    minSpan: 40,
+    r: [70, 255] as [number, number],
+    g: [30, 230] as [number, number],
+    b: [5, 190] as [number, number],
+};
+const hash = (bytes: Uint8Array) => createHash("sha256").update(bytes).digest("hex");
+const bindings = Object.fromEntries(
+    [
+        "@dylanebert/shallot/harness",
+        "@dylanebert/shallot/harness/pixels",
+        "./gpu-adapter.ts",
+        "@playwright/test",
+    ].map((id) => {
+        const path = realpathSync(fileURLToPath(import.meta.resolve(id)));
+        return [id, { path, sha256: hash(readFileSync(path)) }];
+    }),
+);
+const readerPath = realpathSync(fileURLToPath(import.meta.url));
+const barrelPath = realpathSync(fileURLToPath(import.meta.resolve("@dylanebert/shallot/harness")));
+const motionPath = realpathSync(join(dirname(barrelPath), "motion.ts"));
+const barrelSource = readFileSync(barrelPath, "utf8");
+expect(barrelSource.match(/export \{ assertMotion \} from "\.\/motion";/g)).toHaveLength(1);
+expect(harness.assertMotion).toBe(assertMotion);
 
-// Criterion 5: the Cells system publishes a non-empty grid on the canvas and the compositor presents
-// the cube's glyph-colored pixels. The two signals are independent: metadata alone cannot prove a
-// framebuffer reached presentation, while the warm swatch alone is also available from an uncelled cube.
-test("ascii showcase — the cell grid reaches the compositor", async ({ page }) => {
-    const errors: string[] = [];
-    const warnings: string[] = [];
-    page.on("pageerror", (error) => errors.push(String(error)));
-    page.on("console", (message) => {
-        if (message.type() === "error" || isDegradedBootMessage(message.text())) {
-            errors.push(`[console.${message.type()}] ${message.text()}`);
+async function gesture(page: Page, canvas: Locator) {
+    const box = await canvas.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) throw new Error("missing gesture canvas");
+    const x = box.x + box.width * 0.4;
+    const y = box.y + box.height * 0.5;
+    await page.mouse.move(x, y);
+    await page.mouse.down();
+    try {
+        for (let move = 1; move <= 6; move++) {
+            await page.mouse.move(x + box.width * 0.03 * move, y + box.height * 0.01 * move);
         }
-        if (message.type() === "warning" && !KNOWN_PREEXISTING_WARNING.test(message.text())) {
-            warnings.push(`[console.warning] ${message.text()}`);
-        }
+    } finally {
+        await page.mouse.up();
+    }
+}
+
+// The compositor population includes the full canvas, but not overlaid DOM controls.
+test("ascii showcase — the cell grid reaches the compositor", async ({
+    browser,
+    baseURL,
+}, info) => {
+    const record = (kind: string, data: object) => {
+        console.log(
+            `ASCII_PROBE ${JSON.stringify({ utc: new Date().toISOString(), monoNs: process.hrtime.bigint().toString(), kind, ...data })}`,
+        );
+    };
+    record("identity", {
+        bindings,
+        reader: { path: readerPath, sha256: hash(readFileSync(readerPath)) },
+        motion: {
+            path: motionPath,
+            sha256: hash(readFileSync(motionPath)),
+            barrelPath: realpathSync(barrelPath),
+            export: "assertMotion",
+            callerIdentity: true,
+        },
+        node: process.version,
+        browser: browser.version(),
     });
-
-    await page.goto("/");
-    const adapter = await adapterName(page);
-    console.log(`ascii pixel-probe adapter: ${adapter || "none offered"}`);
-    test.skip(
-        adapter === "" || SOFTWARE.test(adapter),
-        `no real-GPU adapter (${adapter || "none offered"})`,
-    );
-
-    const canvas = page.locator("canvas").first();
-    await expect(canvas).toBeVisible();
-    await expect
-        .poll(() =>
-            canvas.evaluate((element) => {
+    for (const phase of ["positive", "locked", "absent"] as const) {
+        const context = await browser.newContext({ baseURL });
+        const errors: string[] = [];
+        const warnings: string[] = [];
+        let responses = 0;
+        let captures = 0;
+        record("phase-start", { phase });
+        try {
+            const page = await context.newPage();
+            page.on("pageerror", (error) => errors.push(String(error)));
+            page.on("console", (message) => {
+                if (message.type() === "error" || isDegradedBootMessage(message.text())) {
+                    errors.push(`[console.${message.type()}] ${message.text()}`);
+                }
+                if (
+                    message.type() === "warning" &&
+                    !KNOWN_PREEXISTING_WARNING.test(message.text())
+                ) {
+                    warnings.push(`[console.warning] ${message.text()}`);
+                }
+            });
+            if (phase !== "positive") {
+                await page.route("**/scenes/ascii.scene", async (route) => {
+                    responses++;
+                    expect(responses, `${phase} scene response count`).toBe(1);
+                    const response = await route.fetch();
+                    expect(response.ok()).toBe(true);
+                    const original = await response.body();
+                    const source = original.toString("utf8");
+                    const pattern =
+                        phase === "locked"
+                            ? /<a\b[^>]*\bid="camera"[^>]*\/>/g
+                            : /<a\b[^>]*\bid="box"[^>]*\/>/g;
+                    const targets = source.match(pattern) ?? [];
+                    expect(targets, `${phase} intended scene target`).toHaveLength(1);
+                    const target = targets[0];
+                    if (targets.length !== 1 || target === undefined)
+                        throw new Error("scene target is not unique");
+                    let replacement = "";
+                    if (phase === "locked") {
+                        const orbits = target.match(/\borbit="[^"]*"/g) ?? [];
+                        expect(orbits).toHaveLength(1);
+                        const orbit = orbits[0];
+                        if (orbits.length !== 1 || orbit === undefined)
+                            throw new Error("camera orbit is not unique");
+                        expect(orbit).not.toMatch(/\bmode\s*:/);
+                        replacement = target.replace(orbit, orbit.replace(/"$/, '; mode: 1"'));
+                    }
+                    const mutated = Buffer.from(source.replace(target, replacement));
+                    await info.attach(`${phase}-scene-original`, {
+                        body: original,
+                        contentType: "application/xml",
+                    });
+                    await info.attach(`${phase}-scene-mutated`, {
+                        body: mutated,
+                        contentType: "application/xml",
+                    });
+                    record("mutation", {
+                        phase,
+                        responses,
+                        targets: targets.length,
+                        originalBytes: original.length,
+                        mutatedBytes: mutated.length,
+                        originalSha256: hash(original),
+                        mutatedSha256: hash(mutated),
+                    });
+                    await route.fulfill({ response, body: mutated });
+                });
+            }
+            const sceneResponse = page.waitForResponse(
+                (response) => new URL(response.url()).pathname === "/scenes/ascii.scene",
+            );
+            await page.goto("/");
+            const served = await sceneResponse;
+            const servedBytes = await served.body();
+            await info.attach(`${phase}-scene-served`, {
+                body: servedBytes,
+                contentType: "application/xml",
+            });
+            record("served", {
+                phase,
+                url: served.url(),
+                sha256: hash(servedBytes),
+                bytes: servedBytes.length,
+            });
+            const adapter = await adapterName(page);
+            record("adapter", { phase, adapter });
+            test.skip(
+                adapter === "" || SOFTWARE.test(adapter),
+                `no real-GPU adapter (${adapter || "none offered"})`,
+            );
+            const canvas = page.locator("canvas").first();
+            await expect(canvas).toBeVisible();
+            await expect
+                .poll(() =>
+                    canvas.evaluate((element) => {
+                        const cells = element as HTMLCanvasElement & {
+                            cellCols?: number;
+                            cellRows?: number;
+                        };
+                        return (cells.cellCols ?? 0) * (cells.cellRows ?? 0);
+                    }),
+                )
+                .toBeGreaterThan(0);
+            const metadata = await canvas.evaluate((element) => {
                 const cells = element as HTMLCanvasElement & {
                     cellCols?: number;
                     cellRows?: number;
                 };
-                return (cells.cellCols ?? 0) * (cells.cellRows ?? 0);
-            }),
-        )
-        .toBeGreaterThan(0);
-
-    const swatch = {
-        name: "glyph-colored cube reaches the compositor",
-        minPixels: 500,
-        minSpan: 40,
-        r: [70, 255] as [number, number],
-        g: [30, 230] as [number, number],
-        b: [5, 190] as [number, number],
-    };
-    let result = { pixels: 0, width: 0, height: 0 };
-    await expect
-        .poll(
-            async () => {
-                const png = PNG.sync.read(await canvas.screenshot({ timeout: 5_000 }));
-                result = probePixels(png.data, png.width, png.height, swatch);
-                return pixelProbePass(result, swatch);
-            },
-            { message: "the composited cell grid should contain the cube swatch", timeout: 15_000 },
-        )
-        .toBe(true);
-
-    expect(
-        pixelProbePass(result, swatch),
-        `matched ${result.pixels} px, span ${result.width}x${result.height}`,
-    ).toBe(true);
-    const before = PNG.sync.read(await canvas.screenshot()).data;
-    await page.waitForTimeout(500);
-    const after = PNG.sync.read(await canvas.screenshot()).data;
-    assertMotion(before, after, 0.1);
-    expect(errors, `page errors: ${errors.join("\n")}`).toEqual([]);
-    expect(warnings, `page console warnings: ${warnings.join("\n")}`).toEqual([]);
+                return { cols: cells.cellCols, rows: cells.cellRows };
+            });
+            if (phase !== "positive") expect(responses).toBe(1);
+            const box = await canvas.boundingBox();
+            expect(box).not.toBeNull();
+            if (!box) throw new Error("missing phase canvas box");
+            record("ready", { phase, metadata, responses, box });
+            const panel = page
+                .getByRole("button", { name: "+", exact: true })
+                .first()
+                .locator("..")
+                .locator("..");
+            await expect(panel).toBeVisible();
+            const capture = async (name: string, exclude = true) => {
+                const beforeBox = await canvas.boundingBox();
+                expect(beforeBox).toEqual(box);
+                const visibility = await panel.evaluate(
+                    (element) => getComputedStyle(element).visibility,
+                );
+                const bytes = await canvas.screenshot({
+                    timeout: 5_000,
+                    style: exclude ? EXCLUDE_DOM : undefined,
+                });
+                const png = PNG.sync.read(bytes);
+                expect(png.width).toBeGreaterThan(0);
+                expect(png.height).toBeGreaterThan(0);
+                expect(png.data.length).toBe(png.width * png.height * 4);
+                expect(await canvas.boundingBox()).toEqual(box);
+                expect(
+                    await panel.evaluate((element) => getComputedStyle(element).visibility),
+                ).toBe(visibility);
+                await expect(panel).toBeVisible();
+                const id = `${phase}-${captures++}-${name}`;
+                await info.attach(`${id}.png`, { body: bytes, contentType: "image/png" });
+                await info.attach(`${id}.rgba`, {
+                    body: png.data,
+                    contentType: "application/octet-stream",
+                });
+                record("capture", {
+                    phase,
+                    id,
+                    exclude,
+                    width: png.width,
+                    height: png.height,
+                    count: png.data.length,
+                    box: beforeBox,
+                    visibility,
+                    pngSha256: hash(bytes),
+                    rgbaSha256: hash(png.data),
+                });
+                return png;
+            };
+            let result = { pixels: 0, width: 0, height: 0 };
+            let captureError: unknown;
+            const swatches = async () => {
+                await expect
+                    .poll(
+                        async () => {
+                            const png = await capture("swatch").catch((error: unknown) => {
+                                captureError = error;
+                                throw error;
+                            });
+                            result = probePixels(png.data, png.width, png.height, swatch);
+                            record("swatch", {
+                                phase,
+                                ...result,
+                                pass: pixelProbePass(result, swatch),
+                            });
+                            return pixelProbePass(result, swatch);
+                        },
+                        { message: SWATCH_MESSAGE, timeout: 15_000 },
+                    )
+                    .toBe(true);
+                expect(
+                    pixelProbePass(result, swatch),
+                    `matched ${result.pixels} px, span ${result.width}x${result.height}`,
+                ).toBe(true);
+            };
+            if (phase === "absent") {
+                await expect(
+                    swatches(),
+                    "absent cube must reject at the swatch consumer",
+                ).rejects.toThrow(SWATCH_MESSAGE);
+                expect(
+                    captureError,
+                    "absent control must not consume a capture error",
+                ).toBeUndefined();
+                expect(captures).toBeGreaterThan(0);
+                expect(pixelProbePass(result, swatch)).toBe(false);
+                record("absent-rejected", { phase, ...result });
+            } else {
+                await swatches();
+                const rawBefore = phase === "locked" ? await capture("raw-before", false) : null;
+                const before = await capture("before");
+                if (phase === "positive") {
+                    await gesture(page, canvas);
+                } else {
+                    await gesture(page, canvas);
+                    await panel.evaluate((element) => {
+                        (element as HTMLElement).style.backgroundColor = "rgb(255, 255, 255)";
+                    });
+                }
+                await page.waitForTimeout(500);
+                const after = await capture("after");
+                const motion = (first: PNG, second: PNG, population: string) => {
+                    expect([second.width, second.height]).toEqual([first.width, first.height]);
+                    expect(second.data.length).toBe(first.data.length);
+                    let sum = 0;
+                    for (let i = 0; i < first.data.length; i++)
+                        sum += Math.abs(first.data[i] - second.data[i]);
+                    record("motion", {
+                        phase,
+                        population,
+                        sum,
+                        count: first.data.length,
+                        mean: sum / first.data.length,
+                    });
+                    return () => assertMotion(first.data, second.data, 0.1);
+                };
+                if (phase === "positive") {
+                    motion(before, after, "excluded")();
+                } else {
+                    expect(rawBefore).not.toBeNull();
+                    if (!rawBefore) throw new Error("missing DOM foil capture");
+                    const rawAfter = await capture("raw-after", false);
+                    motion(rawBefore, rawAfter, "raw")();
+                    expect(
+                        motion(before, after, "excluded"),
+                        "locked camera must reject as parked",
+                    ).toThrow(PARKED);
+                    record("locked-rejected", { phase });
+                }
+            }
+            expect(errors, `page errors: ${errors.join("\n")}`).toEqual([]);
+            expect(warnings, `page console warnings: ${warnings.join("\n")}`).toEqual([]);
+            if (phase !== "positive") expect(responses).toBe(1);
+            record("phase-pass", { phase, responses, captures });
+        } finally {
+            await context.close();
+            record("phase-closed", { phase, responses, captures, errors, warnings });
+        }
+    }
 });

--- a/examples/showcase/ascii/test/pixel-probe.playwright.ts
+++ b/examples/showcase/ascii/test/pixel-probe.playwright.ts
@@ -1,11 +1,12 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { readFileSync, realpathSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import * as harness from "@dylanebert/shallot/harness";
 import { assertMotion, isDegradedBootMessage } from "@dylanebert/shallot/harness";
 import { pixelProbePass, probePixels } from "@dylanebert/shallot/harness/pixels";
-import { expect, type Locator, type Page, test } from "@playwright/test";
+import { expect, type Locator, type Page, type TestInfo, test } from "@playwright/test";
 import { PNG } from "pngjs";
 import { adapterName, SOFTWARE } from "./gpu-adapter";
 
@@ -40,6 +41,84 @@ const motionPath = realpathSync(join(dirname(barrelPath), "motion.ts"));
 const barrelSource = readFileSync(barrelPath, "utf8");
 expect(barrelSource.match(/export \{ assertMotion \} from "\.\/motion";/g)).toHaveLength(1);
 expect(harness.assertMotion).toBe(assertMotion);
+
+/** Persist full bytes independently of the reporter, then attach the physical file. */
+export async function retain(info: TestInfo, name: string, bytes: Uint8Array, contentType: string) {
+    const path = info.outputPath(`${randomUUID()}-${name}`);
+    await writeFile(path, bytes, { flag: "wx" });
+    await info.attach(name, { path, contentType });
+    const attachmentPath = info.attachments.at(-1)?.path;
+    if (!attachmentPath || attachmentPath === path) throw new Error("missing attachment copy");
+    return { name, path, attachmentPath, bytes: bytes.length, sha256: hash(bytes), contentType };
+}
+
+/** The shared synchronous swatch consumer, after sampling has succeeded. */
+export function assertSwatch(result: ReturnType<typeof probePixels>) {
+    expect(pixelProbePass(result, swatch), SWATCH_MESSAGE).toBe(true);
+}
+
+/** Measure the full compositor population with the same inclusive color bands. */
+export function measureSwatch(png: PNG) {
+    return probePixels(png.data, png.width, png.height, swatch);
+}
+
+/** Keep positive readiness tolerant of initial blank frames. */
+export async function pollSwatch(sample: () => Promise<boolean>) {
+    await expect.poll(sample, { message: SWATCH_MESSAGE, timeout: 15_000 }).toBe(true);
+}
+
+/** Consume only the synchronous swatch refusal, never a capture or readiness failure. */
+export function rejectAbsent(result: ReturnType<typeof probePixels>) {
+    expect(() => assertSwatch(result), "absent cube must reject at the swatch consumer").toThrow(
+        SWATCH_MESSAGE,
+    );
+}
+
+/** Fence the existing canvas queue and allow paint before an absent sample. */
+export async function painted(element: Element) {
+    const cells = element as HTMLCanvasElement & { cellCols?: number; cellRows?: number };
+    const order = ["metadata"];
+    if (!((cells.cellCols ?? 0) * (cells.cellRows ?? 0) > 0))
+        throw new Error("missing cell metadata before fence");
+    const context = cells.getContext("webgpu");
+    if (!context || context.canvas !== cells || typeof context.getConfiguration !== "function")
+        throw new Error("missing existing canvas configuration API");
+    const configuration = context.getConfiguration();
+    const queue = configuration?.device?.queue;
+    if (!queue || typeof queue.onSubmittedWorkDone !== "function")
+        throw new Error("missing configured canvas queue");
+    order.push("configured");
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let frame = 0;
+    try {
+        await Promise.race([
+            (async () => {
+                order.push("fence-start");
+                await queue.onSubmittedWorkDone();
+                order.push("fence-done");
+                await new Promise<void>((resolve) => {
+                    frame = requestAnimationFrame(() => {
+                        order.push("raf-1");
+                        frame = requestAnimationFrame(() => {
+                            order.push("raf-2");
+                            resolve();
+                        });
+                    });
+                });
+            })(),
+            new Promise<never>((_, reject) => {
+                timer = setTimeout(
+                    () => reject(new Error("canvas paint readiness timeout")),
+                    5_000,
+                );
+            }),
+        ]);
+        return order;
+    } finally {
+        clearTimeout(timer);
+        cancelAnimationFrame(frame);
+    }
+}
 
 async function gesture(page: Page, canvas: Locator) {
     const box = await canvas.boundingBox();
@@ -88,6 +167,9 @@ test("ascii showcase — the cell grid reaches the compositor", async ({
         let responses = 0;
         let captures = 0;
         record("phase-start", { phase });
+        const persist = async (name: string, bytes: Uint8Array, contentType: string) => {
+            record("artifact", { phase, ...(await retain(info, name, bytes, contentType)) });
+        };
         try {
             const page = await context.newPage();
             page.on("pageerror", (error) => errors.push(String(error)));
@@ -130,14 +212,8 @@ test("ascii showcase — the cell grid reaches the compositor", async ({
                         replacement = target.replace(orbit, orbit.replace(/"$/, '; mode: 1"'));
                     }
                     const mutated = Buffer.from(source.replace(target, replacement));
-                    await info.attach(`${phase}-scene-original`, {
-                        body: original,
-                        contentType: "application/xml",
-                    });
-                    await info.attach(`${phase}-scene-mutated`, {
-                        body: mutated,
-                        contentType: "application/xml",
-                    });
+                    await persist(`${phase}-scene-original`, original, "application/xml");
+                    await persist(`${phase}-scene-mutated`, mutated, "application/xml");
                     record("mutation", {
                         phase,
                         responses,
@@ -156,10 +232,7 @@ test("ascii showcase — the cell grid reaches the compositor", async ({
             await page.goto("/");
             const served = await sceneResponse;
             const servedBytes = await served.body();
-            await info.attach(`${phase}-scene-served`, {
-                body: servedBytes,
-                contentType: "application/xml",
-            });
+            await persist(`${phase}-scene-served`, servedBytes, "application/xml");
             record("served", {
                 phase,
                 url: served.url(),
@@ -204,6 +277,7 @@ test("ascii showcase — the cell grid reaches the compositor", async ({
                 .locator("..");
             await expect(panel).toBeVisible();
             const capture = async (name: string, exclude = true) => {
+                const started = performance.now();
                 const beforeBox = await canvas.boundingBox();
                 expect(beforeBox).toEqual(box);
                 const visibility = await panel.evaluate(
@@ -223,11 +297,8 @@ test("ascii showcase — the cell grid reaches the compositor", async ({
                 ).toBe(visibility);
                 await expect(panel).toBeVisible();
                 const id = `${phase}-${captures++}-${name}`;
-                await info.attach(`${id}.png`, { body: bytes, contentType: "image/png" });
-                await info.attach(`${id}.rgba`, {
-                    body: png.data,
-                    contentType: "application/octet-stream",
-                });
+                await persist(`${id}.png`, bytes, "image/png");
+                await persist(`${id}.rgba`, png.data, "application/octet-stream");
                 record("capture", {
                     phase,
                     id,
@@ -239,49 +310,45 @@ test("ascii showcase — the cell grid reaches the compositor", async ({
                     visibility,
                     pngSha256: hash(bytes),
                     rgbaSha256: hash(png.data),
+                    durationMs: performance.now() - started,
                 });
                 return png;
             };
             let result = { pixels: 0, width: 0, height: 0 };
-            let captureError: unknown;
-            const swatches = async () => {
-                await expect
-                    .poll(
-                        async () => {
-                            const png = await capture("swatch").catch((error: unknown) => {
-                                captureError = error;
-                                throw error;
-                            });
-                            result = probePixels(png.data, png.width, png.height, swatch);
-                            record("swatch", {
-                                phase,
-                                ...result,
-                                pass: pixelProbePass(result, swatch),
-                            });
-                            return pixelProbePass(result, swatch);
-                        },
-                        { message: SWATCH_MESSAGE, timeout: 15_000 },
-                    )
-                    .toBe(true);
-                expect(
-                    pixelProbePass(result, swatch),
-                    `matched ${result.pixels} px, span ${result.width}x${result.height}`,
-                ).toBe(true);
+            const sample = async () => {
+                result = measureSwatch(await capture("swatch"));
+                record("swatch", { phase, ...result, pass: pixelProbePass(result, swatch) });
+                return pixelProbePass(result, swatch);
             };
             if (phase === "absent") {
-                await expect(
-                    swatches(),
-                    "absent cube must reject at the swatch consumer",
-                ).rejects.toThrow(SWATCH_MESSAGE);
-                expect(
-                    captureError,
-                    "absent control must not consume a capture error",
-                ).toBeUndefined();
-                expect(captures).toBeGreaterThan(0);
-                expect(pixelProbePass(result, swatch)).toBe(false);
+                const order = await canvas.evaluate(painted);
+                expect(order).toEqual([
+                    "metadata",
+                    "configured",
+                    "fence-start",
+                    "fence-done",
+                    "raf-1",
+                    "raf-2",
+                ]);
+                const rechecked = await canvas.evaluate((element) => {
+                    const cells = element as HTMLCanvasElement & {
+                        cellCols?: number;
+                        cellRows?: number;
+                    };
+                    return { cols: cells.cellCols, rows: cells.cellRows };
+                });
+                expect(rechecked).toEqual(metadata);
+                expect(await canvas.boundingBox()).toEqual(box);
+                expect(errors).toEqual([]);
+                expect(warnings).toEqual([]);
+                record("painted", { phase, order, metadata: rechecked, box });
+                await sample();
+                rejectAbsent(result);
+                expect(captures).toBe(1);
                 record("absent-rejected", { phase, ...result });
             } else {
-                await swatches();
+                await pollSwatch(sample);
+                assertSwatch(result);
                 const rawBefore = phase === "locked" ? await capture("raw-before", false) : null;
                 const before = await capture("before");
                 if (phase === "positive") {

--- a/examples/showcase/ocean/src/ocean/gpu-fft.ts
+++ b/examples/showcase/ocean/src/ocean/gpu-fft.ts
@@ -39,8 +39,7 @@ function isPow2(n: number): boolean {
  * expression `makeRowFftKernel`/`makeColFftKernel` evaluate at every stage, every frame. Exported
  * so a CPU-side measurement of the device's own trig accuracy (`measureTwiddleTrigError`, below)
  * drives the real kernel through this one shared formula rather than a hand-copied second
- * version that could silently drift from what the WGSL actually emits (`checks.md`'s "two things
- * one author wrote from one document" class). Calling this directly from JS still round-trips
+ * version that could silently drift from what the WGSL actually emits. Calling this directly from JS still round-trips
  * through typegpu's `d.f32` return-type cast, so it is an f32-ROUNDED value, not a device
  * measurement — see that function's own docblock for why a real GPU dispatch is still required.
  */

--- a/examples/showcase/ocean/test/mesh-inversion-sweep.oracle.ts
+++ b/examples/showcase/ocean/test/mesh-inversion-sweep.oracle.ts
@@ -53,8 +53,7 @@
 // Rings 1-4 (leg a) stay population-only, on purpose: coarsening past the Nyquist bound is EXPECTED
 // to under-count folds (a fold that fits between two widely-spaced vertices cannot invert a triangle
 // there), so a coarser ring's flip fraction has no reason to track any reference rate and asserting
-// it as if it should would defend the wrong claim (`checks.md`'s "pins the status quo at a position
-// nobody has questioned").
+// it as if it should would defend the wrong claim.
 //
 // I3m-r correction round (2026-09-01): leg (b)'s ring-0 flip fraction used to be ASSERTED
 // non-increasing across the three near-spacing legs. The consult ruled that ordering claim wrong too

--- a/examples/showcase/ocean/test/wrap-catmullrom-lockstep.test.ts
+++ b/examples/showcase/ocean/test/wrap-catmullrom-lockstep.test.ts
@@ -42,7 +42,7 @@ describe("wrapIndex vs reconstruction.ts's wrap — same formula, called directl
 
 describe("vertex-displacement.ts's catmullRom1D vs reconstruction.ts's — same formula, per channel", () => {
     // a position-encoded fixture: every source texel and channel a distinct value, so a swapped tap
-    // or dropped channel is visible (`checks.md`'s own recorded shape for this class of arm).
+    // or dropped channel is visible.
     const p0 = [1.1, 2.2, 3.3, 4.4];
     const p1 = [5.5, 6.6, 7.7, 8.8];
     const p2 = [9.9, 10.1, 11.2, 12.3];

--- a/examples/showcase/roads/src/corridorPose.test.ts
+++ b/examples/showcase/roads/src/corridorPose.test.ts
@@ -14,8 +14,7 @@
 // independently re-derives cutDepth from the real network geometry (buildNetworkGeometry) and
 // computes the projected extents from that independent cutDepth plus the fixed-literal pose. So a
 // future stage that moves cutDepth reds this arm — the pose does not auto-adjust, which is the
-// whole point (per checks.md's "re-derives its own rule" and Residue: "re-run that arithmetic
-// whenever any earlier stage moves the subject's magnitude").
+// whole point.
 
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";

--- a/examples/showcase/roads/src/corridorPose.ts
+++ b/examples/showcase/roads/src/corridorPose.ts
@@ -21,8 +21,7 @@
 // import this module under plain `bun test` and independently verify the budget by computing cutDepth
 // from the real network geometry. A future stage that moves cutDepth reds the arm because the
 // fixed-literal pose does not satisfy the budget at the new cutDepth — the pose does not
-// auto-adjust, which is the whole point (per checks.md's "re-derives its own rule" and this unit's
-// Residue: "re-run that arithmetic whenever any earlier stage moves the subject's magnitude").
+// auto-adjust, which is the whole point.
 
 // ─── Scene constants (Playwright defaults and camera defaults — see sourcing arm) ─────────────
 //

--- a/examples/showcase/roads/src/dragCorpus.ts
+++ b/examples/showcase/roads/src/dragCorpus.ts
@@ -1,7 +1,5 @@
 // The frozen drag fixture the corridor-flatness scan runs over, shared by exactly two readers so the
-// default suite and the by-path tier scan the *same* corpus rather than two hand-picked ones
-// (`coding.md` Suite speed: a golden gate leaving the default suite leaves a cheap sentinel behind
-// against the same frozen fixture):
+// default suite and the by-path tier scan the *same* corpus rather than two hand-picked ones:
 //   - `editCorridor.tier.ts` — the full 200-drag corpus, run by path. Which edits are the cue to run it
 //     is that file's own header (its transitive import cone, walked there) — not listed here.
 //   - `edit.test.ts` — the sentinel, the corpus's own first `SENTINEL_DRAGS` entries.
@@ -69,8 +67,7 @@ export function dragCorpus(count: number): CorpusDrag[] {
         const len = Math.hypot(b[0] - a[0], b[1] - a[1]);
         const hA = heightAtCpu(a[0], a[1], perm);
         const hB = heightAtCpu(b[0], b[1], perm);
-        // Measured extent of this exclusion on the frozen corpus (`checks.md`: an exclusion's extent is
-        // measured in the diff that adds it) — it never fires. All 200 corpus drags come out of the
+        // Measured extent of this exclusion on the frozen corpus — it never fires. All 200 corpus drags come out of the
         // first 200 attempts: 0 rejections, steepest chord 0.0509 (42 % of `MAX_GRADE` = 0.12), median
         // 0.0073. So on this corpus neither the `attempts < 50000` guard nor the tier's "fully
         // populated" arm can discriminate: both are loop bounds, not witnesses for this filter. Stated

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -193,7 +193,7 @@ describe(`edit — corridor flatness sentinel (${SENTINEL_DRAGS} of the ${CORPUS
     // The default-suite sentinel for the corridor-flatness criterion (spec Validation "Corridor
     // flatness", extended to edited documents). The full corpus lives in `editCorridor.tier.ts`, run by
     // path; this arm scans the *same* frozen fixture's first `SENTINEL_DRAGS` drags, so the coverage
-    // moved tiers rather than shrinking (`coding.md` Suite speed). The reading is the one the tier
+    // moved tiers rather than shrinking. The reading is the one the tier
     // asserts: exactly 0 violations / 0.0000 m on both axes at SPACING and SPACING/2, over the banded
     // lattice — whose equivalence to the full lattice for this oracle is `flatness.test.ts`'s null
     // control ("the banded lattice reads what the full lattice reads").

--- a/examples/showcase/roads/src/editCorridor.tier.ts
+++ b/examples/showcase/roads/src/editCorridor.tier.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { CORPUS_DRAGS, dragCorpus, scanDrag } from "./dragCorpus";
 
-// By-path tier (`coding.md` Suite speed): the whole 200-drag corridor-flatness corpus, run by path
+// By-path tier: the whole 200-drag corridor-flatness corpus, run by path
 // rather than in the default suite because it costs ~12 s there against a whole-suite budget of ~30 s,
 // while the property it pins is one corpus-scale oracle over one kernel. The default suite keeps
 // `edit.test.ts`'s sentinel over the *same* frozen fixture's first `SENTINEL_DRAGS` entries
@@ -19,8 +19,7 @@ import { CORPUS_DRAGS, dragCorpus, scanDrag } from "./dragCorpus";
 // adds `harness.ts` — 19 files beyond the tier itself. The cone is wider than the set of modules the
 // scan's readings are a *function* of (`overlay/queue.ts` and `posts.ts` cannot move a flatness
 // reading, they arrive because `terrain/terrain.ts` exports `SEED`): that over-inclusion is what a
-// derived list costs and it is accepted rather than re-narrowed by hand (`checks.md`, by-path tier
-// trigger lists). The tier reads no non-imported file at runtime, so there is no runtime-read input to
+// derived list costs and it is accepted rather than re-narrowed by hand. The tier reads no non-imported file at runtime, so there is no runtime-read input to
 // list beside the cone.
 //
 // Advisory, not a trigger: nothing runs this tier automatically — a person reads this header and runs

--- a/examples/showcase/roads/src/flatness.test.ts
+++ b/examples/showcase/roads/src/flatness.test.ts
@@ -35,8 +35,7 @@ describe("surface flatness — sanity (the oracle can read flat)", () => {
     test("a manufactured target === natural profile reads flat on both axes", () => {
         // when the flatten target height exactly equals the natural height everywhere, flattenHeight
         // returns that one value regardless of coreDist (`terrain/flatten.ts`'s own definition) — so this
-        // is flat by construction, the mutation-style proof the checker isn't just always red
-        // (`coding.md`'s "survives its own mutations").
+        // is flat by construction, the mutation-style proof the checker isn't just always red.
         const doc: StrokeDocument = {
             polylines: [
                 {
@@ -198,8 +197,7 @@ describe("surface flatness — null control: no cut, real relief (arm iii)", () 
         // define the sampled footprint is still the real network — so the sampled lines run through
         // genuinely undeformed, rolling terrain (RELIEF=40) that was never asked to be flat. This is a
         // *different* mechanism from the shipped defect (raw noise steepness, not a reconstruction crease)
-        // — it's the null control that still has something to find (`checks.md`'s witness-distinguishable
-        // clause): a broken instrument that always reads "flat" would fail this arm the same way it would
+        // — it's the null control that still has something to find: a broken instrument that always reads "flat" would fail this arm the same way it would
         // pass arm ii, so the two arms together are what makes either one meaningful.
         const doc = generateNetwork();
         const perm = makePermutation(SEED);

--- a/examples/showcase/roads/src/flatness.ts
+++ b/examples/showcase/roads/src/flatness.ts
@@ -36,7 +36,7 @@
 //     output, and its `surface-flatness-property-on-device` check re-asserts the *property* device-side —
 //     the same unconditional exact zero the default suite asserts, over real `readVertices()`.
 //
-// What this oracle cannot see (name the blind axes, `checks.md`'s granularity clause):
+// What this oracle cannot see:
 //   - albedo registration — the overlay's own texel/coverage crispness is a separate render-half property
 //     (the spec's "Fs composite" criterion, `terrain.ts`'s fs), untouched by anything read here.
 //   - shading normals — the finite-difference normal `generate.ts`'s kernel emits alongside height is

--- a/examples/showcase/roads/src/overlay/queue.ts
+++ b/examples/showcase/roads/src/overlay/queue.ts
@@ -25,8 +25,7 @@ export function drain(pending: number[], pendingSet: Set<number>, n: number): nu
  * resolve tile `id`'s atlas layer against the indirection CPU mirror `cpu` (negative = unallocated):
  * already resident → its existing layer; otherwise pop the next free layer off `free` and write
  * `cpu[id]` in place. Throws when `free` is empty rather than silently overwriting a resident layer —
- * no plausible-fallback substitute for a real capacity limit. The free list is the complete shape
- * (`coding.md`): `release` pushes layers back, so an edit that releases old tiles before allocating new
+ * no plausible-fallback substitute for a real capacity limit. The free list is the complete shape: `release` pushes layers back, so an edit that releases old tiles before allocating new
  * ones never exhausts a layer pool the counter-with-a-reset stopgap could only flush wholesale.
  *
  * @example allocate(new Int32Array(4).fill(-1), 2, [0, 1, 2, 3], 4) // → 0, cpu[2] === 0

--- a/examples/showcase/roads/test/roads.playwright.ts
+++ b/examples/showcase/roads/test/roads.playwright.ts
@@ -153,7 +153,7 @@ test("terrain generator gate — sized, deterministic, reseeds, not flat (real G
     // In-frame assertion: each probe's fractional screen coordinates must be strictly inside (0, 1)
     // before any pixel is read — `luminanceAt` clamps out-of-range coordinates to the border, so an
     // off-screen probe silently reads a border pixel and passes instead of reding (the same class as
-    // the unreachable null control, `checks.md`'s audit-check-vacuity). Measured on the shipped default
+    // the unreachable null control). Measured on the shipped default
     // (distance 120 m): onRoad sits at 0.905/0.464 and offRoad at 0.929/0.492 of frame — on-screen, but
     // one small camera change from the clamp. Red-first demonstrated: tightening the x-bound to
     // `toBeLessThan(0.9)` reds on the offRoad probe (x=0.917), exit 1 — the assertion fires before

--- a/packages/shallot/bin/prebuilt.test.ts
+++ b/packages/shallot/bin/prebuilt.test.ts
@@ -74,7 +74,7 @@ describe("resolvePrebuiltDecision", () => {
     });
 
     // Exhaustive over PrebuiltFetchResult. The Record<..., true> assignment fails at compile time
-    // if the union gains a member, so the arm's name stays true to its assertion (checks.md).
+    // if the union gains a member, so the arm's name stays true to its assertion.
     test("every fetch result maps to a decision with a non-empty reason", () => {
         const exhaustive: Record<PrebuiltFetchResult, true> = {
             ok: true,

--- a/packages/shallot/bin/tui.probes.ts
+++ b/packages/shallot/bin/tui.probes.ts
@@ -4,8 +4,7 @@ import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { EXIT_PASS } from "./tui";
 
-// Criterion 6's real determinism red-proof ("the terminal command is deterministic into a pipe" —
-// specs/shallot-tui.md), split out of `tui.test.ts` as its own by-path gate — a genuine subprocess boot
+// Criterion 6's real determinism red-proof ("the terminal command is deterministic into a pipe"), split out of `tui.test.ts` as its own by-path gate — a genuine subprocess boot
 // under bun-webgpu costs ~2.5s fixed (measured: GPU device acquisition + pipeline compile, essentially
 // independent of --frames), which blows the shared per-file test-duration cap (`tests/test-cap.ts`,
 // 5000ms) at just two runs. Mirrors `bin/verify.probes.ts`'s own precedent exactly ("browser probes stay
@@ -38,8 +37,8 @@ function runPiped(extra: string[] = [], env: NodeJS.ProcessEnv = process.env) {
     });
 }
 
-// a software-adapter seat (llvmpipe, dzn) still renders correctly (measured in this unit's own two-seat
-// table, specs/shallot-tui.md) — only a seat offering no adapter at all should skip.
+// a software-adapter seat (llvmpipe, dzn) still renders correctly — only a seat offering no adapter
+// at all should skip.
 function skipReason(result: ReturnType<typeof runPiped>): string | null {
     if (result.status === EXIT_PASS) return null;
     const stderr = result.stderr?.toString() ?? "";
@@ -72,7 +71,7 @@ describe("shallot tui — deterministic into a pipe (criterion 6, real subproces
     // regression) reds this the moment the two hashes diverge, and an accidentally-nondeterministic
     // command (real-time pacing, a Math.random seed, an object-iteration-order dependency) reds it
     // exactly as reliably. A hand-pinned golden hash was rejected: the engine's glyph selection/ramp is
-    // still evolving (specs/shallot-tui.md's own Live log), so a hard-pinned byte constant would red on
+    // still evolving, so a hard-pinned byte constant would red on
     // every unrelated tuning pass rather than on the property this criterion actually names.
     test.skipIf(!hasBunWebgpu)(
         "two independent runs against the same recipe, piped non-tty, hash identically",

--- a/packages/shallot/bin/tui.ts
+++ b/packages/shallot/bin/tui.ts
@@ -245,7 +245,7 @@ class TuiKeyEvent extends Event {
  * `STORAGE_BINDING` usage for Glaze's compute composite, a capability this command never needs since it
  * drops `GlazePlugin` the same way that script does). `addEventListener`/`style` additionally satisfy
  * `InputSystem`'s own per-canvas pointer-listener registration (pointer events are never dispatched here
- * — mouse/pointer input is out of scope, `specs/shallot-tui.md`'s Out of scope — so those listeners just
+ * — mouse/pointer input is out of scope — so those listeners just
  * sit unused).
  */
 class TuiCanvas {

--- a/packages/shallot/bin/tui/color-support.ts
+++ b/packages/shallot/bin/tui/color-support.ts
@@ -1,7 +1,6 @@
 // Color-support detection: the portability ladder's tier selector — portability is a ladder in
 // the encoder, not a second design. Pure function over an injected env snapshot — no `process`
-// read here, so it's testable with a plain object and carries no ambient state (`checks.md` "A
-// test that exercises a function whose destination comes from ambient env must stub that env").
+// read here, so it's testable with a plain object and carries no ambient state.
 
 /**
  * The four output tiers, cheapest first. `plain` is non-interactive (no cursor addressing, no

--- a/packages/shallot/bin/verify.test.ts
+++ b/packages/shallot/bin/verify.test.ts
@@ -2742,9 +2742,7 @@ describe("decodeSampleNode area-average equivalence — the blocker repair's own
     // independently-derived area-average reference: for each 64×64 destination cell, weight every
     // overlapping source pixel by its fractional coverage of the cell's continuous source-space rect —
     // the textbook box-filter resize, not decodeSampleNode's own integer-cell grouping. Two different
-    // implementations of "area average", so agreement is evidence rather than a restated identity
-    // (checks.md: "an equality between two quantities the same expression produces is only a check when
-    // one side comes from outside the artifact").
+    // implementations of "area average", so agreement is evidence rather than a restated identity.
     function areaAverageReference(png: { width: number; height: number; data: Buffer }): number[] {
         const { width: W0, height: H0, data } = png;
         const W = 64;
@@ -2973,8 +2971,7 @@ describe("sampleFrameNode — the S1c decontaminated frame sampler", () => {
 
 // shallot-boot-stall-repair S1: the boot wait poll's routing seam. `drive` itself (the loop's real
 // caller, ~line 2161) drives a live `page.goto` + CDP session no unit test mocks, so `pollFrameSample`
-// is the extracted pure function the loop now calls (checks.md's "extract it into a pure sibling
-// module" escape) — these arms are the oracle over THAT seam, not a re-test of `sampleFrameNode` in
+// is the extracted pure function the loop now calls — these arms are the oracle over THAT seam, not a re-test of `sampleFrameNode` in
 // isolation (already covered above): they prove the poll's non-attribution consumer takes the Node
 // decode, not just `--attribution`'s.
 describe("pollFrameSample — S1's boot wait poll routing seam", () => {

--- a/packages/shallot/bin/verify.ts
+++ b/packages/shallot/bin/verify.ts
@@ -55,7 +55,7 @@ export function displayGateExit(hardware: string): number | null {
 }
 
 /** the refusal diagnostic for a non-hardware adapter: names what was offered and why the CLI won't run
- *  checks against it, never the caller or its environment (`branding.md` — point at the diagnostic). */
+ *  checks against it, never the caller or its environment. */
 export function displayGateMessage(hardware: string): string {
     const reason =
         hardware === "unknown"
@@ -391,7 +391,7 @@ export interface LoafPhaseReport {
  * large LoAF spikes standing *before* the compile chain have no owner. Entry-level LoAF fields
  * (`duration`, `blockingDuration`) cannot name one; `scripts` can, and this is the reader over that
  * pair. Pure — no DOM, no observer, no CDP — so it arms against hand-built entry sets
- * (`.claude/rules/checks.md`'s extract-the-arithmetic move) rather than needing a GPU.
+ * rather than needing a GPU.
  *
  * @example
  * const report = loafByCompilePhase(attribution.longAnimationFrames, attribution.compileMeasures, PREFIX);
@@ -1490,7 +1490,7 @@ export async function sampleFrameNode(
 
 // shallot-boot-stall-repair S1: the boot wait loop's per-tick sample selection, extracted out of
 // `drive` so it is a testable seam — `drive` itself takes no page mock (it drives a real `page.goto`
-// plus a CDP session), so this is the "extract it into a pure sibling module" escape (`checks.md`)
+// plus a CDP session), so this is the "extract it into a pure sibling module" escape
 // rather than a source-text proxy over `drive`'s call site. Every poll consumer now takes the Node
 // decode; `attribution` only selects `sampleFrameNode`'s own throw-vs-fallback contract, never a
 // different sampler. `harnessDefined` short-circuits to null without sampling — unchanged from the

--- a/packages/shallot/scripts/dump-cells-ascii.ts
+++ b/packages/shallot/scripts/dump-cells-ascii.ts
@@ -1,5 +1,4 @@
-// The tier-0 ASCII dump — criterion 8's own artifact promoted into the repo (s3r item 2,
-// specs/shallot-tui.md): "the grid is readable as text at a stock 80x24 with color removed... read from
+// The tier-0 ASCII dump: "the grid is readable as text at a stock 80x24 with color removed... read from
 // the recipe" (examples/recipes/render-to-a-terminal). Boots that recipe's scene headlessly through
 // bun-webgpu — no browser, no `shallot verify`, no dev/preview server — drives the orbit camera to a
 // named yaw, steps the real `CellsPlugin` pipeline (`select.ts`'s structure-first glyph selection over

--- a/packages/shallot/scripts/generate-ramp.ts
+++ b/packages/shallot/scripts/generate-ramp.ts
@@ -1,8 +1,7 @@
-// Generates `extras/cells/ramp-table.ts`: the coverage-ordered fill glyph ramp the Locked decision
-// requires (`specs/shallot-tui.md`'s glyph-selection addendum — "the ramp is an ordered artifact, sorted
-// by measured ink coverage", not a hand-authored character set in code-point order). Renders each
+// Generates `extras/cells/ramp-table.ts`: the coverage-ordered fill glyph ramp, sorted
+// by measured ink coverage, not a hand-authored character set in code-point order. Renders each
 // candidate printable-ASCII glyph's outline against the cells face (`assets/jetbrains-mono.ttf`, the house
-// monospace from `branding.md`) and measures its ink coverage: the glyph's TrueType contour area (Green's theorem over
+// monospace) and measures its ink coverage: the glyph's TrueType contour area (Green's theorem over
 // the parsed outline, `extras/text/font.ts`'s own `glyphPath`) divided by the font's em-square area,
 // sorted ascending.
 //

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -1111,8 +1111,7 @@ describe("precompile", () => {
             // silently dropped — `c` stays queued and drains on a later call — and the throw still
             // names `broken`, not the level.
             //
-            // Mutation witnesses (both restored via `git show HEAD:<path>` after the read, per
-            // `checks.md`): (a) changing the serial re-drain's start index so it restarts a failing
+            // Mutation witnesses (both restored via `git show HEAD:<path>` after the read): (a) changing the serial re-drain's start index so it restarts a failing
             // level from `ranThrough` (its own last-attempted member) instead of `0` reds this arm —
             // `expect(order).toEqual(["a", "b", "c", "a", "b"])` becomes `["a", "b", "c", "b"]`, i.e.
             // `a` is never re-run — `bun test` exit 1, this arm the sole failure. (b) making the batch

--- a/packages/shallot/src/extras/cells/draw.test.ts
+++ b/packages/shallot/src/extras/cells/draw.test.ts
@@ -30,8 +30,7 @@ describe("drawWgsl", () => {
 });
 
 // cellFootprintPx is the s3r item 9 fix's own arithmetic, extracted to a plain TS-callable TGSL function
-// so its numbers are asserted directly rather than only through resolved shader text (`checks.md`: "an
-// arm over a shader's resolved text is not an arm over its behaviour"). One TGSL source, dual-mode like
+// so its numbers are asserted directly rather than only through resolved shader text. One TGSL source, dual-mode like
 // `cell.ts`'s `packCell` — `cellVertex` resolves the identical body real-device-side.
 describe("cellFootprintPx", () => {
     test("a non-square cell scales both axes by the SAME factor — no anisotropic stretch", () => {

--- a/packages/shallot/src/extras/cells/draw.ts
+++ b/packages/shallot/src/extras/cells/draw.ts
@@ -1,11 +1,9 @@
 // The web sink: an instanced draw of `cols * rows` monospace quads against the shared SDF glyph atlas
-// (`text/core`), no readback — the Locked decision's "same pipeline with the expensive tail deleted"
-// (`specs/shallot-tui.md`). A simplification of `extras/text`'s own instanced glyph draw: no world
+// (`text/core`), no readback — the same pipeline with the expensive tail deleted. A simplification of `extras/text`'s own instanced glyph draw: no world
 // transform, no per-entity eid lookup, no per-string layout pass — every cell is a fixed monospace box
 // whose position derives purely from its instance index. The quad's *geometry* always covers the whole
-// box (`checks.md`'s "invariant enforced on the quantity it constrains": the Goal's "the grid is the
-// frame" property lives in every pixel of every cell getting a real write, so the rasterized polygon can
-// never be smaller than the cell — `specs/shallot-tui.md`'s s3r item 9), and the glyph's own ink is drawn
+// box ("the grid is the frame" property lives in every pixel of every cell getting a real write, so
+// the rasterized polygon can never be smaller than the cell), and the glyph's own ink is drawn
 // *within* that full-cell quad, shrunk + centered to the glyph's own measured em-normalized footprint
 // (`glyphFootprintT`/`cellFootprintPx` below, against `glyphs.ts`'s size table) — size-proportional
 // placement, the same principle `extras/text`'s own `layoutText` applies per glyph (`ramp.ts`'s module
@@ -169,8 +167,7 @@ export const cellVertex = tgpu
         const has = std.select(d.u32(0), d.u32(1), rect.z > rect.x);
 
         // full-cell geometry, unconditionally — every fragment of every cell gets a real write, so
-        // nothing the scene rendered before this pass can show through (`specs/shallot-tui.md`'s s3r
-        // item 9: "the grid is the frame", not an overlay on one).
+        // nothing the scene rendered before this pass can show through ("the grid is the frame", not an overlay on one).
         const px = (d.f32(col) + corner.x) * cellW;
         const py = (d.f32(row) + corner.y) * cellH;
         const ndcX = px / (drawLayout.$.params.viewW * 0.5) - 1;
@@ -274,7 +271,7 @@ export function resetDrawPipeline(): void {
  * `Render.format` — `view.framebuffer` in production) as one instanced draw. `loadOp: "clear"`: the
  * geometry now tiles the view exactly (every cell's quad always covers its whole box, `cellVertex`'s own
  * docblock), so every pixel the pass writes is a real cell-authored value and nothing before this pass
- * needs to survive it — `"load"` was the s3r item 9 defect (`specs/shallot-tui.md`): it composited the
+ * needs to survive it — `"load"` was the s3r item 9 defect: it composited the
  * grid *over* the rendered scene, so a cols/rows pair that doesn't evenly divide the view (or any other
  * rasterizer-level gap) left the scene showing through. `"clear"` makes that impossible by construction
  * rather than by exact tiling alone — a gap now clears to black instead of leaking whatever rendered

--- a/packages/shallot/src/extras/cells/glyphs.ts
+++ b/packages/shallot/src/extras/cells/glyphs.ts
@@ -56,9 +56,9 @@ export const MISSING_GLYPH_SIZE: readonly [number, number] = [1, 1];
  *  cell. {@link MISSING_GLYPH_SIZE} when the font has no outline for it, mirroring {@link glyphUvRect}'s
  *  fallback. This is the measurement `draw.ts`'s vertex stage scales the glyph's footprint by
  *  (`cellFootprintPx`, isotropically — both axes share one scale so the cell's own aspect never
- *  re-stretches the glyph's true shape, `specs/shallot-tui.md`'s s3r item 9) — without it every glyph's
+ *  re-stretches the glyph's true shape) — without it every glyph's
  *  own tightly-cropped SDF tile stretches across the whole cell regardless of true size, destroying the
- *  coverage-ordered ramp's monotone progression at the point of use (`specs/shallot-tui.md`'s s3r item 8).
+ *  coverage-ordered ramp's monotone progression at the point of use.
  *  @example const size = glyphSizeRect(atlas, 0); // the lowest-coverage fill glyph's own footprint */
 export function glyphSizeRect(atlas: GlyphAtlas, index: number): readonly [number, number] {
     const metrics = atlas.glyphs.get(cellGlyphChar(index));

--- a/packages/shallot/src/extras/cells/index.ts
+++ b/packages/shallot/src/extras/cells/index.ts
@@ -82,8 +82,7 @@ let _warnedMultiCamera = false;
  * reallocated) per call and shared across every caller in the frame — correct only when every caller
  * that frame requests the same `cols`/`rows`/`viewW`/`viewH`. A second camera with a different view size
  * would silently corrupt both the first camera's still-unsubmitted recording and its own (`select.ts`'s
- * own docblock names the hazard; this is the demonstrated instance of it, `specs/shallot-tui.md`'s s3r
- * item 5). Per-camera buffer keying is the eventual fix; until then, draw the first camera with a
+ * own docblock names the hazard; this is the demonstrated instance of it). Per-camera buffer keying is the eventual fix; until then, draw the first camera with a
  * rendered scene and warn once rather than composite garbage for every camera after it.
  */
 const CellsSystem: System = {

--- a/packages/shallot/src/extras/cells/ramp-boundary.test.ts
+++ b/packages/shallot/src/extras/cells/ramp-boundary.test.ts
@@ -11,7 +11,7 @@ import {
 // the `CELL_GLYPH_COUNT` boundary had zero test references repo-wide before this file — the one property
 // S3 is told to build against (fill indices below the boundary, directional above, in bucket order) had
 // no arm, and neither did the range throws `cellGlyphChar` names in its own docblock. This is a
-// `review:stage` first-instance-of-a-pattern stage (`specs/shallot-tui.md`), so it's exhaustive over the
+// `review:stage` first-instance-of-a-pattern stage, so it's exhaustive over the
 // whole index space rather than a handful of examples: the space is small (~100 entries), and a
 // boundary-only sample can't see an off-by-one anywhere except at the two edges it happened to pick.
 describe("cellGlyphChar / CELL_GLYPH_COUNT boundary (S3's contract, ramp.ts's module doc)", () => {

--- a/packages/shallot/src/extras/cells/ramp-table.test.ts
+++ b/packages/shallot/src/extras/cells/ramp-table.test.ts
@@ -3,8 +3,7 @@ import { computeRampTable, glyphCoverage, loadBrandFont } from "../../../scripts
 import { CELL_DIRECTIONAL_GLYPHS, CELL_FILL_EXCLUDED_GLYPHS } from "./ramp";
 import { RAMP_TABLE } from "./ramp-table";
 
-// The reproduction arm the Locked decision requires (`specs/shallot-tui.md`'s glyph-selection
-// addendum): "a derived table nobody can re-derive is a hand-authored guess with extra steps" — this
+// The reproduction arm: "a derived table nobody can re-derive is a hand-authored guess with extra steps" — this
 // proves `ramp-table.ts` (the committed data) is exactly what `generate-ramp.ts`'s own pure
 // `computeRampTable` produces off the same JetBrains Mono face, right now, not just at the moment it was
 // generated.
@@ -39,7 +38,7 @@ describe("RAMP_TABLE reproduces from generate-ramp.ts's own computeRampTable", (
     });
 
     // the s3r fill-treatment amendment's own regression guard: "the fill role emits angular glyphs only,
-    // never curved ones" (`specs/shallot-tui.md`) — pinned against `CELL_FILL_EXCLUDED_GLYPHS` (`ramp.ts`'s
+    // never curved ones" — pinned against `CELL_FILL_EXCLUDED_GLYPHS` (`ramp.ts`'s
     // own curated set) rather than a hardcoded literal, so a widened exclusion in `ramp.ts` is what this
     // arm proves reached the generated table, not a copy of today's four characters.
     test("excludes every curated curved glyph — a regenerated ramp cannot reintroduce a parenthesis or brace into the fill role", () => {

--- a/packages/shallot/src/extras/cells/ramp.ts
+++ b/packages/shallot/src/extras/cells/ramp.ts
@@ -5,8 +5,7 @@ import { RAMP_TABLE } from "./ramp-table";
 // instanced draw (a GPU-side uv-rect table indexed the same way, contract below — not built here), and
 // S4's terminal encoder (glyph index → the literal character it writes to the pipe).
 //
-// Glyph selection is structure-first (Locked decision, `specs/shallot-tui.md`'s glyph-selection
-// addendum, grounded against Xu/Zhang/Wong SIGGRAPH/TOG 2010): S3's detector picks a directional glyph
+// Glyph selection is structure-first (grounded against Xu/Zhang/Wong SIGGRAPH/TOG 2010): S3's detector picks a directional glyph
 // where a strong edge exists and falls back to a coverage-ordered fill ramp elsewhere. That splits this
 // module's index space into two differently-selected halves, each ordered by the rule that selects it:
 //
@@ -34,7 +33,7 @@ import { RAMP_TABLE } from "./ramp-table";
 // committed enumeration, so it survives a font swap or an atlas rebuild unchanged — a coverage-derived
 // table is exactly as stable as a code-point one, only its *ordering rule* differs.
 
-/** the small curated directional set (Locked decision, `specs/shallot-tui.md`) — one glyph per quantized
+/** the small curated directional set — one glyph per quantized
  *  edge-*tangent* angle bucket, 0°(`-`)/45°(`/`)/90°(`|`)/135°(`\`), the shape S3's structure-based
  *  selector consumes. This is the angle the glyph visually runs along, **not** the gradient angle Canny
  *  non-max suppression buckets (a gradient is perpendicular to its edge's tangent — module doc above has
@@ -45,8 +44,7 @@ import { RAMP_TABLE } from "./ramp-table";
 export const CELL_DIRECTIONAL_GLYPHS: readonly string[] = ["-", "/", "|", "\\"] as const;
 
 /**
- * the fill role's curated curved-glyph exclusion (the s3r fill-treatment amendment,
- * `specs/shallot-tui.md`: "the fill role emits angular glyphs only, never curved ones" — grounded against
+ * the fill role's curated curved-glyph exclusion ("the fill role emits angular glyphs only, never curved ones" — grounded against
  * the reference's own selection habit, which uses `+ : X 0 " - .` for fill and never selects `(`/`)` even
  * though its wider atlas contains them). A curved glyph reads as bumpy texture rather than a flat surface,
  * which is the whole job of a fill glyph — but this is a hand-curated exclusion, not an ink-coverage or

--- a/packages/shallot/src/extras/cells/select.test.ts
+++ b/packages/shallot/src/extras/cells/select.test.ts
@@ -27,8 +27,7 @@ import {
 // Sobel formula (`select.ts`), not picked as abstract numbers — the class of bug this arm exists to catch
 // is a y-frame mix-up (grid y-down vs. the glyph labels' y-up visual convention), which an abstract
 // `(gx, gy)` pair can't discriminate: the old version of this table asserted `gx=1,gy=1 -> "\\"`, which is
-// what you get if you *don't* convert frames, and it passed for a full review round (`specs/shallot-tui.md`
-// s3r item 1). Naming the luma neighborhood a case derives from ties the expectation to a real edge
+// what you get if you *don't* convert frames, and it passed for a full review round. Naming the luma neighborhood a case derives from ties the expectation to a real edge
 // instead of to whatever the code under test currently computes.
 describe("directionalGlyphIndex", () => {
     // l(dx, dy) = 0.5 + A*dx + B*dy over the 8 neighbors selectKernel reads (dx/dy in {-1,0,1}, own
@@ -142,7 +141,7 @@ describe("EDGE_MAGNITUDE_THRESHOLD", () => {
     });
 });
 
-// rule 1's own repair proof (`specs/shallot-tui.md`'s fill-treatment amendment, "a shared face boundary
+// rule 1's own repair proof ("a shared face boundary
 // carries its own rule"): FACE_BOUNDARY_MAGNITUDE_THRESHOLD's own docblock claims a witnessed reproduction
 // — a real yaw (2.4 rad) where a genuinely flat 4-connected neighborhood still read a nonzero full-Sobel
 // magnitude solely from its diagonal taps landing in the next face over. This reproduces that shape
@@ -206,7 +205,7 @@ describe("selectWgsl", () => {
 // The s3r item-8 repair's own regression guard: a real device dispatch (not the device-free structural
 // arms above), because the defect this repair closes lived entirely in a runtime comparison
 // (`BG_MATCH_EPSILON`'s distance gate against a live tonemapped average) no WGSL-text or pure-function
-// arm can see. `specs/shallot-tui.md`'s residue log names what this replaces: a non-black clear color's
+// arm can see. A non-black clear color's
 // tonemapped luma never rounds to the ramp's zero-coverage entry, so a real scene's empty background read
 // as a uniform field of `'` (glyph index 2) instead of blank — refuted twice at the wrong layer before
 // this repair (the directional-glyph mechanism was never it; the fill computation itself was).
@@ -342,8 +341,7 @@ function roundTiesToEven(v: number): number {
 }
 
 // the reference mapping computed from scratch, never by calling `fillIndexForLuma` — a defect in the
-// production rounding or clamping can't hide behind a shared implementation this way (`checks.md`:
-// "an oracle that shares an assumption with the thing it checks proves nothing").
+// production rounding or clamping can't hide behind a shared implementation this way.
 function referenceFillIndex(luma: number, fillCount: number): number {
     const sat = Math.min(1, Math.max(0, luma));
     const idx = roundTiesToEven(sat * (fillCount - 1));

--- a/packages/shallot/src/extras/cells/select.ts
+++ b/packages/shallot/src/extras/cells/select.ts
@@ -1,6 +1,5 @@
 // The real content producer `grid.ts`'s module doc names as the thing S3 ships: two compute passes that
-// fill a cell grid from a rendered scene, structure-first (Locked decision, `specs/shallot-tui.md`'s
-// glyph-selection addendum) rather than `grid.ts`'s deterministic test pattern, which stays untouched —
+// fill a cell grid from a rendered scene, structure-first rather than `grid.ts`'s deterministic test pattern, which stays untouched —
 // the shape-proving headless producer the `cells` gym scenario and its own tests pin, not the content
 // path a real scene drives. `CellsPlugin` (`./index.ts`) dispatches both passes each frame, in order.
 //
@@ -21,7 +20,7 @@
 // {@link EDGE_MAGNITUDE_THRESHOLD}; over threshold picks a directional glyph from the gradient angle
 // (converted to its perpendicular tangent bucket, `ramp.ts`'s locked contract); under it picks a
 // coverage-ordered fill glyph from the cell's own luma. The s3r fill-treatment amendment's "a shared face
-// boundary carries its own rule" (`specs/shallot-tui.md`) is a **second, independent** gate,
+// boundary carries its own rule" is a **second, independent** gate,
 // {@link FACE_BOUNDARY_MAGNITUDE_THRESHOLD} — not a lower setting of the same one: the full 3×3 Sobel
 // kernel's diagonal taps carry a real face boundary's influence *past* its own row/column into an
 // adjacent, genuinely flat cell (measured directly, `FACE_BOUNDARY_MAGNITUDE_THRESHOLD`'s own docblock has
@@ -34,8 +33,7 @@
 // fine for angle, since a slightly bled angle is a far smaller defect than a mis-classified cell). The glyph's
 // `fg` carries the cell's own tonemapped average for both directional and fill branches while `bg` stays at
 // the dark floor. The glyph is the mark in both sinks; painting the cell background with scene color would turn
-// the grid into a low-resolution image with text overlaid rather than an ASCII render (the locked color model
-// in `specs/shallot-tui.md`).
+// the grid into a low-resolution image with text overlaid rather than an ASCII render.
 
 import tgpu, { type StorageFlag, type TgpuBuffer, type TgpuComputePipeline } from "typegpu";
 import * as d from "typegpu/data";
@@ -72,7 +70,7 @@ const PI = Math.PI;
 export const EDGE_MAGNITUDE_THRESHOLD = 0.4;
 
 /**
- * the shared-face-boundary gate (the s3r fill-treatment amendment, `specs/shallot-tui.md`: "a shared face
+ * the shared-face-boundary gate ("a shared face
  * boundary carries its own rule") — independent of {@link EDGE_MAGNITUDE_THRESHOLD}, on an independent
  * metric: a **4-connected central difference**, `dx = l21 - l01` (own row, right minus left) and
  * `dy = l12 - l10` (own column, bottom minus top), `magnitude = sqrt(dx² + dy²)`, using none of the full
@@ -101,8 +99,8 @@ export const EDGE_MAGNITUDE_THRESHOLD = 0.4;
  * cell one this gate exists to avoid. Bound: the metric is a central difference across the two cells
  * flanking the one being classified (`dx = right − left`, a 2-cell baseline), so on a smooth gradient with
  * a constant per-cell luma step `s` the magnitude reads ≈2s — the gate fires once the per-cell gradient
- * exceeds a **quarter** ramp step, not half, so it presumes the spec's per-face-constant shading
- * (`specs/shallot-tui.md`'s "cell shading is flat and unlit" lock) — a surface whose luma varies smoothly
+ * exceeds a **quarter** ramp step, not half, so it presumes per-face-constant shading
+ * (cell shading is flat and unlit) — a surface whose luma varies smoothly
  * cell-to-cell (a gradient, not a hard face boundary) would cross this threshold at a shallower per-cell
  * slope than half a ramp step and read as a false boundary.
  */
@@ -112,7 +110,7 @@ export const FACE_BOUNDARY_MAGNITUDE_THRESHOLD = 0.5 / (CELL_FILL_GLYPHS.length 
  * the background-match gate: how close a cell's own tonemapped block average must sit to the
  * caller-supplied background reference (`SelectParams.bg`, tonemapped the same way inside the kernel)
  * before the cell is forced to the blank fill glyph regardless of luma or edge (the s3r item-8 repair —
- * `specs/shallot-tui.md`'s residue log names the mechanism: a non-black clear color's tonemapped luma
+ * a non-black clear color's tonemapped luma
  * never reaches the ramp's zero-coverage entry, so an unlit background read as a uniform field of `'`
  * instead of blank). Derived from `rg11b10ufloat`'s own quantization, not fitted: the format packs R/G
  * as 11-bit unsigned floats (5 exponent + 6 mantissa bits) and B as 10-bit (5 exponent + 5 mantissa),
@@ -219,7 +217,7 @@ export const luma = tgpu.fn(
  * represent. Dropping the y-down→y-up conversion swaps the two diagonal glyphs and leaves the two
  * axis-aligned buckets untouched — negating `gy` doesn't change `atan2`'s bucket for `gy = 0` (horizontal)
  * or `gx = 0` (vertical), only for a true diagonal, which is exactly the shape the first version of this
- * function shipped with (`specs/shallot-tui.md`'s s3r item 1). A pure function of `(gx, gy)` — no binding
+ * function shipped with. A pure function of `(gx, gy)` — no binding
  * access — so it's callable directly from `bun test` (typegpu's dual CPU/GPU form, `packCell`'s own shape)
  * with no device.
  * @example const glyph = directionalGlyphIndex(gx, gy); // CELL_FILL_GLYPHS.length + a tangent bucket 0..3
@@ -240,11 +238,10 @@ export const directionalGlyphIndex = tgpu.fn(
  * the fill role's own luma→index map: round `luma` linearly across the coverage-ordered ramp, clamped to
  * the last fill index. Extracted from `selectKernel`'s own inline arithmetic (unchanged) so the exact same
  * mapping is callable with no device (`directionalGlyphIndex`'s own dual CPU/GPU shape) — the facade-ink
- * measurement below (rule 3, `specs/shallot-tui.md`'s fill-treatment amendment) has to use the *real*
- * mapping the kernel selects with, not a re-derived copy that could silently drift from it
- * (`checks.md`: "an oracle that shares an assumption with the thing it checks proves nothing" runs the
- * other way here — the risk is a *second*, drifting implementation, not a shared blind spot, so sharing one
- * function is the fix).
+ * measurement below (rule 3) has to use the *real*
+ * mapping the kernel selects with, not a re-derived copy that could silently drift from it.
+ * The risk is a *second*, drifting implementation, not a shared blind spot, so sharing one
+ * function is the fix.
  * @example const idx = fillIndexForLuma(0.55); // an index into CELL_FILL_GLYPHS
  */
 export const fillIndexForLuma = tgpu.fn(
@@ -277,8 +274,7 @@ export const localBoundaryMagnitude = tgpu.fn(
 });
 
 /**
- * the facade luma band the fill-treatment amendment's rule 3 measurement renders against
- * (`specs/shallot-tui.md`'s fill-treatment amendment): three values hand-picked, not derived, to sit
+ * the facade luma band the fill-treatment amendment's rule 3 measurement renders against: three values hand-picked, not derived, to sit
  * inside the luma band the recipe's faces occupy in the tier-0 dump (`examples/recipes/render-to-a-terminal`
  * at one orbit angle), not the fill ramp's whole `[0, 1]` domain the prior version of this measurement
  * swept — criterion 8's round-1 rejection named exactly that mismatch, since the ramp's own blank and
@@ -300,7 +296,7 @@ export const FACADE_BAND_LUMAS: readonly number[] = [0.52, 0.56, 0.6];
 export const FACADE_PIXEL_LUMA_THRESHOLD = 0.18;
 
 /**
- * the facade-ink band's floor and ceiling (rule 3, `specs/shallot-tui.md`: "the target is the number").
+ * the facade-ink band's floor and ceiling (rule 3: "the target is the number").
  * Ratios of the densest-glyph control's own reading, not copied from the reference's crops unread:
  * {@link fillIndexForLuma}'s device caller (`examples/gym/src/scenarios/cells.ts`'s `assertFacadeInk`)
  * renders a blank-glyph control (0% of pixels above {@link FACADE_PIXEL_LUMA_THRESHOLD}, by construction —

--- a/packages/shallot/src/harness/pixels.test.ts
+++ b/packages/shallot/src/harness/pixels.test.ts
@@ -58,8 +58,8 @@ describe("probePixels", () => {
     // criterion 5): a near-white grayscale band meant to discriminate the Cells system's glyph draw from
     // the scene's own chromatic colors. A live browser isn't available to this suite (`testing.md`'s GPU
     // ladder), so this pins the discrimination mechanically against synthetic frames standing in for
-    // "Cells: true" vs. "Cells: true deleted from shallot.json" (`checks.md`: prove a probe reds with the
-    // mechanism it targets removed, not just that it passes on the happy path).
+    // "Cells: true" vs. "Cells: true deleted from shallot.json": prove a probe reds with the
+    // mechanism it targets removed, not just that it passes on the happy path.
     describe("the ascii showcase's cells-only ink probe discriminates Cells from a bare scene", () => {
         const GlyphInk: PixelProbe = {
             name: "cell glyph ink reaches the compositor",
@@ -69,8 +69,7 @@ describe("probePixels", () => {
             g: [210, 255],
             b: [210, 255],
         };
-        // the scene's own two colors, per `specs/shallot-tui.md`'s locked shading + the recipe/showcase
-        // scenes: a warm box albedo (never near-white — the blue channel alone sits well under 210) and a
+        // the recipe/showcase scenes' own two colors: a warm box albedo (never near-white — the blue channel alone sits well under 210) and a
         // near-black clear color. Neither is chromatically neutral, so neither can land in a band that
         // demands r, g, and b all high simultaneously.
         const Box: [number, number, number] = [172, 151, 126];

--- a/packages/shallot/tests/avbd/coloring.ts
+++ b/packages/shallot/tests/avbd/coloring.ts
@@ -1,5 +1,5 @@
 // CPU reference for the GPU incremental-greedy body coloring (step.ts COLORING_PASS_WGSL) — the
-// Phase-4 coloring crux's executable spec (scratch.md "AVBD rebuild" → Distributed cruxes → Coloring).
+// Phase-4 coloring crux's executable spec.
 // One "thread" per body, no atomics, reading a stable prior-frame snapshot: deterministic integer
 // logic; the GPU reproduces it (gym `pile` coloring-conflict counter, the real-GPU home).
 // Mirrors webphysics greedyBodyColorsShader: the higher-id symmetry break, the 32-wide usedMask, the

--- a/packages/shallot/tests/avbd/corpus.oracle.ts
+++ b/packages/shallot/tests/avbd/corpus.oracle.ts
@@ -13,7 +13,7 @@ import {
 } from "./corpus";
 import { makeSolver, step } from "./solver";
 
-// The Phase-4.6 topology stability corpus, oracle tier (scratch.md "AVBD rebuild" → Phase 4.6).
+// The Phase-4.6 topology stability corpus, oracle tier.
 // The gym `pile` scenario is one jittered grid; this is the band-gated corpus across distinct
 // topologies (corpus.ts) so stability problems have somewhere to surface. Here it runs through the
 // f64 oracle — the reference for what "stable" looks like: every scene settles, energy never
@@ -21,7 +21,7 @@ import { makeSolver, step } from "./solver";
 // `pile` scenario runs the identical scenes + band; a scene steady here but wobbling there is a
 // GPU bug, not a band that's wrong (avbd.md "the oracle is not the suspect").
 //
-// The band is the gate-ladder's statistical band (scratch.md "Gate ladder"), never a long-horizon
+// The band is the gate-ladder's statistical band, never a long-horizon
 // trajectory match — chaotic settling can't bit-match. Bounds are derived (corpus.ts BAND_*) and
 // the oracle sits an order inside each (measured values in-line).
 

--- a/packages/shallot/tests/avbd/fixtures.ts
+++ b/packages/shallot/tests/avbd/fixtures.ts
@@ -2,7 +2,7 @@
 // reference trajectories — see gen-fixtures.ts). Builds a Solver from a fixture's initial state
 // + params, and exposes the per-frame reference state the oracle is checked against. Test
 // scaffolding; the fixtures are f32 (C++ float), the oracle f64 — so trajectory comparison is
-// tolerant (and chaotic scenes only on the statistical band — scratch.md "Gate ladder").
+// tolerant (and chaotic scenes only on the statistical band).
 
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/packages/shallot/tests/avbd/manifold.ts
+++ b/packages/shallot/tests/avbd/manifold.ts
@@ -5,7 +5,7 @@
 // Hessian into a body's 6×6 system, `updateDual` advances λ + the penalty ramp. This is the
 // `Force` interface (initialize / updatePrimal / updateDual) joints + springs reuse later.
 //
-// AL layer toggle (scratch.md "AVBD rebuild"): the same solver, three constraint laws.
+// AL layer toggle: the same solver, three constraint laws.
 //   penalty   — fixed stiffness, λ = 0, no ramp, no cross-frame state (phase 1, the mg/k gate)
 //   dual      — λ accumulation + conditional penalty ramp, reset each frame (phase 2)
 //   warmstart — dual + cross-frame persistence: merge by feature key, decay λ/k (phase 3)

--- a/packages/shallot/tests/avbd/oracle.oracle.ts
+++ b/packages/shallot/tests/avbd/oracle.oracle.ts
@@ -10,7 +10,7 @@ import { spring } from "./spring";
 
 // The phase-0 standing gate: the TS oracle is the executable AVBD spec. Tolerances are derived
 // + checked (the values in the comments were measured against the oracle, not guessed), and the
-// gate is laid out by the ladder in scratch.md "AVBD rebuild → Gate ladder": closed-form gates
+// gate follows the ladder: closed-form gates
 // (tightest, no reference), fixture reproduction (deterministic parts only — the rest state +
 // the energy invariant, never a long-horizon trajectory match), and the scheduler bridge.
 //
@@ -409,7 +409,7 @@ describe("AVBD oracle — friction + rotation reproduce the C++ fixtures", () =>
     // the 100-wide ground and free-fall (never settle). These three harness scenes (harness-dense.cpp,
     // mirroring tests/avbd/corpus.ts) cover the dynamics that were never gold-checked: kinetic friction
     // that stops a box, a box tipping vertex→face, and a stack toppling. Each is gated where it's
-    // deterministic (scratch.md "Gate ladder"): a clean slide / a contained tip track the C++ over the
+    // deterministic: a clean slide / a contained tip track the C++ over the
     // whole run; a chaotic topple only early + on the statistical band.
 
     test("friction-settle: tracks the C++ slide-to-rest + lower-μ-slides-farther", () => {
@@ -1006,8 +1006,7 @@ describe("AVBD oracle — scheduler equivalence", () => {
 });
 
 describe("AVBD oracle — warmstart (cross-frame persistence)", () => {
-    // The Phase-3 warmstart crux at the spec level (scratch.md "AVBD rebuild" → Distributed cruxes →
-    // Warmstart): the reference's force-list manifold persistence — `initManifold` merges this frame's
+    // The Phase-3 warmstart crux at the spec level: the reference's force-list manifold persistence — `initManifold` merges this frame's
     // contacts onto last frame's by feature key, carrying λ/k with γ decay (manifold.ts). The fixtures
     // (oracle.test.ts above) exercise the merge on *settling* scenes; these close the documented gap —
     // a churning scene (flipping feature keys) and the positive "warmstart converges tighter" property

--- a/packages/shallot/tests/avbd/sat.oracle.ts
+++ b/packages/shallot/tests/avbd/sat.oracle.ts
@@ -6,7 +6,7 @@ import { type Box, type Contact, collide } from "./collide";
 import { add, type Quat, scale, sub, transform, type Vec3 } from "./math";
 import gold from "./sat-gold-vectors.json";
 
-// The SAT crux gate (scratch.md "AVBD rebuild" → Distributed cruxes). The gold
+// The SAT crux gate. The gold
 // vectors are the box-box manifolds the reference `Manifold::collide` produces
 // (gen-sat-gold.ts → reference/avbd-demo3d/gold-sat.cpp); collide.ts is the faithful
 // f64 port and must reproduce them. The configs cover all four code paths: FACE_A /
@@ -88,7 +88,7 @@ describe("box-box SAT vs C++ gold vectors", () => {
     });
 });
 
-// Feature-key continuity (scratch.md "AVBD rebuild" → Distributed cruxes → SAT). The key's low byte
+// Feature-key continuity. The key's low byte
 // is the clip-vertex loop index, so a reordered Sutherland-Hodgman output silently reassigns keys —
 // a contact that physically persists across a frame would get a NEW key, miss the warmstart merge,
 // and jitter (not crash). This is the cross-frame precondition the phase-3 warmstart keying builds
@@ -179,8 +179,7 @@ describe("box-box SAT feature-key continuity under sub-box perturbation", () => 
 // on the stable clip-loop ordinal (a body-fixed corner id), matched by (a,b)+key; webphysics re-ordinals
 // the face key to the post-reduction array rank (reference/webphysics/.../contactGeneration.ts:1375).
 // The two are mitigated tradeoffs (ours cold-starts a shifted key, wp false-matches a nearby λ that AVBD
-// absorbs), and which is better is an OPEN 4.9 A/B (vs Jolt/Bullet PCM position-proximity too —
-// roadmap "Phase 4.9 Goal C", scratch.md "Phase 4.8.5" item 4). This guards only against an *accidental*
+// absorbs), and which is better is an OPEN 4.9 A/B (vs Jolt/Bullet PCM position-proximity too). This guards only against an *accidental*
 // re-ordinal while that *deliberate* choice stays open: the continuity test above covers the 4-point
 // interior manifold (no reduction); this reaches the OVER-PRODUCED clip the Jolt reduction prunes to 4,
 // where each kept contact keeps its ORIGINAL clip ordinal (a non-contiguous subset), so a rank-relabel

--- a/packages/shallot/tests/avbd/solver.ts
+++ b/packages/shallot/tests/avbd/solver.ts
@@ -3,7 +3,7 @@
 // force initialize/warmstart → body inertial init + adaptive warmstart → the main loop
 // (primal solve + dual update) → BDF1 velocity recovery.
 //
-// Two axes the reference doesn't have, both required by scratch.md "AVBD rebuild":
+// Two required axes the reference doesn't have:
 //   • scheduler — `sequential` is the C++ exactly (Gauss-Seidel, reverse creation order, commit
 //     in place); `colored` runs a supplied coloring (commit deferred within a color → a rare
 //     same-color neighbor degrades to Jacobi, the paper's §Parallelization).
@@ -51,7 +51,7 @@ export interface Params extends ContactParams {
      * sub-steps per fixed step (the "small steps" form, Macklin 2019): one `step()` runs `substeps`
      * complete AVBD sub-steps of `h = dt/substeps`. Smaller per-sub-step motion keeps the penalty ramp
      * (`k += β|C|`) bounded — a tall dense pile that can't converge in one big step otherwise runs `k`
-     * away into a lateral ejection (scratch.md "Phase 4.9 robustness"). `1` is byte-identical to the
+     * away into a lateral ejection. `1` is byte-identical to the
      * single-step reference, so the corpus + closed-form gates are unchanged.
      */
     substeps: number;

--- a/packages/shallot/tests/bvh/oracle.ts
+++ b/packages/shallot/tests/bvh/oracle.ts
@@ -10,7 +10,7 @@
 // Exact topology is NOT the contract — parallel merge order is non-deterministic
 // even in NexusBVH. The contract is the per-pass output (bounds, codes, sort) and,
 // for the build, the invariants + SAH + ray-vs-brute-force agreement that
-// {@link invariants} and {@link compareRays} check. See scratch.md "H-PLOC BVH".
+// {@link invariants} and {@link compareRays} check.
 
 import { type Prims, primMax, primMin } from "./fixtures";
 

--- a/packages/shallot/tests/check-eval-gates.test.ts
+++ b/packages/shallot/tests/check-eval-gates.test.ts
@@ -15,7 +15,7 @@
 //
 // Rounds 1–3 hand-rolled regex and brace-counting over `evals/` source. All
 // three were green at their own gate and each was holed in the surface form
-// that round's fixtures did not vary. `checks.md` names this class: a check
+// that round's fixtures did not vary. A check
 // that has failed N rounds each green at its own gate is a finding about the
 // gate's *kind*. So the arms that parse read a `@babel/parser` AST and assert
 // a structural property — a call expression's argument node kind, a function's
@@ -598,7 +598,7 @@ describe("S3 — staging failure maps to INCOMPLETE (post-fix)", () => {
     // specifier rather than declaration, and a template-literal union
     // member `TSLiteralType` never matches) — the signal that an absence-
     // over-an-open-shape-space arm cannot be made exhaustive by widening
-    // its reader (`checks.md`'s N-rounds clause), so this leg retires the
+    // its reader, so this leg retires the
     // scan rather than authoring a fifth reader.
     //
     // Dominance measurement (this round's acceptance evidence, reproduced
@@ -628,9 +628,7 @@ describe("S3 — staging failure maps to INCOMPLETE (post-fix)", () => {
     // name `grade.ts` imports from a source ending `harness/result` must
     // resolve to a real export of that module (never a spelling, never a
     // filename guess — the same binding-resolution shape as the
-    // harness/lib arm above). Renamed for exactly that assertion, per
-    // `checks.md`'s "name the arm for what it asserts, not for the
-    // property you wish it had".
+    // harness/lib arm above). The arm is named for exactly that assertion.
     test("grade.ts's harness/result import resolves to a real export of that module", () => {
         const root = evalRoot();
         const ast = gradeAst(root);
@@ -1125,9 +1123,8 @@ describe("S4 — blocker 2's floor: per-test value covers the gate's OWN boot() 
 // re-exported, an options object spread together at the call site) evades
 // it; that shape reds this leg instead of passing silently, but it is not
 // something this leg positively verifies as safe. This is a match-shape
-// limit, not a promise that every restatement is caught — `checks.md`'s own
-// clause on why a docblock claiming "any restatement" would be a false
-// statement in a permanent file.
+// limit, not a promise that every restatement is caught — claiming "any restatement"
+// would be a false statement in a permanent file.
 //
 // Population control across the whole class: at least one `timeout:` is
 // actually evaluated (checked, pass or fail) somewhere in the six gates

--- a/packages/shallot/tests/conformance-roster.ts
+++ b/packages/shallot/tests/conformance-roster.ts
@@ -1,7 +1,7 @@
 // the shared roster and rebuild-conformance harness, read by both the default-tier
 // `conformance.test.ts` and the by-path `conformance.tier.ts`. One roster, split by a declared
 // predicate (`isPipelineCompiling`), never two hand-copied lists — the one-source-of-truth law
-// (`coding.md` "One source of truth") holds here by construction: the single `roster` export plus the
+// holds here by construction: the single `roster` export plus the
 // `isPipelineCompiling` predicate, not by a mechanical check (no gate scans for a restated
 // conformance roster).
 //

--- a/packages/shallot/tests/conformance.test.ts
+++ b/packages/shallot/tests/conformance.test.ts
@@ -7,8 +7,7 @@
 // is the survive-reload flow at examples/flows/survive-reload/ (`bun run flows`), which rebuilds through a real page
 // reload; this roster is the sole per-plugin conformance coverage.
 //
-// This is the default-tier SENTINEL (`coding.md` Suite speed: a gate leaving the default suite
-// leaves a cheap sentinel): the pipeline-compiling arms — Render, Part, Sear, Glaze, Lines, Sprite,
+// This is the default-tier SENTINEL: the pipeline-compiling arms — Render, Part, Sear, Glaze, Lines, Sprite,
 // Skin, Physics, Character, Player, both toggle arms, and the SkinPlugin+GltfPlugin pair — were
 // promoted to the by-path tier `conformance.tier.ts` because their real GPU pipeline-compile cost
 // (render arms measured 4.6–6.3 s, readings 5062–6279 ms) straddled the 5000 ms per-file cap

--- a/packages/shallot/tests/conformance.tier.ts
+++ b/packages/shallot/tests/conformance.tier.ts
@@ -21,7 +21,7 @@
 // — a sentinel stays behind in the default suite against the same frozen fixture." `.oracle.ts` is the
 // heavy deterministic CPU reference tier (the f64 AVBD physics oracle), not this case.
 //
-// Trigger cone (derived per `checks.md`'s by-path rule, `coding.md` Suite speed): this file's own
+// Trigger cone: this file's own
 // transitive import cone — the plugin source modules whose reload conformance the promoted arms pin,
 // walked from this file's import statements. The cone is the source tree of every plugin this file
 // (and the shared roster it imports) pulls in for a promoted arm: `src/standard/render/`,

--- a/scripts/check-docs.test.ts
+++ b/scripts/check-docs.test.ts
@@ -14,7 +14,7 @@
 // must land in an existing tracked file. The test appends comments to `scripts/rosters.ts`
 // (a tracked .ts file, not in POINTER_EXCLUSION), runs the real script as a subprocess, and
 // restores the original content in `finally` — same pattern as check-imports.test.ts. Both
-// cites are seeded in a single subprocess run. The subprocess is driven from `beforeAll` so
+// cites and a private-only basename are seeded in a single subprocess run. The subprocess is driven from `beforeAll` so
 // its wall-clock cost is invisible to the per-file test-duration cap (5000 ms), which measures
 // only the test body, not `beforeAll`/`afterAll` (see packages/shallot/tests/test-cap.ts).
 
@@ -30,13 +30,13 @@ let captured: { exitCode: number; output: string };
 beforeAll(async () => {
     const original = readFileSync(SEED_FILE, "utf-8");
     try {
-        // Seed both a dead cite (resolves to nothing) and a live cite (README.md is tracked
-        // in-repo) in the same file. One subprocess run covers both sides.
+        // Seed a dead cite, a live in-repo cite (README.md), and a private-only basename in one run.
         writeFileSync(
             SEED_FILE,
             original +
                 "\n// vacuity-arm-seed: see zzz-vacuity-dead-seed.md for details\n" +
-                "// vacuity-arm-seed: see README.md for details\n",
+                "// vacuity-arm-seed: see README.md for details\n" +
+                "// vacuity-arm-seed: see checks.md for details\n",
         );
         const proc = Bun.spawn({
             cmd: ["bun", SCRIPT],
@@ -69,4 +69,9 @@ test("pointer-validity — two-sided vacuity reading (dead reds, live spared)", 
     // (Exit code is not asserted on this side: pre-sweep the script reds at 46 from
     // existing sites, post-sweep it greens — either way the live cite is spared.)
     expect(captured.output).not.toMatch(/rosters\.ts:\d+: README\.md/);
+});
+
+test("pointer-validity — a private-only basename does not resolve", () => {
+    expect(captured.exitCode).toBe(1);
+    expect(captured.output).toMatch(/rosters\.ts:\d+: checks\.md/);
 });

--- a/scripts/check-docs.ts
+++ b/scripts/check-docs.ts
@@ -1155,7 +1155,7 @@ if (staleCitations.length > 0) {
 // *.md path citation is the greppable surface form of that anchor: `roads-interactive.md`,
 // `ecs.md`, `gpu.md:110`. The arm scans every tracked .ts file's comment lines for *.md
 // path citations and checks each basename against the set of .md files tracked in the
-// shallot repo or the superproject (the full repo a reader has). A citation that
+// shallot repo. A citation that
 // resolves to nothing is a dead anchor — it reads as authoritative for years.
 //
 // The discrimination follows the fixture-pin scan's shape (the `fixtureUnclassified`
@@ -1182,25 +1182,11 @@ if (staleCitations.length > 0) {
 // `scripts/rosters.ts:100: zzz-dead-pointer-mutation-proof.md` moves the count from 46
 // to 47).
 
-// Build the resolved .md basenames set: shallot tracked + superproject tracked. A
-// citation resolves if SOME file with that basename is tracked in the shallot repo or
-// the superproject — the full repo a reader has. `checks.md` and `coding.md` live in
-// the superproject's `.claude/rules/`, not the shallot submodule, so a shallot-only
-// check would false-positive on them. `scratch.md` lives in a sibling submodule
-// (`orrstead/`), tracked by the superproject. `roads-interactive.md` is tracked by
-// neither — it resolves to nothing.
+// A citation resolves only if its basename is tracked in this repo, so the gate
+// holds for a standalone reader without access to a private containing repository.
 const resolvedMdBasenames = new Set<string>();
 for (const path of docs) {
     resolvedMdBasenames.add(path.split("/").pop()!);
-}
-const superprojectRoot = resolve(root, "..");
-const superprojectMd = Bun.spawnSync(["git", "ls-files", "-z", "*.md"], {
-    cwd: superprojectRoot,
-});
-if (superprojectMd.success) {
-    for (const path of superprojectMd.stdout.toString().split("\0").filter(Boolean)) {
-        resolvedMdBasenames.add(path.split("/").pop()!);
-    }
 }
 
 // A *.md path citation in a comment: a word ending in .md, not preceded by a word

--- a/scripts/check-node-import.ts
+++ b/scripts/check-node-import.ts
@@ -140,8 +140,7 @@ try {
     const out = `${proc.stdout.toString()}${proc.stderr.toString()}`;
     // Assert the test *ran*, not merely that the process was happy: a module-load failure leaves
     // `playwright test --list` exiting 0 with "Total: 0 tests in 0 files" (measured 2026-08-25), so an
-    // exit code alone is not a witness that the subject was ever imported (`checks.md`: "an arm whose
-    // subject never launched reads clean on a predicate that checks only survivors").
+    // exit code alone is not a witness that the subject was ever imported.
     if (proc.exitCode !== 0 || !/\b1 passed\b/.test(out)) {
         fail(
             `real node could not import ${SUBJECT} (exit ${proc.exitCode})`,

--- a/scripts/compile-concurrency.ts
+++ b/scripts/compile-concurrency.ts
@@ -9,8 +9,7 @@ import { queryFlags, skipReason, teardownBridge, verify } from "./verify";
 // the boot window, unfiltered), fed through the pure reader `compileConcurrencyRatio`
 // (`site/rum-compile-vitals.ts`) rather than re-deriving the ratio here. Prints
 // `{count, sum, span, ratio}` plus the absolute span ungated — a concurrency claim (the ratio) is
-// host-independent by construction, so nothing here gates on a wall-clock number
-// (`.claude/rules/checks.md` on a threshold over wall-clock duration).
+// host-independent by construction, so nothing here gates on a wall-clock number.
 //
 //     bun run scripts/compile-concurrency.ts [--dir <project>] [--query k=v ...]
 //

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -254,7 +254,7 @@ function createShallotFlow(work: string, engineTgz: string) {
         `exit ${noPw.exitCode}`,
     );
 
-    // criterion 7 (specs/shallot-tui.md): "a missing bun-webgpu produces a named remedy" — the genuine-
+    // criterion 7: "a missing bun-webgpu produces a named remedy" — the genuine-
     // absence rung, mirroring the playwright check directly above exactly. This scaffold never installs
     // bun-webgpu (a devDependency of the monorepo's own packages/shallot, never shipped or declared for a
     // consumer), so `shallot tui` here hits a real absence, not an injected one — real subprocess stdout/


### PR DESCRIPTION
## Problem

Source comments could cite documentation available only in a containing private repository, so the documentation check did not protect standalone readers. The ASCII pixel gate could also mistake DOM panel changes for scene motion without supplying orbit input.

## Cause

The documentation resolver searched the containing repository. The old ASCII reader measured full compositor changes without separating DOM UI or driving the camera.

## Fix

Remove the containing-repository resolution leg and 94 private/dead anchors, retaining invariant sentences and 408 internal citations. Add a private-only resolution refusal fixture.

Repair only the ASCII pixel test: real orbit input, visibility-only DOM exclusion with full image geometry, live locked-camera and absent-box controls, durable PNG/RGBA/response attachments, and direct absent readiness using the existing queue fence plus two animation frames. Density, motion arithmetic and thresholds remain unchanged.

Accepted head: `451769d987533768cd118d7cf62a48fe83a7e397`. This branch is a Git-only transfer of that exact accepted tree, not a new runtime execution seat.

## Evidence

- Final accepted source: format/check/test exit 0; 3,190 unit tests pass, no failures or skips.
- Complete 52-path delta: 49 comment-only files, two documentation-check files, and the ASCII reader. Whole-tree paths/modes and common-reader identity bound; source AST, operative pragma attachment, installed TypeGPU host filters and emitted ASTs, and Vite TypeScript erasure agree for all 49 files. Seven production-filtered transformations; eight was the separate forced-handler count.
- Command/input map includes workspace exports, loader/config/preload paths, dynamic loads, source readers, reflection and the glTF module-worker entry. One independent boundary review found the omitted worker edge; the corrected map and edge/entry/filter refusal controls passed.
- Actual full base-to-head selector dry-run: 1 CPU / 39 display rows. No absolute full-selector PASS is claimed. The historical paired full selectors and comparator remain exit 1; all 39 non-ASCII rows match, with existing roads/fog failures retained.
- Actual committed reader-only selector: exit 0, both tests, all positive/locked/absent phases, no skips, real adapter. All 50 final physical artifacts verified; all 54 retained mutation artifacts verified. Immutable mutation replay confirms discrimination without changing the original admission refusal.
- No product source, selector/registry, threshold, packaging or release change beyond the stated documentation checks and ASCII test. No new display invocation for acceptance or transfer.
