### PR TITLE
shallot-strip-back: ratchet instructions and shorten style

### DIFF
--- a/.claude/rules/style.md
+++ b/.claude/rules/style.md
@@ -1,57 +1,23 @@
 # Style
 
-How shallot code is shaped: naming, the shape of a function, and when to comment — across all code in this repo: engine source (`src/engine/`, `src/standard/`, `src/extras/`), tests, `bin/`, `scripts/`, `evals/`, and examples alike. The data-over-methods philosophy lives in `packages/shallot/AGENTS.md`; choosing a component, system, or singleton primitive lives in `ecs.md`. This file covers the rest: what to call things, how a function reads, and what's worth a comment.
-
-## Imitate the existing code
-
-`src/engine/` and `src/standard/` are the reference for both. Before writing a new function, system, or plugin, read a sibling in the same directory and follow its shape. The names and structure already there are the spec. Two minutes grepping neighbors for the verb that fits beats inventing one, and keeps the surface consistent.
+Applies to all repo code, including tests, tooling and examples. Read a sibling before adding a function, system or plugin; follow the naming and shape in `src/engine/` and `src/standard/`. Data-over-methods lives in `packages/shallot/AGENTS.md`; primitive choices live in `ecs.md`.
 
 ## Naming
 
-The shortest word that's clear in context, a single verb where one fits: `mesh`, `pack`, `warm`, `sparse`, `slab`, `attachCanvas`. Module scope is the context: a function doesn't repeat the name of the file or type it lives in.
-
-- Add a qualifier only to distinguish two real things: `composeTransform` (one entity) vs `composeTransforms` (the batch). Never to describe what the body already shows. A function that builds a mesh from vertices is `mesh`, not `createMeshGeometryFromVertices`. (anti-pattern)
-- A multi-word name is usually a function doing several things. Split it, or the name is covering for a call chain.
-- PascalCase for components, plugins, and singletons (`Transform`, `RenderPlugin`, `Compute`); camelCase for functions and locals.
+Use the shortest clear word, a single verb where it fits. Module scope supplies context: don't repeat the file or type name. Qualify only to distinguish real alternatives, not to describe the body. A multi-word name may hide several jobs; split those jobs rather than disguise a call chain. Use PascalCase for components, plugins and singletons; camelCase for functions and locals.
 
 ## A function is a transform; a system is a loop
 
-Logic is data in, data out. Orchestration is a flat sequence or a query loop, not a stack of private helpers calling helpers. The dominant shape is a system that queries entities and acts on each:
-
-```ts
-// standard/sear/index.ts — query, guard, act. Flat.
-const ColorSystem: System = {
-    group: "draw",
-    after: [PrepassSystem],
-    update(state) {
-        if (!Render.encoder) return;
-        for (const eid of state.query([Camera, Sear])) {
-            const view = Views.get(eid);
-            if (!view?.framebuffer) continue;
-            renderColor(eid, view, _frameDraws);
-        }
-    },
-};
-```
-
-Guards are early returns, not nested branches. The work it hands off (`renderColor`) is one named transform, not a `prepareX` then `buildY` then `applyZ` chain of helpers calling each other. Extract a step into its own function when it's pure and a test can call it in isolation; inline a step that only runs from one place. A plugin is the same idea, as data: a plain object of `name`, `components`, `systems`, `dependencies`, and lifecycle hooks (`initialize` / `warm`), not a class. See `SearPlugin` and `PartPlugin` in `standard/`. (anti-pattern)
+Logic is data in, data out. Orchestration is a flat sequence or entity-query loop: query, guard, act. Use early returns instead of nested branches, and named transforms instead of private helpers calling helpers. Extract pure steps that tests can call in isolation; inline steps used only once. Plugins are plain objects with components, systems, dependencies and lifecycle hooks, not classes. Follow `SearPlugin` and `PartPlugin` in `standard/`.
 
 ## Comments earn their place
 
