### PR TITLE
shallot-reliability-batch: Stop lost owners and unwind slab failures

### DIFF
--- a/packages/shallot/src/engine/app/index.test.ts
+++ b/packages/shallot/src/engine/app/index.test.ts
@@ -1,0 +1,88 @@
+import { expect, spyOn, test } from "bun:test";
+import { clear } from "../ecs/core";
+import { observeDevice } from "../runtime/gpu";
+import { type App, run } from ".";
+
+function owner() {
+    const loss = Promise.withResolvers<GPUDeviceLostInfo>();
+    let fences = 0;
+    const device = {
+        queue: {
+            onSubmittedWorkDone: async () => {
+                fences++;
+            },
+        },
+        features: new Set(),
+        limits: {},
+        lost: loss.promise,
+        pushErrorScope: () => {},
+        popErrorScope: async () => null,
+    } as unknown as GPUDevice;
+    const diagnostics: string[] = [];
+    observeDevice(device, (message) => diagnostics.push(message));
+    return { device, loss, diagnostics, fences: () => fences };
+}
+
+for (const mode of ["loss", "replacement", "same-device-rebuild"] as const) {
+    test(`${mode} stops the original managed loop without stopping the replacement`, async () => {
+        clear();
+        const callbacks: (() => void)[] = [];
+        const timer = spyOn(globalThis, "setTimeout").mockImplementation(((
+            callback: () => void,
+        ) => {
+            callbacks.push(callback);
+            return 0;
+        }) as typeof setTimeout);
+        const apps: App[] = [];
+        const old = owner();
+        const next = mode === "same-device-rebuild" ? old : owner();
+        let oldSteps = 0;
+        let nextSteps = 0;
+        const loading = { show() {}, update() {} };
+        try {
+            apps.push(
+                await run({
+                    defaults: false,
+                    device: old.device,
+                    loading,
+                    plugins: [{ name: "old", systems: [{ update: () => oldSteps++ }] }],
+                }),
+            );
+            expect(callbacks).toHaveLength(1);
+            callbacks.shift()!();
+            expect(oldSteps).toBe(1);
+            expect(old.fences()).toBe(1);
+            apps.push(
+                await run({
+                    defaults: false,
+                    device: next.device,
+                    loading,
+                    plugins: [{ name: "next", systems: [{ update: () => nextSteps++ }] }],
+                }),
+            );
+            if (mode === "loss") {
+                old.loss.resolve({ reason: "unknown", message: "old owner" } as GPUDeviceLostInfo);
+                await old.loss.promise;
+            }
+            expect(callbacks).toHaveLength(2);
+            callbacks.shift()!();
+            expect(oldSteps).toBe(1);
+            expect(next.fences()).toBe(next === old ? 1 : 0);
+            expect(callbacks).toHaveLength(1);
+            callbacks.shift()!();
+            expect(nextSteps).toBe(1);
+            expect(next.fences()).toBe(next === old ? 2 : 1);
+            next.loss.resolve({ reason: "destroyed", message: "next owner" } as GPUDeviceLostInfo);
+            await next.loss.promise;
+            callbacks.shift()!();
+            expect(nextSteps).toBe(1);
+            expect(callbacks).toHaveLength(0);
+            expect(old.diagnostics).toHaveLength(mode === "replacement" ? 0 : 1);
+            expect(next.diagnostics).toHaveLength(1);
+        } finally {
+            for (const app of apps.reverse()) app.dispose();
+            timer.mockRestore();
+            clear();
+        }
+    });
+}

