### PR TITLE
shallot-reliability-batch: repair native and Roads/fog boundaries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -361,7 +361,7 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "bun-webgpu": "^0.1.4",
+        "bun-webgpu": "0.1.7",
         "fast-check": "^4.6.0",
         "js-yaml": "^4.1.0",
         "typegpu": "~0.12.4",
@@ -371,7 +371,7 @@
         "pngjs": "^7.0.0",
       },
       "peerDependencies": {
-        "bun-webgpu": "^0.1.4",
+        "bun-webgpu": "0.1.7",
         "playwright": "^1.0.0",
         "typegpu": "~0.12.4",
       },

--- a/examples/recipes/fog-and-light-shafts/public/scenes/fog-and-light-shafts.scene
+++ b/examples/recipes/fog-and-light-shafts/public/scenes/fog-and-light-shafts.scene
@@ -18,7 +18,7 @@
         camera
         sear
         depth
-        orbit="distance: 14; yaw: 0.7; pitch: 0.12; pan: 0 1.5 -8"
+        orbit="distance: 3; yaw: 0.7; pitch: 0.12; pan: -2 1 0"
         transform
     />
 

--- a/examples/showcase/roads/src/edit.test.ts
+++ b/examples/showcase/roads/src/edit.test.ts
@@ -156,6 +156,40 @@ describe("edit — every drag constraint clamps (stage 4c)", () => {
     });
 });
 