-The comment rule is universal: default to none, earn one only with a public export's JSDoc contract or the *why* behind a non-obvious line. One thing is shallot-specific: shallot code is minimal enough that the bar sits higher than elsewhere — `sear/` and `slab/` are the reference for how much to say, and when in doubt, say less.
+Default to none. Earn a comment with a public export's JSDoc contract or the why behind a non-obvious line; `sear/` and `slab/` set the bar. State today's invariant, never restate the code or narrate an edit. History sections, refuted alternatives and workflow chronologies belong in Git. Algorithm step labels are fine: they name the algorithm, not this repo's workflow.
 
-**A comment states what is true now; how the code got that way is the commit message's job.** Never restate the line, and never narrate the edit — "now we…", "changed to…", "no longer…", "previously…", "used to…" are the greppable surface forms. A `History:` section, a refuted-alternative record, or a workflow-stage chronology in a module header is the same defect at essay length: rewrite it as the invariant that holds today, or delete it. (Algorithm step labels like `// Stage 1:` in a ported kernel are fine — they name the algorithm's own stages, not this repo's workflow.)
+Never anchor comments to workflow stage IDs, private planning paths or deleted symbols. Write the invariant so a standalone reader can check it. `scripts/check-docs.ts` checks tracked `.ts` comment citations against `.md` basenames tracked in this repo only. It does not validate full paths, scan other source languages or distinguish bare workflow IDs from algorithm labels; those still need a read. `check-docs.test.ts` preserves dead/private refusal and live resolution.
 
-**A comment anchored to something outside this repo rots invisibly.** Never cite a workflow stage ID, a private planning path, or a symbol you are deleting; write the invariant instead, so the comment stays checkable by a reader who has only this repo. A stale anchor reads as authoritative for years — one sweep found ~90 such sites, and the last of them had to be caught by name because no regex spelled its surface form. **The `*.md`-cite half is partly gated and the stage-ID half never will be.** `scripts/check-docs.ts` reds on a **tracked `.ts`** comment citing a `.md` **basename** that no tracked `.md` matches, in this repo or the one containing it (`check-docs.test.ts` holds the two-sided reading — a dead cite reds, a live one is spared), so a pointer to a deleted spec cannot re-accrete there. Know the three edges it leaves: the *path* is never checked, only the basename; non-`.ts` sources are unscanned; and a basename tracked only by the containing repo is spared, so a cite that resolves for a reader who has that repo still rots for one who has only this one. A bare stage ID has no resolution target at all, and separating a workflow anchor from an algorithm's own `// Stage N:` labels is semantic rather than mechanical, so that half re-accretes silently and only a read catches it.
+## Instruction budgets
 
-- **The entry-doc chain from repo root down to the working directory stays under the Codex 32768 B budget** — `scripts/check-docs.ts`'s `ENTRY_DOC_BUDGET = 32768` arm enforces this per chain in `bun run check` (root + `packages/shallot`, root + `examples`), so a manual `wc -c` before an entry-doc addition is work the gate already does; the chain sits at ~32752 B — 16 B of headroom — so the next addition must fold detail down into a path-scoped rule rather than pay for it in the entry doc; past the budget Codex silently drops the deepest file and its whole contract vanishes.
+Keep root-to-leaf entry-doc chains within 32768 bytes. `scripts/check-docs.ts` enforces root plus `packages/shallot`, and root plus `examples`, in `bun run check`. Fold detail into scoped rules: exceeding the context-loader budget silently drops the deepest file and its contract.
 
-```ts
-// good — says why; survives the next edit
-// the shadow pass reads positions only; the attributes stream stays bound for the color pass
-bindMesh(state, view.positions);
-
-// bad — narrates the change and restates the code
-// now we bind positions instead of the whole mesh like before
-bindMesh(state, view.positions); // bind the positions
-```
+The same check ratchets instruction bytes and longest blank-line-delimited paragraph per file, plus corpus bytes. After cuts, explicitly run `bun run scripts/check-docs.ts --lower`; checking never writes. Its Git-derived population covers any-depth AGENTS.md, CLAUDE.md and `.claude/rules/*.md`, including untracked files; ignored files and other names are outside that vocabulary. New members and symlinks refuse.