--- a/packages/shallot/src/engine/app/index.ts
+++ b/packages/shallot/src/engine/app/index.ts
@@ -2,6 +2,7 @@ import { type Component, State, type System } from "../ecs";
 import { entries, fields, register, type Traits } from "../ecs/core";
 import {
     Compute,
+    deviceLost,
     now,
     precompileAll,
     Runtime,
@@ -383,6 +384,7 @@ export function mountOverlay(canvas: HTMLElement | null, state?: State): HTMLDiv
 export async function run(config: Config): Promise<App> {
     const app = await build(config);
     const state = app.state;
+    const { device, pending, sync } = Compute;
     // UI teardown is State-owned: the overlay auto-registers its removal (mountOverlay above), and the
     // ui cleanup registers beside it. Both run at state.dispose() — after the plugin dispose hooks on the
     // App.dispose path (UI cleanup is DOM/unmount work with no dependency on plugin GPU state), and it also
@@ -412,7 +414,7 @@ export async function run(config: Config): Promise<App> {
     const scratch: number[] = [];
 
     function frame(timestamp?: number): void {
-        if (disposed) return;
+        if (disposed || deviceLost(device) || Compute.sync !== sync) return;
         // rAF clocks the loop and reschedules first, before any GPU work: the next frame is registered
         // while the browser's paint deadline is still open, so frame delivery stays vsync-aligned. The
         // alternative — scheduling the next rAF off the completion fence — slips a paint whenever the
@@ -441,25 +443,21 @@ export async function run(config: Config): Promise<App> {
         // the in-flight depth. The bound sits well above a present-throttled pipeline's depth (~3 frames),
         // since `onSubmittedWorkDone` is present-gated and a tighter cap would drop frames Chrome is ready to
         // present (a 60Hz fullscreen throttle reads ~3 in flight with the GPU idle).
-        if ((Compute.pending?.() ?? 0) >= MAX_FRAMES_IN_FLIGHT) return;
+        if ((pending?.() ?? 0) >= MAX_FRAMES_IN_FLIGHT) return;
         const dt = frameDelta(t, lastTime);
         lastTime = t;
         state.fenceWait(pendingFenceWaitMs);
         pendingFenceWaitMs = 0;
         state.step(dt);
-        const fence = Compute.sync?.();
+        const fence = sync?.();
         if (fence) {
             const waitStart = now();
             fence.then(
                 () => {
                     pendingFenceWaitMs = now() - waitStart;
                 },
-                // a rejected fence is device loss, and this continuation carries nothing but a timing
-                // sample — drop it rather than reporting a bogus wait. The handler exists only so the
-                // rejection isn't unhandled; the loss itself is reported by `observeDevice`, and the
-                // loop deliberately keeps running (report-only device-loss policy). Don't delete this
-                // as dead code: `Compute.sync`'s own `inFlight` accounting is what must not wedge, and
-                // it is guarded at the fence in `runtime/gpu.ts`, not here.
+                // A rejected fence has no timing sample. Device loss is reported once by
+                // observeDevice; the next scheduled callback stops at the original owner guard.
                 () => {},
             );
         }

--- a/packages/shallot/src/engine/runtime/gpu.test.ts
+++ b/packages/shallot/src/engine/runtime/gpu.test.ts
@@ -9,6 +9,7 @@ import {
     checkTextureLimits,
     checkTgsl,
     deviceLimits,
+    deviceLost,
     GpuDiagnosticError,
     observeDevice,
     PIPELINE_COMPILE_MEASURE_PREFIX,
@@ -43,13 +44,24 @@ describe("device failure listeners", () => {
         observeDevice(device, (message) => reported.push(message));
         observeDevice(device, (message) => reported.push(`duplicate:${message}`));
 
+        const other = { lost: new Promise<GPUDeviceLostInfo>(() => {}) } as GPUDevice;
+        observeDevice(other, (message) => reported.push(message));
+        expect(deviceLost(device)).toBe(false);
+        expect(deviceLost(other)).toBe(false);
         expect(device.onuncapturederror).toBe(host);
         listener?.({ error: new Error("bad binding") } as unknown as GPUUncapturedErrorEvent);
+        expect(deviceLost(device)).toBe(false);
         lose({ reason: "destroyed", message: "host closed" } as GPUDeviceLostInfo);
         await Promise.resolve();
+        expect(deviceLost(device)).toBe(true);
+        expect(deviceLost(other)).toBe(false);
+        observeDevice(device, (message) => reported.push(`late:${message}`));
+        expect(deviceLost(device)).toBe(true);
+        listener?.({ error: new Error("unrelated failure") } as unknown as GPUUncapturedErrorEvent);
         expect(reported).toEqual([
             "GPU uncaptured Error: bad binding",
             "GPU device lost destroyed: host closed",
+            "GPU uncaptured Error: unrelated failure",
         ]);
     });
 });

--- a/packages/shallot/src/engine/runtime/gpu.ts
+++ b/packages/shallot/src/engine/runtime/gpu.ts
@@ -518,6 +518,12 @@ function endArtifactScope(scope: ArtifactScope | undefined): void {
 }
 
 const _observedDevices = new WeakSet<GPUDevice>();
+const _lostDevices = new WeakSet<GPUDevice>();
+
+/** whether the original device's loss has been observed; never follows the active build. @internal */
+export function deviceLost(device: GPUDevice): boolean {
+    return _lostDevices.has(device);
+}
 
 function failure(error: unknown): { errorClass: string; message: string } {
     if (error instanceof Error) return { errorClass: error.name, message: error.message };
@@ -593,6 +599,7 @@ export function observeDevice(
     _observedDevices.add(device);
 
     void device.lost?.then((info) => {
+        _lostDevices.add(device);
         report(`GPU device lost ${info.reason}: ${info.message}`);
     });
 

--- a/packages/shallot/src/engine/runtime/index.ts
+++ b/packages/shallot/src/engine/runtime/index.ts
@@ -3,6 +3,7 @@ export {
     checkStorageBinding,
     checkTextureLimits,
     checkTgsl,
+    deviceLost,
     type LazyAlloc,
     PIPELINE_COMPILE_MEASURE_PREFIX,
     precompile,

--- a/packages/shallot/src/standard/mirror/index.test.ts
+++ b/packages/shallot/src/standard/mirror/index.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, expect, test } from "bun:test";
+import { afterEach, expect, spyOn, test } from "bun:test";
 import type { TgpuBuffer } from "typegpu";
 import * as d from "typegpu/data";
 import { Compute, type State } from "../../engine";
+import { observeDevice } from "../../engine/runtime/gpu";
 import { Mirror, mirror } from ".";
 
 afterEach(() => {
+    Mirror.reset();
     Object.assign(Compute, { root: undefined });
 });
 
@@ -60,38 +62,179 @@ test("Mirror's ring growth marks its staging slot lazy", () => {
     expect(created[0].lazy).toBe(true);
 });
 
-// a mapAsync rejection recycles the slot with no diagnostic, so the snapshot silently stops advancing.
-// The rejection handler must signal — not swallow — so a host can see the readback died.
-test("a rejected mapAsync signals a diagnostic, not silent slot recycling", async () => {
-    const raw = { size: 16 } as GPUBuffer;
-    const stagingSlot = {
-        mapAsync: () => Promise.reject(new Error("map failed")),
-        destroy: () => {},
-    } as unknown as GPUBuffer;
+function readbackDevice() {
+    const loss = Promise.withResolvers<GPUDeviceLostInfo>();
+    const maps: ReturnType<typeof Promise.withResolvers<void>>[] = [];
+    const slots: { destroyed: number; reads: number; bytes: ArrayBuffer }[] = [];
+    const calls = { encoders: 0, submits: 0, copies: 0 };
     const device = {
-        createCommandEncoder: () => ({ copyBufferToBuffer: () => {}, finish: () => ({}) }),
-        createBuffer: () => stagingSlot,
-        queue: { submit: () => {} },
+        lost: loss.promise,
+        createCommandEncoder: () => {
+            calls.encoders++;
+            return {
+                copyBufferToBuffer: () => calls.copies++,
+                finish: () => ({}),
+            };
+        },
+        createBuffer: () => {
+            const slot = { destroyed: 0, reads: 0, bytes: new ArrayBuffer(16) };
+            slots.push(slot);
+            return {
+                mapAsync: () => {
+                    const map = Promise.withResolvers<void>();
+                    maps.push(map);
+                    return map.promise;
+                },
+                getMappedRange: () => {
+                    slot.reads++;
+                    return slot.bytes;
+                },
+                unmap: () => {},
+                destroy: () => slot.destroyed++,
+            };
+        },
+        queue: { submit: () => calls.submits++ },
     } as unknown as GPUDevice;
-    const prevDevice = Compute.device;
-    Object.assign(Compute, { device, frame: 0 });
+    const diagnostics: string[] = [];
+    observeDevice(device, (message) => diagnostics.push(message));
+    return { device, loss, maps, slots, calls, diagnostics };
+}
 
-    const errors: unknown[][] = [];
-    const origError = console.error;
-    console.error = (...args: unknown[]) => {
-        errors.push(args);
-    };
+test("loss terminates multiple mirrors without publishing stale maps or touching a replacement", async () => {
+    const old = readbackDevice();
+    const next = readbackDevice();
+    const state = { time: { fixedTick: 7 } } as unknown as State;
+    const raw = { size: 16 } as GPUBuffer;
+    Object.assign(Compute, { device: old.device, frame: 1 });
+    const a = mirror(raw);
+    const b = mirror(raw);
+    Mirror.flush(state);
+    expect(old.maps).toHaveLength(2);
+    old.loss.resolve({ reason: "unknown", message: "test loss" } as GPUDeviceLostInfo);
+    await old.loss.promise;
+    old.maps[0].resolve();
+    old.maps[1].reject(new Error("lost map"));
+    await Promise.allSettled(old.maps.map((map) => map.promise));
+    expect(a.snapshot).toBeNull();
+    expect(b.snapshot).toBeNull();
+    const calls = { ...old.calls };
+    for (let i = 0; i < 4; i++) Mirror.flush(state);
+    expect(old.calls).toEqual(calls);
+    expect(old.maps).toHaveLength(2);
+    expect(old.slots.every((slot) => slot.reads === 0)).toBe(true);
+    expect(old.diagnostics).toHaveLength(1);
 
-    const m = mirror(raw);
+    Object.assign(Compute, { device: next.device, frame: 2 });
+    const replacement = mirror(raw);
+    Mirror.flush(state);
+    expect(next.maps).toHaveLength(1);
+    next.maps[0].resolve();
+    await next.maps[0].promise;
+    expect(replacement.snapshot?.frame).toBe(2);
+    expect(a.snapshot).toBeNull();
+    expect(b.snapshot).toBeNull();
+});
+
+test("loss before first flush allocates nothing while another device remains live", async () => {
+    const owner = readbackDevice();
+    Object.assign(Compute, { device: owner.device, frame: 0 });
+    mirror({ size: 16 } as GPUBuffer);
+    owner.loss.resolve({ reason: "destroyed", message: "before flush" } as GPUDeviceLostInfo);
+    await owner.loss.promise;
+    Mirror.flush({ time: { fixedTick: 0 } } as unknown as State);
+    expect(owner.slots).toHaveLength(0);
+    expect(owner.calls).toEqual({ encoders: 0, copies: 0, submits: 0 });
+});
+
+test("ordinary rejection is loud and the same ring recovers without allocating", async () => {
+    const owner = readbackDevice();
+    const state = { time: { fixedTick: 0 } } as unknown as State;
+    Object.assign(Compute, { device: owner.device, frame: 0 });
+    const m = mirror({ size: 16, label: "recoverable" } as GPUBuffer, { ring: 1 });
+    const errors = spyOn(console, "error").mockImplementation(() => {});
     try {
-        Mirror.flush({ time: { fixedTick: 0 } } as unknown as State);
-        // wait for the rejection callback to fire
-        await new Promise((resolve) => setTimeout(resolve, 10));
-
-        expect(errors.length).toBeGreaterThan(0); // fails: rejection is silent
+        for (let i = 0; i < 2; i++) {
+            Mirror.flush(state);
+            owner.maps[i].reject(new Error("ordinary map refusal"));
+            await Promise.allSettled([owner.maps[i].promise]);
+            expect(errors).toHaveBeenCalledTimes(i + 1);
+            expect(m.snapshot).toBeNull();
+        }
+        Object.assign(Compute, { frame: 3 });
+        Mirror.flush(state);
+        new Uint8Array(owner.slots[0].bytes)[0] = 73;
+        owner.maps[2].resolve();
+        await owner.maps[2].promise;
+        expect(owner.slots).toHaveLength(1);
+        expect(m.snapshot?.frame).toBe(3);
+        expect(new Uint8Array(m.snapshot!.bytes)[0]).toBe(73);
+        expect(owner.slots[0].destroyed).toBe(0);
+        expect(errors.mock.calls[0][0]).toContain("recoverable");
     } finally {
-        console.error = origError;
-        m.dispose();
-        Object.assign(Compute, { device: prevDevice });
+        errors.mockRestore();
     }
 });
+
+test("out-of-order success preserves the newest bytes and recycles the older slot", async () => {
+    const owner = readbackDevice();
+    const state = { time: { fixedTick: 1 } } as unknown as State;
+    Object.assign(Compute, { device: owner.device, frame: 1 });
+    const m = mirror({ size: 16 } as GPUBuffer);
+    Mirror.flush(state);
+    Object.assign(Compute, { frame: 2 });
+    Mirror.flush(state);
+    new Uint8Array(owner.slots[0].bytes)[0] = 11;
+    new Uint8Array(owner.slots[1].bytes)[0] = 22;
+    owner.maps[1].resolve();
+    await owner.maps[1].promise;
+    owner.maps[0].resolve();
+    await owner.maps[0].promise;
+    expect(m.snapshot?.frame).toBe(2);
+    expect(new Uint8Array(m.snapshot!.bytes)[0]).toBe(22);
+    Object.assign(Compute, { frame: 3 });
+    Mirror.flush(state);
+    expect(owner.slots).toHaveLength(2);
+    expect(owner.maps).toHaveLength(3);
+});
+
+for (const retirement of ["dispose", "reset", "replacement", "loss"] as const) {
+    test(`${retirement} makes success and rejection harmless across multiple mirrors`, async () => {
+        const old = readbackDevice();
+        const next = retirement === "replacement" ? readbackDevice() : old;
+        const state = { time: { fixedTick: 1 } } as unknown as State;
+        Object.assign(Compute, { device: old.device, frame: 1 });
+        const a = mirror({ size: 16 } as GPUBuffer);
+        const b = mirror({ size: 16 } as GPUBuffer);
+        Mirror.flush(state);
+        const errors = spyOn(console, "error").mockImplementation(() => {});
+        try {
+            if (retirement === "dispose") {
+                a.dispose();
+                b.dispose();
+            }
+            if (retirement === "reset") Mirror.reset();
+            if (retirement === "loss") {
+                old.loss.resolve({ reason: "unknown", message: "retired" } as GPUDeviceLostInfo);
+                await old.loss.promise;
+            }
+            Object.assign(Compute, { device: next.device, frame: 2 });
+            old.maps[0].resolve();
+            old.maps[1].reject(new Error("retired map"));
+            await Promise.allSettled(old.maps.map((map) => map.promise));
+            expect(a.snapshot).toBeNull();
+            expect(b.snapshot).toBeNull();
+            expect(old.slots.every((slot) => slot.reads === 0 && slot.destroyed === 1)).toBe(true);
+            expect(errors).not.toHaveBeenCalled();
+            if (retirement !== "loss") {
+                const live = mirror({ size: 16 } as GPUBuffer);
+                Mirror.flush(state);
+                expect(next.maps.length).toBe(next === old ? 3 : 1);
+                next.maps.at(-1)!.resolve();
+                await next.maps.at(-1)!.promise;
+                expect(live.snapshot?.frame).toBe(2);
+            }
+        } finally {
+            errors.mockRestore();
+        }
+    });
+}

--- a/packages/shallot/src/standard/mirror/index.ts
+++ b/packages/shallot/src/standard/mirror/index.ts
@@ -1,7 +1,7 @@
 import { isBuffer, type TgpuBuffer } from "typegpu";
 import type { AnyData } from "typegpu/data";
 import { Compute, type Plugin, type State, type System } from "../../engine";
-import type { LazyAlloc } from "../../engine/runtime";
+import { deviceLost, type LazyAlloc } from "../../engine/runtime";
 
 /** what {@link mirror} reads back: a raw `GPUBuffer` or its typed twin. Mirror is byte-granular either
  *  way — a typed source is unwrapped at construction and the snapshot stays opaque bytes. */
@@ -56,9 +56,11 @@ export class Mirror<T extends MirrorSource = MirrorSource> {
     private _disposed: boolean = false;
 
     private readonly _raw: GPUBuffer;
+    private readonly _device: GPUDevice;
 
     constructor(source: T, opts?: { ring?: number }) {
         this.source = source;
+        this._device = Compute.device;
         this._raw = unwrap(source);
         this.size = this._raw.size;
         this._ringSize = opts?.ring ?? 2;
@@ -97,6 +99,7 @@ export class Mirror<T extends MirrorSource = MirrorSource> {
     static flush(state: State): void {
         if (Mirror._all.length === 0) return;
         const device = Compute.device;
+        if (deviceLost(device)) return;
         const fixedTick = state.time.fixedTick;
         const frame = Compute.frame;
 
@@ -104,6 +107,7 @@ export class Mirror<T extends MirrorSource = MirrorSource> {
         const pending: { m: Mirror; slot: GPUBuffer }[] = [];
 
         for (const m of Mirror._all) {
+            if (m._device !== device) continue;
             let slot = m._free.pop();
             if (!slot) {
                 // Ring saturated — every staging slot still mapping. Skip this tick.
@@ -135,6 +139,10 @@ export class Mirror<T extends MirrorSource = MirrorSource> {
             slot.mapAsync(GPUMapMode.READ, 0, m.size).then(
                 () => {
                     if (m._disposed) return;
+                    if (deviceLost(m._device) || m._device !== Compute.device) {
+                        m.dispose();
+                        return;
+                    }
                     // A stale (out-of-order) map resolution must not clobber a newer snapshot — without
                     // the per-readback fresh buffer, last-resolved-wins would otherwise overwrite the
                     // reused buffer with older data + an older frame stamp.
@@ -156,12 +164,15 @@ export class Mirror<T extends MirrorSource = MirrorSource> {
                     }
                 },
                 () => {
-                    if (!m._disposed) {
-                        m._free.push(slot);
-                        console.error(
-                            `Mirror readback (source ${m._raw.label ?? "<unlabeled>"}) mapAsync rejected; this map failed and the slot was recycled — the snapshot may recover on the next flush`,
-                        );
+                    if (m._disposed) return;
+                    if (deviceLost(m._device) || m._device !== Compute.device) {
+                        m.dispose();
+                        return;
                     }
+                    m._free.push(slot);
+                    console.error(
+                        `Mirror readback (source ${m._raw.label ?? "<unlabeled>"}) mapAsync rejected; this map failed and the slot was recycled — the snapshot may recover on the next flush`,
+                    );
                 },
             );
         }

--- a/packages/shallot/src/standard/slab/index.ts
+++ b/packages/shallot/src/standard/slab/index.ts
@@ -13,7 +13,7 @@ import {
     type TypedArray,
 } from "../../engine";
 import { entries } from "../../engine/ecs/core";
-import { type LazyAlloc, precompile } from "../../engine/runtime";
+import { deviceLost, type LazyAlloc, precompile } from "../../engine/runtime";
 import { allocMembership, MembershipSystem } from "./membership";
 import {
     compiled,
@@ -109,6 +109,7 @@ export class Slab {
     // bumped by release(): a stager whose mapAsync resolves after its epoch ended belongs to a
     // torn-down build (prior size, possibly prior device) and must be destroyed, not re-pooled
     private _epoch = 0;
+    private _device: GPUDevice | null = null;
 
     constructor(type: Type = f32, name: string | null = null) {
         this.type = type;
@@ -216,6 +217,7 @@ export class Slab {
             );
         }
         const root = Compute.root;
+        this._device = Compute.device;
         const values = d.arrayOf(element, capacity);
         this.typed = root
             .createBuffer(values)
@@ -282,7 +284,6 @@ export class Slab {
                     count++;
                     bits ^= lsb;
                 }
-                dirty[w] = 0;
             }
             slotView[0] = count;
             stager.unmap();
@@ -314,7 +315,6 @@ export class Slab {
                 count++;
                 bits ^= lsb;
             }
-            dirty[w] = 0;
         }
         slotView[0] = count;
         stager.unmap();
@@ -338,6 +338,7 @@ export class Slab {
         this._rawValues = null;
         this._bindGroup = null;
         this._bound = null;
+        this._device = null;
         this._stagingPool.length = 0;
         this._epoch++;
     }
@@ -401,58 +402,74 @@ export class Slab {
     static flush(): void {
         if (Slab._all.length === 0) return;
         const device = Compute.device;
+        if (deviceLost(device)) return;
         const encoder = device.createCommandEncoder({ label: "slab-flush" });
         const used: { slab: Slab; stager: GPUBuffer; count: number }[] = [];
 
-        for (const slab of Slab._all) {
-            if (!slab.gpu) continue;
-            const dirty = slab.dirty;
-            let anyDirty = false;
-            for (let w = 0; w < dirty.length; w++) {
-                if (dirty[w] !== 0) {
-                    anyDirty = true;
-                    break;
+        try {
+            for (const slab of Slab._all) {
+                if (!slab.gpu || slab._device !== device) continue;
+                const dirty = slab.dirty;
+                let anyDirty = false;
+                for (let w = 0; w < dirty.length; w++) {
+                    if (dirty[w] !== 0) {
+                        anyDirty = true;
+                        break;
+                    }
                 }
+                if (!anyDirty) continue;
+                const bytes = elementBytes(slab.type)!;
+                const stagerBytes = (capacity + 1) * 4 + capacity * bytes;
+                const stager = slab._stagingPool.pop() ?? createStager(device, stagerBytes);
+                const entry = { slab, stager, count: 0 };
+                used.push(entry);
+                const count = slab.pack(stager);
+                entry.count = count;
+                encoder.copyBufferToBuffer(stager, 0, slab._rawSlots!, 0, (count + 1) * 4);
+                encoder.copyBufferToBuffer(
+                    stager,
+                    (capacity + 1) * 4,
+                    slab._rawValues!,
+                    0,
+                    count * bytes,
+                );
             }
-            if (!anyDirty) continue;
-            const bytes = elementBytes(slab.type)!;
-            const stagerBytes = (capacity + 1) * 4 + capacity * bytes;
-            const stager = slab._stagingPool.pop() ?? createStager(device, stagerBytes);
-            const count = slab.pack(stager);
-            encoder.copyBufferToBuffer(stager, 0, slab._rawSlots!, 0, (count + 1) * 4);
-            encoder.copyBufferToBuffer(
-                stager,
-                (capacity + 1) * 4,
-                slab._rawValues!,
-                0,
-                count * bytes,
-            );
-            used.push({ slab, stager, count });
+
+            if (used.length === 0) return;
+
+            // One compute pass for all slabs — each dispatch rebinds its own group; the pass is shared, which
+            // saves N-1 beginComputePass/endPass round-trips.
+            const pass = encoder.beginComputePass({
+                label: "slab-scatter",
+                timestampWrites: Compute.span?.("slab:flush"),
+            });
+            for (const { slab, count } of used) {
+                slab._bound!.with(pass).dispatchWorkgroups(Math.ceil(count / 64));
+            }
+            pass.end();
+
+            device.queue.submit([encoder.finish()]);
+        } catch (error) {
+            // Nothing submitted: retain every dirty word, and release even a stager whose pack failed.
+            for (const { stager } of used) stager.destroy();
+            throw error;
         }
-
-        if (used.length === 0) return;
-
-        // One compute pass for all slabs — each dispatch rebinds its own group; the pass is shared, which
-        // saves N-1 beginComputePass/endPass round-trips.
-        const pass = encoder.beginComputePass({
-            label: "slab-scatter",
-            timestampWrites: Compute.span?.("slab:flush"),
-        });
-        for (const { slab, count } of used) {
-            slab._bound!.with(pass).dispatchWorkgroups(Math.ceil(count / 64));
-        }
-        pass.end();
-
-        device.queue.submit([encoder.finish()]);
         for (const { slab, stager } of used) {
+            slab.dirty.fill(0);
             const epoch = slab._epoch;
             stager
                 .mapAsync(GPUMapMode.WRITE)
                 .then(() => {
-                    if (slab._epoch === epoch) slab._stagingPool.push(stager);
-                    else stager.destroy();
+                    if (slab._epoch === epoch && !deviceLost(device) && Compute.device === device) {
+                        slab._stagingPool.push(stager);
+                    } else stager.destroy();
                 })
-                .catch(() => {});
+                .catch((error) => {
+                    stager.destroy();
+                    if (slab._epoch === epoch && !deviceLost(device) && Compute.device === device) {
+                        console.error("Slab staging mapAsync rejected:", error);
+                    }
+                });
         }
     }
 }

--- a/packages/shallot/src/standard/slab/slab.test.ts
+++ b/packages/shallot/src/standard/slab/slab.test.ts
@@ -17,7 +17,7 @@ import {
     vec4,
 } from "../..";
 import { clear, lanes, register } from "../../engine/ecs/core";
-import { Slab, SlabPlugin } from "./";
+import { Slab, SlabPlugin, SlabSystem } from "./";
 import { elementBytes, scatterWgsl } from "./scatter";
 
 // Pure-CPU slab logic (no device): CPU-storage alloc, set/get + dirty bits, defaults-through-.set,
@@ -25,7 +25,8 @@ import { elementBytes, scatterWgsl } from "./scatter";
 // dirty-clear) is gated by the gym `render` scenario's transport round-trip (`bun bench --scenario
 // render`), the product-truth gate for the resolved pipeline's execution. `Slab.collect()` is the
 // device-free CPU-alloc pass `build()` runs over the registry; the `.gpu` mirror is `prepare()` at warm.
-// One exception binds a device here: the reset/in-flight-stager lifecycle race, unreachable from the gym.
+// Native devices below exercise allocation unwind and staging-map lifetimes; GPU value correctness
+// stays with the gym transport assertion.
 
 beforeEach(() => {
     clear();
@@ -202,6 +203,238 @@ describe("reset during an in-flight flush", () => {
     });
 });
 
+describe("stager completion ownership", () => {
+    for (const retirement of ["live", "loss", "dispose", "rebuild"] as const) {
+        test(`${retirement} discriminates successful and rejected native maps`, async () => {
+            const Thing = { scalar: new Slab(f32), packed: new Slab(f16x4) };
+            const config = {
+                plugins: [SlabPlugin, { name: "thing", components: { Thing } }],
+                defaults: false,
+            };
+            const app = await build(config);
+            let replacement: Awaited<ReturnType<typeof build>> | undefined;
+            const device = Compute.device;
+            const create = device.createBuffer.bind(device);
+            const ready: Promise<void>[] = [];
+            const controls: ReturnType<typeof Promise.withResolvers<void>>[] = [];
+            const destroyed: ReturnType<typeof spyOn>[] = [];
+            const maps: ReturnType<typeof spyOn>[] = [];
+            let allocations = 0;
+            const allocation = spyOn(device, "createBuffer").mockImplementation((desc) => {
+                const buffer = create(desc);
+                if (desc.label !== "slab-staging") return buffer;
+                allocations++;
+                if (allocations > 2) return buffer;
+                const control = Promise.withResolvers<void>();
+                controls.push(control);
+                const map = buffer.mapAsync.bind(buffer);
+                maps.push(
+                    spyOn(buffer, "mapAsync").mockImplementation((...args) => {
+                        const native = map(...args);
+                        ready.push(native);
+                        return native.then(() => control.promise).then(() => undefined);
+                    }),
+                );
+                destroyed.push(spyOn(buffer, "destroy"));
+                return buffer;
+            });
+            const errors = spyOn(console, "error").mockImplementation(() => {});
+            try {
+                Thing.scalar.set(31, 7);
+                Thing.packed.set(65, 1, 2, 3, 4);
+                app.state.step();
+                expect(controls).toHaveLength(2);
+                await Promise.all(ready);
+                if (retirement === "loss") {
+                    device.destroy();
+                    await device.lost;
+                }
+                if (retirement === "dispose" || retirement === "rebuild") app.dispose();
+                if (retirement === "rebuild") replacement = await build(config);
+                // Native device.destroy also destroys its buffers; count the continuation separately.
+                const priorDestroys = destroyed.map((destroy) => destroy.mock.calls.length);
+                const refusal = new Error("injected ordinary map rejection");
+                controls[0].resolve();
+                controls[1].reject(refusal);
+                await Promise.allSettled(controls.map((control) => control.promise));
+                // Drain the native-map -> controlled-completion -> pool/error chain.
+                for (let i = 0; i < 4; i++) await Promise.resolve();
+                const pools = Object.values(Thing).map(
+                    (slab) => (slab as unknown as { _stagingPool: GPUBuffer[] })._stagingPool,
+                );
+                expect(pools.map((pool) => pool.length)).toEqual(
+                    retirement === "live" ? [1, 0] : [0, 0],
+                );
+                expect(destroyed[0]).toHaveBeenCalledTimes(
+                    priorDestroys[0] + (retirement === "live" ? 0 : 1),
+                );
+                expect(destroyed[1]).toHaveBeenCalledTimes(priorDestroys[1] + 1);
+                if (retirement === "live") {
+                    expect(errors.mock.calls).toEqual([
+                        ["Slab staging mapAsync rejected:", refusal],
+                    ]);
+                    Thing.scalar.set(31, 8);
+                    Thing.packed.set(65, 2, 3, 4, 5);
+                    app.state.step();
+                    expect(allocations).toBe(3);
+                    expect(Thing.scalar.dirty.some(Boolean)).toBe(false);
+                    expect(Thing.packed.dirty.some(Boolean)).toBe(false);
+                } else {
+                    expect(errors).toHaveBeenCalledTimes(retirement === "loss" ? 1 : 0);
+                }
+                if (replacement) {
+                    const submit = spyOn(Compute.device.queue, "submit");
+                    try {
+                        Thing.scalar.set(31, 9);
+                        replacement.state.step();
+                        expect(submit).toHaveBeenCalledTimes(1);
+                        expect(Thing.scalar.dirty.some(Boolean)).toBe(false);
+                    } finally {
+                        submit.mockRestore();
+                    }
+                }
+            } finally {
+                allocation.mockRestore();
+                replacement?.dispose();
+                app.dispose();
+                for (const map of maps) map.mockRestore();
+                for (const destroy of destroyed) destroy.mockRestore();
+                errors.mockRestore();
+            }
+        });
+    }
+});
+
+describe("lost slab owner", () => {
+    test("a lost device receives no further flush work and retains dirty data", async () => {
+        const Thing = { v: new Slab(f32) };
+        const app = await build({
+            plugins: [SlabPlugin, { name: "thing", components: { Thing } }],
+            defaults: false,
+        });
+        const device = Compute.device;
+        const errors = spyOn(console, "error").mockImplementation(() => {});
+        const encoder = spyOn(device, "createCommandEncoder");
+        const create = spyOn(device, "createBuffer");
+        const submit = spyOn(device.queue, "submit");
+        try {
+            Thing.v.set(31, 2);
+            device.destroy();
+            await device.lost;
+            const dirty = Thing.v.dirty.slice();
+            for (let i = 0; i < 3; i++) Slab.flush();
+            expect(encoder).not.toHaveBeenCalled();
+            expect(create).not.toHaveBeenCalled();
+            expect(submit).not.toHaveBeenCalled();
+            expect(Thing.v.dirty).toEqual(dirty);
+            expect(errors).toHaveBeenCalledTimes(1);
+        } finally {
+            encoder.mockRestore();
+            create.mockRestore();
+            submit.mockRestore();
+            errors.mockRestore();
+            app.dispose();
+        }
+    });
+});
+
+describe("allocation failure unwind", () => {
+    for (const mode of ["fresh", "pooled", "submit"] as const) {
+        test(`${mode} failure preserves dirty words, releases stagers and quarantines the real system`, async () => {
+            const Thing = {
+                scalar: new Slab(f32),
+                color: new Slab(srgb8x4),
+                half: new Slab(f16x4),
+            };
+            const app = await build({
+                plugins: [SlabPlugin, { name: "thing", components: { Thing } }],
+                defaults: false,
+            });
+            const device = Compute.device;
+            const create = device.createBuffer.bind(device);
+            const refusal = new RangeError("injected mapped backing allocation failure");
+            const allocated: GPUBuffer[] = [];
+            const destroyed: ReturnType<typeof spyOn>[] = [];
+            let attempts = 0;
+            let fail = true;
+            const allocation = spyOn(device, "createBuffer").mockImplementation((desc) => {
+                if (desc.label !== "slab-staging") return create(desc);
+                attempts++;
+                expect(desc.mappedAtCreation).toBe(true);
+                expect(desc.usage).toBe(GPUBufferUsage.MAP_WRITE | GPUBufferUsage.COPY_SRC);
+                if (fail && mode !== "submit" && attempts === (mode === "pooled" ? 1 : 3))
+                    throw refusal;
+                const buffer = create(desc);
+                allocated.push(buffer);
+                destroyed.push(spyOn(buffer, "destroy"));
+                return buffer;
+            });
+            const nativeSubmit = device.queue.submit.bind(device.queue);
+            const submit = spyOn(device.queue, "submit").mockImplementation((commands) => {
+                if (fail && mode === "submit") throw refusal;
+                nativeSubmit(commands);
+            });
+            const errors = spyOn(console, "error").mockImplementation(() => {});
+            try {
+                const slabs = Object.values(Thing);
+                if (mode === "pooled") {
+                    fail = false;
+                    Thing.scalar.set(1, 1);
+                    Thing.color.set(1, 1, 1, 1, 1);
+                    app.state.step();
+                    const pools = slabs
+                        .slice(0, 2)
+                        .map(
+                            (slab) =>
+                                (slab as unknown as { _stagingPool: GPUBuffer[] })._stagingPool,
+                        );
+                    for (let i = 0; i < 20 && pools.some((pool) => pool.length !== 1); i++) {
+                        await new Promise((resolve) => setTimeout(resolve, 5));
+                    }
+                    expect(pools.map((pool) => pool.length)).toEqual([1, 1]);
+                    attempts = 0;
+                    submit.mockClear();
+                    fail = true;
+                }
+                const failedAttempts = mode === "pooled" ? 1 : 3;
+                for (const slab of slabs) {
+                    for (const eid of [1, 31, 32, 65]) slab.set(eid, 1, 0.5, 0.25, 1);
+                }
+                const dirty = slabs.map((slab) => slab.dirty.slice());
+                app.state.step();
+                expect(attempts).toBe(failedAttempts);
+                expect(errors.mock.calls).toEqual([
+                    [expect.stringContaining('System "Slab/0" threw and is paused'), refusal],
+                ]);
+                expect(submit).toHaveBeenCalledTimes(mode === "submit" ? 1 : 0);
+                // Scheduler quarantine is observable through repeated production steps, not its private set.
+                app.state.step();
+                app.state.step();
+                expect(attempts).toBe(failedAttempts);
+                expect(errors).toHaveBeenCalledTimes(1);
+                expect(slabs.map((slab) => slab.dirty)).toEqual(dirty);
+                expect(destroyed).toHaveLength(mode === "submit" ? 3 : 2);
+                for (const destroy of destroyed) expect(destroy).toHaveBeenCalledTimes(1);
+
+                fail = false;
+                app.state.swap(SlabSystem, { ...SlabSystem });
+                app.state.step();
+                expect(attempts).toBe(failedAttempts + 3);
+                expect(submit).toHaveBeenCalledTimes(mode === "submit" ? 2 : 1);
+                for (const slab of slabs) expect(slab.dirty.some(Boolean)).toBe(false);
+                await device.queue.onSubmittedWorkDone();
+            } finally {
+                allocation.mockRestore();
+                submit.mockRestore();
+                errors.mockRestore();
+                app.dispose();
+                for (const destroy of destroyed) destroy.mockRestore();
+                for (const buffer of allocated) buffer.destroy();
+            }
+        });
+    }
+});
+
 describe("staging pool allocation", () => {
     // `createStager` (module-private in index.ts) is the site that carries `lazy: true` (index.ts:49) —
     // it fires whenever `Slab.flush()` finds an empty `_stagingPool` for a dirty slab, i.e. real GPU
@@ -218,6 +451,7 @@ describe("staging pool allocation", () => {
 
         const s = Marker.v as unknown as {
             gpu: unknown;
+            _device: GPUDevice;
             _rawSlots: unknown;
             _rawValues: unknown;
             _bound: { with: (pass: unknown) => { dispatchWorkgroups: (n: number) => void } };
@@ -247,6 +481,7 @@ describe("staging pool allocation", () => {
             queue: { submit: () => {} },
         } as unknown as GPUDevice;
         const prevDevice = Compute.device;
+        s._device = device;
         Object.assign(Compute, { device });
 
         try {


### PR DESCRIPTION
## Problem

Device loss left Mirror readbacks recycling rejected slots and managed loops scheduling more work. A mapped Slab staging allocation failure could discard dirty data packed for earlier slabs before any submission occurred.

## Cause

Readback completion and app-loop ownership followed mutable active-device state rather than the original device/build. Slab cleared dirty words while packing individual slabs, before the complete staging transaction could succeed.

## Fix

Track observed loss per device; bind managed loops and readback work to their original owners. Keep ordinary map failures visible and recoverable while making retired completions harmless. Retain Slab dirty words until submission succeeds, destroy acquired staging buffers on synchronous unwind, and preserve the existing scheduler quarantine and allocation limits.

## Evidence

Candidate `8f18c1289a90aa3b96af81b615b92de8cd05031f`:

- Required-corpus suite: 3643 passed, 0 failed; focused ownership/allocator/app/scheduler tests: 204 passed.
- Gym CPU: 94 passed; render reference: 19 checks, including 25 scattered writes with untouched data intact.
- Full packed-install/browser gate passed.
- Final candidate and own-commit selectors each passed all 39 selected display rows with zero warnings, including collapse, physics and readback consumers.
- Production mutations fail dirty preservation, staging unwind, stale repooling/publication, ordinary failure diagnostics and replacement-build loop assertions.
- Format and complete check passed on the committed bytes.

Measured on Bun 1.4.0, macOS arm64 and Apple Metal/Chromium. No device recreation, capacity increase, global manual-host recovery or platform/production-recurrence claim.