+describe("edit — finite floor at coincident targets", () => {
+    test("short and coincident starting chords project to a finite bounded floor", () => {
+        for (const a of [
+            [0, 0],
+            [BOUND, BOUND],
+            [-BOUND, -BOUND],
+        ] as const) {
+            for (const length of [0, 1, ROAD_MIN_LENGTH - Number.EPSILON * ROAD_MIN_LENGTH]) {
+                const sign = a[0] > 0 ? -1 : 1;
+                const doc: StrokeDocument = {
+                    polylines: [
+                        { points: [a, [a[0] + sign * length, a[1]]], halfWidth: ROAD_HALF_WIDTH },
+                    ],
+                };
+                const target = clampDragTarget(doc, 1, a[0], a[1]);
+                expect(target.every(Number.isFinite)).toBe(true);
+                expect(target.every((v) => Math.abs(v) <= BOUND)).toBe(true);
+                expect(chordLength(applyEdit(doc, 1, ...target))).toBeCloseTo(ROAD_MIN_LENGTH, 8);
+            }
+        }
+    });
+
+    test("repeated floor contacts never turn roundoff into NaN", () => {
+        let doc = generateNetwork();
+        for (let i = 0; i < 50; i++) {
+            const a = doc.polylines[0].points[0];
+            const target = clampDragTarget(doc, 1, a[0] + (i % 2 ? 0 : 1e-12), a[1]);
+            expect(target.every(Number.isFinite)).toBe(true);
+            doc = applyEdit(doc, 1, ...target);
+            expect(chordLength(doc)).toBeGreaterThanOrEqual(ROAD_MIN_LENGTH - 1e-9);
+        }
+    });
+});
+
 describe("edit — worst-case chord capacity (stage 4d)", () => {
     // The invariant that matters:
     // "no admissible drag can throw out of `allocate`". The worst case the world allows is a

--- a/examples/showcase/roads/src/edit.ts
+++ b/examples/showcase/roads/src/edit.ts
@@ -98,6 +98,16 @@ let hovered = -1;
 let grab = createGrabState();
 let claimInstalled = false;
 
+/** The actual pick owner and current ray, read on demand by the device regression. */
+export function editSnapshot() {
+    return {
+        camera: camEid,
+        hovered,
+        grab: { ...grab },
+        ray: liveState ? cursorRay(liveState, camEid) : null,
+    };
+}
+
 /** march `ray` against the continuous flattened field (`flattenFieldAt`) and return the (x, z) where the
  *  ray crosses the surface. If the ray doesn't cross within `MARCH_MAX` (aimed at the sky, or the crossing
  *  sits past the max distance), the ray's projection onto the world bound is returned instead — never null,
@@ -185,6 +195,16 @@ const EditSystem: System = {
         }
         if (camEid < 0) return;
 
+        const doc = getDocument();
+        const line = doc.polylines[0];
+        if (!line || line.points.length < 2) {
+            for (const eid of handleEids) if (eid >= 0) state.destroy(eid);
+            handleEids = [-1, -1];
+            hovered = -1;
+            grab = { ...createGrabState(), prevLeft: Inputs.mouse.left };
+            return;
+        }
+
         // create the handle entities once the sphere mesh is registered
         if (handleEids[0] < 0 && Meshes.id("sphere") !== undefined) {
             handleEids = createHandles(state);
@@ -192,8 +212,6 @@ const EditSystem: System = {
         if (handleEids[0] < 0) return;
 
         // read the live document and place the handles at its endpoints (y = heightAtCpu)
-        const doc = getDocument();
-        const line = doc.polylines[0];
         const perm = makePermutation(getCurrentSeed());
         for (let i = 0; i < 2; i++) {
             const [x, z] = line.points[i];

--- a/examples/showcase/roads/src/editPure.ts
+++ b/examples/showcase/roads/src/editPure.ts
@@ -62,6 +62,8 @@ export function clampDragTarget(
     x: number,
     z: number,
 ): [number, number] {
+    if (!Number.isFinite(x) || !Number.isFinite(z))
+        throw new Error("roads: drag target must be finite");
     const line = doc.polylines[0];
     const other = (end === 0 ? line.points[1] : line.points[0]) as [number, number];
     const current = line.points[end] as [number, number];
@@ -77,8 +79,6 @@ export function clampDragTarget(
     // drag direction: from current position toward target
     const ddx = x - px;
     const ddz = z - pz;
-    const dlen = Math.hypot(ddx, ddz);
-    if (dlen < 1e-9) return [x, z]; // target equals current — no-op
 
     // solve |V + s*D|^2 = ROAD_MIN_LENGTH^2 for s, where V = P - O, D = (ddx, ddz)
     // the chord is valid at s=0 (current) and invalid at s=1 (target), so the crossing in (0, 1] is
@@ -89,16 +89,24 @@ export function clampDragTarget(
     const b = 2 * (vx * ddx + vz * ddz);
     const c = vx * vx + vz * vz - ROAD_MIN_LENGTH * ROAD_MIN_LENGTH;
     const disc = b * b - 4 * a * c;
-    if (disc < 0) {
-        // no intersection — shouldn't happen if current is valid and target is invalid;
-        // fallback: project target onto the floor circle
-        return [ox + (tdx / tdist) * ROAD_MIN_LENGTH, oz + (tdz / tdist) * ROAD_MIN_LENGTH];
+    if (a > 0 && c >= 0 && disc >= 0) {
+        const s = (-b - Math.sqrt(disc)) / (2 * a);
+        if (s >= 0 && s <= 1) return [px + ddx * s, pz + ddz * s];
     }
-    const s = (-b - Math.sqrt(disc)) / (2 * a);
-    if (s < 0) {
-        return [ox + (tdx / tdist) * ROAD_MIN_LENGTH, oz + (tdz / tdist) * ROAD_MIN_LENGTH];
+
+    // A loaded short chord or rounding just inside the floor has no entering root.
+    // At the opposite endpoint the target direction is zero: use the old chord,
+    // then an inward axis if even that is coincident or its projection leaves the grid.
+    const vxFloor = tdist > 0 ? tdx : vx;
+    const vzFloor = tdist > 0 ? tdz : vz;
+    const length = Math.hypot(vxFloor, vzFloor);
+    if (length > 0) {
+        const fx = ox + (vxFloor / length) * ROAD_MIN_LENGTH;
+        const fz = oz + (vzFloor / length) * ROAD_MIN_LENGTH;
+        const bound = WORLD_HALF - BOUND_MARGIN;
+        if (Math.abs(fx) <= bound && Math.abs(fz) <= bound) return [fx, fz];
     }
-    return [px + ddx * s, pz + ddz * s];
+    return [ox + (ox > 0 ? -ROAD_MIN_LENGTH : ROAD_MIN_LENGTH), oz];
 }
 
 /** Project a ray onto the world bound — find where the ray's (x, z) trajectory hits the world bound

--- a/examples/showcase/roads/src/harness.ts
+++ b/examples/showcase/roads/src/harness.ts
@@ -1,4 +1,48 @@
-import { Compute, type Mirror } from "@dylanebert/shallot";
+import { Camera, Compute, Inputs, type Mirror, Transform } from "@dylanebert/shallot";
+import { Orbit } from "@dylanebert/shallot/extras";
+import { Views } from "@dylanebert/shallot/render/core";
+
+/** Read actual view/camera/input state independently of the edit and pixel predicates. */
+export function cameraSnapshot() {
+    return {
+        frame: Compute.frame,
+        mouse: { ...Inputs.mouse },
+        touch: { ...Inputs.touch },
+        cameras: [...Views].map(([eid, view]) => ({
+            eid,
+            canvas: view.canvas !== null,
+            fov: Camera.fov.get(eid),
+            near: Camera.near.get(eid),
+            pos: [Transform.pos.x.get(eid), Transform.pos.y.get(eid), Transform.pos.z.get(eid)],
+            rot: [
+                Transform.rot.x.get(eid),
+                Transform.rot.y.get(eid),
+                Transform.rot.z.get(eid),
+                Transform.rot.w.get(eid),
+            ],
+            yaw: Orbit.yaw.get(eid),
+            pitch: Orbit.pitch.get(eid),
+            distance: Orbit.distance.get(eid),
+        })),
+    };
+}
+
+/** Set only the live display camera for device controls, never the authored scene. */
+export function poseCamera(values: {
+    distance?: number;
+    pitch?: number;
+    yaw?: number;
+    smoothness?: number;
+    mode?: number;
+}): void {
+    for (const [eid, view] of Views) {
+        if (!view.canvas) continue;
+        for (const key of ["distance", "pitch", "yaw", "smoothness", "mode"] as const) {
+            const value = values[key];
+            if (value !== undefined) Orbit[key].set(eid, value);
+        }
+    }
+}
 
 // The project's own tiny test/boot helpers — published-surface-only (no reach into the repo harness),
 // the same shape as voxel's `src/harness.ts`. {@link Check} is the gate's verdict shape, read by

--- a/examples/showcase/roads/src/overlay/atlas.ts
+++ b/examples/showcase/roads/src/overlay/atlas.ts
@@ -131,7 +131,8 @@ export function warm(state: State): void {
     indirectionRaw = device.createBuffer({
         label: "overlay-indirection",
         size: TILE_COUNT * 4,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+        // The clear/reload device gate reads the actual table consumed by the surface.
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
     });
     invalidateQueue(indirectionCpu, free, ATLAS_LAYERS, pending, pendingSet);
     device.queue.writeBuffer(indirectionRaw, 0, indirectionCpu as Int32Array<ArrayBuffer>);

--- a/examples/showcase/roads/src/overlay/document.test.ts
+++ b/examples/showcase/roads/src/overlay/document.test.ts
@@ -110,8 +110,33 @@ describe("documentDistance", () => {
 });
 
 describe("documentDirtyTiles", () => {
-    test("an empty document throws rather than producing a degenerate set", () => {
-        expect(() => documentDirtyTiles({ polylines: [] })).toThrow();
+    test("cleared and unfinished strokes touch no tiles", () => {
+        for (const polylines of [
+            [],
+            [{ points: [], halfWidth: 4 }],
+            [{ points: [[0, 0] as const], halfWidth: 4 }],
+        ]) {
+            expect(documentDirtyTiles({ polylines })).toEqual([]);
+            expect(documentDistance(0, 0, { polylines })).toBe(Infinity);
+        }
+    });
+
+    test("non-finite document geometry refuses instead of silently losing dirty tiles", () => {
+        for (const value of [NaN, Infinity, -Infinity]) {
+            expect(() =>
+                documentDirtyTiles({
+                    polylines: [
+                        {
+                            points: [
+                                [0, 0],
+                                [value, 0],
+                            ],
+                            halfWidth: 4,
+                        },
+                    ],
+                }),
+            ).toThrow("finite");
+        }
     });
 
     test("matches strokeRect/dirtyTiles' original row/column set for strokeDocument()", () => {

--- a/examples/showcase/roads/src/overlay/document.ts
+++ b/examples/showcase/roads/src/overlay/document.ts
@@ -47,11 +47,25 @@ export interface Segment {
     readonly halfWidth: number;
 }
 
+/** Refuse invalid upload coordinates before publishing an edit or deriving its dirty tiles. */
+export function validateDocument(doc: StrokeDocument): void {
+    for (const line of doc.polylines) {
+        if (
+            !Number.isFinite(line.halfWidth) ||
+            line.halfWidth < 0 ||
+            line.points.some((point) => point.length !== 2 || !point.every(Number.isFinite))
+        ) {
+            throw new Error("roads: document coordinates and non-negative widths must be finite");
+        }
+    }
+}
+
 /** every polyline in `doc`, flattened to its consecutive-point segments — pure data marshaling (not
  *  distance math), shared by the CPU oracle and the GPU buffer packer alike; sharing this step doesn't
  *  weaken the differential, since the two sides only diverge in how they measure distance to a segment,
  *  not in which segments exist. */
 export function flattenSegments(doc: StrokeDocument): Segment[] {
+    validateDocument(doc);
     const out: Segment[] = [];
     for (const line of doc.polylines) {
         for (let i = 0; i < line.points.length - 1; i++) {
@@ -263,8 +277,8 @@ export function drivable(px: number, pz: number, doc: StrokeDocument): boolean {
  *
  * Deliberately not one bounding rect over the whole document — two primitives far apart would otherwise
  * mark every tile *between* them too, which is exactly the over-approximation the spec's
- * "only-touched-tiles oracle" rules out. Sorted ascending by tile id, de-duplicated. Empty documents
- * throw — an empty edit (`markDirty` on nothing) is a caller bug, not a valid zero-tile mark.
+ * "only-touched-tiles oracle" rules out. Sorted ascending by tile id, de-duplicated. A cleared or
+ * unfinished stroke touches no tiles; retile still releases the outgoing document's tiles.
  */
 export function documentDirtyTiles(doc: StrokeDocument): number[] {
     const ids = new Set<number>();
@@ -274,8 +288,5 @@ export function documentDirtyTiles(doc: StrokeDocument): number[] {
             if (segmentRectDistance(seg, tileWorldRect(tx, tz)) <= seg.halfWidth + MARGIN)
                 ids.add(id);
         }
-    if (ids.size === 0) {
-        throw new Error("documentDirtyTiles: an empty document (no polylines) touches no tile");
-    }
     return [...ids].sort((a, b) => a - b);
 }

--- a/examples/showcase/roads/src/overlay/network.ts
+++ b/examples/showcase/roads/src/overlay/network.ts
@@ -28,13 +28,15 @@ const STANDARD_CHORD: readonly [readonly [number, number], readonly [number, num
 
 /** the chord (endpoints + halfWidth) of the one road in `doc` — the analytic fs's marking geometry
  *  input. One road means one chord; the fs receives this as a uniform and computes marking distances
- *  from it directly, without decoding a texel. */
+ *  from it directly, without decoding a texel. Empty/unfinished strokes use a neutral chord;
+ *  the atlas indirection independently disables their overlay contribution. */
 export function chordOf(doc: StrokeDocument): {
     a: readonly [number, number];
     b: readonly [number, number];
     halfWidth: number;
 } {
     const line = doc.polylines[0];
+    if (!line || line.points.length < 2) return { a: [0, 0], b: [0, 0], halfWidth: 0 };
     return {
         a: line.points[0],
         b: line.points[1],

--- a/examples/showcase/roads/src/terrain/flatten.ts
+++ b/examples/showcase/roads/src/terrain/flatten.ts
@@ -21,7 +21,7 @@ import { Compute, type State } from "@dylanebert/shallot";
 import tgpu from "typegpu";
 import * as d from "typegpu/data";
 import * as std from "typegpu/std";
-import type { StrokeDocument } from "../overlay/document";
+import { type StrokeDocument, validateDocument } from "../overlay/document";
 import { SPACING } from "./grid";
 import { heightAt, makePermutation } from "./noise";
 import { buildPolylineProfile, heightAtCpu, PROFILE_STEP } from "./profile";
@@ -285,10 +285,12 @@ export interface NetworkGeometry {
  * `overlay/document.ts` uses for its own geometry math.
  */
 export function buildNetworkGeometry(doc: StrokeDocument, seed: number): NetworkGeometry {
+    validateDocument(doc);
     const perm = makePermutation(seed);
     const segments: ProfileSegment[] = [];
     let cutDepth = 0;
     for (const [road, line] of doc.polylines.entries()) {
+        if (line.points.length < 2) continue;
         const profile = buildPolylineProfile(line.points, perm);
         for (let i = 0; i < profile.length - 1; i++) {
             const a = profile[i];
@@ -334,10 +336,9 @@ export function buildNetworkGeometry(doc: StrokeDocument, seed: number): Network
  *  dispatches instead of being rebuilt per redraw — the kernel dispatches once per reseed, not once per
  *  throttled tile. */
 export function setNetwork(doc: StrokeDocument, seed: number): void {
+    const { segments, cutDepth } = buildNetworkGeometry(doc, seed);
     teardownNetworkBuffers();
     const { device, root } = Compute;
-
-    const { segments, cutDepth } = buildNetworkGeometry(doc, seed);
     const falloff = computeFalloff(cutDepth);
     const segmentsData: readonly ProfileSegment[] =
         segments.length > 0

--- a/examples/showcase/roads/src/terrain/terrain.ts
+++ b/examples/showcase/roads/src/terrain/terrain.ts
@@ -482,8 +482,8 @@ export async function regenerate(seed: number): Promise<void> {
  */
 export async function editDocument(doc: StrokeDocument): Promise<void> {
     const oldDoc = liveDocument;
-    liveDocument = doc;
     setNetwork(doc, currentSeed);
+    liveDocument = doc;
     await dispatchPosts(currentSeed); // re-write post positions for the edited chord
     overlayAtlas.updateChord(doc);
     overlayAtlas.retile(oldDoc, doc);

--- a/examples/showcase/roads/test/edit-safety.playwright.ts
+++ b/examples/showcase/roads/test/edit-safety.playwright.ts
@@ -1,0 +1,165 @@
+import { isDegradedBootMessage } from "@dylanebert/shallot/harness";
+import { expect, test } from "@playwright/test";
+
+test("real handle pick, constrained edit, empty clear and reload", async ({ page }, info) => {
+    const errors: string[] = [];
+    page.on("pageerror", (error) => errors.push(String(error)));
+    page.on("console", (message) => {
+        if (message.type() === "error" || isDegradedBootMessage(message.text()))
+            errors.push(message.text());
+    });
+    await page.goto("/");
+    await page.waitForFunction(() => window.__roadsOverlayIdle?.() === true);
+    const before = await page.evaluate(async () => {
+        const path = "/src/harness.ts";
+        const h = await import(path);
+        h.poseCamera({ distance: 300, pitch: 0.7, yaw: 0, smoothness: 1 });
+        await h.frames(3);
+        const edit = await import("/src/" + "edit.ts");
+        return {
+            camera: h.cameraSnapshot(),
+            edit: edit.editSnapshot(),
+            positions: edit.handlePositions(),
+        };
+    });
+    await info.attach("before", { body: JSON.stringify(before), contentType: "application/json" });
+    const display = before.camera.cameras.find((c: any) => c.canvas);
+    expect(before.edit.camera, "pick must use the canvas-presenting camera").toBe(display.eid);
+    const screen = await page.evaluate(
+        (positions) => window.__roadsProbe!(positions),
+        before.positions,
+    );
+    const canvas = page.locator("canvas").first();
+    const box = (await canvas.boundingBox())!;
+    const end = screen.findIndex((p) => p.x > 0.1 && p.x < 0.9 && p.y > 0.1 && p.y < 0.9);
+    expect(end, "at least one handle in frame").toBeGreaterThanOrEqual(0);
+    const at = screen[end];
+    await page.mouse.move(box.x + at.x * box.width, box.y + at.y * box.height);
+    await expect
+        .poll(() =>
+            page.evaluate(async () => (await import("/src/" + "edit.ts")).editSnapshot().hovered),
+        )
+        .toBe(end);
+    await page.mouse.down();
+    await expect
+        .poll(() =>
+            page.evaluate(
+                async () => (await import("/src/" + "edit.ts")).editSnapshot().grab.dragging,
+            ),
+        )
+        .toBe(true);
+    for (let step = 1; step <= 12; step++) {
+        await page.mouse.move(
+            box.x + at.x * box.width + (70 * step) / 12,
+            box.y + at.y * box.height + (30 * step) / 12,
+        );
+        await page.evaluate(async () => (await import("/src/" + "harness.ts")).frames(2));
+    }
+    const held = await page.evaluate(async () => ({
+        edit: (await import("/src/" + "edit.ts")).editSnapshot(),
+        camera: (await import("/src/" + "harness.ts")).cameraSnapshot(),
+        doc: (await import("/src/terrain/" + "terrain.ts")).getDocument(),
+    }));
+    console.log("EDIT_HELD", JSON.stringify({ before, screen, end, held }));
+    expect(held.edit.grab.dragEnd).toBe(end);
+    expect(held.edit.grab.dragging).toBe(true);
+    const heldCamera = held.camera.cameras.find((c: any) => c.canvas);
+    expect([heldCamera.pos, heldCamera.rot]).toEqual([display.pos, display.rot]);
+    expect(held.edit.ray.origin.concat(held.edit.ray.dir).every(Number.isFinite)).toBe(true);
+    await info.attach("held", { body: JSON.stringify(held), contentType: "application/json" });
+    await page.mouse.up();
+    await page.waitForFunction(() => window.__roadsOverlayIdle?.() === true);
+    const after = await page.evaluate(async () => {
+        const terrain = await import("/src/terrain/" + "terrain.ts");
+        const h = await import("/src/" + "harness.ts");
+        await h.frames(3);
+        return {
+            doc: terrain.getDocument(),
+            vertices: Array.from(await terrain.readVertices()),
+            camera: h.cameraSnapshot(),
+        };
+    });
+    expect(after.doc.polylines[0].points[end]).not.toEqual([
+        before.positions[end][0],
+        before.positions[end][2],
+    ]);
+    expect(after.doc.polylines[0].points.flat().every(Number.isFinite)).toBe(true);
+    expect(after.vertices.length).toBeGreaterThan(0);
+    expect(await page.evaluate(() => window.__roadsFlatnessViolations!())).toEqual({
+        longitudinal: 0,
+        crossSection: 0,
+    });
+    const refused = await page.evaluate(async () => {
+        const terrain = await import("/src/terrain/" + "terrain.ts");
+        const old = terrain.getDocument();
+        try {
+            await terrain.editDocument({
+                polylines: [
+                    {
+                        points: [
+                            [0, 0],
+                            [NaN, 0],
+                        ],
+                        halfWidth: 4,
+                    },
+                ],
+            });
+            return false;
+        } catch (error) {
+            return String(error).includes("finite") && terrain.getDocument() === old;
+        }
+    });
+    expect(refused, "invalid coordinates cannot replace the live document").toBe(true);
+    for (const length of [0, 1]) {
+        const repaired = await page.evaluate(async (length) => {
+            const terrain = await import("/src/terrain/" + "terrain.ts");
+            await terrain.editDocument({
+                polylines: [
+                    {
+                        points: [
+                            [0, 0],
+                            [length, 0],
+                        ],
+                        halfWidth: 4,
+                    },
+                ],
+            });
+            await window.__roadsEdit!(1, 0, 0);
+            return terrain.getDocument();
+        }, length);
+        const [a, b] = repaired.polylines[0].points;
+        expect([a, b].flat().every(Number.isFinite)).toBe(true);
+        expect(Math.hypot(b[0] - a[0], b[1] - a[1])).toBe(80);
+        await page.waitForFunction(() => window.__roadsOverlayIdle?.() === true);
+    }
+    await info.attach("after", {
+        body: JSON.stringify({ doc: after.doc, camera: after.camera }),
+        contentType: "application/json",
+    });
+    for (const polylines of [
+        [],
+        [{ points: [], halfWidth: 4 }],
+        [{ points: [[0, 0]], halfWidth: 4 }],
+    ]) {
+        const cleared = await page.evaluate(async (polylines) => {
+            const terrain = await import("/src/terrain/" + "terrain.ts");
+            const atlas = await import("/src/overlay/" + "atlas.ts");
+            const h = await import("/src/" + "harness.ts");
+            await terrain.editDocument({ polylines });
+            await h.frames(3);
+            const bindings = atlas.bindings();
+            return {
+                idle: terrain.overlayIdle(),
+                tiles: Array.from(await bindings.indirection.read()),
+                doc: terrain.getDocument(),
+            };
+        }, polylines);
+        expect(cleared.idle).toBe(true);
+        expect(cleared.tiles.every((tile) => tile === -1)).toBe(true);
+        await page.evaluate(() => window.__roadsRegenerate!(1337));
+        await page.waitForFunction(() => window.__roadsOverlayIdle?.() === true);
+    }
+    await page.reload();
+    await page.waitForFunction(() => window.__roadsOverlayIdle?.() === true);
+    expect(errors, errors.join("\n")).toEqual([]);
+});

--- a/examples/showcase/roads/test/touch-drag.ts
+++ b/examples/showcase/roads/test/touch-drag.ts
@@ -27,12 +27,14 @@ export async function oneFingerDrag(
     from: { x: number; y: number },
     to: { x: number; y: number },
     steps = 10,
+    onStart?: () => Promise<void>,
 ): Promise<void> {
     const id = 1;
     await cdp.send("Input.dispatchTouchEvent", {
         type: "touchStart",
         touchPoints: [{ x: from.x, y: from.y, id }],
     });
+    await onStart?.();
     await wait(STEP_MS);
     for (let i = 1; i <= steps; i++) {
         const x = lerp(from.x, to.x, i / steps);

--- a/examples/showcase/roads/test/touch-smoke.playwright.ts
+++ b/examples/showcase/roads/test/touch-smoke.playwright.ts
@@ -1,41 +1,14 @@
 import { assertMotion, isDegradedBootMessage } from "@dylanebert/shallot/harness";
 import { expect, type Page, test } from "@playwright/test";
+import { PNG } from "pngjs";
 import { oneFingerDrag } from "./touch-drag";
 
-// S5's showcase touch smoke (`shallot-mobile-controls` spec): the roads demo loads clean and its primary
-// interaction (drag-to-orbit) works under a real `hasTouch` mobile context, driven through CDP
-// `Input.dispatchTouchEvent` — the same integration-honest instrument gym's own touch gate uses, never
-// Playwright's synthetic `dispatchEvent` (bypasses the touch-action/listener path this asserts). Runs by
-// path — `cd examples/showcase/roads && bunx playwright test test/touch-smoke.playwright.ts` —
-// display-gated (WSL bridge, `playwright.global-setup.ts`), never part of `bun run test`.
-
-test.use({
-    hasTouch: true,
-    isMobile: true,
-    viewport: { width: 390, height: 844 },
-});
-
-// Software rasterizers by the name they report in `GPUAdapterInfo` — the same display-gate pattern
-// `test/roads.playwright.ts` uses (that file's header has the full rationale).
-const SOFTWARE = /swiftshader|llvmpipe|lavapipe|warp|basic render/i;
-
-const adapterName = (page: Page): Promise<string> =>
-    page.evaluate(async () => {
-        const adapter = await navigator.gpu?.requestAdapter();
-        if (!adapter) return "";
-        const { vendor, architecture, device, description } = adapter.info;
-        return [vendor, architecture, device, description].filter(Boolean).join(" ");
-    });
-
-// how much a 0-255 channel sample must move, averaged over a coarse grid, to count as "the frame
-// changed" — comfortably above screenshot encoding noise, well under what an actual ~60px-of-travel orbit
-// drag produces against roads' terrain + network.
+test.use({ hasTouch: true, isMobile: true, viewport: { width: 390, height: 844 } });
 const FrameChangeThreshold = 3;
 
-async function sampleCanvas(page: Page): Promise<number[]> {
-    const canvas = page.locator("canvas").first();
-    const screenshot = await canvas.screenshot();
-    return page.evaluate(async (base64) => {
+async function sampleCanvas(page: Page) {
+    const png = await page.locator("canvas").first().screenshot();
+    const channels: number[] = await page.evaluate(async (base64) => {
         const bytes = Uint8Array.from(atob(base64), (c) => c.charCodeAt(0));
         const bitmap = await createImageBitmap(new Blob([bytes], { type: "image/png" }));
         const surface = new OffscreenCanvas(32, 32);
@@ -44,50 +17,196 @@ async function sampleCanvas(page: Page): Promise<number[]> {
         ctx.drawImage(bitmap, 0, 0, 32, 32);
         bitmap.close();
         return Array.from(ctx.getImageData(0, 0, 32, 32).data);
-    }, screenshot.toString("base64"));
+    }, png.toString("base64"));
+    return { png, channels };
 }
 
-test("roads showcase — loads clean and orbits by touch", async ({ page }) => {
+const snapshot = (page: Page) =>
+    page.evaluate(async () => {
+        const h = await import("/src/" + "harness.ts");
+        const edit = await import("/src/" + "edit.ts");
+        const terrain = await import("/src/terrain/" + "terrain.ts");
+        return { ...h.cameraSnapshot(), pick: edit.editSnapshot(), doc: terrain.getDocument() };
+    });
+
+test("roads touch motion rejects no-input, disabled-handler and frozen-camera controls", async ({
+    page,
+}, info) => {
     const errors: string[] = [];
     page.on("pageerror", (e) => errors.push(String(e)));
     page.on("console", (m) => {
-        if (m.type() === "error" || isDegradedBootMessage(m.text())) {
-            errors.push(`[console.${m.type()}] ${m.text()}`);
+        if (m.type() === "error" || isDegradedBootMessage(m.text())) errors.push(m.text());
+    });
+    const results: any[] = [];
+    for (const control of ["drag", "no-input", "disabled-handler", "frozen-camera"]) {
+        await page.goto("/");
+        await page.waitForFunction(() => window.__roadsOverlayIdle?.() === true);
+        const adapter = await page.evaluate(async () => {
+            const a = await navigator.gpu?.requestAdapter();
+            return a
+                ? [a.info.vendor, a.info.architecture, a.info.device, a.info.description].join(" ")
+                : "";
+        });
+        expect(adapter).not.toBe("");
+        expect(adapter).not.toMatch(/swiftshader|llvmpipe|lavapipe|warp|basic render/i);
+        await page.evaluate(async (control) => {
+            const h = await import("/src/" + "harness.ts");
+            if (control === "frozen-camera") h.poseCamera({ smoothness: 0 });
+            const receipts: unknown[] = [];
+            (window as any).__touchReceipts = receipts;
+            for (const type of [
+                "pointerdown",
+                "pointermove",
+                "pointerup",
+                "pointercancel",
+                "touchstart",
+                "touchmove",
+                "touchend",
+            ]) {
+                window.addEventListener(
+                    type,
+                    (event) => {
+                        receipts.push({
+                            type: event.type,
+                            trusted: event.isTrusted,
+                            target: (event.target as Element)?.tagName,
+                            time: event.timeStamp,
+                        });
+                    },
+                    { capture: true },
+                );
+                if (control === "disabled-handler") {
+                    document.addEventListener(type, (event) => event.stopImmediatePropagation(), {
+                        capture: true,
+                    });
+                }
+            }
+            await h.frames(3);
+        }, control);
+        const beforeState = await snapshot(page);
+        const before = await sampleCanvas(page);
+        const canvas = page.locator("canvas").first();
+        const box = (await canvas.boundingBox())!;
+        const from = { x: box.x + box.width / 2 - 80, y: box.y + box.height / 2 };
+        const to = { x: from.x + 160, y: from.y + 40 };
+        const target = await page.evaluate(
+            (p) => document.elementFromPoint(p.x, p.y)?.tagName,
+            from,
+        );
+        expect(target).toBe("CANVAS");
+        let firstFrame: Awaited<ReturnType<typeof snapshot>> | null = null;
+        if (control !== "no-input") {
+            const cdp = await page.context().newCDPSession(page);
+            try {
+                await oneFingerDrag(cdp, from, to, 10, async () => {
+                    await page.evaluate(async () =>
+                        (await import("/src/" + "harness.ts")).frames(2),
+                    );
+                    firstFrame = await snapshot(page);
+                });
+            } finally {
+                await cdp.detach();
+            }
         }
-    });
-
-    await page.goto("/");
-
-    const adapter = await adapterName(page);
-    console.log(`roads touch smoke adapter: ${adapter || "none offered"}`);
-    test.skip(
-        adapter === "" || SOFTWARE.test(adapter),
-        `no real-GPU adapter (${adapter || "none offered"})`,
-    );
-
-    const canvas = page.locator("canvas").first();
-    await expect(canvas).toBeVisible();
-    await page.waitForFunction(() => {
-        const c = document.querySelector("canvas");
-        return c instanceof HTMLCanvasElement && c.width > 0 && c.height > 0;
-    });
-
-    const before = await sampleCanvas(page);
-
-    const cdp = await page.context().newCDPSession(page);
-    const box = await canvas.boundingBox();
-    if (!box) throw new Error("touch smoke: canvas has no bounding box");
-    const cx = box.x + box.width / 2;
-    const cy = box.y + box.height / 2;
-    await oneFingerDrag(cdp, { x: cx - 80, y: cy }, { x: cx + 80, y: cy + 40 });
-
-    // poll instead of a fixed sleep — the orbit's smoothed pose (`smoothLerp`, extras/orbit) settles
-    // over a few frames, not instantly, so wait on the condition itself: the sampled frame diverging.
-    await expect
-        .poll(async () => assertMotion(before, await sampleCanvas(page), FrameChangeThreshold), {
-            message: "a one-finger drag should visibly rotate the orbit camera",
-        })
-        .toBeGreaterThan(FrameChangeThreshold);
-
-    expect(errors, `page errors: ${errors.join("\n")}`).toEqual([]);
+        // A fixed frame observation window is shared by positives and negatives, not a retry-to-pass.
+        await page.evaluate(async () => (await import("/src/" + "harness.ts")).frames(30));
+        const after = await sampleCanvas(page);
+        const afterState = await snapshot(page);
+        const events = await page.evaluate(() => (window as any).__touchReceipts);
+        const numerator = before.channels.reduce(
+            (sum, v, i) => sum + Math.abs(v - after.channels[i]),
+            0,
+        );
+        const denominator = before.channels.length;
+        let motion = false;
+        try {
+            assertMotion(before.channels, after.channels, FrameChangeThreshold);
+            motion = true;
+        } catch (error) {
+            if (!String(error).includes("samples are parked")) throw error;
+        }
+        // Independent immutable-frame truth: full-resolution PNG decode, not the 32x32 predicate.
+        const a = PNG.sync.read(before.png),
+            b = PNG.sync.read(after.png);
+        expect([a.width, a.height]).toEqual([b.width, b.height]);
+        let changedChannels = 0,
+            fullDifference = 0;
+        for (let i = 0; i < a.data.length; i++) {
+            const d = Math.abs(a.data[i] - b.data[i]);
+            if (d) changedChannels++;
+            fullDifference += d;
+        }
+        const cameraBefore = beforeState.cameras.find((c: any) => c.canvas);
+        const cameraAfter = afterState.cameras.find((c: any) => c.canvas);
+        const cameraMoved =
+            JSON.stringify([cameraBefore.pos, cameraBefore.rot]) !==
+            JSON.stringify([cameraAfter.pos, cameraAfter.rot]);
+        const yawMoved = cameraBefore.yaw !== cameraAfter.yaw;
+        const result = {
+            control,
+            adapter,
+            box,
+            from,
+            to,
+            target,
+            firstFrame,
+            numerator,
+            denominator,
+            mean: numerator / denominator,
+            motion,
+            cameraMoved,
+            yawMoved,
+            changedChannels,
+            fullDifference,
+            beforeState,
+            afterState,
+            events,
+        };
+        results.push(result);
+        await info.attach(`${control}-before.png`, { body: before.png, contentType: "image/png" });
+        await info.attach(`${control}-after.png`, { body: after.png, contentType: "image/png" });
+        await info.attach(`${control}.json`, {
+            body: JSON.stringify({ ...result, before: before.channels, after: after.channels }),
+            contentType: "application/json",
+        });
+        console.log("TOUCH_CONTROL", JSON.stringify(result));
+    }
+    for (const r of results) {
+        expect(r.denominator).toBe(4096);
+        expect(r.afterState.doc, `${r.control}: orbit must not edit the road`).toEqual(
+            r.beforeState.doc,
+        );
+        if (r.firstFrame) {
+            expect(
+                r.firstFrame.pick.grab.dragging,
+                `${r.control}: first press is not a handle hit`,
+            ).toBe(false);
+            expect(
+                r.firstFrame.pick.ray.origin
+                    .concat(r.firstFrame.pick.ray.dir)
+                    .every(Number.isFinite),
+            ).toBe(true);
+        }
+        expect(r.motion, `${r.control}: ${r.numerator}/${r.denominator}`).toBe(
+            r.control === "drag",
+        );
+        expect(r.cameraMoved, r.control).toBe(r.control === "drag");
+        expect(r.yawMoved, r.control).toBe(r.control === "drag" || r.control === "frozen-camera");
+        if (r.control === "no-input") expect(r.events).toEqual([]);
+        else {
+            expect(
+                r.events.some(
+                    (e: any) => e.type === "pointerdown" && e.target === "CANVAS" && e.trusted,
+                ),
+                r.control,
+            ).toBe(true);
+            expect(
+                r.events.some((e: any) => e.type === "pointermove" && e.trusted),
+                r.control,
+            ).toBe(true);
+        }
+        if (r.control === "drag") expect(r.changedChannels).toBeGreaterThan(0);
+        else expect(r.fullDifference, r.control).toBe(0);
+    }
+    expect(errors, errors.join("\n")).toEqual([]);
 });

--- a/packages/shallot/bin/bun-native.ts
+++ b/packages/shallot/bin/bun-native.ts
@@ -1,0 +1,23 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+export const nativeSourceHash = "afc3b46db7b2e1b62602a146dca0749e0df5f456a3b742bca38505aa17537ee1";
+export const nativePatchHash = "c1ce7d567b2e83b7e6cae33a29e507aa150c20178a77f335f45a4492b06b6bb3";
+export const nativeHash = "2f573c74b9f8cb96aa86c17e7a4c47ab9b210edd8335526126e40c8d8288d86c";
+
+/** Load only the carried acquisition repair, without executing the optional upstream peer. */
+export async function loadNative(): Promise<typeof import("bun-webgpu")> {
+    if (typeof Bun === "undefined") throw new Error("Shallot native setup requires Bun");
+    createRequire(import.meta.url).resolve("bun-webgpu");
+    const file = resolve(import.meta.dir, "../dist/native.js");
+    if (!existsSync(file)) {
+        throw new Error(
+            "Shallot native projection is missing. In a source checkout, run bun packages/shallot/scripts/build-tooling.ts from the repository root after install or pack. For an installed package, reinstall @dylanebert/shallot.",
+        );
+    }
+    const hash = createHash("sha256").update(readFileSync(file)).digest("hex");
+    if (hash !== nativeHash) throw new Error("Shallot native projection hash mismatch");
+    return import(file);
+}

--- a/packages/shallot/bin/tui.ts
+++ b/packages/shallot/bin/tui.ts
@@ -190,6 +190,8 @@ export const EXIT_NO_BUN_WEBGPU = 3; // bun-webgpu isn't installed
 
 const INSTALL_BUN_WEBGPU = "bun add -d bun-webgpu";
 
+import { loadNative } from "./bun-native";
+
 /** the refusal diagnostic for a missing `bun-webgpu` — names the install command, never a stack trace
  *  (criterion 7's own wording). Mirrors `verify.ts`'s `displayGateMessage` / playwright-remedy shape. */
 export function noBunWebgpuMessage(): string {
@@ -210,11 +212,21 @@ export function noBunWebgpuMessage(): string {
  * in `scripts/install-test.ts`, mirroring its existing `importPlaywright` sibling check exactly.
  */
 export async function importBunWebgpu(
-    loader: () => Promise<typeof import("bun-webgpu")> = () => import("bun-webgpu"),
+    loader: () => Promise<typeof import("bun-webgpu")> = loadNative,
 ): Promise<typeof import("bun-webgpu") | null> {
     try {
         return await loader();
-    } catch {
+    } catch (error) {
+        if (
+            loader === loadNative &&
+            !(
+                error instanceof Error &&
+                "code" in error &&
+                error.code === "MODULE_NOT_FOUND" &&
+                error.message.includes("'bun-webgpu'")
+            )
+        )
+            throw error;
         return null;
     }
 }

--- a/packages/shallot/package.json
+++ b/packages/shallot/package.json
@@ -99,7 +99,7 @@
         "vite": "^8.0.16"
     },
     "peerDependencies": {
-        "bun-webgpu": "^0.1.4",
+        "bun-webgpu": "0.1.7",
         "playwright": "^1.0.0",
         "typegpu": "~0.12.4"
     },
@@ -116,7 +116,7 @@
     },
     "devDependencies": {
         "@types/bun": "latest",
-        "bun-webgpu": "^0.1.4",
+        "bun-webgpu": "0.1.7",
         "fast-check": "^4.6.0",
         "js-yaml": "^4.1.0",
         "typegpu": "~0.12.4",

--- a/packages/shallot/patches/bun-webgpu-0.1.7.patch
+++ b/packages/shallot/patches/bun-webgpu-0.1.7.patch
@@ -1,0 +1,818 @@
+--- a/index.js
++++ b/index.js
+@@ -1,74 +1,27 @@
+ // @bun
++// bun-webgpu 0.1.7, Apache-2.0 (see bun-webgpu-LICENSE).
++// Modified by Shallot: acquisition allocation/callback ownership and peer-relative native loading.
+ // src/ffi.ts
+ import { dlopen, suffix, FFIType } from "bun:ffi";
+-import { existsSync } from "fs";
+-import path from "path";
+-import { fileURLToPath } from "url";
+-var __filename2 = fileURLToPath(import.meta.url);
+-var __dirname2 = path.dirname(__filename2);
+-var targetLibPath = null;
+-function debugLoader(message) {
+-  if (process.env.WGPU_DEBUG_LOADER === "true") {
+-    console.error(`[ffi-loader] ${message}`);
+-  }
+-}
+-function resolveFromInstalledPackage() {
+-  return targetLibPath;
+-}
+-function resolveFromLocalBuild() {
+-  const platformMap = {
+-    darwin: "macos",
+-    linux: "linux",
+-    win32: "windows"
+-  };
+-  const archMap = {
+-    x64: "x86_64",
+-    arm64: "aarch64",
+-    aarch64: "aarch64"
+-  };
+-  const targetDir = `${archMap[process.arch] ?? process.arch}-${platformMap[process.platform] ?? process.platform}`;
+-  const localBaseDir = path.resolve(__dirname2, "lib", targetDir);
+-  const candidates = [
+-    path.join(localBaseDir, `libwebgpu_wrapper.${suffix}`),
+-    path.join(localBaseDir, `webgpu_wrapper.${suffix}`)
+-  ];
+-  for (const candidate of candidates) {
+-    if (existsSync(candidate)) {
+-      debugLoader(`resolved local library -> ${candidate}`);
+-      return candidate;
+-    }
+-    debugLoader(`failed local library candidate '${candidate}'`);
+-  }
+-  return null;
+-}
+-function findLibrary() {
+-  const fromPackage = resolveFromInstalledPackage();
+-  if (fromPackage) {
+-    return fromPackage;
+-  }
+-  const fromLocal = resolveFromLocalBuild();
+-  if (fromLocal) {
+-    return fromLocal;
+-  }
+-  throw new Error(`bun-webgpu is not supported on the current platform: ${process.platform}-${process.arch} (no installed package or local src/lib build found)`);
+-}
+-try {
+-  const module = await import(`bun-webgpu-${process.platform}-${process.arch}/index.ts`);
+-  let resolvedTargetLibPath = module.default;
+-  if (/\$bunfs/.test(resolvedTargetLibPath)) {
+-    resolvedTargetLibPath = resolvedTargetLibPath.replace("../", "");
+-  }
+-  if (!existsSync(resolvedTargetLibPath)) {
+-    debugLoader(`installed package resolved to missing path '${resolvedTargetLibPath}'`);
+-  } else {
+-    targetLibPath = resolvedTargetLibPath;
+-    debugLoader(`resolved installed package library -> ${targetLibPath}`);
+-  }
+-} catch (error) {
+-  debugLoader(`failed installed package import: ${error instanceof Error ? error.message : String(error)}`);
+-}
++import { existsSync, readFileSync, realpathSync } from 'node:fs';
++import { createRequire } from 'node:module';
++import path from 'node:path';
++const peerRequire = createRequire(import.meta.url);
++const peerEntry = peerRequire.resolve('bun-webgpu');
++const peerManifest = JSON.parse(readFileSync(path.join(path.dirname(peerEntry), 'package.json'), 'utf8'));
++if (peerManifest.version !== '0.1.7') throw new Error('Shallot native carrier requires bun-webgpu 0.1.7');
++const platformRequire = createRequire(peerEntry);
++const platformEntry = platformRequire.resolve(`bun-webgpu-${process.platform}-${process.arch}/index.ts`);
++const platformManifest = JSON.parse(readFileSync(path.join(path.dirname(platformEntry), 'package.json'), 'utf8'));
++if (platformManifest.version !== '0.1.7') throw new Error('Shallot native platform requires version 0.1.7');
++const platformLibrary = path.join(path.dirname(platformEntry), `libwebgpu_wrapper.${suffix}`);
++if (!existsSync(platformLibrary)) throw new Error('Shallot native platform library is missing');
++const targetLibPath = (await import(platformEntry)).default;
++if (typeof targetLibPath !== 'string' || !existsSync(targetLibPath) || realpathSync(targetLibPath) !== realpathSync(platformLibrary)) throw new Error('Shallot native platform library path mismatch');
++function findLibrary() { return targetLibPath; }
+ function _loadLibrary(libPath) {
+-  const resolvedPath = libPath || findLibrary();
++  if (libPath !== undefined) throw new Error('Shallot native library override is unsupported');
++  const resolvedPath = findLibrary();
+   const { symbols } = dlopen(resolvedPath, {
+     zwgpuCreateInstance: {
+       args: [FFIType.pointer],
+@@ -1335,8 +1288,16 @@
+ function isObjectPointerDef(type) {
+   return typeof type === "object" && type !== null && type.__type === "objectPointer";
+ }
++class CallArena {
++  owners = new Set();
++  hold(value) { this.owners.add(value); return value; }
++  release() { this.owners.clear(); }
++}
++function owned(value, options) {
++  return options?.arena ? options.arena.hold(value) : value;
++}
+ function allocStruct(structDef, options) {
+-  const buffer = new ArrayBuffer(structDef.size);
++  const buffer = owned(new ArrayBuffer(structDef.size), options);
+   const view = new DataView(buffer);
+   const result = { buffer, view };
+   const { pack: pointerPacker } = primitivePackers("pointer");
+@@ -1347,7 +1308,7 @@
+       if (!arrayMeta) {
+         throw new Error(`Field '${arrayFieldName}' is not an array field with a lengthOf field`);
+       }
+-      const subBuffer = new ArrayBuffer(length * arrayMeta.elementSize);
++      const subBuffer = owned(new ArrayBuffer(length * arrayMeta.elementSize), options);
+       subBuffers[arrayFieldName] = subBuffer;
+       const pointer = length > 0 ? ptr(subBuffer) : null;
+       pointerPacker(view, arrayMeta.arrayOffset, pointer);
+@@ -1444,8 +1405,9 @@
+   return { pack, unpack };
+ }
+ var { pack: pointerPacker, unpack: pointerUnpacker } = primitivePackers("pointer");
+-function packObjectArray(val) {
+-  const buffer = new ArrayBuffer(val.length * pointerSize);
++function packObjectArray(val, options) {
++  const buffer = owned(new ArrayBuffer(val.length * pointerSize), options);
++  for (const value of val) owned(value, options);
+   const bufferView = new DataView(buffer);
+   for (let i = 0;i < val.length; i++) {
+     const instance = val[i];
+@@ -1478,8 +1440,8 @@
+     } else if (typeof typeOrStruct === "string" && typeOrStruct === "cstring") {
+       size = pointerSize;
+       align = pointerSize;
+-      pack = (view, off, val) => {
+-        const bufPtr = val ? ptr(encoder.encode(val + "\x00")) : null;
++      pack = (view, off, val, obj, options2) => {
++        const bufPtr = val ? ptr(owned(encoder.encode(val + "\x00"), options2)) : null;
+         pointerPacker(view, off, bufPtr);
+       };
+       unpack = (view, off) => {
+@@ -1489,8 +1451,8 @@
+     } else if (typeof typeOrStruct === "string" && typeOrStruct === "char*") {
+       size = pointerSize;
+       align = pointerSize;
+-      pack = (view, off, val) => {
+-        const bufPtr = val ? ptr(encoder.encode(val)) : null;
++      pack = (view, off, val, obj, options2) => {
++        const bufPtr = val ? ptr(owned(encoder.encode(val), options2)) : null;
+         pointerPacker(view, off, bufPtr);
+       };
+       unpack = (view, off) => {
+@@ -1542,7 +1504,8 @@
+     } else if (isObjectPointerDef(typeOrStruct)) {
+       size = pointerSize;
+       align = pointerSize;
+-      pack = (view, off, value) => {
++      pack = (view, off, value, obj, options2) => {
++        owned(value, options2);
+         const ptrValue = value?.ptr ?? null;
+         if (ptrValue === undefined) {
+           console.warn(`Field '${name}' expected object with '.ptr' property, but got undefined pointer value from:`, value);
+@@ -1561,12 +1524,12 @@
+       let arrayElementSize;
+       if (isEnum(def)) {
+         arrayElementSize = typeSizes[def.type];
+-        pack = (view, off, val, obj) => {
++        pack = (view, off, val, obj, options2) => {
+           if (!val || val.length === 0) {
+             pointerPacker(view, off, null);
+             return;
+           }
+-          const buffer = new ArrayBuffer(val.length * arrayElementSize);
++          const buffer = owned(new ArrayBuffer(val.length * arrayElementSize), options2);
+           const bufferView = new DataView(buffer);
+           for (let i = 0;i < val.length; i++) {
+             const num = def.to(val[i]);
+@@ -1584,7 +1547,7 @@
+             pointerPacker(view, off, null);
+             return;
+           }
+-          const buffer = new ArrayBuffer(val.length * arrayElementSize);
++          const buffer = owned(new ArrayBuffer(val.length * arrayElementSize), options2);
+           const bufferView = new DataView(buffer);
+           for (let i = 0;i < val.length; i++) {
+             def.packInto(val[i], bufferView, i * arrayElementSize, options2);
+@@ -1597,12 +1560,12 @@
+       } else if (isPrimitiveType(def)) {
+         arrayElementSize = typeSizes[def];
+         const { pack: primitivePack } = primitivePackers(def);
+-        pack = (view, off, val) => {
++        pack = (view, off, val, obj, options2) => {
+           if (!val || val.length === 0) {
+             pointerPacker(view, off, null);
+             return;
+           }
+-          const buffer = new ArrayBuffer(val.length * arrayElementSize);
++          const buffer = owned(new ArrayBuffer(val.length * arrayElementSize), options2);
+           const bufferView = new DataView(buffer);
+           for (let i = 0;i < val.length; i++) {
+             primitivePack(bufferView, i * arrayElementSize, val[i]);
+@@ -1612,12 +1575,12 @@
+         unpack = null;
+       } else if (isObjectPointerDef(def)) {
+         arrayElementSize = pointerSize;
+-        pack = (view, off, val) => {
++        pack = (view, off, val, obj, options2) => {
+           if (!val || val.length === 0) {
+             pointerPacker(view, off, null);
+             return;
+           }
+-          const packedView = packObjectArray(val);
++          const packedView = packObjectArray(val, options2);
+           pointerPacker(view, off, ptr(packedView.buffer));
+         };
+         unpack = () => {
+@@ -1740,7 +1703,7 @@
+     layoutByName,
+     arrayFields,
+     pack(obj, options) {
+-      const buf = new ArrayBuffer(totalSize);
++      const buf = owned(new ArrayBuffer(totalSize), options);
+       const view = new DataView(buf);
+       let mappedObj = obj;
+       if (structDefOptions?.mapValue) {
+@@ -1761,6 +1724,7 @@
+       return view.buffer;
+     },
+     packInto(obj, view, offset2, options) {
++      owned(view.buffer, options);
+       let mappedObj = obj;
+       if (structDefOptions?.mapValue) {
+         mappedObj = structDefOptions.mapValue(obj);
+@@ -2957,7 +2921,7 @@
+   _onSubmittedWorkDoneCallback;
+   _onSubmittedWorkDoneResolves = [];
+   _onSubmittedWorkDoneRejects = [];
+-  constructor(ptr3, lib, instanceTicker) {
++  constructor(ptr3, lib, instanceTicker, acquisition) {
+     this.ptr = ptr3;
+     this.lib = lib;
+     this.instanceTicker = instanceTicker;
+@@ -2976,6 +2940,7 @@
+       args: [FFIType2.u32, FFIType2.pointer, FFIType2.pointer],
+       returns: FFIType2.void
+     });
++    acquisition?.initialized(this._onSubmittedWorkDoneCallback);
+   }
+   submit(commandBuffers) {
+     const commandBuffersArray = Array.from(commandBuffers);
+@@ -4352,7 +4317,7 @@
+   _buffers = new Set;
+   __brand = "GPUDevice";
+   label = "";
+-  constructor(devicePtr, lib, instanceTicker) {
++  constructor(devicePtr, lib, instanceTicker, acquisition) {
+     super();
+     this.devicePtr = devicePtr;
+     this.lib = lib;
+@@ -4363,8 +4328,9 @@
+       fatalError("Failed to get device queue");
+     }
+     this.queuePtr = queuePtr;
++    if (acquisition) acquisition.queuePtr = queuePtr;
+     this._ticker = new DeviceTicker(this.devicePtr, this.lib);
+-    this._queue = new GPUQueueImpl(this.queuePtr, this.lib, this.instanceTicker);
++    this._queue = new GPUQueueImpl(this.queuePtr, this.lib, this.instanceTicker, acquisition);
+     this._lost = new Promise((resolve) => {
+       this._lostPromiseResolve = resolve;
+     });
+@@ -4390,6 +4356,7 @@
+     }, {
+       args: [FFIType4.u32, FFIType4.u32, FFIType4.pointer, FFIType4.u64, FFIType4.pointer, FFIType4.pointer]
+     });
++    acquisition?.initialized(this._popErrorScopeCallback);
+     this._createComputePipelineAsyncCallback = new JSCallback3((status, pipeline, messagePtr, messageSize, userdata1, userdata2) => {
+       this.instanceTicker.unregister();
+       const asyncId = unpackUserDataId(userdata1);
+@@ -4413,6 +4380,7 @@
+     }, {
+       args: [FFIType4.u32, FFIType4.pointer, FFIType4.pointer, FFIType4.u64, FFIType4.pointer, FFIType4.pointer]
+     });
++    acquisition?.initialized(this._createComputePipelineAsyncCallback);
+     this._createRenderPipelineAsyncCallback = new JSCallback3((status, pipeline, messagePtr, messageSize, userdata1, userdata2) => {
+       this.instanceTicker.unregister();
+       const asyncId = unpackUserDataId(userdata1);
+@@ -4436,6 +4404,7 @@
+     }, {
+       args: [FFIType4.u32, FFIType4.pointer, FFIType4.pointer, FFIType4.u64, FFIType4.pointer, FFIType4.pointer]
+     });
++    acquisition?.initialized(this._createRenderPipelineAsyncCallback);
+   }
+   tick() {
+     this.lib.wgpuDeviceTick(this.devicePtr);
+@@ -4529,9 +4498,10 @@
+       return Object.freeze(new Set);
+     }
+     if (this._features === null) {
+-      let supportedFeaturesStructPtr = null;
++      const arena = new CallArena();
+       try {
+         const { buffer: featuresStructBuffer } = allocStruct(WGPUSupportedFeaturesStruct, {
++          arena,
+           lengths: {
+             features: 128
+           }
+@@ -4544,15 +4514,7 @@
+       } catch (e) {
+         console.error("Error getting device features via wgpuDeviceGetFeatures:", e);
+         this._features = Object.freeze(new Set);
+-      } finally {
+-        if (supportedFeaturesStructPtr) {
+-          try {
+-            this.lib.wgpuSupportedFeaturesFreeMembers(supportedFeaturesStructPtr);
+-          } catch (freeError) {
+-            console.error("Error calling wgpuSupportedFeaturesFreeMembers:", freeError);
+-          }
+-        }
+-      }
++      } finally { arena.release(); }
+     }
+     return this._features;
+   }
+@@ -5086,8 +5048,10 @@
+       return Object.freeze(new Set);
+     }
+     if (this._features === null) {
++      const arena = new CallArena();
+       try {
+         const { buffer: featuresStructBuffer, subBuffers } = allocStruct(WGPUSupportedFeaturesStruct, {
++          arena,
+           lengths: {
+             features: 128
+           }
+@@ -5104,7 +5068,7 @@
+       } catch (e) {
+         console.error("Error calling adapterGetFeatures FFI function:", e);
+         return Object.freeze(new Set);
+-      }
++      } finally { arena.release(); }
+     }
+     return this._features;
+   }
+@@ -5113,9 +5077,10 @@
+       return this._limits ?? DEFAULT_LIMITS2;
+     }
+     if (this._limits === null) {
++      const arena = new CallArena();
+       let limitsStructPtr = null;
+       try {
+-        const { buffer: structBuffer } = allocStruct(WGPULimitsStruct);
++        const { buffer: structBuffer } = allocStruct(WGPULimitsStruct, { arena });
+         limitsStructPtr = ptr10(structBuffer);
+         const status = this.lib.wgpuAdapterGetLimits(this.adapterPtr, limitsStructPtr);
+         if (status !== 1) {
+@@ -5132,147 +5097,79 @@
+         }));
+       } catch (e) {
+         console.error("Error calling wgpuAdapterGetLimits or unpacking struct:", e);
+-      }
++      } finally { arena.release(); }
+     }
+     return this._limits ?? DEFAULT_LIMITS2;
+   }
+   get isFallbackAdapter() {
+     console.error("get isFallbackAdapter", this.adapterPtr);
+     throw new Error("Not implemented");
+-  }
+-  handleUncapturedError(devicePtr, typeInt, messagePtr, messageSize, userdata1, userdata2) {
+-    const message = decodeCallbackMessage(messagePtr, messageSize);
+-    const error = createWGPUError(typeInt, message);
+-    if (this._device) {
+-      const event = new GPUUncapturedErrorEventImpl(error);
+-      this._device.handleUncapturedError(event);
+-      this._device.dispatchEvent(event);
+-    } else {
+-      console.error(`Device not found for uncaptured error`);
+-    }
+-  }
+-  handleDeviceLost(devicePtr, reason, messagePtr, messageSize, userdata1, userdata2) {
+-    const message = decodeCallbackMessage(messagePtr, messageSize);
+-    this._state = "invalid";
+-    if (this._device) {
+-      this._device.handleDeviceLost(WGPUDeviceLostReasonDef.from(reason), message);
+-    }
+   }
+   requestDevice(descriptor) {
+-    if (this._destroyed) {
+-      return Promise.reject(new Error("Adapter destroyed"));
+-    }
+-    if (this._state === "invalid") {
+-      this._device?.handleDeviceLost("unknown", "Adapter already invalid", true);
+-      return Promise.resolve(this._device);
+-    }
+-    if (this._state === "consumed") {
+-      return Promise.reject(new OperationError("Adapter already consumed"));
+-    }
+-    this._state = "consumed";
++    if (this._destroyed) return Promise.reject(new Error('Adapter destroyed'));
++    if (this._state === 'consumed') return Promise.reject(new OperationError('Adapter already consumed'));
++    this._state = 'consumed';
+     return new Promise((resolve, reject) => {
+-      let packedDescriptorPtr = null;
+-      let jsCallback = null;
++      const attempt = new Acquisition(this.instanceTicker, true);
++      const args = [FFIType5.pointer, FFIType5.u32, FFIType5.pointer, FFIType5.u64, FFIType5.pointer, FFIType5.pointer];
+       try {
+-        const uncapturedErrorCallback = new JSCallback4((devicePtr, typeInt, messagePtr, messageSize, userdata1, userdata2) => {
+-          this.handleUncapturedError(devicePtr, typeInt, messagePtr, messageSize, userdata1, userdata2);
+-        }, {
+-          args: [FFIType5.pointer, FFIType5.u32, FFIType5.pointer, FFIType5.u64, FFIType5.pointer, FFIType5.pointer],
+-          returns: FFIType5.void
+-        });
+-        if (!uncapturedErrorCallback.ptr) {
+-          fatalError("Failed to create uncapturedErrorCallback");
+-        }
+-        const deviceLostCallback = new JSCallback4((devicePtr, reason, messagePtr, messageSize, userdata1, userdata2) => {
+-          this.handleDeviceLost(devicePtr, reason, messagePtr, messageSize, userdata1, userdata2);
+-        }, {
+-          args: [FFIType5.pointer, FFIType5.u32, FFIType5.pointer, FFIType5.u64, FFIType5.pointer, FFIType5.pointer],
+-          returns: FFIType5.void
+-        });
+-        if (!deviceLostCallback.ptr) {
+-          fatalError("Failed to create deviceLostCallback");
+-        }
+-        const fullDescriptor = {
++        nullBoundary(descriptor?.nextInChain, 'device chain');
++        nullBoundary(descriptor?.requiredLimits?.nextInChain, 'limits chain');
++        nullBoundary(descriptor?.defaultQueue?.nextInChain, 'queue chain');
++        const error = attempt.callback('error', (deviceAddress, type, message, size) => {
++          // deviceAddress is WGPUDevice const*, not the device handle. Routing is
++          // through this attempt, never the adapter's most recently returned device.
++          const event = new GPUUncapturedErrorEventImpl(createWGPUError(type, decodeCallbackMessage(message, size)));
++          if (attempt.device) {
++            attempt.device.handleUncapturedError(event);
++          } else attempt.errors.push(event);
++        }, args);
++        const loss = attempt.callback('loss', (deviceAddress, reason, message, size) => {
++          attempt.loss = [WGPUDeviceLostReasonDef.from(reason), 'Native device lost (message decoding failed)'];
++          try { attempt.loss[1] = decodeCallbackMessage(message, size); }
++          finally { attempt.deliverLoss(); }
++        }, args);
++        const options = { arena: attempt.arena, validationHints: { limits: this.limits, features: this.features } };
++        const packed = ptr10(WGPUDeviceDescriptorStruct.pack({
+           ...descriptor,
+-          uncapturedErrorCallbackInfo: {
+-            callback: uncapturedErrorCallback.ptr,
+-            userdata1: null,
+-            userdata2: null
+-          },
+-          deviceLostCallbackInfo: {
+-            nextInChain: null,
+-            mode: "AllowProcessEvents",
+-            callback: deviceLostCallback.ptr,
+-            userdata1: null,
+-            userdata2: null
+-          },
+-          defaultQueue: {
+-            label: "default queue"
+-          }
+-        };
+-        try {
+-          const limits = this.limits;
+-          const features = this.features;
+-          const descBuffer = WGPUDeviceDescriptorStruct.pack(fullDescriptor, {
+-            validationHints: {
+-              limits,
+-              features
++          defaultQueue: descriptor?.defaultQueue ?? { label: 'default queue' },
++          deviceLostCallbackInfo: { nextInChain: null, mode: 'AllowProcessEvents', callback: loss, userdata1: null, userdata2: null },
++          uncapturedErrorCallbackInfo: { nextInChain: null, callback: error, userdata1: null, userdata2: null }
++        }, options));
++        const request = attempt.callback('request', (status, devicePtr, message, size) => {
++          // A successful handle belongs to this attempt before any fallible JS work.
++          const ownedDevice = status === RequestDeviceStatus.Success && devicePtr;
++          try {
++            const text = decodeCallbackMessage(message, size);
++            if (status !== RequestDeviceStatus.Success || !devicePtr) {
++              this._state = 'valid';
++              reject(new OperationError(`WGPU Error (${ReverseDeviceStatus[status] ?? status}): ${text}`));
++              return;
+             }
+-          });
+-          packedDescriptorPtr = ptr10(descBuffer);
+-        } catch (e) {
+-          this._state = "valid";
+-          reject(e);
+-          return;
+-        }
+-        const callbackFn = (status, devicePtr, messagePtr, messageSize, userdata1, userdata2) => {
+-          this.instanceTicker.unregister();
+-          const message = decodeCallbackMessage(messagePtr, messageSize);
+-          if (status === RequestDeviceStatus.Success) {
+-            if (devicePtr) {
+-              const device = new GPUDeviceImpl(devicePtr, this.lib, this.instanceTicker);
+-              this._device = device;
+-              resolve(device);
+-            } else {
+-              console.error("WGPU Error: requestDevice Success but device pointer is null.");
+-              reject(new Error(`WGPU Error (Success but null device): ${message || "No message."}`));
++            const device = new GPUDeviceImpl(devicePtr, this.lib, this.instanceTicker, attempt);
++            device._acquisition = attempt;
++            attempt.device = device;
++            for (const event of attempt.errors) {
++              device.handleUncapturedError(event);
+             }
+-          } else {
+-            this._state = "valid";
+-            let statusName = ReverseDeviceStatus[status] || "Unknown WGPU Error";
+-            reject(new OperationError(`WGPU Error (${statusName}): ${message || "No message provided."}`));
++            attempt.errors.length = 0;
++            if (attempt.loss) attempt.deliverLoss();
++            this._device = device;
++            attempt.initializers.length = 0;
++            attempt.queuePtr = null;
++            resolve(device);
++          } catch (error) {
++            this._state = 'valid';
++            if (ownedDevice) queueMicrotask(() => attempt.rollback(devicePtr, this.lib));
++            reject(error);
+           }
+-          if (jsCallback) {
+-            const callbackToClose = jsCallback;
+-            jsCallback = null;
+-            queueMicrotask(() => {
+-              callbackToClose.close();
+-            });
+-          }
+-        };
+-        jsCallback = new JSCallback4(callbackFn, {
+-          args: [FFIType5.u32, FFIType5.pointer, FFIType5.pointer, FFIType5.u64, FFIType5.pointer, FFIType5.pointer],
+-          returns: FFIType5.void
+-        });
+-        if (!jsCallback?.ptr) {
+-          fatalError("Failed to create JSCallback");
+-        }
+-        const buffer = WGPUCallbackInfoStruct.pack({
+-          nextInChain: null,
+-          mode: "AllowProcessEvents",
+-          callback: jsCallback?.ptr,
+-          userdata1: null,
+-          userdata2: null
+-        });
+-        const packedCallbackInfoPtr = ptr10(buffer);
+-        this.lib.wgpuAdapterRequestDevice(this.adapterPtr, packedDescriptorPtr, packedCallbackInfoPtr);
+-        this.instanceTicker.register();
+-      } catch (e) {
+-        console.error("Error during requestDevice:", e);
+-        this._state = "valid";
+-        if (jsCallback)
+-          jsCallback.close();
+-        reject(e);
++        }, [FFIType5.u32, FFIType5.pointer, FFIType5.pointer, FFIType5.u64, FFIType5.pointer, FFIType5.pointer]);
++        const info = ptr10(WGPUCallbackInfoStruct.pack({ nextInChain: null, mode: 'AllowProcessEvents', callback: request, userdata1: null, userdata2: null }, options));
++        attempt.call(() => this.lib.wgpuAdapterRequestDevice(this.adapterPtr, packed, info));
++      } catch (error) {
++        if (!attempt.entered) this._state = 'valid';
++        attempt.abort();
++        reject(error);
+       }
+     });
+   }
+@@ -5299,8 +5196,105 @@
+   Error: 4,
+   Unknown: 5
+ };
++
++// Request completion and loss have independent terminal events. Microtasks run after
++// both the callback and its enclosing native stack, including instance shutdown.
++class Acquisition {
++  arena = new CallArena();
++  handles = new Map();
++  entered = false;
++  requestDone = false;
++  lossDone;
++  device = null;
++  loss = null;
++  errors = [];
++  initializers = [];
++  queuePtr = null;
++  initialized(handle) {
++    this.initializers.push(handle);
++    if (!handle.ptr) throw new Error('Failed to create device initialization callback');
++  }
++  deliverLoss() {
++    if (!this.device || !this.loss) return;
++    try { this.device.handleDeviceLost(...this.loss); }
++    finally {
++      this.device._lostPromiseResolve?.({ reason: this.loss[0], message: this.loss[1], __brand: 'GPUDeviceLostInfo' });
++    }
++  }
++  rollback(pointer, lib) {
++    // No initializer has been published or submitted native work. Unwind after
++    // the request callback's enclosing native stack, without normal device teardown.
++    try {
++      for (const handle of this.initializers.splice(0)) handle.close();
++    } finally {
++      try { if (this.queuePtr) lib.wgpuQueueRelease(this.queuePtr); }
++      finally {
++        this.queuePtr = null;
++        try { lib.wgpuDeviceDestroy(pointer); this.ticker.processEvents(); }
++        finally { lib.wgpuDeviceRelease(pointer); this.device = null; this.errors.length = 0; }
++      }
++    }
++  }
++  constructor(ticker, deviceAttempt = false) {
++    this.ticker = ticker;
++    this.lossDone = !deviceAttempt;
++    ticker.acquisitions.add(this);
++    ticker.register();
++  }
++  callback(key, fn, args) {
++    const handle = new JSCallback5((...values) => {
++      try { fn(...values); }
++      catch (error) {
++        // Never unwind a JS exception through the native ABI. Terminal state and
++        // handle cleanup must complete before the original failure is reported.
++        queueMicrotask(() => { this.drain(); throw error; });
++      }
++      finally {
++        if (key === 'request') this.requestDone = true;
++        if (key === 'loss') this.lossDone = true;
++        queueMicrotask(() => this.drain());
++      }
++    }, { args, returns: FFIType6.void });
++    this.handles.set(key, handle);
++    if (!handle.ptr) throw new Error(`Failed to create ${key} callback`);
++    return handle.ptr;
++  }
++  drain() {
++    if (this.requestDone && this.handles.has('request')) {
++      this.handles.get('request').close();
++      this.handles.delete('request');
++    }
++    if (this.requestDone && !this.unregistered) {
++      this.unregistered = true;
++      this.ticker.unregister();
++    }
++    if (this.lossDone) {
++      for (const key of ['loss', 'error']) {
++        this.handles.get(key)?.close();
++        this.handles.delete(key);
++      }
++    }
++    if (this.requestDone && this.lossDone) this.ticker.acquisitions.delete(this);
++  }
++  abort() {
++    if (this.entered) return;
++    this.requestDone = this.lossDone = true;
++    this.arena.release();
++    this.drain();
++  }
++  call(fn) {
++    this.entered = true;
++    try { return fn(); }
++    finally { this.arena.release(); }
++  }
++}
++function nullBoundary(value, name) {
++  if (value != null && value !== 0 && value !== 0n) throw new TypeError(`Unsupported acquisition ${name}`);
++}
+ 
+ class InstanceTicker {
++  acquisitions = new Set();
++  stopped = false;
+   instancePtr;
+   lib;
+   _waiting = 0;
+@@ -5324,6 +5318,7 @@
+     return this._waiting > 0;
+   }
+   processEvents() {
++    if (this.stopped) return;
+     this.lib.wgpuInstanceProcessEvents(this.instancePtr);
+   }
+   scheduleTick() {
+@@ -5331,6 +5326,7 @@
+       return;
+     this._ticking = true;
+     setImmediate(() => {
++      if (this.stopped) { this._ticking = false; return; }
+       const now = performance.now();
+       this._accTime += now - this._lastTime;
+       this._lastTime = now;
+@@ -5367,8 +5363,10 @@
+       return Object.freeze(new Set);
+     }
+     if (this._wgslLanguageFeatures === null) {
++      const arena = new CallArena();
+       try {
+         const { buffer: structBuffer } = allocStruct(WGPUSupportedWGSLLanguageFeaturesStruct, {
++          arena,
+           lengths: {
+             features: 32
+           }
+@@ -5390,71 +5388,42 @@
+       } catch (e) {
+         console.error("Error in wgslLanguageFeatures getter:", e);
+         this._wgslLanguageFeatures = Object.freeze(new Set);
+-      }
++      } finally { arena.release(); }
+     }
+     return this._wgslLanguageFeatures;
+   }
+   requestAdapter(options) {
+-    if (this._destroyed) {
+-      return Promise.reject(new Error("GPU instance has been destroyed"));
+-    }
++    if (this._destroyed) return Promise.reject(new Error('GPU instance has been destroyed'));
+     return new Promise((resolve, reject) => {
+-      let packedOptionsPtr = null;
+-      let jsCallback = null;
++      const attempt = new Acquisition(this._ticker);
+       try {
+-        if (options) {
+-          try {
+-            const buffer2 = WGPURequestAdapterOptionsStruct.pack(options);
+-            packedOptionsPtr = ptr11(buffer2);
+-          } catch (e) {
+-            resolve(null);
+-            return;
+-          }
++        let packed = null;
++        try {
++          nullBoundary(options?.nextInChain, 'adapter chain');
++          nullBoundary(options?.compatibleSurface, 'compatible surface');
++          if (options) packed = ptr11(WGPURequestAdapterOptionsStruct.pack(options, { arena: attempt.arena }));
++        } catch (error) {
++          attempt.abort();
++          resolve(null);
++          return;
+         }
+-        const callbackFn = (status, adapterPtr, messagePtr, messageSize, userdata1, userdata2) => {
+-          this._ticker.unregister();
+-          const message = decodeCallbackMessage(messagePtr, messageSize);
+-          if (status === RequestAdapterStatus.Success) {
+-            if (adapterPtr) {
+-              resolve(new GPUAdapterImpl(adapterPtr, this.instancePtr, this.lib, this._ticker));
+-            } else {
+-              reject(new Error(`WGPU Error (Success but null adapter): ${message || "No message."}`));
+-            }
+-          } else if (status === RequestAdapterStatus.Unavailable) {
+-            resolve(null);
+-          } else {
+-            let statusName = Object.keys(RequestAdapterStatus).find((key) => RequestAdapterStatus[key] === status) || "Unknown WGPU Error";
+-            reject(new Error(`WGPU Error (${statusName}): ${message || "No message provided."}`));
++        const request = attempt.callback('request', (status, adapterPtr, message, size) => {
++          const ownedAdapter = status === RequestAdapterStatus.Success && adapterPtr;
++          try {
++            const text = decodeCallbackMessage(message, size);
++            if (status === RequestAdapterStatus.Success && adapterPtr) resolve(new GPUAdapterImpl(adapterPtr, this.instancePtr, this.lib, this._ticker));
++            else if (status === RequestAdapterStatus.Unavailable) resolve(null);
++            else reject(new Error(`WGPU Error (${status}): ${text}`));
++          } catch (error) {
++            if (ownedAdapter) queueMicrotask(() => this.lib.wgpuAdapterRelease(adapterPtr));
++            reject(error);
+           }
+-          if (jsCallback) {
+-            const callbackToClose = jsCallback;
+-            jsCallback = null;
+-            queueMicrotask(() => {
+-              callbackToClose.close();
+-            });
+-          }
+-        };
+-        jsCallback = new JSCallback5(callbackFn, {
+-          args: [FFIType6.u32, FFIType6.pointer, FFIType6.pointer, FFIType6.u64, FFIType6.pointer, FFIType6.pointer],
+-          returns: FFIType6.void
+-        });
+-        if (!jsCallback?.ptr) {
+-          fatalError("Failed to create JSCallback");
+-        }
+-        const buffer = WGPUCallbackInfoStruct.pack({
+-          nextInChain: null,
+-          mode: "AllowProcessEvents",
+-          callback: jsCallback?.ptr,
+-          userdata1: null,
+-          userdata2: null
+-        });
+-        const packedCallbackInfoPtr = ptr11(buffer);
+-        this.lib.wgpuInstanceRequestAdapter(this.instancePtr, packedOptionsPtr, packedCallbackInfoPtr);
+-        this._ticker.register();
+-      } catch (e) {
+-        if (jsCallback)
+-          jsCallback.close();
+-        reject(e);
++        }, [FFIType6.u32, FFIType6.pointer, FFIType6.pointer, FFIType6.u64, FFIType6.pointer, FFIType6.pointer]);
++        const info = ptr11(WGPUCallbackInfoStruct.pack({ nextInChain: null, mode: 'AllowProcessEvents', callback: request, userdata1: null, userdata2: null }, { arena: attempt.arena }));
++        attempt.call(() => this.lib.wgpuInstanceRequestAdapter(this.instancePtr, packed, info));
++      } catch (error) {
++        attempt.abort();
++        reject(error);
+       }
+     });
+   }
+@@ -5464,6 +5433,7 @@
+     this._destroyed = true;
+     try {
+       this.lib.wgpuInstanceRelease(this.instancePtr);
++      this._ticker.stopped = true;
+     } catch (e) {
+       console.error("FFI Error: wgpuInstanceRelease", e);
+     }
+@@ -5611,6 +5581,8 @@
+   GPUSupportedLimits: GPUSupportedLimitsImpl
+ };
+ async function setupGlobals({ libPath } = {}) {
++  if (libPath !== undefined) throw new Error('Shallot native library override is unsupported');
++  if (navigator.gpu && !(navigator.gpu instanceof GPUImpl)) throw new Error('Shallot native setup refuses an existing foreign GPU instance');
+   if (!navigator.gpu) {
+     const gpuInstance = createGPUInstance(libPath);
+     global.navigator = {

--- a/packages/shallot/patches/bun-webgpu-LICENSE
+++ b/packages/shallot/patches/bun-webgpu-LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/shallot/scripts/build-tooling.ts
+++ b/packages/shallot/scripts/build-tooling.ts
@@ -13,8 +13,12 @@
 // package, which would be the actual regression this build must not introduce, fails loud in review
 // rather than silently inlining.
 
-import { mkdirSync, readFileSync, rmSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
+import { nativeHash, nativePatchHash, nativeSourceHash } from "../bin/bun-native";
 
 const ROOT = resolve(import.meta.dir, ".."); // packages/shallot
 const OUT = resolve(ROOT, "dist");
@@ -102,4 +106,29 @@ for (const { out } of entries) {
     }
 }
 
-console.log(`build-tooling: compiled ${entries.map((e) => `dist/${e.out}.js`).join(", ")}`);
+const peer = createRequire(import.meta.url).resolve("bun-webgpu");
+const patch = resolve(ROOT, "patches/bun-webgpu-0.1.7.patch");
+const hash = (file: string) => createHash("sha256").update(readFileSync(file)).digest("hex");
+if (hash(peer) !== nativeSourceHash || hash(patch) !== nativePatchHash) {
+    throw new Error("build-tooling: native source/patch drift");
+}
+const temp = mkdtempSync(resolve(tmpdir(), "shallot-native-"));
+try {
+    cpSync(peer, resolve(temp, "index.js"));
+    const applied = Bun.spawnSync(["git", "apply", patch], { cwd: temp });
+    if (applied.exitCode !== 0) throw new Error(applied.stderr.toString());
+    const projected = resolve(temp, "index.js");
+    if (hash(projected) !== nativeHash) throw new Error("build-tooling: native projection drift");
+    cpSync(projected, resolve(OUT, "native.js"));
+    cpSync(resolve(ROOT, "patches/bun-webgpu-LICENSE"), resolve(OUT, "bun-webgpu-LICENSE"));
+    writeFileSync(
+        resolve(OUT, "bun-webgpu-NOTICE"),
+        "bun-webgpu 0.1.7 (https://github.com/kommander/bun-webgpu), Apache-2.0.\n" +
+            "Modified by Shallot: acquisition allocation/callback ownership and peer-relative native loading.\n",
+    );
+} finally {
+    rmSync(temp, { recursive: true, force: true });
+}
+console.log(
+    `build-tooling: compiled ${entries.map((e) => `dist/${e.out}.js`).join(", ")}, dist/native.js`,
+);

--- a/packages/shallot/scripts/dump-cells-ascii.ts
+++ b/packages/shallot/scripts/dump-cells-ascii.ts
@@ -26,8 +26,8 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { plugin } from "bun";
-import { setupGlobals } from "bun-webgpu";
 import typegpuBunPlugin from "unplugin-typegpu/bun";
+import { loadNative } from "../bin/bun-native";
 
 // TGSL function bodies are transpiled at load time (`tests/tgsl.ts`'s own docblock: without this
 // transform every kernel resolves with no metadata and CPU-called kernels return NaN). `bunfig.toml`'s
@@ -172,7 +172,7 @@ export function renderAsciiGrid(bytes: ArrayBuffer, cols: number, rows: number):
 export async function dumpCellsAscii(
     args: DumpCellsAsciiArgs,
 ): Promise<{ grid: { cols: number; rows: number }; text: string }> {
-    await setupGlobals();
+    await (await loadNative()).setupGlobals();
 
     const sceneXml = readFileSync(fileURLToPath(SCENE_URL), "utf8");
     const app = await build({

--- a/packages/shallot/src/standard/input/index.ts
+++ b/packages/shallot/src/standard/input/index.ts
@@ -317,9 +317,7 @@ function createHandlers(s: InputState): void {
         s.mouse.canvasHeight = rect.height;
     };
 
-    s.pointerEnter = () => {
-        s.mouse.hover = true;
-    };
+    s.pointerEnter = s.pointerHover;
 
     s.pointerLeave = () => {
         if (s.activePointerId === null) s.mouse.hover = false;
@@ -359,6 +357,8 @@ function createHandlers(s: InputState): void {
         // ignore multi-touch (different pointerId on the same canvas) so a
         // second pointer's buttons can't masquerade as the captured one's.
         if (s.activePointerId === null || s.activePointerId === e.pointerId) {
+            // Touch can press without a preceding move; pickers consume this press's ray immediately.
+            s.pointerHover(e);
             syncButtons(s.mouse, gateButtons(s, e.buttons));
         }
         if (s.activePointerId === null) {

--- a/packages/shallot/src/standard/input/input.test.ts
+++ b/packages/shallot/src/standard/input/input.test.ts
@@ -360,6 +360,36 @@ describe("InputPlugin", () => {
         expect(Inputs.mouse.left).toBe(true); // requireLock off → button reads immediately
     });
 
+    for (const type of ["pointerenter", "pointerdown"]) {
+        test(`${type} seeds a fresh canvas-relative pick before any pointer move`, () => {
+            canvas.getBoundingClientRect = () => ({
+                ...MOCK_RECT,
+                left: 100,
+                top: 50,
+                width: 640,
+                height: 480,
+            });
+            onCanvas(type)({
+                target: canvas,
+                pointerId: 1,
+                pointerType: "touch",
+                button: 0,
+                buttons: 1,
+                clientX: 225,
+                clientY: 180,
+                preventDefault() {},
+            });
+            expect(Inputs.mouse.hover).toBe(true);
+            expect([
+                Inputs.mouse.x,
+                Inputs.mouse.y,
+                Inputs.mouse.canvasWidth,
+                Inputs.mouse.canvasHeight,
+            ]).toEqual([125, 130, 640, 480]);
+            expect([Inputs.mouse.deltaX, Inputs.mouse.deltaY]).toEqual([0, 0]);
+        });
+    }
+
     test("pointer down captures the pointer and tracks the pressed button", () => {
         onCanvas("pointerdown")({
             target: canvas,
@@ -854,7 +884,7 @@ describe("InputPlugin", () => {
 
     test("a held-pointer move at a non-canvas target keeps mouse.x/y tracking", () => {
         // pointer enters the canvas — sets hover true
-        onCanvas("pointerenter")({ target: canvas });
+        onCanvas("pointerenter")({ target: canvas, clientX: 0, clientY: 0 });
         expect(Inputs.mouse.hover).toBe(true);
         // pointer down on the canvas — establishes the active pointer and activeCanvas
         onCanvas("pointerdown")({
@@ -896,7 +926,7 @@ describe("InputPlugin", () => {
     });
 
     test("pointerLeave clears hover when no pointer is active", () => {
-        onCanvas("pointerenter")({ target: canvas });
+        onCanvas("pointerenter")({ target: canvas, clientX: 0, clientY: 0 });
         expect(Inputs.mouse.hover).toBe(true);
         onCanvas("pointerleave")({ target: canvas });
         expect(Inputs.mouse.hover).toBe(false); // no active pointer → hover clears

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -271,6 +271,17 @@ export function checkCliCoverage(
  */
 export const CLI_COVERAGE: readonly CoverageRow[] = [
     {
+        file: "packages/shallot/bin/bun-native.ts",
+        arm: "tier",
+        reason:
+            "native-abi.test.ts drives loadNative's non-Bun refusal in real Node. " +
+            "bun run test:install's nativeFlow drives the actual shipped loader in physical " +
+            "normal/nested installs: optional-peer absence, missing/altered projection refusals, " +
+            "repeated imports and native acquisition. Build tooling checks nativeSourceHash and " +
+            "nativePatchHash against the inputs and nativeHash against the generated projection; " +
+            "the installed loader checks that projection again before importing it.",
+    },
+    {
         file: "packages/shallot/bin/build.ts",
         arm: "gap",
         reason:

--- a/packages/shallot/tests/format-gate.test.ts
+++ b/packages/shallot/tests/format-gate.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    renameSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
 
 // Arm for `scripts/format.ts`'s report-only mode — the mechanism that lets `check`
@@ -38,6 +46,41 @@ function runFormat(args: string[]) {
         stderr: "pipe",
     });
 }
+
+test("formatting needs no native projection; native setup still refuses its absence", () => {
+    const projection = join(REPO_ROOT, "packages/shallot/dist/native.js");
+    const { dir, scenePath } = fixtureScene();
+    const saved = join(dir, "native.js");
+    writeFileSync(join(dir, "error.scene"), "<scene><unknown /></scene>");
+    const before = runFormat(["--check"]);
+    expect(before.exitCode).toBe(1);
+    expect(before.stdout.toString()).toContain("would format:");
+    expect(before.stderr.toString()).toContain("xml parse error: Unknown tag <unknown>");
+    renameSync(projection, saved);
+    try {
+        const after = runFormat(["--check"]);
+        expect(after.exitCode).toBe(before.exitCode);
+        expect(after.stdout.toString()).toBe(before.stdout.toString());
+        expect(after.stderr.toString()).toBe(before.stderr.toString());
+        expect(readFileSync(scenePath, "utf8")).toBe(UNFORMATTED_SCENE);
+        expect(existsSync(projection)).toBe(false);
+
+        const native = Bun.spawnSync(
+            [
+                "bun",
+                "-e",
+                'const { loadNative } = await import("./packages/shallot/bin/bun-native.ts"); await loadNative();',
+            ],
+            { cwd: REPO_ROOT, stdout: "pipe", stderr: "pipe" },
+        );
+        expect(native.exitCode).toBe(1);
+        expect(native.stderr.toString()).toContain("Shallot native projection is missing");
+        expect(existsSync(projection)).toBe(false);
+    } finally {
+        renameSync(saved, projection);
+        rmSync(dir, { recursive: true, force: true });
+    }
+});
 
 describe("format.ts report-only mode — Validation 1: check does not write", () => {
     test("--check leaves a would-change fixture byte-identical", () => {

--- a/packages/shallot/tests/native-abi.test.ts
+++ b/packages/shallot/tests/native-abi.test.ts
@@ -1,0 +1,151 @@
+import { ptr, toArrayBuffer } from "bun:ffi";
+import { expect, test } from "bun:test";
+import { loadNative } from "../bin/bun-native";
+import { BASE_FEATURES, deviceLimits } from "../src/engine/runtime/gpu";
+
+const { createGPUInstance } = await loadNative();
+
+test("native loader refuses real Node before attempting the Bun FFI import", () => {
+    const loader = new URL("../bin/bun-native.ts", import.meta.url).href;
+    const child = Bun.spawnSync([
+        "node",
+        "--input-type=module",
+        "-e",
+        `import { loadNative } from ${JSON.stringify(loader)}; await loadNative();`,
+    ]);
+    expect(child.exitCode).toBe(1);
+    expect(child.stderr.toString()).toContain("Shallot native setup requires Bun");
+    expect(child.stderr.toString()).not.toContain("Unsupported URL scheme");
+});
+
+test("native get-limits writes its 152-byte structure, not the carrier's 168-byte allocation", async () => {
+    const gpu = createGPUInstance() as any;
+    try {
+        const adapter = await gpu.requestAdapter();
+        expect(adapter).not.toBeNull();
+        const bytes = new Uint8Array(256).fill(0xa5);
+        new DataView(bytes.buffer).setBigUint64(0, 0n, true);
+        expect(adapter.lib.wgpuAdapterGetLimits(adapter.adapterPtr, ptr(bytes))).toBe(1);
+        const native = new DataView(bytes.buffer);
+        expect(native.getUint32(52, true)).toBeGreaterThanOrEqual(10);
+        expect(native.getBigUint64(72, true)).toBe(
+            BigInt(adapter.limits.maxStorageBufferBindingSize),
+        );
+        expect(native.getBigUint64(96, true)).toBe(BigInt(adapter.limits.maxBufferSize));
+        expect([...bytes.slice(152)]).toEqual(Array(104).fill(0xa5));
+        expect(native.getUint32(148, true)).not.toBe(0xa5a5a5a5);
+        const device = await adapter.requestDevice({
+            requiredFeatures: [...BASE_FEATURES],
+            requiredLimits: deviceLimits(adapter.limits),
+        });
+        for (const feature of BASE_FEATURES) expect(device.features.has(feature)).toBe(true);
+        expect(device.limits.maxStorageBuffersPerShaderStage).toBe(10);
+        expect(device.limits.maxStorageBufferBindingSize).toBe(
+            adapter.limits.maxStorageBufferBindingSize,
+        );
+        expect(device.limits.maxBufferSize).toBe(adapter.limits.maxBufferSize);
+        device.destroy();
+        await device.lost;
+        adapter.destroy();
+    } finally {
+        gpu.destroy();
+    }
+});
+
+test("actual native uncaptured error survives request completion until loss", async () => {
+    const gpu = createGPUInstance() as any;
+    try {
+        const adapter = await gpu.requestAdapter();
+        const device = await adapter.requestDevice({
+            requiredFeatures: [...BASE_FEATURES],
+            requiredLimits: deviceLimits(adapter.limits),
+        });
+        let errors = 0;
+        device.addEventListener("uncapturederror", () => {
+            errors++;
+        });
+        const buffer = device.createBuffer({ size: 4, usage: 0 });
+        gpu._ticker.processEvents();
+        expect(errors).toBe(1);
+        expect(device._acquisition.handles.has("error")).toBe(true);
+        buffer.destroy();
+        device.destroy();
+        await device.lost;
+        await Promise.resolve();
+        expect(device._acquisition.handles.size).toBe(0);
+        adapter.destroy();
+    } finally {
+        gpu.destroy();
+    }
+});
+
+test("actual native rejects an owned device graph with a post-validation excessive limit", async () => {
+    const gpu = createGPUInstance() as any;
+    const adapter = await gpu.requestAdapter();
+    await Promise.resolve();
+    const limit = adapter.limits.maxStorageBuffersPerShaderStage;
+    const lib = adapter.lib;
+    let entries = 0;
+    let returns = 0;
+    let attempt: any;
+    adapter.lib = {
+        ...lib,
+        wgpuAdapterRequestDevice: (pointer: number, descriptor: number, info: number) => {
+            attempt = [...gpu._ticker.acquisitions].at(-1);
+            const view = new DataView(toArrayBuffer(descriptor, 0, 144));
+            const address = Number(view.getBigUint64(40, true));
+            expect(
+                [...attempt.arena.owners].some(
+                    (buffer: any) => buffer instanceof ArrayBuffer && ptr(buffer) === address,
+                ),
+            ).toBe(true);
+            const limits = new DataView(toArrayBuffer(address, 0, 168));
+            expect(limits.getUint32(52, true)).toBe(10);
+            limits.setUint32(52, limit + 1, true);
+            entries++;
+            const result = lib.wgpuAdapterRequestDevice(pointer, descriptor, info);
+            returns++;
+            return result;
+        },
+    };
+    try {
+        await expect(
+            adapter.requestDevice({
+                requiredFeatures: [...BASE_FEATURES],
+                requiredLimits: deviceLimits(adapter.limits),
+            }),
+        ).rejects.toThrow("WGPU Error (Error)");
+        gpu._ticker.processEvents();
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(entries).toBe(1);
+        expect(returns).toBe(1);
+        expect(attempt.requestDone).toBe(true);
+        expect(attempt.lossDone).toBe(true);
+        expect(attempt.handles.size).toBe(0);
+        expect(gpu._ticker.acquisitions.size).toBe(0);
+        expect(gpu._ticker._waiting).toBe(0);
+    } finally {
+        adapter.destroy();
+        gpu.destroy();
+    }
+});
+
+test("actual native shutdown cancels a pending adapter request", async () => {
+    const gpu = createGPUInstance() as any;
+    const completion = gpu.requestAdapter().then(
+        (adapter: any) => {
+            adapter?.destroy();
+            return "success";
+        },
+        () => "cancelled",
+    );
+    const attempt = [...gpu._ticker.acquisitions][0] as any;
+    expect(attempt.handles.size).toBe(1);
+    gpu.destroy();
+    expect(await completion).toBe("cancelled");
+    await Promise.resolve();
+    expect(attempt.handles.size).toBe(0);
+    expect(gpu._ticker.acquisitions.size).toBe(0);
+    expect(gpu._ticker._waiting).toBe(0);
+});

--- a/packages/shallot/tests/native-callbacks-delivery.fixture.ts
+++ b/packages/shallot/tests/native-callbacks-delivery.fixture.ts
@@ -1,0 +1,224 @@
+import * as ffi from "bun:ffi";
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+
+const mode = process.env.CALLBACK_MODE!;
+const failure = new Error(`controlled ${mode} failure`);
+const message = Buffer.from("valid native callback message");
+const stringify = Buffer.prototype.toString;
+let decoding = false;
+Buffer.prototype.toString = function (...args: any[]) {
+    if (decoding) throw failure;
+    return stringify.apply(this, args as any);
+};
+const real = ffi.JSCallback;
+let armed = false;
+let count = 0;
+let active = 0;
+const records: { closes: number }[] = [];
+mock.module("bun:ffi", () => ({
+    ...ffi,
+    JSCallback: new Proxy(real, {
+        construct(_target, [fn, options]) {
+            const index = armed ? ++count : 0;
+            const record = { closes: 0 };
+            if (armed) records.push(record);
+            const handle = new real((...args: any[]) => {
+                const inject =
+                    (mode === "adapter-decode" && index === 1) ||
+                    (mode === "device-decode" && index === 3) ||
+                    (mode === "loss-decode" && index === 2) ||
+                    (mode === "error-decode" && index === 1);
+                if (inject) {
+                    args[2] = ffi.ptr(message);
+                    args[3] = BigInt(message.length);
+                }
+                active++;
+                decoding = inject;
+                try {
+                    return fn(...args);
+                } finally {
+                    active--;
+                    decoding = false;
+                }
+            }, options);
+            return new Proxy(handle, {
+                get(object, key) {
+                    if (key === "close")
+                        return () => {
+                            assert.equal(active, 0, "no close on native callback stack");
+                            record.closes++;
+                            handle.close();
+                        };
+                    return Reflect.get(object, key);
+                },
+            });
+        },
+    }),
+}));
+const { loadNative } = await import("../bin/bun-native");
+const { BASE_FEATURES, deviceLimits } = await import("../src/engine/runtime/gpu");
+const native = await loadNative();
+const gpu = native.createGPUInstance() as any;
+const turn = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+let diagnostic: unknown;
+process.on("uncaughtException", (error) => {
+    if (error !== failure) {
+        console.error(error);
+        process.exit(2);
+    }
+    diagnostic = error;
+});
+let adapter: any;
+let device: any;
+let attempt: any;
+let releases = 0;
+let destroys = 0;
+let entries = 0;
+let returns = 0;
+try {
+    if (mode !== "adapter-decode") adapter = await gpu.requestAdapter();
+    await turn();
+    const owner = adapter ?? gpu;
+    const lib = owner.lib;
+    const request = adapter ? "wgpuAdapterRequestDevice" : "wgpuInstanceRequestAdapter";
+    const release = adapter ? "wgpuDeviceRelease" : "wgpuAdapterRelease";
+    owner.lib = {
+        ...lib,
+        [request]: (...args: any[]) => {
+            entries++;
+            if (mode === "queued-error") {
+                const view = new DataView(ffi.toArrayBuffer(args[1], 0, 144));
+                const error = ffi.CFunction({
+                    ptr: Number(view.getBigUint64(120, true)) as any,
+                    args: ["ptr", "u32", "ptr", "u64", "ptr", "ptr"],
+                    returns: "void",
+                });
+                error(null, 1, ffi.ptr(message), BigInt(message.length), null, null);
+                error.close();
+            }
+            active++;
+            try {
+                const value = lib[request](...args);
+                returns++;
+                return value;
+            } finally {
+                active--;
+            }
+        },
+        [release]: (pointer: number) => {
+            releases++;
+            return lib[release](pointer);
+        },
+        wgpuDeviceDestroy: (pointer: number) => {
+            destroys++;
+            return lib.wgpuDeviceDestroy(pointer);
+        },
+    };
+    const register = gpu._ticker.register.bind(gpu._ticker);
+    gpu._ticker.register = () => {
+        attempt = [...gpu._ticker.acquisitions].at(-1);
+        register();
+    };
+    if (mode === "queued-error" || mode === "live-error") {
+        (native.globalConstructors.GPUDevice as any).prototype.handleUncapturedError = () => {
+            throw failure;
+        };
+    }
+    if (mode === "loss-delivery") {
+        (native.globalConstructors.GPUDevice as any).prototype.handleDeviceLost = () => {
+            throw failure;
+        };
+    }
+    armed = true;
+    const result = await (adapter
+        ? adapter.requestDevice({
+              requiredFeatures: [...BASE_FEATURES],
+              requiredLimits: deviceLimits(adapter.limits),
+          })
+        : gpu.requestAdapter()
+    ).then(
+        (value: any) => ({ value, error: null }),
+        (error: Error) => ({ value: null, error }),
+    );
+    const rejected = ["adapter-decode", "device-decode", "queued-error"].includes(mode);
+    if (rejected) assert.equal(result.error, failure, "original request failure preserved");
+    else {
+        assert.equal(result.error, null);
+        device = result.value;
+        if (mode === "live-error" || mode === "error-decode") {
+            let buffer: any;
+            try {
+                buffer = device.createBuffer({ size: 4, usage: 0 });
+                gpu._ticker.processEvents();
+            } catch (error) {
+                assert.equal(error, failure);
+            }
+            buffer?.destroy();
+            await turn();
+            assert.equal(
+                attempt.handles.size,
+                2,
+                "live error does not terminate loss/error lifetime",
+            );
+        }
+        try {
+            device.destroy();
+        } catch (error) {
+            assert.equal(error, failure, "only controlled callback failure can interrupt teardown");
+        }
+        let lost: any;
+        device.lost.then((value: any) => {
+            lost = value;
+        });
+        await turn();
+        assert(lost, "terminal lost delivered despite callback throw");
+        assert.equal(typeof lost.reason, "string", "terminal lost reason");
+        if (mode === "loss-decode") assert.match(lost.message, /decoding failed/);
+    }
+    await turn();
+    gpu._ticker.processEvents();
+    await turn();
+    assert.equal(entries, 1);
+    assert.equal(returns, 1);
+    assert.equal(attempt.handles.size, 0);
+    assert.equal(gpu._ticker.acquisitions.size, 0);
+    assert.equal(gpu._ticker._waiting, 0);
+    if (rejected) {
+        assert.equal(releases, 1, "unpublished successful native handle released");
+        assert.equal(destroys, adapter ? 1 : 0);
+        assert(
+            records.every((record) => record.closes === 1),
+            "all unpublished callback resources close once",
+        );
+    } else {
+        assert.equal(diagnostic, failure, "original callback exception reported after unwind");
+        assert(
+            records.slice(0, 3).every((record) => record.closes === 1),
+            "terminal acquisition callbacks close once",
+        );
+    }
+    console.log(
+        JSON.stringify({
+            mode,
+            entries,
+            returns,
+            releases,
+            destroys,
+            handles: attempt.handles.size,
+            pending: gpu._ticker._waiting,
+            diagnostic: diagnostic === failure,
+            closes: records.map((record) => record.closes),
+        }),
+    );
+    if (!rejected) {
+        console.error(failure.message);
+        process.exitCode = 1;
+    }
+} finally {
+    adapter?.destroy();
+    gpu.destroy();
+}

--- a/packages/shallot/tests/native-callbacks.fixture.ts
+++ b/packages/shallot/tests/native-callbacks.fixture.ts
@@ -1,0 +1,152 @@
+import * as ffi from "bun:ffi";
+import { mock } from "bun:test";
+import assert from "node:assert/strict";
+
+// Isolated process: the exported constructor still creates real Bun callbacks.
+// Failure before construction, or a constructed but unusable handle, must unwind
+// every earlier handle without ever forwarding a null callback to Dawn.
+const mode = process.env.CALLBACK_MODE!;
+const target = Number(process.env.CALLBACK_TARGET ?? 0);
+const real = ffi.JSCallback;
+const handles: { handle: InstanceType<typeof real>; closes: number }[] = [];
+let constructed = 0;
+let armed = false;
+let active = 0;
+mock.module("bun:ffi", () => ({
+    ...ffi,
+    JSCallback: new Proxy(real, {
+        construct(_target, [fn, options]) {
+            const index = armed ? ++constructed : 0;
+            if (index === target && mode === "before")
+                throw new Error("callback construction failure");
+            const handle = new real((...args: any[]) => {
+                active++;
+                try {
+                    return fn(...args);
+                } finally {
+                    active--;
+                }
+            }, options);
+            if (!armed) return handle;
+            const record = { handle, closes: 0 };
+            handles.push(record);
+            return new Proxy(handle, {
+                get(object, key) {
+                    if (key === "ptr" && index === target && mode === "null") return null;
+                    if (key === "close")
+                        return () => {
+                            assert.equal(active, 0, "close outside native/callback stack");
+                            record.closes++;
+                            handle.close();
+                        };
+                    return Reflect.get(object, key);
+                },
+            });
+        },
+    }),
+}));
+const { loadNative } = await import("../bin/bun-native");
+const { BASE_FEATURES, deviceLimits } = await import("../src/engine/runtime/gpu");
+const native = await loadNative();
+const gpu = native.createGPUInstance() as any;
+const turn = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+const adapterSite = process.env.CALLBACK_SITE === "adapter";
+let adapter: any;
+let entries = 0;
+let returns = 0;
+let destroys = 0;
+let releases = 0;
+let queueReleases = 0;
+let attempt: any;
+try {
+    if (!adapterSite) adapter = await gpu.requestAdapter();
+    await turn();
+    const owner = adapterSite ? gpu : adapter;
+    const lib = owner.lib;
+    const name = adapterSite ? "wgpuInstanceRequestAdapter" : "wgpuAdapterRequestDevice";
+    owner.lib = {
+        ...lib,
+        [name]: (...args: any[]) => {
+            entries++;
+            active++;
+            try {
+                const result = lib[name](...args);
+                returns++;
+                return result;
+            } finally {
+                active--;
+            }
+        },
+        wgpuDeviceDestroy: (pointer: number) => {
+            destroys++;
+            return lib.wgpuDeviceDestroy(pointer);
+        },
+        wgpuDeviceRelease: (pointer: number) => {
+            releases++;
+            return lib.wgpuDeviceRelease(pointer);
+        },
+        wgpuQueueRelease: (pointer: number) => {
+            queueReleases++;
+            return lib.wgpuQueueRelease(pointer);
+        },
+    };
+    const register = gpu._ticker.register.bind(gpu._ticker);
+    gpu._ticker.register = () => {
+        attempt = [...gpu._ticker.acquisitions].at(-1);
+        register();
+    };
+    const descriptor = adapterSite
+        ? undefined
+        : {
+              requiredFeatures: [...BASE_FEATURES],
+              requiredLimits: deviceLimits(adapter.limits),
+              label: "callback constructor",
+              defaultQueue: { label: "callback queue" },
+          };
+    armed = true;
+    const outcome = await (adapterSite
+        ? gpu.requestAdapter()
+        : adapter.requestDevice(descriptor)
+    ).then(
+        () => null,
+        (error: Error) => error,
+    );
+    assert(outcome instanceof Error, "constructor failure rejects request");
+    await turn();
+    gpu._ticker.processEvents();
+    await turn();
+    assert.equal(constructed, target, "target constructor reached");
+    assert.equal(entries, adapterSite || target <= 3 ? 0 : 1, "native entry population");
+    assert.equal(returns, entries, "actual native returns");
+    assert.equal(destroys, entries, "unpublished device destroyed");
+    assert.equal(releases, entries, "unpublished device released");
+    assert.equal(queueReleases, entries, "partial constructor queue released");
+    assert(
+        handles.every((record) => record.closes === 1),
+        "every constructed handle closes exactly once",
+    );
+    assert.equal(attempt.arena.owners.size, 0);
+    assert.equal(attempt.handles.size, 0);
+    assert.equal(gpu._ticker.acquisitions.size, 0);
+    assert.equal(gpu._ticker._waiting, 0);
+    console.log(
+        JSON.stringify({
+            mode,
+            target,
+            site: adapterSite ? "adapter" : "device",
+            entries,
+            returns,
+            destroys,
+            releases,
+            queueReleases,
+            handles: handles.length,
+            closes: handles.map((r) => r.closes),
+        }),
+    );
+} finally {
+    adapter?.destroy();
+    gpu.destroy();
+}

--- a/packages/shallot/tests/native-callbacks.test.ts
+++ b/packages/shallot/tests/native-callbacks.test.ts
@@ -1,0 +1,461 @@
+import { CFunction, toArrayBuffer } from "bun:ffi";
+import { expect, test } from "bun:test";
+import { loadNative } from "../bin/bun-native";
+import { BASE_FEATURES, deviceLimits } from "../src/engine/runtime/gpu";
+
+const { createGPUInstance } = await loadNative();
+const descriptor = (adapter: GPUAdapter) => ({
+    label: "callbacks label",
+    defaultQueue: { label: "callbacks queue" },
+    requiredFeatures: [...BASE_FEATURES],
+    requiredLimits: deviceLimits(adapter.limits),
+});
+const turn = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+};
+
+for (const mode of [
+    "adapter-decode",
+    "device-decode",
+    "queued-error",
+    "loss-decode",
+    "error-decode",
+    "loss-delivery",
+    "live-error",
+]) {
+    test(`actual callback delivery ${mode}`, () => {
+        const child = Bun.spawnSync(
+            [process.execPath, `${import.meta.dir}/native-callbacks-delivery.fixture.ts`],
+            {
+                env: { ...process.env, CALLBACK_MODE: mode },
+                timeout: 4000,
+            },
+        );
+        const diagnostic = ["loss-decode", "error-decode", "loss-delivery", "live-error"].includes(
+            mode,
+        );
+        expect(child.stderr.toString()).toBe(diagnostic ? `controlled ${mode} failure\n` : "");
+        expect(child.exitCode).toBe(diagnostic ? 1 : 0);
+        const result = JSON.parse(child.stdout.toString());
+        expect(result.returns).toBe(1);
+        expect(result.handles).toBe(0);
+        expect(result.diagnostic).toBe(diagnostic);
+    });
+}
+
+for (const status of [1, 2, 3, 4, 5]) {
+    test(`adapter callback status ${status} with null handle`, async () => {
+        const gpu = createGPUInstance() as any;
+        let attempt: any;
+        let closes = 0;
+        gpu.lib = {
+            ...gpu.lib,
+            wgpuInstanceRequestAdapter: (_instance: number, _options: number, info: number) => {
+                attempt = [...gpu._ticker.acquisitions].at(-1);
+                const handle = attempt.handles.get("request");
+                const close = handle.close.bind(handle);
+                handle.close = () => {
+                    closes++;
+                    close();
+                };
+                const view = new DataView(toArrayBuffer(info, 0, 40));
+                const callback = CFunction({
+                    ptr: Number(view.getBigUint64(16, true)) as any,
+                    args: ["u32", "ptr", "ptr", "u64", "ptr", "ptr"],
+                    returns: "void",
+                });
+                callback(status, null, null, 0n, null, null);
+                expect(closes).toBe(0);
+                callback.close();
+                return 0n;
+            },
+        };
+        try {
+            if (status === 3) expect(await gpu.requestAdapter()).toBeNull();
+            else
+                await expect(gpu.requestAdapter()).rejects.toThrow(
+                    `WGPU Error (${status}): [empty message]`,
+                );
+            await turn();
+            expect(closes).toBe(1);
+            expect(attempt.handles.size).toBe(0);
+            expect(gpu._ticker.acquisitions.size).toBe(0);
+            expect(gpu._ticker._waiting).toBe(0);
+        } finally {
+            gpu.destroy();
+        }
+    });
+}
+
+test("reentrant instance shutdown inside acquisition entry defers callback closes", async () => {
+    const gpu = createGPUInstance() as any;
+    const lib = gpu.lib;
+    let attempt: any;
+    let closes = 0;
+    let eventsAfterRelease = 0;
+    const processEvents = gpu._ticker.lib.wgpuInstanceProcessEvents;
+    gpu._ticker.lib = {
+        ...lib,
+        wgpuInstanceProcessEvents: (pointer: number) => {
+            if (gpu._destroyed) eventsAfterRelease++;
+            return processEvents(pointer);
+        },
+    };
+    gpu.lib = {
+        ...lib,
+        wgpuInstanceRequestAdapter: (...args: any[]) => {
+            attempt = [...gpu._ticker.acquisitions].at(-1);
+            const handle = attempt.handles.get("request");
+            const close = handle.close.bind(handle);
+            handle.close = () => {
+                closes++;
+                close();
+            };
+            const result = lib.wgpuInstanceRequestAdapter(...args);
+            gpu.destroy();
+            expect(closes).toBe(0);
+            return result;
+        },
+    };
+    await expect(gpu.requestAdapter()).rejects.toThrow("WGPU Error (2)");
+    await turn();
+    gpu._ticker.processEvents();
+    expect(closes).toBe(1);
+    expect(eventsAfterRelease).toBe(0);
+    expect(attempt.handles.size).toBe(0);
+    expect(gpu._ticker.acquisitions.size).toBe(0);
+    expect(gpu._ticker._waiting).toBe(0);
+});
+
+for (const mode of ["before", "null"]) {
+    for (const site of ["adapter", "device"]) {
+        for (let target = 1; target <= (site === "adapter" ? 1 : 7); target++) {
+            test(`callback constructor ${site} ${target} ${mode}`, () => {
+                const child = Bun.spawnSync(
+                    [process.execPath, `${import.meta.dir}/native-callbacks.fixture.ts`],
+                    {
+                        env: {
+                            ...process.env,
+                            CALLBACK_MODE: mode,
+                            CALLBACK_SITE: site,
+                            CALLBACK_TARGET: String(target),
+                        },
+                        timeout: 4000,
+                    },
+                );
+                expect(child.stderr.toString()).toBe("");
+                expect(child.exitCode).toBe(0);
+                expect(JSON.parse(child.stdout.toString()).target).toBe(target);
+            });
+        }
+    }
+}
+
+for (const status of [1, 2, 3, 4]) {
+    for (const order of ["loss-first", "request-first"]) {
+        test(`native callback trampolines: request ${status}, ${order}`, async () => {
+            const gpu = createGPUInstance() as any;
+            try {
+                const adapter = await gpu.requestAdapter();
+                await turn();
+                let attempt: any;
+                let callbacks: any;
+                adapter.lib = {
+                    ...adapter.lib,
+                    wgpuAdapterRequestDevice: (_adapter: number, desc: number, info: number) => {
+                        attempt = [...gpu._ticker.acquisitions].at(-1);
+                        const d = new DataView(toArrayBuffer(desc, 0, 144));
+                        const r = new DataView(toArrayBuffer(info, 0, 40));
+                        callbacks = {
+                            request: CFunction({
+                                ptr: Number(r.getBigUint64(16, true)) as any,
+                                args: ["u32", "ptr", "ptr", "u64", "ptr", "ptr"],
+                                returns: "void",
+                            }),
+                            loss: CFunction({
+                                ptr: Number(d.getBigUint64(88, true)) as any,
+                                args: ["ptr", "u32", "ptr", "u64", "ptr", "ptr"],
+                                returns: "void",
+                            }),
+                            error: CFunction({
+                                ptr: Number(d.getBigUint64(120, true)) as any,
+                                args: ["ptr", "u32", "ptr", "u64", "ptr", "ptr"],
+                                returns: "void",
+                            }),
+                        };
+                        return 0n;
+                    },
+                };
+                const rejected = adapter.requestDevice(descriptor(adapter)).then(
+                    () => null,
+                    (error: Error) => error,
+                );
+                expect(attempt.handles.size).toBe(3);
+                const handles = [...attempt.handles.values()] as any[];
+                const counts = new Map(handles.map((handle) => [handle, 0]));
+                for (const handle of handles) {
+                    const close = handle.close.bind(handle);
+                    handle.close = () => {
+                        counts.set(handle, counts.get(handle)! + 1);
+                        close();
+                    };
+                }
+                callbacks.error(null, 1, null, 0n, null, null);
+                expect(attempt.handles.size).toBe(3);
+                if (order === "loss-first") callbacks.loss(null, 4, null, 0n, null, null);
+                callbacks.request(status, null, null, 0n, null, null);
+                // No handle can close on the callback/native stack itself.
+                expect([...counts.values()]).toEqual([0, 0, 0]);
+                if (order === "request-first") {
+                    await turn();
+                    expect(attempt.handles.has("loss")).toBe(true);
+                    expect(attempt.handles.has("error")).toBe(true);
+                    callbacks.loss(null, 4, null, 0n, null, null);
+                }
+                const failure = await rejected;
+                expect(failure).toBeInstanceOf(Error);
+                expect(failure?.name).toBe("OperationError");
+                expect(failure?.message).toBe(
+                    `WGPU Error (${{ 1: "Success", 2: "CallbackCancelled", 3: "Error", 4: "Unknown" }[status]}): [empty message]`,
+                );
+                await turn();
+                expect([...counts.values()]).toEqual([1, 1, 1]);
+                expect(attempt.handles.size).toBe(0);
+                expect(gpu._ticker.acquisitions.size).toBe(0);
+                expect(gpu._ticker._waiting).toBe(0);
+                for (const callback of Object.values(callbacks) as any[]) callback.close();
+                adapter.destroy();
+            } finally {
+                gpu.destroy();
+            }
+        });
+    }
+}
+
+for (let allocation = 1; allocation <= 11; allocation++) {
+    test(`pre-entry allocation ${allocation} unwinds callbacks and pending registration`, async () => {
+        const gpu = createGPUInstance() as any;
+        try {
+            const adapter = await gpu.requestAdapter();
+            await turn();
+            const input = descriptor(adapter);
+            const register = gpu._ticker.register.bind(gpu._ticker);
+            let attempt: any;
+            gpu._ticker.register = () => {
+                attempt = [...gpu._ticker.acquisitions].at(-1);
+                const hold = attempt.arena.hold.bind(attempt.arena);
+                let count = 0;
+                attempt.arena.hold = (value: any) => {
+                    hold(value);
+                    if (++count === allocation) throw new Error("packing allocation failure");
+                    return value;
+                };
+                register();
+            };
+            await expect(adapter.requestDevice(input)).rejects.toThrow(
+                "packing allocation failure",
+            );
+            expect(attempt.entered).toBe(false);
+            expect(attempt.handles.size).toBe(0);
+            expect(attempt.arena.owners.size).toBe(0);
+            expect(gpu._ticker.acquisitions.size).toBe(0);
+            expect(gpu._ticker._waiting).toBe(0);
+            adapter.destroy();
+        } finally {
+            gpu.destroy();
+        }
+    });
+}
+
+test("failed attempt delayed events cannot reach overlapping replacement devices on one instance", async () => {
+    const gpu = createGPUInstance() as any;
+    const adapter = await gpu.requestAdapter();
+    const other = await gpu.requestAdapter();
+    const lib = adapter.lib;
+    let stale: any;
+    let failedRequest: any;
+    let loss: any;
+    let error: any;
+    adapter.lib = {
+        ...lib,
+        wgpuAdapterRequestDevice: (_pointer: number, descriptor: number, info: number) => {
+            stale = [...gpu._ticker.acquisitions].at(-1);
+            const d = new DataView(toArrayBuffer(descriptor, 0, 144));
+            const r = new DataView(toArrayBuffer(info, 0, 40));
+            const args = ["ptr", "u32", "ptr", "u64", "ptr", "ptr"] as const;
+            loss = CFunction({
+                ptr: Number(d.getBigUint64(88, true)) as any,
+                args: [...args],
+                returns: "void",
+            });
+            error = CFunction({
+                ptr: Number(d.getBigUint64(120, true)) as any,
+                args: [...args],
+                returns: "void",
+            });
+            failedRequest = CFunction({
+                ptr: Number(r.getBigUint64(16, true)) as any,
+                args: ["u32", "ptr", "ptr", "u64", "ptr", "ptr"],
+                returns: "void",
+            });
+            return 0n;
+        },
+    };
+    try {
+        const pending = adapter.requestDevice(descriptor(adapter));
+        await expect(adapter.requestDevice(descriptor(adapter))).rejects.toThrow(
+            "Adapter already consumed",
+        );
+        expect(stale.requestDone).toBe(false);
+        failedRequest(3, null, null, 0n, null, null);
+        failedRequest.close();
+        await expect(pending).rejects.toThrow("WGPU Error (Error)");
+        await turn();
+        expect(stale.handles.size).toBe(2);
+        adapter.lib = lib;
+        const [replacement, distinct] = await Promise.all([
+            adapter.requestDevice(descriptor(adapter)),
+            other.requestDevice(descriptor(other)),
+        ]);
+        await turn();
+        let replacementErrors = 0;
+        let distinctErrors = 0;
+        replacement.onuncapturederror = () => {
+            replacementErrors++;
+        };
+        distinct.onuncapturederror = () => {
+            distinctErrors++;
+        };
+        let replacementLost = false;
+        replacement.lost.then(() => {
+            replacementLost = true;
+        });
+        error(null, 1, null, 0n, null, null);
+        loss(null, 4, null, 0n, null, null);
+        error.close();
+        loss.close();
+        await turn();
+        expect(stale.handles.size).toBe(0);
+        expect(replacementErrors).toBe(0);
+        expect(distinctErrors).toBe(0);
+        expect(replacementLost).toBe(false);
+        const buffer = distinct.createBuffer({ size: 4, usage: 0 });
+        gpu._ticker.processEvents();
+        expect(distinctErrors).toBe(1);
+        expect(replacementErrors).toBe(0);
+        buffer.destroy();
+        distinct.destroy();
+        await distinct.lost;
+        await turn();
+        expect(replacementLost).toBe(false);
+        expect(replacement._acquisition.handles.size).toBe(2);
+        replacement.destroy();
+        await replacement.lost;
+        await turn();
+        expect(gpu._ticker.acquisitions.size).toBe(0);
+        expect(gpu._ticker._waiting).toBe(0);
+    } finally {
+        adapter.destroy();
+        other.destroy();
+        gpu.destroy();
+    }
+});
+
+test("actual successful native device is rolled back when queue construction throws", async () => {
+    const gpu = createGPUInstance() as any;
+    const adapter = await gpu.requestAdapter();
+    await turn();
+    const lib = adapter.lib;
+    let destroys = 0;
+    let releases = 0;
+    let attempt: any;
+    adapter.lib = {
+        ...lib,
+        wgpuDeviceGetQueue: () => {
+            attempt = [...gpu._ticker.acquisitions].at(-1);
+            throw new Error("queue construction failed");
+        },
+        wgpuDeviceDestroy: (pointer: number) => {
+            destroys++;
+            return lib.wgpuDeviceDestroy(pointer);
+        },
+        wgpuDeviceRelease: (pointer: number) => {
+            releases++;
+            return lib.wgpuDeviceRelease(pointer);
+        },
+    };
+    try {
+        await expect(adapter.requestDevice(descriptor(adapter))).rejects.toThrow(
+            "queue construction failed",
+        );
+        await turn();
+        gpu._ticker.processEvents();
+        await turn();
+        expect(destroys).toBe(1);
+        expect(releases).toBe(1);
+        expect(attempt.requestDone).toBe(true);
+        expect(attempt.lossDone).toBe(true);
+        expect(attempt.handles.size).toBe(0);
+        expect(gpu._ticker.acquisitions.size).toBe(0);
+    } finally {
+        adapter.destroy();
+        gpu.destroy();
+    }
+});
+
+test("actual loader refuses explicit native library overrides", async () => {
+    const native = await loadNative();
+    expect(() => native.createGPUInstance("/not-the-peer/library.dylib")).toThrow(
+        "library override",
+    );
+    await expect(native.setupGlobals({ libPath: "/not-the-peer/library.dylib" })).rejects.toThrow(
+        "library override",
+    );
+});
+
+test("actual adapter success owns a valid handle and drains its request once", async () => {
+    const gpu = createGPUInstance() as any;
+    const pending = gpu.requestAdapter();
+    const attempt = [...gpu._ticker.acquisitions][0] as any;
+    const handle = attempt.handles.get("request");
+    const close = handle.close.bind(handle);
+    let closes = 0;
+    handle.close = () => {
+        closes++;
+        close();
+    };
+    const adapter = await pending;
+    try {
+        expect(adapter.adapterPtr).toBeGreaterThan(0);
+        await turn();
+        expect(closes).toBe(1);
+        expect(attempt.handles.size).toBe(0);
+        expect(gpu._ticker.acquisitions.size).toBe(0);
+        expect(gpu._ticker._waiting).toBe(0);
+    } finally {
+        adapter.destroy();
+        gpu.destroy();
+    }
+});
+
+test("actual native destroy delivers loss and drains its independent handles", async () => {
+    const gpu = createGPUInstance() as any;
+    try {
+        const adapter = await gpu.requestAdapter();
+        const device = await adapter.requestDevice(descriptor(adapter));
+        await turn();
+        const attempt = device._acquisition;
+        expect(attempt.handles.has("request")).toBe(false);
+        expect(attempt.handles.size).toBe(2);
+        device.destroy();
+        await device.lost;
+        await turn();
+        expect(attempt.lossDone).toBe(true);
+        expect(attempt.handles.size).toBe(0);
+        expect(gpu._ticker.acquisitions.size).toBe(0);
+        adapter.destroy();
+    } finally {
+        gpu.destroy();
+    }
+});

--- a/packages/shallot/tests/native-features.fixture.ts
+++ b/packages/shallot/tests/native-features.fixture.ts
@@ -1,0 +1,169 @@
+import { ptr, toArrayBuffer } from "bun:ffi";
+import assert from "node:assert/strict";
+import { loadNative } from "../bin/bun-native";
+import { BASE_FEATURES, deviceLimits } from "../src/engine/runtime/gpu";
+
+const site = process.argv[2] ?? "device";
+const mode = process.argv[3] ?? "ownership";
+const { createGPUInstance } = await loadNative();
+const gpu = createGPUInstance() as any;
+const adapter = await gpu.requestAdapter();
+assert.ok(adapter);
+const device = await adapter.requestDevice({
+    requiredFeatures: BASE_FEATURES,
+    requiredLimits: deviceLimits(adapter.limits),
+});
+const subject = site === "device" ? device : site === "adapter" ? adapter : gpu;
+const key = site === "instance" ? "wgslLanguageFeatures" : "features";
+// Acquisition capability admission may already have read the adapter cache.
+subject[site === "instance" ? "_wgslLanguageFeatures" : "_features"] = null;
+const name =
+    site === "instance"
+        ? "wgpuInstanceGetWGSLLanguageFeatures"
+        : site === "adapter"
+          ? "wgpuAdapterGetFeatures"
+          : "wgpuDeviceGetFeatures";
+const original = subject.lib[name];
+let active = false;
+let guard = false;
+let forwarded = 0;
+let reads = 0;
+let releases = 0;
+let pressures = 0;
+let violation = "";
+const records: {
+    address: number;
+    width: number;
+    value: WeakRef<ArrayBuffer>;
+    owners?: Set<unknown>;
+}[] = [];
+function check() {
+    if (!active || guard || mode === "gc") return;
+    for (const row of records) {
+        if (!row.owners?.has(row.value.deref())) {
+            violation ||= `${site}.missing-output-owner`;
+            if (mode !== "delete-assertion") assert.fail(violation);
+        }
+    }
+}
+function pressure() {
+    if (mode === "gc") {
+        Bun.gc(true);
+        pressures++;
+    }
+}
+const Original = ArrayBuffer;
+globalThis.ArrayBuffer = new Proxy(Original, {
+    construct(ctor, args) {
+        check();
+        if (active) pressure();
+        const value = Reflect.construct(ctor, args);
+        if (active && mode !== "gc")
+            records.push({
+                address: ptr(value),
+                width: value.byteLength,
+                value: new WeakRef(value),
+            });
+        return value;
+    },
+});
+const add = Set.prototype.add;
+Set.prototype.add = function (value: unknown) {
+    if (active && mode !== "gc") {
+        const row = records.find((r) => r.value.deref() === value);
+        if (row) {
+            row.owners = this;
+            if ((mode === "omit" || mode === "delete-assertion") && records.indexOf(row) === 1)
+                return this;
+        }
+    }
+    return add.call(this, value);
+};
+const clear = Set.prototype.clear;
+Set.prototype.clear = function () {
+    if (active && records.some((r) => r.owners === this)) releases++;
+    return clear.call(this);
+};
+for (const method of ["getUint32", "getBigUint64"] as const) {
+    const get = DataView.prototype[method];
+    (DataView.prototype as any)[method] = function (...args: any[]) {
+        if (active && !guard) {
+            check();
+            pressure();
+            if (forwarded) {
+                reads++;
+                if (mode === "decode-failure") throw Error("injected output decode failure");
+            }
+        }
+        return (get as any).apply(this, args);
+    };
+}
+subject.lib = {
+    ...subject.lib,
+    [name]: (handle: number, output: number) => {
+        check();
+        // This guard is independent of the assertion: assertion deletion must not forward bad memory.
+        if (violation) throw Error(`nonforwarding safety stop: ${violation}`);
+        if (mode !== "gc") {
+            assert.deepEqual(
+                records.map((r) => r.width),
+                [16, site === "instance" ? 128 : 512],
+            );
+            assert.equal(output, records[0]!.address);
+            guard = true;
+            try {
+                const view = new DataView(toArrayBuffer(output, 0, 16));
+                assert.equal(view.getBigUint64(8, true), BigInt(records[1]!.address));
+            } finally {
+                guard = false;
+            }
+        }
+        pressure();
+        if (mode === "native-failure") throw Error("injected native failure");
+        if (mode === "status-failure") return 2;
+        const result = original(handle, output);
+        forwarded++;
+        check();
+        pressure();
+        return result;
+    },
+};
+let failure: unknown;
+try {
+    active = true;
+    const features = subject[key];
+    active = false;
+    if (violation) throw Error(violation);
+    if (mode !== "gc") {
+        assert.equal(records.length, 2, "complete output graph");
+        assert.equal(releases, 1, "output arena released once");
+        assert.ok(
+            records.every((r) => r.owners?.size === 0),
+            "output unwind",
+        );
+    }
+    if (mode.endsWith("failure")) {
+        assert.equal(features.size, 0);
+        assert.equal(forwarded, mode === "decode-failure" ? 1 : 0);
+    } else {
+        assert.equal(forwarded, 1);
+        assert.ok(reads > 0, "completed real unpack");
+        if (site !== "instance")
+            for (const feature of BASE_FEATURES) assert.ok(features.has(feature), feature);
+        active = true;
+        assert.equal(subject[key], features, "cached identity");
+        active = false;
+        assert.equal(forwarded, 1, "cached second read does not query");
+    }
+} catch (error) {
+    failure = error;
+} finally {
+    active = false;
+    device.destroy();
+    await device.lost;
+    adapter.destroy();
+    gpu.destroy();
+}
+console.log({ site, mode, forwarded, reads, releases, pressures, violation });
+if (failure) throw failure;
+console.log("FEATURE_OUTPUT_PASS");

--- a/packages/shallot/tests/native-features.test.ts
+++ b/packages/shallot/tests/native-features.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+for (const site of ["adapter", "device", "instance"]) {
+    for (const mode of [
+        "ownership",
+        "gc",
+        "omit",
+        "delete-assertion",
+        "native-failure",
+        "decode-failure",
+        ...(site === "instance" ? ["status-failure"] : []),
+    ]) {
+        test(`${site} real feature output: ${mode}`, () => {
+            const child = Bun.spawnSync(
+                [
+                    process.execPath,
+                    resolve(import.meta.dir, "native-features.fixture.ts"),
+                    site,
+                    mode,
+                ],
+                { timeout: 4000 },
+            );
+            const output = child.stdout.toString() + child.stderr.toString();
+            if (mode === "omit" || mode === "delete-assertion") {
+                expect(output).toContain(`${site}.missing-output-owner`);
+                expect(output).toContain("forwarded: 0");
+                if (mode === "delete-assertion")
+                    expect(output).toContain("nonforwarding safety stop");
+                expect(child.exitCode).toBe(1);
+            } else {
+                expect(output).toContain("FEATURE_OUTPUT_PASS");
+                expect(child.exitCode).toBe(0);
+            }
+        });
+    }
+}

--- a/packages/shallot/tests/native-ownership.fixture.ts
+++ b/packages/shallot/tests/native-ownership.fixture.ts
@@ -1,0 +1,448 @@
+import { ptr, toArrayBuffer } from "bun:ffi";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { resolve } from "node:path";
+import { loadNative } from "../bin/bun-native";
+import { BASE_FEATURES, deviceLimits } from "../src/engine/runtime/gpu";
+
+const carrier = resolve(import.meta.dir, "../dist/native.js");
+const { createGPUInstance } = await loadNative();
+const mode = process.argv[2] ?? "ownership";
+const target = process.argv[3] ?? "device";
+const shape = process.env.ADAPTER_SHAPE ?? "nonempty";
+const omit = process.env.OMIT;
+const mutation = process.env.MUTATE ?? "count-low";
+const gpu = createGPUInstance() as any;
+const copy = (p: number, n: number) => Buffer.from(new Uint8Array(toArrayBuffer(p, 0, n)));
+const u64 = (b: Buffer, o: number) => b.readBigUInt64LE(o);
+const pointer = (b: Buffer, o: number) => {
+    const value = u64(b, o);
+    assert.ok(value <= BigInt(Number.MAX_SAFE_INTEGER), "pointer range");
+    return Number(value);
+};
+// Pinned from the intact pack trace, correlated to the independent native ABI at entry.
+const deviceInventory: [string, number, string][] = [
+    ["outer", 144, "buffer"],
+    ["label-view", 16, "buffer"],
+    ["label", 18, "utf8"],
+    ["features", 12, "buffer"],
+    ["limits", 168, "buffer"],
+    ["queue", 24, "buffer"],
+    ["queue-label-view", 16, "buffer"],
+    ["inline-child", 16, "utf8"],
+    ["loss-info", 40, "buffer"],
+    ["error-info", 32, "buffer"],
+    ["request-info", 40, "buffer"],
+];
+const adapterInventory: [string, number, string][] =
+    shape === "nonempty"
+        ? [
+              ["outer", 32, "buffer"],
+              ["request-info", 40, "buffer"],
+          ]
+        : [["request-info", 40, "buffer"]];
+let calls = 0,
+    returns = 0,
+    allocationCount = 0,
+    pressures = 0;
+let active: any = null,
+    site = "",
+    guard = false,
+    violation: unknown;
+let records: { field: string; p: number; n: number; owner: WeakRef<object> }[] = [];
+const gcRecords: { p: number; n: number }[] = [];
+function checkOwners() {
+    if (!active || guard) return;
+    guard = true;
+    try {
+        for (const record of records)
+            assert.ok(
+                active.arena.owners.has(record.owner.deref()),
+                `${site}.${record.field} ownership`,
+            );
+    } catch (error) {
+        violation ??= error;
+        throw error;
+    } finally {
+        guard = false;
+    }
+}
+function observe(value: ArrayBuffer | Uint8Array, kind: string) {
+    if (!active || guard) return value;
+    guard = true;
+    try {
+        const inventory = site === "adapter" ? adapterInventory : deviceInventory;
+        const row = inventory[records.length];
+        assert.ok(row, `${site} unknown allocation ${records.length}`);
+        const [field, n, expectedKind] = row;
+        assert.equal(kind, expectedKind, `${site}.${field} allocation kind`);
+        assert.equal(value.byteLength, n, `${site}.${field} allocation width`);
+        const p = ptr(value);
+        assert.ok(!records.some((r) => r.p === p), `${site} duplicate allocation`);
+        records.push({ field, p, n, owner: new WeakRef(value) });
+        allocationCount++;
+    } catch (error) {
+        violation ??= error;
+        throw error;
+    } finally {
+        guard = false;
+    }
+    return value;
+}
+function pressure() {
+    const snapshots = gcRecords.map(({ p, n }) => ({ p, bytes: copy(p, n) }));
+    Bun.gc(true);
+    pressures++;
+    for (const { p, bytes } of snapshots)
+        assert.deepEqual(copy(p, bytes.length), bytes, "GC bytes changed during packing");
+}
+assert.ok(gpu._ticker.acquisitions instanceof Set, "instance acquisition observer prerequisite");
+const register = gpu._ticker.register.bind(gpu._ticker);
+gpu._ticker.register = () => {
+    const attempt = [...gpu._ticker.acquisitions].at(-1) as any;
+    assert.ok(attempt?.arena?.owners instanceof Set, "real arena prerequisite");
+    site = attempt.lossDone ? "adapter" : "device";
+    records = [];
+    gcRecords.length = 0;
+    const hold = attempt.arena.hold.bind(attempt.arena);
+    if (mode === "gc") {
+        attempt.arena.hold = (value: any) => {
+            pressure();
+            hold(value);
+            gcRecords.push({ p: ptr(value), n: value.byteLength });
+            allocationCount++;
+            return value;
+        };
+    } else {
+        active = attempt;
+        attempt.arena.hold = (value: any) => {
+            const record = records.find((r) => r.owner.deref() === value);
+            if (!(site === target && record?.field === omit)) hold(value);
+            return value;
+        };
+    }
+    return register();
+};
+if (mode !== "gc") {
+    const Original = ArrayBuffer;
+    globalThis.ArrayBuffer = new Proxy(Original, {
+        construct(ctor, args) {
+            checkOwners();
+            return observe(Reflect.construct(ctor, args), "buffer");
+        },
+    });
+    const encode = TextEncoder.prototype.encode;
+    TextEncoder.prototype.encode = function (text) {
+        checkOwners();
+        return observe(encode.call(this, text), "utf8") as Uint8Array<ArrayBuffer>;
+    };
+    for (const key of Object.getOwnPropertyNames(DataView.prototype).filter((key) =>
+        key.startsWith("set"),
+    )) {
+        const original = (DataView.prototype as any)[key];
+        (DataView.prototype as any)[key] = function (...args: any[]) {
+            checkOwners();
+            return original.apply(this, args);
+        };
+    }
+}
+function address(field: string) {
+    const record = records.find((r) => r.field === field);
+    assert.ok(record, `${site}.${field} allocation missing`);
+    return BigInt(record.p);
+}
+function instrument(lib: any, name: string, acquisitionSite: string) {
+    const original = lib[name];
+    return {
+        ...lib,
+        [name]: (handle: number, arg: number, cb: number) => {
+            calls++;
+            site = acquisitionSite;
+            checkOwners();
+            // Observer allocations and native readback are not pack allocations.
+            guard = true;
+            try {
+                const inventory = site === "adapter" ? adapterInventory : deviceInventory;
+                if (mode !== "gc") {
+                    assert.equal(records.length, inventory.length, `${site} complete inventory`);
+                    assert.equal(
+                        BigInt(cb),
+                        address("request-info"),
+                        `${site} callback-info identity`,
+                    );
+                    assert.equal(
+                        BigInt(arg ?? 0),
+                        site === "adapter" && shape !== "nonempty" ? 0n : address("outer"),
+                        `${site} outer identity`,
+                    );
+                }
+                const outer = arg ? copy(arg, site === "adapter" ? 32 : 144) : null;
+                const callback = copy(cb, 40);
+                const graph: [string, number, Buffer][] = [["request-info", cb, callback]];
+                if (outer) graph.push(["outer", arg, outer]);
+                let fp = 0,
+                    lp = 0;
+                if (site === "device") {
+                    assert.ok(outer);
+                    if (mode !== "gc") {
+                        assert.equal(
+                            u64(outer, 32),
+                            address("features"),
+                            "feature pointer identity",
+                        );
+                        assert.equal(u64(outer, 40), address("limits"), "limits pointer identity");
+                    }
+                    fp = pointer(outer, 32);
+                    lp = pointer(outer, 40);
+                    graph.push(["features", fp, copy(fp, 12)], ["limits", lp, copy(lp, 168)]);
+                    for (const [offset, field, text] of [
+                        [8, "label", "ownership boundary"],
+                        [56, "inline-child", "production queue"],
+                    ] as const) {
+                        if (mode !== "gc")
+                            assert.equal(
+                                u64(outer, offset),
+                                address(field),
+                                `${field} pointer identity`,
+                            );
+                        assert.equal(
+                            u64(outer, offset + 8),
+                            BigInt(text.length),
+                            `${field} string size`,
+                        );
+                        const p = pointer(outer, offset);
+                        assert.equal(
+                            copy(p, text.length).toString(),
+                            text,
+                            `${field} string value`,
+                        );
+                        graph.push([field, p, copy(p, text.length)]);
+                    }
+                }
+                if (mode === "layout" && site === target) {
+                    const [field, bit] = mutation.split("-");
+                    const view = new DataView(
+                        toArrayBuffer(
+                            field === "feature" ? fp : field === "size" ? lp : arg,
+                            0,
+                            field === "feature" ? 12 : field === "size" ? 168 : 144,
+                        ),
+                    );
+                    const offset =
+                        field === "pointer"
+                            ? 32
+                            : field === "count"
+                              ? 24
+                              : field === "size"
+                                ? 96
+                                : 0;
+                    if (field === "feature")
+                        view.setUint32(
+                            offset,
+                            view.getUint32(offset, true) ^ (bit === "high" ? 0x10000 : 1),
+                            true,
+                        );
+                    else
+                        view.setBigUint64(
+                            offset,
+                            view.getBigUint64(offset, true) ^ (bit === "high" ? 1n << 40n : 1n),
+                            true,
+                        );
+                }
+                // Read malformed producer output before any native forwarding. Never dereference a mutated pointer.
+                const current = outer ? copy(arg, outer.length) : null;
+                if (current) assert.equal(u64(current, 0), 0n, `${site} outer chain`);
+                assert.equal(u64(callback, 0), 0n, `${site} request chain`);
+                assert.equal(callback.readUInt32LE(8), 2, `${site} request mode`);
+                for (const offset of [24, 32])
+                    assert.equal(u64(callback, offset), 0n, `${site} request userdata ${offset}`);
+                if (mode !== "gc")
+                    assert.equal(
+                        u64(callback, 16),
+                        BigInt(active.handles.get("request").ptr),
+                        `${site} request callback identity`,
+                    );
+                else assert.notEqual(u64(callback, 16), 0n, `${site} request callback`);
+                if (site === "adapter" && current) {
+                    assert.equal(current.readUInt32LE(8), 2, "core feature level");
+                    assert.equal(current.readUInt32LE(12), 2, "high-performance");
+                    assert.equal(current.readUInt32LE(16), 0, "not fallback");
+                    assert.equal(u64(current, 24), 0n, "surface");
+                } else if (site === "device") {
+                    assert.ok(current);
+                    assert.equal(u64(current, 24), 3n, "feature count");
+                    assert.equal(u64(current, 32), BigInt(fp), "feature pointer identity");
+                    assert.equal(u64(current, 40), BigInt(lp), "limits pointer identity");
+                    const features = copy(fp, 12),
+                        limits = copy(lp, 168);
+                    assert.deepEqual(
+                        [0, 4, 8].map((o) => features.readUInt32LE(o)),
+                        [9, 12, 11],
+                        "u32 feature values",
+                    );
+                    assert.equal(u64(limits, 0), 0n, "limits chain");
+                    assert.equal(limits.readUInt32LE(52), 10, "storage binding floor");
+                    assert.equal(
+                        u64(limits, 72),
+                        BigInt(expectedLimits.maxStorageBufferBindingSize),
+                        "u64 storage binding size",
+                    );
+                    assert.equal(
+                        u64(limits, 96),
+                        BigInt(expectedLimits.maxBufferSize),
+                        "u64 buffer size",
+                    );
+                    for (const o of [48, 72, 112])
+                        assert.equal(u64(current, o), 0n, `nested chain ${o}`);
+                    assert.equal(current.readUInt32LE(80), 2, "loss mode");
+                    for (const [o, key] of [
+                        [88, "loss"],
+                        [120, "error"],
+                    ] as const) {
+                        if (mode !== "gc")
+                            assert.equal(
+                                u64(current, o),
+                                BigInt(active.handles.get(key).ptr),
+                                `${key} callback identity`,
+                            );
+                        else assert.notEqual(u64(current, o), 0n, `${key} callback`);
+                    }
+                    for (const o of [96, 104, 128, 136])
+                        assert.equal(u64(current, o), 0n, `userdata ${o}`);
+                    if (mode !== "gc") {
+                        for (const [field, offset, n] of [
+                            ["label-view", 8, 16],
+                            ["queue", 48, 24],
+                            ["queue-label-view", 56, 16],
+                            ["loss-info", 72, 40],
+                            ["error-info", 112, 32],
+                        ] as const)
+                            assert.deepEqual(
+                                copy(Number(address(field)), n),
+                                current.subarray(offset, offset + n),
+                                `${field} inline copy`,
+                            );
+                    }
+                }
+                if (mode === "layout" && site === target) {
+                    console.log({
+                        diagnostic: "semantic assertion absent",
+                        mutation,
+                        calls,
+                        returns,
+                    });
+                    process.exit(0); // Non-forwarding assertion-deletion control.
+                }
+                if (mode === "gc" && site === target) pressure();
+                if (mode === "gc")
+                    for (const [field, p, bytes] of graph)
+                        assert.deepEqual(
+                            copy(p, bytes.length),
+                            bytes,
+                            `${site}.${field} changed before native consumption`,
+                        );
+                guard = false;
+                checkOwners();
+                guard = true;
+                if (omit === "premature-release" && site === target) active.arena.release();
+                guard = false;
+                checkOwners();
+                guard = true;
+                const result = original(handle, arg, cb);
+                returns++;
+                if (omit === "release-on-return" && site === target) active.arena.release();
+                guard = false;
+                checkOwners();
+                guard = true;
+                if (mode === "gc")
+                    for (const [field, p, bytes] of graph)
+                        assert.deepEqual(
+                            copy(p, bytes.length),
+                            bytes,
+                            `${site}.${field} changed through native return`,
+                        );
+                console.log({
+                    site,
+                    inventory:
+                        mode === "gc" ? "GC numeric snapshots only" : records.map((r) => r.field),
+                    nativeReturned: true,
+                });
+                return result;
+            } finally {
+                active = null;
+                guard = false;
+            }
+        },
+    };
+}
+let expectedLimits: Record<string, number>;
+try {
+    gpu.lib = instrument(gpu.lib, "wgpuInstanceRequestAdapter", "adapter");
+    const adapter = await gpu.requestAdapter(
+        shape === "nonempty"
+            ? { featureLevel: "core", powerPreference: "high-performance" }
+            : shape === "null"
+              ? null
+              : undefined,
+    );
+    if (violation) throw violation;
+    assert.ok(adapter, "actual adapter");
+    active = null;
+    expectedLimits = deviceLimits(adapter.limits);
+    void adapter.features;
+    adapter.lib = instrument(adapter.lib, "wgpuAdapterRequestDevice", "device");
+    const device = await adapter.requestDevice({
+        label: "ownership boundary",
+        requiredFeatures: [...BASE_FEATURES],
+        requiredLimits: expectedLimits,
+        defaultQueue: { label: "production queue" },
+    });
+    if (violation) throw violation;
+    device.destroy();
+    adapter.destroy();
+    await Promise.resolve();
+    assert.equal(calls, 2);
+    assert.equal(returns, 2);
+    assert.equal(gpu._ticker.acquisitions.size, 0, "attempts drained after actual destroy/loss");
+    assert.equal(gpu._ticker._waiting, 0, "pending requests drained");
+    assert.equal(
+        allocationCount,
+        deviceInventory.length + adapterInventory.length,
+        "exact allocation population",
+    );
+    if (mode === "gc") assert.ok(pressures > 10, "GC pressure population");
+    console.log({
+        mode,
+        target,
+        shape,
+        omit,
+        mutation,
+        carrier,
+        sha256: createHash("sha256")
+            .update(await Bun.file(carrier).bytes())
+            .digest("hex"),
+        calls,
+        returns,
+        allocationCount,
+        pressures,
+        pass: true,
+    });
+} catch (error) {
+    console.error(violation ?? error);
+    console.log({
+        mode,
+        target,
+        shape,
+        omit,
+        mutation,
+        calls,
+        returns,
+        allocationCount,
+        pass: false,
+    });
+    process.exitCode = 1;
+} finally {
+    active = null;
+    gpu.destroy();
+}
+process.exit(process.exitCode ?? 0);

--- a/packages/shallot/tests/native-ownership.test.ts
+++ b/packages/shallot/tests/native-ownership.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+function run(mode: string, target: string, omit = "", mutation = "", shape = "nonempty") {
+    const child = Bun.spawnSync(
+        [process.execPath, resolve(import.meta.dir, "native-ownership.fixture.ts"), mode, target],
+        {
+            env: { ...process.env, OMIT: omit, MUTATE: mutation, ADAPTER_SHAPE: shape },
+            timeout: 4000,
+        },
+    );
+    return { exit: child.exitCode, output: child.stdout.toString() + child.stderr.toString() };
+}
+for (const mode of ["ownership", "gc"]) {
+    for (const shape of ["nonempty", "undefined", "null"]) {
+        test(`${mode} independently qualifies actual acquisition with ${shape} adapter options`, () => {
+            const result = run(mode, "device", "", "", shape);
+            expect(result.output).toContain("returns: 2");
+            expect(result.output).toContain("pass: true");
+            expect(result.exit).toBe(0);
+        });
+    }
+}
+test("real GC also pressures actual adapter entry", () => {
+    const result = run("gc", "adapter");
+    expect(result.output).toContain("returns: 2");
+    expect(result.exit).toBe(0);
+});
+for (const [field, predicate] of [
+    ["count", "feature count"],
+    ["pointer", "feature pointer identity"],
+    ["chain", "device outer chain"],
+    ["feature", "u32 feature values"],
+    ["size", "u64 buffer size"],
+]) {
+    for (const bits of ["low", "high"]) {
+        test(`semantic full-width reader rejects ${field}-${bits} before forwarding`, () => {
+            const result = run("layout", "device", "", `${field}-${bits}`);
+            expect(result.output).toContain(predicate!);
+            expect(result.output).toContain("returns: 1");
+            expect(result.exit).toBe(1);
+        });
+    }
+}
+for (const site of ["adapter", "device"]) {
+    const fields =
+        site === "adapter"
+            ? ["outer", "request-info"]
+            : [
+                  "outer",
+                  "features",
+                  "label",
+                  "limits",
+                  "inline-child",
+                  "request-info",
+                  "label-view",
+                  "queue",
+                  "queue-label-view",
+                  "loss-info",
+                  "error-info",
+              ];
+    for (const field of [...fields, "premature-release", "release-on-return"]) {
+        test(`${site} removed ${field} fails independent ownership before native consumption`, () => {
+            const result = run("ownership", site, field);
+            expect(result.output).toContain(
+                `${site}.${field === "premature-release" || field === "release-on-return" ? "outer" : field} ownership`,
+            );
+            expect(result.output).toContain(
+                `returns: ${(site === "adapter" ? 0 : 1) + (field === "release-on-return" ? 1 : 0)}`,
+            );
+            expect(result.exit).toBe(1);
+        });
+    }
+}

--- a/packages/shallot/tests/setup.ts
+++ b/packages/shallot/tests/setup.ts
@@ -1,3 +1,3 @@
-import { setupGlobals } from "bun-webgpu";
+import { loadNative } from "../bin/bun-native";
 
-await setupGlobals();
+await (await loadNative()).setupGlobals();

--- a/scripts/bench.ts
+++ b/scripts/bench.ts
@@ -416,7 +416,8 @@ function printMemory(m: Memory): void {
 // check asserts both directions), but `--list` reads the real one anyway per the spec's naming-trap
 // motivation, not the side table that exists to avoid booting a page.
 async function registeredScenarios(): Promise<string[]> {
-    const { setupGlobals } = await import("bun-webgpu");
+    const { loadNative } = await import("../packages/shallot/bin/bun-native");
+    const { setupGlobals } = await loadNative();
     await setupGlobals();
     const { scenarioNames } = await import("../examples/gym/src/gym");
     await import("../examples/gym/src/scenarios/index");

--- a/scripts/format.ts
+++ b/scripts/format.ts
@@ -1,11 +1,6 @@
 import { resolve } from "node:path";
 import { Glob } from "bun";
-import { setupGlobals } from "bun-webgpu";
 import type { Node } from "../packages/shallot/src";
-
-// the engine references WebGPU globals (e.g. GPUShaderStage) at module scope, so define
-// them before importing it — mirrors tests/setup.ts. ES imports are hoisted, hence dynamic.
-await setupGlobals();
 
 const {
     State,

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -7,6 +7,7 @@
 // shallot` (scaffold → install → build the starter). The packaging / resolution / asset failures the
 // repo's own symlinked dev setup hides. Run: `bun run scripts/install-test.ts` (or `bun run test:install`).
 
+import assert from "node:assert/strict";
 import {
     existsSync,
     mkdirSync,
@@ -74,6 +75,240 @@ async function waitFor(cond: () => Promise<boolean>, ms: number): Promise<boolea
         await Bun.sleep(250);
     }
     return false;
+}
+
+/** Exercise the shipped native loader in physical, external installs; retain raw child receipts. */
+export function nativeFlow(work: string, engineTgz: string): void {
+    const evidence = join(work, "native");
+    mkdirSync(evidence, { recursive: true });
+    let sequence = 0;
+    const exec = (name: string, cmd: string[], cwd: string) => {
+        const result = Bun.spawnSync(cmd, { cwd, stdout: "pipe", stderr: "pipe", timeout: 120000 });
+        const stem = join(evidence, `${++sequence}-${name}`);
+        writeFileSync(`${stem}.stdout`, result.stdout);
+        writeFileSync(`${stem}.stderr`, result.stderr);
+        writeFileSync(
+            `${stem}.json`,
+            JSON.stringify({
+                cmd,
+                cwd,
+                exit: result.exitCode,
+                signal: result.signalCode,
+                runtime: Bun.version,
+            }),
+        );
+        return {
+            exit: result.exitCode,
+            out: `${result.stdout.toString()}\n${result.stderr.toString()}`,
+        };
+    };
+    const expect = (
+        name: string,
+        result: { exit: number; out: string },
+        exit: number,
+        text: RegExp,
+    ) => {
+        assert.equal(result.exit, exit, `${name}: ${result.out}`);
+        assert.match(result.out, text, name);
+        console.log(`native: ${name}`);
+    };
+    for (const layout of ["absent", "normal", "nested"]) {
+        const project =
+            layout === "nested"
+                ? join(evidence, layout, "node_modules/native-consumer")
+                : join(evidence, layout);
+        mkdirSync(project, { recursive: true });
+        writeFileSync(
+            join(project, "package.json"),
+            pkgJson({
+                name: `native-${layout}`,
+                private: true,
+                type: "module",
+                dependencies: {
+                    "@dylanebert/shallot": `file:${engineTgz}`,
+                    typegpu: "~0.12.4",
+                    ...(layout === "absent" ? {} : { "bun-webgpu": "0.1.7" }),
+                },
+            }),
+        );
+        const install = exec(
+            `${layout}-install`,
+            layout === "nested"
+                ? [
+                      "npm",
+                      "install",
+                      "--install-strategy=nested",
+                      "--ignore-scripts",
+                      "--no-audit",
+                      "--no-fund",
+                  ]
+                : ["bun", "install"],
+            project,
+        );
+        assert.equal(install.exit, 0, install.out);
+        const shipped = join(project, "node_modules/@dylanebert/shallot");
+        assert.equal(realpathSync(shipped), shipped, "engine is a physical install");
+        for (const file of [
+            "dist/native.js",
+            "dist/bun-webgpu-LICENSE",
+            "dist/bun-webgpu-NOTICE",
+            "bin/bun-native.ts",
+        ]) {
+            assert(existsSync(join(shipped, file)), `tar contains ${file}`);
+        }
+        assert.match(
+            readFileSync(join(shipped, "dist/bun-webgpu-NOTICE"), "utf8"),
+            /Modified by Shallot/,
+        );
+        writeFileSync(
+            join(project, "native.fixture.ts"),
+            readFileSync(join(import.meta.dir, "install-test/native.fixture.ts")),
+        );
+        writeFileSync(
+            join(project, "shallot.json"),
+            JSON.stringify({ scene: "main.scene", plugins: { Cells: true } }),
+        );
+        mkdirSync(join(project, "public"));
+        writeFileSync(
+            join(project, "public/main.scene"),
+            '<scene><a camera sear cells transform="pos: 0 0 5" /><a part transform /></scene>',
+        );
+        const cli = (args: string[]) => ["bun", CLI, ...args];
+        expect(
+            `${layout}-help`,
+            exec(`${layout}-help`, cli(["tui", "--help"]), project),
+            0,
+            /--frames/,
+        );
+        expect(
+            `${layout}-import`,
+            exec(
+                `${layout}-import`,
+                [
+                    "bun",
+                    "-e",
+                    'import { run } from "@dylanebert/shallot"; if(typeof run !== "function") throw Error("run missing"); console.log("NONNATIVE_IMPORT_OK")',
+                ],
+                project,
+            ),
+            0,
+            /NONNATIVE_IMPORT_OK/,
+        );
+        if (layout === "absent") {
+            assert(!existsSync(join(project, "node_modules/bun-webgpu")));
+            expect(
+                "absent-tui",
+                exec("absent-tui", cli(["tui", ".", "--frames", "1"]), project),
+                3,
+                /bun add -d bun-webgpu/,
+            );
+            continue;
+        }
+        for (const mode of ["acquire", "foreign", "override"]) {
+            expect(
+                `${layout}-${mode}`,
+                exec(`${layout}-${mode}`, ["bun", "native.fixture.ts", mode], project),
+                0,
+                mode === "acquire"
+                    ? /PACKED_NATIVE_ACQUIRED_DRAINED/
+                    : mode === "foreign"
+                      ? /FOREIGN_REFUSED_UNCHANGED/
+                      : /OVERRIDE_REFUSED/,
+            );
+        }
+        expect(
+            `${layout}-tui`,
+            exec(`${layout}-tui`, cli(["tui", ".", "--frames", "1", "--tier", "plain"]), project),
+            0,
+            /./s,
+        );
+        const peer = join(project, "node_modules/bun-webgpu");
+        const platformName = `bun-webgpu-${process.platform}-${process.arch}`;
+        const platform =
+            layout === "nested"
+                ? join(peer, "node_modules", platformName)
+                : join(project, "node_modules", platformName);
+        assert.equal(realpathSync(peer), peer, "peer is a physical install");
+        assert.equal(
+            realpathSync(platform),
+            platform,
+            "platform is a physical install at the intended depth",
+        );
+        const control = (
+            name: string,
+            file: string,
+            replace: (original: Buffer) => Buffer | null,
+            diagnostic: RegExp,
+        ) => {
+            const original = readFileSync(file);
+            try {
+                const changed = replace(original);
+                if (changed === null) rmSync(file);
+                else writeFileSync(file, changed);
+                const result = exec(
+                    `${layout}-${name}`,
+                    cli(["tui", ".", "--frames", "1"]),
+                    project,
+                );
+                assert.notEqual(result.exit, 0, name);
+                assert.notEqual(result.exit, 3, `${name} misclassified as absent peer`);
+                assert.match(result.out, diagnostic, name);
+                assert(!result.out.includes("bun add -d bun-webgpu"), name);
+                console.log(`native: ${layout}-${name}`);
+            } finally {
+                writeFileSync(file, original);
+            }
+        };
+        const wrongVersion = (original: Buffer) =>
+            Buffer.from(JSON.stringify({ ...JSON.parse(original.toString()), version: "0.0.0" }));
+        control(
+            "wrong-peer",
+            join(peer, "package.json"),
+            wrongVersion,
+            /requires bun-webgpu 0.1.7/,
+        );
+        control(
+            "wrong-platform",
+            join(platform, "package.json"),
+            wrongVersion,
+            /platform requires version 0.1.7/,
+        );
+        control(
+            "missing-platform-entry",
+            join(platform, "index.ts"),
+            () => null,
+            /bun-webgpu-.*\/index.ts/,
+        );
+        const library = readdirSync(platform).find((file) => /\.(dylib|so|dll)$/.test(file));
+        assert(library, "installed native library");
+        const alternate = join(project, library);
+        writeFileSync(alternate, readFileSync(join(platform, library)));
+        control(
+            "wrong-library-path",
+            join(platform, "index.ts"),
+            () => Buffer.from(`export default ${JSON.stringify(alternate)};\n`),
+            /platform library path mismatch/,
+        );
+        control(
+            "missing-library",
+            join(platform, library),
+            () => null,
+            /platform library is missing/,
+        );
+        control(
+            "missing-projection",
+            join(shipped, "dist/native.js"),
+            () => null,
+            /native projection is missing/,
+        );
+        control(
+            "altered-projection",
+            join(shipped, "dist/native.js"),
+            (original) => Buffer.concat([original, Buffer.from("\n// altered\n")]),
+            /projection hash mismatch/,
+        );
+    }
+    console.log(`native: ${sequence} commands completed`);
 }
 
 const fails: string[] = [];
@@ -256,8 +491,8 @@ function createShallotFlow(work: string, engineTgz: string) {
 
     // criterion 7: "a missing bun-webgpu produces a named remedy" — the genuine-
     // absence rung, mirroring the playwright check directly above exactly. This scaffold never installs
-    // bun-webgpu (a devDependency of the monorepo's own packages/shallot, never shipped or declared for a
-    // consumer), so `shallot tui` here hits a real absence, not an injected one — real subprocess stdout/
+    // bun-webgpu (the optional native peer), so `shallot tui` here hits a real absence, not an injected
+    // one — real subprocess stdout/
     // stderr, never a mock. The fast DI-driven proof of the same exit-code + message wiring lives in
     // bin/tui.test.ts, which can't see whether the real dynamic import actually fails on a real install.
     const tuiHelp = run(["bun", CLI, "tui", "--help"], proj);
@@ -1179,6 +1414,7 @@ if (import.meta.main) {
         identityFlow(work, engineTgz);
         pmIdentityFlow(work, engineTgz, "npm");
         pmIdentityFlow(work, engineTgz, "pnpm");
+        nativeFlow(work, engineTgz);
 
         // a real manifest project: installed engine + an installed plugin library + a local plugin, the
         // audio plugin pulling its wasm in. No vite.config, no index.html — the CLI supplies the harness.

--- a/scripts/install-test/native.fixture.ts
+++ b/scripts/install-test/native.fixture.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+// Copied into the installed consumer: every product import resolves there, never in this checkout.
+const require = createRequire(import.meta.url);
+const engine = dirname(dirname(require.resolve("@dylanebert/shallot")));
+const loader = join(engine, "bin/bun-native.ts");
+const mode = process.argv[2] ?? "acquire";
+const watchdog = setTimeout(() => {
+    console.error("native fixture watchdog");
+    process.exit(2);
+}, 4000);
+try {
+    const { loadNative } = await import(loader);
+    const native = await loadNative();
+    if (mode === "foreign") {
+        const foreign = {};
+        Object.defineProperty(navigator, "gpu", { value: foreign, configurable: true });
+        await assert.rejects(native.setupGlobals(), /refuses an existing foreign GPU instance/);
+        assert.equal(navigator.gpu, foreign);
+        console.log("FOREIGN_REFUSED_UNCHANGED");
+    } else if (mode === "override") {
+        assert.throws(
+            () => native.createGPUInstance("/not/the/peer/library"),
+            /library override is unsupported/,
+        );
+        await assert.rejects(
+            native.setupGlobals({ libPath: "/not/the/peer/library" }),
+            /library override is unsupported/,
+        );
+        console.log("OVERRIDE_REFUSED");
+    } else {
+        await native.setupGlobals();
+        const gpu = navigator.gpu as any;
+        const constructors = Object.entries(native.globalConstructors);
+        assert.equal(constructors.length, 13, "complete carried global table");
+        assert.equal(typeof native.globalConstructors.GPUDevice, "function");
+        const gpuConstructor = gpu.constructor;
+        assert.equal(typeof gpuConstructor, "function");
+        await native.setupGlobals();
+        const again = await loadNative();
+        await again.setupGlobals();
+        assert.equal(navigator.gpu, gpu);
+        assert.equal(gpu.constructor, gpuConstructor);
+        assert.equal(again.globalConstructors, native.globalConstructors);
+        for (const [name, value] of constructors) {
+            assert.equal((globalThis as any)[name], value, name);
+        }
+        const { BASE_FEATURES, deviceLimits } = await import(
+            join(engine, "src/engine/runtime/gpu.ts")
+        );
+        const adapter = await gpu.requestAdapter();
+        assert(adapter, "actual packed adapter");
+        try {
+            const device = await adapter.requestDevice({
+                label: "packed-native",
+                defaultQueue: { label: "packed-native-queue" },
+                requiredFeatures: [...BASE_FEATURES],
+                requiredLimits: deviceLimits(adapter.limits),
+            });
+            try {
+                for (const feature of BASE_FEATURES) assert(device.features.has(feature));
+                assert.equal(device.limits.maxStorageBuffersPerShaderStage, 10);
+                const peer = realpathSync(createRequire(loader).resolve("bun-webgpu"));
+                const platform = realpathSync(
+                    createRequire(peer).resolve(
+                        `bun-webgpu-${process.platform}-${process.arch}/index.ts`,
+                    ),
+                );
+                const library = realpathSync((await import(platform)).default);
+                const js = realpathSync(join(engine, "dist/native.js"));
+                const hash = (file: string) =>
+                    createHash("sha256").update(readFileSync(file)).digest("hex");
+                const mapping =
+                    process.platform === "darwin"
+                        ? Bun.spawnSync(["vmmap", "-w", String(process.pid)], {
+                              stdout: "pipe",
+                              stderr: "pipe",
+                          })
+                        : null;
+                const maps = mapping
+                    ? `${mapping.stdout.toString()}\n${mapping.stderr.toString()}`
+                    : readFileSync(`/proc/${process.pid}/maps`, "utf8");
+                writeFileSync("native-maps.txt", maps);
+                assert(!mapping || mapping.exitCode === 0, "OS mapped-library command");
+                assert(maps.includes(library), "resolved peer library is OS-mapped in this child");
+                console.log(
+                    JSON.stringify({
+                        pid: process.pid,
+                        runtime: Bun.version,
+                        platform: process.platform,
+                        arch: process.arch,
+                        engine: realpathSync(engine),
+                        loader: realpathSync(loader),
+                        loaderHash: hash(loader),
+                        js,
+                        jsHash: hash(js),
+                        peer,
+                        peerHash: hash(peer),
+                        peerVersion: JSON.parse(
+                            readFileSync(join(dirname(peer), "package.json"), "utf8"),
+                        ).version,
+                        platformEntry: platform,
+                        platformVersion: JSON.parse(
+                            readFileSync(join(dirname(platform), "package.json"), "utf8"),
+                        ).version,
+                        library,
+                        libraryHash: hash(library),
+                        identity: true,
+                    }),
+                );
+            } finally {
+                device.destroy();
+                await device.lost;
+                await Promise.resolve();
+                assert.equal(device._acquisition.handles.size, 0);
+            }
+        } finally {
+            adapter.destroy();
+            gpu.destroy();
+        }
+        assert.equal(gpu._ticker.acquisitions.size, 0);
+        console.log("PACKED_NATIVE_ACQUIRED_DRAINED");
+    }
+} finally {
+    clearTimeout(watchdog);
+}

--- a/scripts/physics-bench.ts
+++ b/scripts/physics-bench.ts
@@ -1,10 +1,10 @@
-import { globals } from "bun-webgpu";
+import { loadNative } from "../packages/shallot/bin/bun-native";
 import { type Check, queryFlags, skipReason, verify } from "./verify";
 
 // SMALL_N's module graph (avbd/step → physics/core → sear) references GPU enum constants at module
 // scope, which exist in a browser but not under bare `bun run` — install bun-webgpu's constants-only
 // globals (no adapter) before evaluating it, the same shim `bun test` preloads.
-globals();
+(await loadNative()).globals();
 const { SMALL_N } = await import("../packages/shallot/src/standard/avbd/step");
 
 // physics-bench — the standing perf + scaling-robustness surface for the AVBD solver. Drives the §6 gym


### PR DESCRIPTION
## Problem
Native device acquisition could lose packed FFI memory owners. Roads could publish non-finite or empty edit data, and a first touch could edit a road instead of moving the camera. The fog recipe failed the existing central-framing verification contract.

## Cause
The native carrier retained numeric pointers without all backing owners. Roads had degenerate-chord and empty-document gaps; first pointer-down could reach picking with stale coordinates and a zero-sized canvas. The fog camera left its foreground geometry outside the detector's central region.

## Fix
Carry a pinned, deterministic native ownership patch through the private loader and packed distribution, including acquisition callbacks and feature outputs. Refuse invalid edits before publication, support clear/reload through the actual terrain consumers, initialize pointer coordinates before picking, and frame the fog recipe's foreground pillar. Keep native admission, gesture behavior, selector coverage and verification thresholds unchanged.

## Evidence
Candidate `04b32936efa318cfa47e6de0f6caf122a3facbef`:
- Required-corpus default suite: 3,625 pass, 0 fail, no skips.
- Native focused qualification: 248 pass; packed normal/nested installation matrix: 32 expected command exits, real library mappings and negative controls.
- Roads source/tier tests: 425 pass; three browser tests cover real edits, GPU readback, clear/reload, trusted touch, and no-input/disabled-handler/frozen-camera controls. Touch difference remains above the unchanged >3 threshold; all negative controls read zero.
- Verify unit suite: 202 pass. Fog framing passes with the generic detector unchanged; independently authored central/off-centre/flat/gradient/missing-canvas controls exercise both shipped CLI paths. Blank flow remains an expected rejection.
- Full format/check, packed install/browser gate, gym CPU tests, complete `--all` selector and own-commit selector passed. Each selector ran all four CPU and 39 display rows with no skips.

Measured on Bun 1.4.0, macOS arm64, Apple Metal/Chromium. This does not claim Windows/Firefox, physical Mobile Safari, human feel acceptance, or production recurrence qualification.