--- a/scripts/check-docs.test.ts
+++ b/scripts/check-docs.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import {
     cpSync,
     mkdirSync,
@@ -8,6 +9,7 @@ import {
     symlinkSync,
     writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { EXAMPLE_GATES } from "./example-gates";
 import { OCEAN_CPU_GATES } from "./ocean-oracle-gates";
@@ -15,11 +17,18 @@ import { OCEAN_CPU_GATES } from "./ocean-oracle-gates";
 const root = resolve(import.meta.dir, "..");
 type Reading = { exitCode: number; output: string };
 const readings = new Map<string, Reading>();
+const baselineFile = "scripts/instruction-budget.json";
+const hash = (text: string) => createHash("sha256").update(text).digest("hex");
 
 // A complete tracked-tree fixture keeps every preceding production guard live. Its index
 // preserves the real population; only the named mutation differs from the working tree.
 beforeAll(async () => {
-    const fixture = mkdtempSync(join(root, "node_modules/.check-docs-"));
+    const container = mkdtempSync(join(tmpdir(), "shallot-check-docs-"));
+    const fixture = join(container, "member");
+    mkdirSync(fixture);
+    expect(Bun.spawnSync(["git", "init", "--quiet", container]).exitCode).toBe(0);
+    writeFileSync(join(container, "checks.md"), "# private parent rule\n");
+    expect(Bun.spawnSync(["git", "add", "checks.md"], { cwd: container }).exitCode).toBe(0);
     const index = Bun.spawnSync(["git", "ls-files", "--stage"], { cwd: root });
     expect(index.exitCode).toBe(0);
     try {
@@ -28,6 +37,7 @@ beforeAll(async () => {
             mkdirSync(dirname(join(fixture, file)), { recursive: true });
             cpSync(join(root, file), join(fixture, file));
         }
+        cpSync(join(root, baselineFile), join(fixture, baselineFile));
         expect(Bun.spawnSync(["git", "init", "--quiet", fixture]).exitCode).toBe(0);
         expect(
             Bun.spawnSync(["git", "update-index", "--index-info"], {
@@ -36,8 +46,16 @@ beforeAll(async () => {
             }).exitCode,
         ).toBe(0);
         symlinkSync(join(root, "node_modules"), join(fixture, "node_modules"));
-        const run = async (name: string, edits: Record<string, (text: string) => string>) => {
+        const run = async (
+            name: string,
+            edits: Record<string, (text: string) => string>,
+            args: string[] = [],
+            setup?: () => () => void,
+        ) => {
             const originals = new Map<string, string>();
+            const baselinePath = join(fixture, baselineFile);
+            const baselineOriginal = readFileSync(baselinePath, "utf8");
+            let cleanup: (() => void) | undefined;
             try {
                 for (const [file, mutate] of Object.entries(edits)) {
                     const path = join(fixture, file);
@@ -47,7 +65,9 @@ beforeAll(async () => {
                     expect(changed).not.toBe(original);
                     writeFileSync(path, changed);
                 }
-                const proc = Bun.spawn(["bun", "scripts/check-docs.ts"], {
+                cleanup = setup?.();
+                const before = readFileSync(baselinePath, "utf8");
+                const proc = Bun.spawn(["bun", "run", "scripts/check-docs.ts", ...args], {
                     cwd: fixture,
                     stdout: "pipe",
                     stderr: "pipe",
@@ -59,12 +79,93 @@ beforeAll(async () => {
                 ]);
                 const reading = { exitCode, output: stdout + stderr };
                 readings.set(name, reading);
-                console.log(`[docs control: ${name}] exit=${exitCode}\n${reading.output}`);
+                const after = readFileSync(baselinePath, "utf8");
+                console.log(
+                    `[docs control: ${name}] exit=${exitCode} before=${hash(before)} after=${hash(after)}\n${reading.output}`,
+                );
+                if (!args.length || exitCode !== 0) expect(after).toBe(before);
+                if (name === "valid lowering") {
+                    expect(exitCode).toBe(0);
+                    const oldBudget = JSON.parse(before);
+                    const newBudget = JSON.parse(after);
+                    expect(newBudget.total).toBeLessThan(oldBudget.total);
+                    for (const [file, size] of Object.entries(newBudget.files) as [
+                        string,
+                        { bytes: number; paragraph: number },
+                    ][]) {
+                        expect(size.bytes).toBeLessThanOrEqual(oldBudget.files[file].bytes);
+                        expect(size.paragraph).toBeLessThanOrEqual(oldBudget.files[file].paragraph);
+                    }
+                    expect(hash(after)).not.toBe(hash(before));
+                }
             } finally {
+                cleanup?.();
                 for (const [path, original] of originals) writeFileSync(path, original);
+                writeFileSync(baselinePath, baselineOriginal);
             }
         };
         await run("baseline", {});
+        const visual = ".claude/rules/visual-identity.md";
+        const byteGrowth = { [visual]: (text: string) => `${text}\n\nsmall addition\n` };
+        const paragraphGrowth = { [visual]: (text: string) => text.replace(/\n\s*\n/g, " ") };
+        await run("byte growth", byteGrowth);
+        await run("paragraph growth", paragraphGrowth);
+        await run("lower refuses byte growth", byteGrowth, ["--lower"]);
+        await run("lower refuses paragraph growth", paragraphGrowth, ["--lower"]);
+        const totalGrowth = {
+            [baselineFile]: (text: string) => {
+                const budget = JSON.parse(text);
+                budget.total--;
+                return JSON.stringify(budget);
+            },
+        };
+        await run("corpus growth", totalGrowth);
+        await run("lower refuses corpus growth", totalGrowth, ["--lower"]);
+        await run(
+            "valid lowering",
+            {
+                [visual]: (text) =>
+                    text.replace(
+                        "Shallot's visual language across shipped UI surfaces: examples, overlays, the profiler HUD.\n",
+                        "",
+                    ),
+            },
+            ["--lower"],
+        );
+        const addMember =
+            (file: string, link = false, tracked = false) =>
+            () => {
+                const path = join(fixture, file);
+                mkdirSync(dirname(path), { recursive: true });
+                if (link) symlinkSync(join(fixture, "CLAUDE.md"), path);
+                else writeFileSync(path, "# local instructions\n");
+                if (tracked)
+                    expect(
+                        Bun.spawnSync(["git", "add", "--", file], { cwd: fixture }).exitCode,
+                    ).toBe(0);
+                return () => {
+                    if (tracked)
+                        expect(
+                            Bun.spawnSync(["git", "update-index", "--force-remove", "--", file], {
+                                cwd: fixture,
+                            }).exitCode,
+                        ).toBe(0);
+                    rmSync(path);
+                };
+            };
+        await run("untracked rule", {}, [], addMember("nested/.claude/rules/new.md"));
+        await run("nested entry", {}, [], addMember("nested/deeper/AGENTS.md"));
+        await run("tracked symlink", {}, [], addMember("nested/CLAUDE.md", true, true));
+        await run("tracked symlink mode", {}, [], () => {
+            const cleanup = addMember("nested/CLAUDE.md", true, true)();
+            rmSync(join(fixture, "nested/CLAUDE.md"));
+            writeFileSync(join(fixture, "nested/CLAUDE.md"), "# regular working file\n");
+            return cleanup;
+        });
+        await run("untracked symlink", {}, [], addMember("nested/AGENTS.md", true));
+        await run("lower refuses unlisted", {}, ["--lower"], addMember("nested/AGENTS.md"));
+        await run("closed vocabulary", {}, [], addMember("nested/INSTRUCTIONS.md"));
+        await run("ignored member", {}, [], addMember("dist/AGENTS.md"));
         await run("pointers", {
             "scripts/rosters.ts": (text) =>
                 text + "\n// see zzz-vacuity-dead-seed.md\n// see README.md\n// see checks.md\n",
@@ -140,13 +241,40 @@ beforeAll(async () => {
                     .join(""),
         });
     } finally {
-        rmSync(fixture, { recursive: true, force: true });
+        rmSync(container, { recursive: true, force: true });
     }
 }, 60000);
 
-test("production docs consumer grants the current tree", () => {
-    expect(readings.get("baseline")?.exitCode).toBe(0);
-});
+for (const name of ["baseline", "valid lowering", "closed vocabulary", "ignored member"]) {
+    test(`production docs consumer grants ${name}`, () => {
+        expect(readings.get(name)?.exitCode).toBe(0);
+    });
+}
+
+for (const [name, diagnostic] of [
+    ["byte growth", "byte growth:"],
+    ["paragraph growth", "paragraph growth:"],
+    ["corpus growth", "corpus growth:"],
+    ["lower refuses byte growth", "byte growth:"],
+    ["lower refuses paragraph growth", "paragraph growth:"],
+    ["lower refuses corpus growth", "corpus growth:"],
+    ["untracked rule", "unlisted member: nested/.claude/rules/new.md"],
+    ["nested entry", "unlisted member: nested/deeper/AGENTS.md"],
+    ["tracked symlink", "symlink member: nested/CLAUDE.md"],
+    ["tracked symlink mode", "symlink member: nested/CLAUDE.md"],
+    ["untracked symlink", "symlink member: nested/AGENTS.md"],
+    ["lower refuses unlisted", "unlisted member: nested/AGENTS.md"],
+]) {
+    test(`instruction ratchet refuses ${name} after preceding guards`, () => {
+        const reading = readings.get(name)!;
+        expect(reading.exitCode).toBe(1);
+        expect(reading.output).toContain("✓ command composition");
+        expect(reading.output).toContain("✗ instruction ratchet:");
+        expect(reading.output).toContain(diagnostic);
+        if (name.includes("paragraph")) expect(reading.output).not.toContain("byte growth:");
+        if (name.includes("byte")) expect(reading.output).not.toContain("paragraph growth:");
+    });
+}
 
 test("pointer validity refuses dead and private-only basenames, grants a live basename", () => {
     const reading = readings.get("pointers")!;

--- a/scripts/check-docs.ts
+++ b/scripts/check-docs.ts
@@ -1,3 +1,4 @@
+import { lstatSync } from "node:fs";
 import { Glob } from "bun";
 import { resolve } from "path";
 import { template } from "../packages/create-shallot/index";
@@ -1020,7 +1021,7 @@ if (rosterInTree.length > 0) {
 // The pinned marker-exempted count. This literal is the law the arm already applies to its
 // tier rosters and chain budgets: growth reds, and a swap-in moves prose a reviewer reads.
 // When a marker is added or removed from a rule file, this count must be updated to match.
-const PINNED_MARKER_EXEMPTED_COUNT = 20;
+const PINNED_MARKER_EXEMPTED_COUNT = 16;
 
 type StaleCitation = {
     file: string;
@@ -1336,6 +1337,105 @@ if (compositionFindings.length) {
 }
 console.log(
     `✓ command composition (${rosterCommands.size} derived commands, ${testPaths.length} manifest test paths, ${subsumedCommands} subsumed commands, ${testCones} restated cones)`,
+);
+
+// One closed Git population; ignored files and other instruction names are outside this arm.
+// Paragraphs are nonempty blank-line-delimited blocks, measured in Unicode characters.
+const lowerInstructions = process.argv.slice(2);
+if (lowerInstructions.length && lowerInstructions.join(" ") !== "--lower") {
+    console.error("✗ instruction ratchet: expected no arguments or --lower");
+    process.exit(1);
+}
+const instructionListing = Bun.spawnSync(["git", "ls-files", "-co", "--exclude-standard", "-z"], {
+    cwd: root,
+});
+const instructionModes = Bun.spawnSync(["git", "ls-files", "--stage", "-z"], { cwd: root });
+if (!instructionListing.success || !instructionModes.success) {
+    console.error("✗ instruction ratchet: Git population unavailable");
+    process.exit(1);
+}
+const instructionFiles = [...new Set(instructionListing.stdout.toString().split("\0"))]
+    .filter((file) =>
+        /(?:^|\/)(?:AGENTS|CLAUDE)\.md$|(?:^|\/)\.claude\/rules\/[^/]+\.md$/.test(file),
+    )
+    .sort();
+const symlinkFiles = new Set(
+    instructionModes.stdout
+        .toString()
+        .split("\0")
+        .filter((entry) => entry.startsWith("120000 "))
+        .map((entry) => entry.slice(entry.indexOf("\t") + 1)),
+);
+type InstructionSize = { bytes: number; paragraph: number };
+type InstructionBudget = { total: number; files: Record<string, InstructionSize> };
+const measured: InstructionBudget = { total: 0, files: {} };
+const instructionFindings: string[] = [];
+if (!instructionFiles.length) instructionFindings.push("empty population");
+for (const file of instructionFiles) {
+    try {
+        if (symlinkFiles.has(file) || lstatSync(resolve(root, file)).isSymbolicLink()) {
+            instructionFindings.push(`symlink member: ${file}`);
+            continue;
+        }
+        const text = await Bun.file(resolve(root, file)).text();
+        const bytes = Buffer.byteLength(text);
+        const paragraph = Math.max(
+            0,
+            ...text.split(/\n\s*\n/).map((part) => [...part.trim()].length),
+        );
+        measured.files[file] = { bytes, paragraph };
+        measured.total += bytes;
+    } catch {
+        instructionFindings.push(`unreadable member: ${file}`);
+    }
+}
+const instructionBaseline = Bun.file(resolve(root, "scripts/instruction-budget.json"));
+if (await instructionBaseline.exists()) {
+    const budget = (await instructionBaseline.json()) as InstructionBudget;
+    const ceiling = (value: number) => Number.isSafeInteger(value) && value >= 0;
+    if (!ceiling(budget.total) || !budget.files || Array.isArray(budget.files)) {
+        instructionFindings.push("invalid baseline");
+    } else {
+        for (const [file, size] of Object.entries(budget.files)) {
+            if (!size || !ceiling(size.bytes) || !ceiling(size.paragraph)) {
+                instructionFindings.push(`invalid ceiling: ${file}`);
+            }
+        }
+        for (const [file, size] of Object.entries(measured.files)) {
+            const cap = budget.files[file];
+            if (!Object.hasOwn(budget.files, file))
+                instructionFindings.push(`unlisted member: ${file}`);
+            else {
+                if (size.bytes > cap.bytes)
+                    instructionFindings.push(`byte growth: ${file} ${size.bytes} > ${cap.bytes}`);
+                if (size.paragraph > cap.paragraph)
+                    instructionFindings.push(
+                        `paragraph growth: ${file} ${size.paragraph} > ${cap.paragraph}`,
+                    );
+            }
+        }
+        if (measured.total > budget.total)
+            instructionFindings.push(`corpus growth: ${measured.total} > ${budget.total}`);
+    }
+} else if (!lowerInstructions.length) {
+    instructionFindings.push("missing baseline; seed explicitly with --lower");
+} else {
+    const style = measured.files[".claude/rules/style.md"];
+    if (!style || style.bytes > 3000 || style.paragraph > 800) {
+        instructionFindings.push(
+            "initial style must be <=3000 bytes and <=800 paragraph characters",
+        );
+    }
+}
+if (instructionFindings.length) {
+    console.error(`✗ instruction ratchet:\n${instructionFindings.join("\n")}`);
+    process.exit(1);
+}
+if (lowerInstructions.length) {
+    await Bun.write(instructionBaseline, `${JSON.stringify(measured, null, 4)}\n`);
+}
+console.log(
+    `✓ instruction ratchet (${instructionFiles.length} files, ${measured.total} bytes; ${lowerInstructions.length ? "lowered" : "validate-only"})`,
 );
 
 console.log(

--- a/scripts/instruction-budget.json
+++ b/scripts/instruction-budget.json
@@ -1,0 +1,69 @@
+{
+    "total": 481092,
+    "files": {
+        ".claude/rules/audio.md": {
+            "bytes": 6161,
+            "paragraph": 1517
+        },
+        ".claude/rules/avbd.md": {
+            "bytes": 69400,
+            "paragraph": 16734
+        },
+        ".claude/rules/ecs.md": {
+            "bytes": 22171,
+            "paragraph": 1795
+        },
+        ".claude/rules/examples.md": {
+            "bytes": 11708,
+            "paragraph": 3862
+        },
+        ".claude/rules/exports.md": {
+            "bytes": 24665,
+            "paragraph": 15471
+        },
+        ".claude/rules/gpu.md": {
+            "bytes": 69930,
+            "paragraph": 6264
+        },
+        ".claude/rules/physics.md": {
+            "bytes": 18335,
+            "paragraph": 6116
+        },
+        ".claude/rules/render.md": {
+            "bytes": 64234,
+            "paragraph": 12566
+        },
+        ".claude/rules/style.md": {
+            "bytes": 2784,
+            "paragraph": 473
+        },
+        ".claude/rules/testing.md": {
+            "bytes": 104626,
+            "paragraph": 18471
+        },
+        ".claude/rules/tumble.md": {
+            "bytes": 45105,
+            "paragraph": 2861
+        },
+        ".claude/rules/visual-identity.md": {
+            "bytes": 1224,
+            "paragraph": 451
+        },
+        "AGENTS.md": {
+            "bytes": 13314,
+            "paragraph": 2550
+        },
+        "CLAUDE.md": {
+            "bytes": 169,
+            "paragraph": 156
+        },
+        "examples/AGENTS.md": {
+            "bytes": 7953,
+            "paragraph": 4334
+        },
+        "packages/shallot/AGENTS.md": {
+            "bytes": 19313,
+            "paragraph": 1443
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Instruction files could grow without a downward budget, and the style rule repeated examples and historical measurements while describing obsolete containing-repository pointer resolution.

## Cause

The documentation check held entry-chain and citation properties but did not bound the closed instruction population's bytes or longest paragraphs.

## Fix

- Reduce style from 6,042 to 2,784 bytes, preserving naming, transform/plugin, comment, standalone-pointer and entry-budget laws; longest paragraph is now 473 characters.
- Add one validate-only instruction arm to the existing documentation check and one post-cut baseline. Explicit `--lower` alone writes; per-file byte/paragraph and total ceilings cannot increase.
- Discover tracked and untracked instruction members through Git; refuse unlisted nested members and tracked/untracked symlinks.
- Extend focused controls while preserving pointer and release-command composition protection. Only the four retired illustrative marker exemptions are removed; extraction and rosters are unchanged.

## Evidence

- Fresh required-corpus floor: 3,489 pass / 0 fail. Final format, explicit lowering and check exit 0; final full suite: 3,504 pass / 0 fail, 225 files, no skips.
- Focused production controls: 25 pass / 0 fail, independently replayed. Direct byte/paragraph/corpus growth and attempted ceiling increases refuse; legitimate lowering and closed-vocabulary exclusions discriminate.
- Disposable full-command proof: 12 actual `bun run check` runs, five green and seven independently red at the ratchet, including byte/paragraph growth, new rule, nested entry and three symlink cases. Every check leaves its baseline hash unchanged; only explicit lowering changes it.
- Complete candidate/fixture binding: 1,480 tracked paths and modes match this commit. Changed-path selector on the committed four-path delta exits 0, selecting 0 CPU / 0 display rows.
- One earlier full-suite run was 3,503 pass / 1 fail at an unchanged plugin test: native Dawn returned an invalid DeviceDescriptor-chain error before the injected exception assertion. Localized file passed 46/0, then the final full process passed 3,504/0. The intermittent native error is not claimed repaired.

No runtime, manifest, export, selector, registry or release implementation changes. No browser or release campaign.
