### PR TITLE
shallot release boundaries/A1

### DIFF
--- a/packages/shallot/bin/toolchain.ts
+++ b/packages/shallot/bin/toolchain.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import {
     loadConfigFromFile,
@@ -6,7 +5,7 @@ import {
     type PluginOption,
     type Plugin as VitePlugin,
 } from "vite";
-import { discoverScenes, manifestPath } from "../src/project/vite";
+import { isProject as hostIsProject, missingProjectMessage } from "../src/project/command";
 
 // One toolchain merge shared by `shallot dev` and `shallot build`. A manifest project is pure data, but a
 // project that needs a framework (Svelte, React) declares it the standard vite way — its own
@@ -14,21 +13,17 @@ import { discoverScenes, manifestPath } from "../src/project/vite";
 // identically here, so a framework project runs the same in dev and a build. No `vite.config` →
 // the synthesized zero-config path (a manifest recipe is unaffected).
 
-/** dir holds a shallot project — a shallot.json manifest or a .scene file. */
+/** dir holds a shallot project — a shallot.json manifest or a .scene file. Discovery itself belongs to
+ *  the project host (`src/project/command.ts`), so `shallot dev`/`build`/`tui` cannot disagree on what
+ *  a project is. */
 export function isProject(projectDir: string): boolean {
-    const abs = resolve(projectDir);
-    return existsSync(manifestPath(abs)) || discoverScenes(abs).length > 0;
+    return hostIsProject(resolve(projectDir));
 }
 
 /** exit with the scaffold hint when dir holds neither a shallot.json manifest nor a .scene file. */
 export function requireProject(projectDir: string): void {
     if (isProject(projectDir)) return;
-    console.error(`\n  ✗ No shallot project found at ${projectDir}`);
-    console.error("    Expected a shallot.json manifest or a .scene file\n");
-    console.error("    To create a project:");
-    console.error("      bun create shallot my-game");
-    console.error("      cd my-game && bun install");
-    console.error("      bunx shallot dev\n");
+    for (const line of missingProjectMessage(projectDir)) console.error(line);
     process.exit(1);
 }
 

--- a/packages/shallot/bin/tui.test.ts
+++ b/packages/shallot/bin/tui.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { resolve } from "node:path";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import {
     buildDisposeAll,
     cellsBytesToGrid,
@@ -441,5 +443,30 @@ describe("importBunWebgpu / runTui — missing bun-webgpu", () => {
     test("runTui rejects bad flags before ever reaching bun-webgpu (EXIT_SETUP, distinct code)", async () => {
         const code = await runTui(["--nope"]);
         expect(code).toBe(EXIT_SETUP);
+    });
+
+    // Precedence, pinned: a real project that simply never enabled "Cells" still hears about the absent
+    // peer first (the install gate's own scaffold rung reads exit 3 there, not a manifest complaint).
+    // Moving the cells check ahead of the peer import reds this arm.
+    test("a project without Cells reports the absent peer first, not the manifest", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "shallot-tui-no-cells-"));
+        writeFileSync(join(dir, "shallot.json"), JSON.stringify({ plugins: { Orbit: true } }));
+        const code = await runTui([dir], () =>
+            Promise.reject(new Error("Cannot find module 'bun-webgpu'")),
+        );
+        expect(code).toBe(EXIT_NO_BUN_WEBGPU);
+    });
+
+    // The project half of the same ordering: a directory that is no project at all refuses at setup,
+    // with the scaffold hint, before the peer import (nothing of the project is read or loaded).
+    test("a dir that is no project exits EXIT_SETUP before the peer import", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "shallot-tui-no-project-"));
+        let loaderCalls = 0;
+        const code = await runTui([dir], () => {
+            loaderCalls++;
+            return Promise.reject(new Error("Cannot find module 'bun-webgpu'"));
+        });
+        expect(code).toBe(EXIT_SETUP);
+        expect(loaderCalls).toBe(0);
     });
 });

--- a/packages/shallot/bin/tui.ts
+++ b/packages/shallot/bin/tui.ts
@@ -3,11 +3,10 @@
 
 import { readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-// type-only — erased at compile time, so this carries no runtime import and no GPU touch (unlike a
-// value import, verified already at this file's own module doc: `verify.ts` does the same with
-// `GpuDiagnostics`/`ShaderArtifact`).
-import type { Plugin } from "../src/engine";
-import { requireProject } from "./toolchain";
+// The one project seam this command reaches through (`scripts/boundary-seams.ts`): plan, discovery,
+// resolution and the plugin loaders, shared with the browser generator. No Vite, no export-map read and
+// no private engine path of its own — the command entry owns all of that (src/project/command.ts).
+import { headlessEngineNames, loadHeadlessPlugins, planProject } from "../src/project/command";
 import type { RGB, Tier, Cell as TuiCell, Grid as TuiGrid } from "./tui/index";
 // type-only — erased at compile time, so this carries no runtime import and no encoder touch (unlike a
 // value import, verified already at this file's own module doc: `verify.ts` does the same with
@@ -21,8 +20,6 @@ import {
     onResize,
     terminalSize,
 } from "./tui/index";
-
-const PACKAGE_ROOT = resolve(import.meta.dir, "..");
 
 export const usage = `
   shallot tui [dir] — boot a project headless and render its cell grid to this terminal
@@ -522,57 +519,6 @@ export function cellsBytesToGrid(
     });
 }
 
-// ---------------------------------------------------------------------------------------------------
-// project plugin resolution — the manifest → real Plugin objects a Node process needs, generalizing
-// `dump-cells-ascii.ts`'s hand-copied plugin list via `../src/project/generate.ts`'s `plan()` (the same
-// classifier the browser build's `virtual:project` generator uses) so this command boots ANY project's
-// own shallot.json rather than one fixed scene's plugin set.
-// ---------------------------------------------------------------------------------------------------
-
-/** resolve one engine plugin name (`plan()`'s `engine` list) to its real Plugin object: the main barrel
- *  first (every default + most extras), falling back to its declared subpath module (today only `Avbd` —
- *  `SUBPATH_PLUGIN_MODULES`) read off this package's own `exports` map rather than hand-copied, so a
- *  future subpath-only plugin resolves with no edit here. Throws naming the plugin on total failure —
- *  never a silent `undefined` plugin object. */
-async function resolveEnginePlugin(
-    name: string,
-    barrel: Record<string, unknown>,
-    subpathModules: Readonly<Record<string, string>>,
-    pkgExports: Record<string, unknown>,
-): Promise<Plugin> {
-    const direct = barrel[`${name}Plugin`];
-    if (direct) return direct as Plugin;
-    const subpathSpec = subpathModules[name];
-    if (subpathSpec) {
-        const key = `.${subpathSpec.slice("@dylanebert/shallot".length)}`;
-        const target = pkgExports[key];
-        if (typeof target === "string") {
-            const mod = (await import(resolve(PACKAGE_ROOT, target))) as Record<string, unknown>;
-            const plugin = mod[`${name}Plugin`];
-            if (plugin) return plugin as Plugin;
-        }
-    }
-    throw new Error(
-        `shallot tui: shallot.json enables unknown engine plugin "${name}" (no export named "${name}Plugin")`,
-    );
-}
-
-/** resolve one local plugin entry (`plan()`'s `locals` list) — a module whose default export is the
- *  Plugin, the same runtime contract `generate.ts`'s emitted browser module enforces (its own docblock:
- *  "A wrong/missing default is silently `undefined`... the runtime guard below is what makes a mistake
- *  loud"). Mirrored here rather than reused, since that guard lives inline in generated module source
- *  text, not as a callable function. */
-async function resolveLocalPlugin(name: string, path: string): Promise<Plugin> {
-    const mod = (await import(path)) as { default?: Plugin };
-    const plugin = mod.default;
-    if (!plugin || typeof plugin.name !== "string") {
-        throw new Error(
-            `shallot tui: shallot.json plugin "${name}": its module must default-export a Plugin`,
-        );
-    }
-    return plugin;
-}
-
 const TERMINAL_CELL_BUDGET = 10_000;
 const FALLBACK_CELL_GEOMETRY = { width: 1, height: 2 } as const;
 
@@ -619,11 +565,11 @@ export function terminalGridSize(size: { width: number; height: number }): Termi
 }
 
 /**
- * `shallot tui [dir]` — the real entry, reached only past  {@link importBunWebgpu}'s success. Returns the process exit code rather than calling `process.exit`
- * itself (mirrors `runVerify`/`runRecipe`; `cli.ts` calls `process.exit(await runTui(...))`), except for
- * `requireProject` — reused verbatim from `toolchain.ts`, and like `dev.ts`/`build.ts` already do, it
- * exits the process directly on a missing project rather than threading a second return convention through
- * this one command.
+ * `shallot tui [dir]` — the real entry, reached only past  {@link importBunWebgpu}'s success. Returns the
+ * process exit code rather than calling `process.exit` itself (mirrors `runVerify`/`runRecipe`; `cli.ts`
+ * calls `process.exit(await runTui(...))`), including for a missing project or an unresolvable manifest
+ * plugin: the project host's command entry returns {@link EXIT_SETUP} with its diagnostics, before
+ * anything of the project has been imported.
  *
  * `bunWebgpuLoader` forwards to {@link importBunWebgpu}; tests can inject its absence.
  */
@@ -644,7 +590,23 @@ export async function runTui(
     }
 
     const projectDir = resolve(args.dir);
-    requireProject(projectDir); // exits the process on a missing project (toolchain.ts's own contract)
+    // discovery, resolution and dependency validation, all before any project module is evaluated: a
+    // missing project or an unresolvable plugin exits here with nothing loaded and nothing to clean up.
+    const planned = planProject(projectDir);
+    if (!planned.plan) {
+        for (const line of planned.errors) console.error(line);
+        return planned.code;
+    }
+    const project = planned.plan;
+    // Glaze composites the rendered scene to a swapchain — never applicable headless, so the host's
+    // headless set drops it unconditionally rather than leaving it to the manifest.
+    const enabledNames = headlessEngineNames(project);
+    if (!enabledNames.includes("Cells")) {
+        console.error(
+            `shallot tui: ${projectDir}/shallot.json does not enable "Cells" — add "Cells": true to its plugins`,
+        );
+        return EXIT_SETUP;
+    }
 
     const bunWebgpu = await importBunWebgpu(bunWebgpuLoader);
     if (!bunWebgpu) {
@@ -682,42 +644,20 @@ export async function runTui(
     const { cellsGridFor } = engine;
     const { attachCanvas } = await import("../src/standard/render/core");
     const { unpackCell, cellGlyphChar } = await import("../src/extras/cells/core");
-    const { readManifest } = await import("../src/project/assets");
-    const { plan } = await import("../src/project/generate");
-    const { SUBPATH_PLUGIN_MODULES } = await import("../src/project/engine");
 
-    const manifest = readManifest(projectDir);
-    const { engine: engineNames, locals } = plan(manifest, projectDir);
-    // Glaze composites the rendered scene to a swapchain — never applicable headless, the same reason
-    // `dump-cells-ascii.ts` bypasses it via `defaults: false` + an explicit list. Dropped unconditionally
-    // rather than left to the manifest, since a headless run has no swapchain to disable it against.
-    const enabledNames = engineNames.filter((n) => n !== "Glaze");
-    if (!enabledNames.includes("Cells")) {
-        console.error(
-            `shallot tui: ${projectDir}/shallot.json does not enable "Cells" — add "Cells": true to its plugins`,
-        );
-        return EXIT_SETUP;
-    }
+    // the plan's plugins, loaded by the host: the headless engine set (Glaze already dropped) plus the
+    // manifest's local plugins, each already proven resolvable above.
+    const plugins = await loadHeadlessPlugins(project);
 
-    const pkgExports = (
-        JSON.parse(readFileSync(resolve(PACKAGE_ROOT, "package.json"), "utf8")) as {
-            exports: Record<string, unknown>;
-        }
-    ).exports;
-    const enginePlugins = await Promise.all(
-        enabledNames.map((n) => resolveEnginePlugin(n, engine, SUBPATH_PLUGIN_MODULES, pkgExports)),
-    );
-    const localPlugins = await Promise.all(locals.map((l) => resolveLocalPlugin(l.name, l.path)));
-
-    const sceneXml = manifest.scene
-        ? readFileSync(join(projectDir, "public", manifest.scene), "utf8")
+    const sceneXml = project.manifest.scene
+        ? readFileSync(join(projectDir, "public", project.manifest.scene), "utf8")
         : undefined;
 
     const app = await engine.build({
-        plugins: [...enginePlugins, ...localPlugins],
+        plugins,
         defaults: false,
         scene: sceneXml,
-        capacity: manifest.capacity,
+        capacity: project.manifest.capacity,
         // the default loading screen (`standard/loading`) mounts a DOM overlay via
         // `document.createElement`; `installHeadlessDom`'s shim only implements what `InputSystem`/
         // `attachCanvas` read, not a real DOM, and a terminal command has no browser overlay to show

--- a/packages/shallot/bin/tui.ts
+++ b/packages/shallot/bin/tui.ts
@@ -598,20 +598,23 @@ export async function runTui(
         return planned.code;
     }
     const project = planned.plan;
+
+    const bunWebgpu = await importBunWebgpu(bunWebgpuLoader);
+    if (!bunWebgpu) {
+        console.error(noBunWebgpuMessage());
+        return EXIT_NO_BUN_WEBGPU;
+    }
+
     // Glaze composites the rendered scene to a swapchain — never applicable headless, so the host's
-    // headless set drops it unconditionally rather than leaving it to the manifest.
+    // headless set drops it unconditionally rather than leaving it to the manifest. The missing-peer
+    // refusal above stays first: a project that never asked for cells still hears about the absent
+    // bun-webgpu before a manifest complaint (the install gate's own precedence).
     const enabledNames = headlessEngineNames(project);
     if (!enabledNames.includes("Cells")) {
         console.error(
             `shallot tui: ${projectDir}/shallot.json does not enable "Cells" — add "Cells": true to its plugins`,
         );
         return EXIT_SETUP;
-    }
-
-    const bunWebgpu = await importBunWebgpu(bunWebgpuLoader);
-    if (!bunWebgpu) {
-        console.error(noBunWebgpuMessage());
-        return EXIT_NO_BUN_WEBGPU;
     }
 
     // Past this point the run is committed to the engine — register the TGSL transform (exactly once

--- a/packages/shallot/src/project/catalog.test.ts
+++ b/packages/shallot/src/project/catalog.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import * as shallot from "@dylanebert/shallot";
 import { DEFAULT_PLUGINS } from "@dylanebert/shallot";
 import * as avbd from "@dylanebert/shallot/avbd";
+import { SUBPATH_PLUGIN_LOADERS } from "./command";
 import { DEFAULT_PLUGIN_NAMES, KNOWN_ENGINE_PLUGINS, SUBPATH_PLUGIN_MODULES } from "./engine";
 
 // The manifest references an engine plugin by its `.name` (e.g. "Orbit"); the generated `virtual:project`
@@ -47,6 +48,15 @@ describe("engine plugin naming convention", () => {
             [...pluginExports(shallot), ...pluginExports(avbd)].map(([, p]) => p.name),
         );
         expect(KNOWN_ENGINE_PLUGINS).toEqual(real);
+    });
+
+    test("every subpath plugin the generator declares has a headless loader in the command entry", () => {
+        // the browser generator emits the subpath specifier; the command entry imports that same
+        // published module directly (rather than reading this package's export map at runtime). A
+        // backend plugin added to one and not the other would resolve in the browser and miss headless.
+        expect([...SUBPATH_PLUGIN_LOADERS].sort()).toEqual(
+            Object.keys(SUBPATH_PLUGIN_MODULES).sort(),
+        );
     });
 
     test("SUBPATH_PLUGIN_MODULES (the generator's dep-free list) names a real plugin on its declared subpath", () => {

--- a/packages/shallot/src/project/command.test.ts
+++ b/packages/shallot/src/project/command.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { EXIT_OK, EXIT_SETUP, loadLocalPlugins, planProject } from "./command";
+import { generateModuleFromPlan } from "./generate";
+import { readProject } from "./host";
+
+// The command entry is the one seam `bin/tui.ts` reaches a project through, so its arms run from a real
+// external project root (a temp dir outside this repo): a project root, its own `node_modules`, and
+// nothing of this package's private layout.
+
+function externalRoot(name: string): string {
+    return mkdtempSync(join(tmpdir(), `shallot-command-${name}-`));
+}
+
+/** a local plugin module whose evaluation is observable: it writes `sentinel` at import time, so a
+ *  plugin that must never load is proven not to have loaded rather than merely absent from a list. */
+function writeLocalPlugin(root: string, file: string, sentinel: string, name: string): void {
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(
+        join(root, "src", file),
+        [
+            `import { writeFileSync } from "node:fs";`,
+            `writeFileSync(${JSON.stringify(sentinel)}, "evaluated");`,
+            `export default { name: ${JSON.stringify(name)} };`,
+            "",
+        ].join("\n"),
+    );
+}
+
+describe("planProject", () => {
+    test("a dir holding neither a manifest nor a scene exits setup with the scaffold hint", () => {
+        const root = externalRoot("no-project");
+        const result = planProject(root);
+        expect(result.code).toBe(EXIT_SETUP);
+        expect(result.plan).toBeNull();
+        expect(result.errors.join("\n")).toContain("bun create shallot");
+    });
+
+    test("a manifest-only external root plans clean, exit 0", () => {
+        const root = externalRoot("manifest-only");
+        writeFileSync(join(root, "shallot.json"), JSON.stringify({ plugins: { Cells: true } }));
+        const result = planProject(root);
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.errors).toEqual([]);
+        expect(result.plan?.engine).toContain("Cells");
+    });
+
+    test("a scene-only external root plans clean, exit 0, with its scene discovered", () => {
+        const root = externalRoot("scene-only");
+        mkdirSync(join(root, "public"), { recursive: true });
+        writeFileSync(join(root, "public", "main.scene"), "");
+        const result = planProject(root);
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.plan?.scenes).toEqual([join("public", "main.scene")]);
+    });
+
+    test("an installed bare plugin beside a local one plans clean from the project root", () => {
+        const root = externalRoot("bare-plugin");
+        const dir = join(root, "node_modules", "bare-plugin");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "package.json"),
+            JSON.stringify({ name: "bare-plugin", version: "1.0.0", main: "index.js" }),
+        );
+        writeFileSync(join(dir, "index.js"), `export default { name: "Bare" };\n`);
+        writeLocalPlugin(root, "spin.ts", join(root, "spin.txt"), "Spin");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({ plugins: { Spin: "./src/spin", Bare: "bare-plugin" } }),
+        );
+        const result = planProject(root);
+        expect(result.code).toBe(EXIT_OK);
+        expect(result.plan?.locals.map((l) => l.name)).toEqual(["Spin", "Bare"]);
+    });
+
+    test("a missing dependency exits setup before any plugin module is evaluated", () => {
+        const root = externalRoot("missing-dep");
+        const sentinel = join(root, "evaluated.txt");
+        writeLocalPlugin(root, "spin.ts", sentinel, "Spin");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({ plugins: { Spin: "./src/spin", Gone: "not-installed" } }),
+        );
+        const result = planProject(root);
+        expect(result.code).toBe(EXIT_SETUP);
+        expect(result.plan).toBeNull();
+        expect(result.errors.join("\n")).toContain("not-installed");
+        // the sibling plugin resolves fine — validation runs to completion before any load, so nothing
+        // was imported and there is no half-loaded project to clean up.
+        expect(existsSync(sentinel)).toBe(false);
+    });
+});
+
+describe("loadLocalPlugins", () => {
+    test("an enabled local is evaluated; a disabled local is never evaluated", async () => {
+        const root = externalRoot("disabled");
+        const onSentinel = join(root, "on.txt");
+        const offSentinel = join(root, "off.txt");
+        writeLocalPlugin(root, "on.ts", onSentinel, "On");
+        writeLocalPlugin(root, "off.ts", offSentinel, "Off");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({ plugins: { On: "./src/on", Off: ["./src/off", false] } }),
+        );
+        const result = planProject(root);
+        expect(result.code).toBe(EXIT_OK);
+        if (!result.plan) throw new Error("no plan");
+        const plugins = await loadLocalPlugins(result.plan);
+        expect(plugins.map((p) => p.name)).toEqual(["On"]);
+        expect(existsSync(onSentinel)).toBe(true);
+        expect(existsSync(offSentinel)).toBe(false);
+    });
+
+    test("a module that default-exports no Plugin fails loud, naming its manifest key", async () => {
+        const root = externalRoot("bad-default");
+        mkdirSync(join(root, "src"), { recursive: true });
+        writeFileSync(join(root, "src", "nope.ts"), "export const notDefault = 1;\n");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({ plugins: { Nope: "./src/nope" } }),
+        );
+        const result = planProject(root);
+        expect(result.code).toBe(EXIT_OK);
+        if (!result.plan) throw new Error("no plan");
+        await expect(loadLocalPlugins(result.plan)).rejects.toThrow('"Nope"');
+    });
+});
+
+describe("one resolved plan, two consumers", () => {
+    test("the browser generator emits exactly the local modules the command loads", async () => {
+        const root = externalRoot("shared-plan");
+        writeLocalPlugin(root, "on.ts", join(root, "on.txt"), "On");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({ plugins: { Cells: true, On: "./src/on", Off: ["./src/off", false] } }),
+        );
+        // one plan object, handed to both consumers — the plan identity the A1 row names.
+        const plan = readProject(root);
+        const emitted = generateModuleFromPlan(plan);
+        const loaded = await loadLocalPlugins(plan);
+
+        expect(loaded.map((p) => p.name)).toEqual(["On"]);
+        expect(plan.locals.length).toBe(1);
+        for (const local of plan.locals) expect(emitted).toContain(JSON.stringify(local.path));
+        // the disabled plugin reaches neither consumer: it is imported by neither (the manifest text
+        // itself still rides the module as data, which is why the assertion reads the import lines)
+        const imports = emitted.split("\n").filter((line) => line.startsWith("import "));
+        expect(imports.filter((line) => line.includes("/src/off"))).toEqual([]);
+        expect(imports.filter((line) => line.startsWith("import _l")).length).toBe(1);
+        // and the engine half agrees: every planned engine plugin is imported by name. Glaze rides the
+        // browser module (it composites the swapchain) and is dropped only for a headless run.
+        for (const name of plan.engine) expect(emitted).toContain(`${name}Plugin`);
+        expect(emitted).toContain("GlazePlugin");
+    });
+});
+
+// The purity claim of the A1 row: the command entry loads in a bare `bun` process with no Vite in its
+// loaded module graph and no browser/GPU global installed. `require.cache` is the observable — Bun
+// records every loaded dependency there — and the control below imports `bin/toolchain.ts`, which really
+// does import Vite, so a reader that could never see Vite fails that arm instead of passing this one
+// vacuously.
+const ENTRY = resolve(import.meta.dir, "command.ts");
+const TOOLCHAIN = resolve(import.meta.dir, "../../bin/toolchain.ts");
+const BROWSER_GLOBALS = [
+    "document",
+    "window",
+    "ResizeObserver",
+    "HTMLCanvasElement",
+    "GPUBufferUsage",
+    "GPUShaderStage",
+    "GPUMapMode",
+    "GPUTextureUsage",
+];
+
+function importInBareBun(entry: string): { vite: string[]; globals: string[]; modules: number } {
+    const script = [
+        `await import(${JSON.stringify(entry)});`,
+        `const loaded = Object.keys(require.cache);`,
+        `const vite = loaded.filter((m) => /(^|\\/)(vite|rollup|esbuild)([\\/@]|$)/.test(m));`,
+        `const globals = ${JSON.stringify(BROWSER_GLOBALS)}.filter((k) => k in globalThis);`,
+        `console.log(JSON.stringify({ vite, globals, modules: loaded.length }));`,
+    ].join("\n");
+    const run = spawnSync("bun", ["-e", script], { encoding: "utf8", timeout: 60_000 });
+    if (run.status !== 0) throw new Error(`bare bun import failed: ${run.stderr}`);
+    return JSON.parse(run.stdout.trim().split("\n").at(-1) ?? "{}");
+}
+
+describe("the pure entry in a bare bun process", () => {
+    test("importing the command entry pulls in no Vite module and installs no browser/GPU global", () => {
+        const subject = importInBareBun(ENTRY);
+        expect(subject.vite).toEqual([]);
+        expect(subject.globals).toEqual([]);
+        expect(subject.modules).toBeGreaterThan(0);
+    });
+
+    test("control: the Vite-importing toolchain does load Vite through the same reader", () => {
+        expect(importInBareBun(TOOLCHAIN).vite.length).toBeGreaterThan(0);
+    });
+});

--- a/packages/shallot/src/project/command.ts
+++ b/packages/shallot/src/project/command.ts
@@ -1,0 +1,138 @@
+// The command half of the project host: a project directory in, an exit code and (on success) one
+// resolved plan out, plus the loaders that turn that plan's names into real Plugin objects. This is the
+// single module the package's own tooling (`bin/tui.ts`, `bin/toolchain.ts`) reaches the project through
+// — it exists so a command never repeats resolution, never reads this package's `exports` map and never
+// deep-imports engine source to find a plugin.
+//
+// Two properties this module owes, both gated in `command.test.ts`:
+//   1. **Pure to import.** No Vite, no browser API, no GPU global enters the module graph when this file
+//      is imported in a bare `bun` process. Every engine reach below is a lazy `import()` inside a
+//      function, because importing the barrel evaluates GPU-touching module code.
+//   2. **Nothing loads before validation passes.** `planProject` resolves and validates; only then may a
+//      caller run `loadLocalPlugins`/`loadEnginePlugins`. A missing or invalid dependency exits with a
+//      code and no module of the project has been evaluated, so there is nothing to clean up.
+//
+// Presentation stays with the tool: this module says which plugins a headless run enables
+// (`headlessEngineNames`, Glaze dropped — it composites a swapchain no headless run owns) and never
+// touches a terminal, canvas, encoder or frame loop.
+
+import type { Plugin } from "../engine";
+import { SUBPATH_PLUGIN_MODULES } from "./engine";
+import {
+    headlessEngineNames,
+    isProject,
+    localModuleErrors,
+    missingProjectMessage,
+    type ProjectIo,
+    type ProjectPlan,
+    readProject,
+} from "./host";
+
+export {
+    discoverScenes,
+    emptyPlan,
+    headlessEngineNames,
+    isProject,
+    localModuleErrors,
+    missingProjectMessage,
+    type PlannedLocal,
+    type ProjectPlan,
+    readProject,
+} from "./host";
+
+// exit codes: 0 and the setup code every sibling command already uses for "bad input, never reached the
+// real work" (`bin/tui.ts`'s EXIT_SETUP, `bin/verify.ts`'s own numbering).
+export const EXIT_OK = 0;
+export const EXIT_SETUP = 2;
+
+/** the outcome of planning one project directory: an exit code the caller returns, the plan when there
+ *  is one, and the diagnostics to print. `plan` is null exactly when `code` is non-zero. */
+export interface ProjectCommand {
+    readonly code: number;
+    readonly plan: ProjectPlan | null;
+    readonly errors: readonly string[];
+}
+
+/**
+ * plan a project directory for a command: discovery (is this a project at all), resolution (its manifest,
+ * scenes and plugin set) and dependency validation (every enabled local plugin resolves from the project
+ * root), in that order, with no module of the project evaluated. Returns an exit code rather than
+ * exiting, so the command entry composes.
+ */
+export function planProject(dir: string, io?: ProjectIo): ProjectCommand {
+    if (!isProject(dir))
+        return { code: EXIT_SETUP, plan: null, errors: missingProjectMessage(dir) };
+    const plan = readProject(dir, io);
+    const errors = localModuleErrors(plan);
+    if (errors.length > 0) return { code: EXIT_SETUP, plan: null, errors };
+    return { code: EXIT_OK, plan, errors: [] };
+}
+
+/** the engine plugins that ship on their own subpath rather than the main barrel, as lazy literal
+ *  imports of the modules the export map publishes for them (`./avbd`) — resolved here rather than by
+ *  reading this package's `exports` map at runtime. `catalog.test.ts` gates the keys against
+ *  `SUBPATH_PLUGIN_MODULES`, so a new backend plugin cannot land on only one of the two. */
+const SUBPATH_PLUGIN_IMPORTERS: Record<string, () => Promise<Record<string, unknown>>> = {
+    Avbd: () => import("../standard/avbd/index"),
+};
+
+/** the subpath-plugin names this module can load — the catalog gate's other side. */
+export const SUBPATH_PLUGIN_LOADERS: readonly string[] = Object.keys(SUBPATH_PLUGIN_IMPORTERS);
+
+/**
+ * resolve engine plugin names to real Plugin objects: the main barrel first (every default and most
+ * extras), then a backend plugin's own published subpath module. Throws naming the plugin rather than
+ * handing back a silent `undefined`. Lazy by construction — the barrel evaluates GPU-touching module
+ * code, so it is imported here, at call time, never at module scope.
+ */
+export async function loadEnginePlugins(names: readonly string[]): Promise<Plugin[]> {
+    const barrel = (await import("../index")) as unknown as Record<string, unknown>;
+    const plugins: Plugin[] = [];
+    for (const name of names) {
+        const direct = barrel[`${name}Plugin`];
+        if (direct) {
+            plugins.push(direct as Plugin);
+            continue;
+        }
+        const importer = SUBPATH_PLUGIN_IMPORTERS[name];
+        const subpath = importer ? ((await importer()) as Record<string, unknown>) : null;
+        const plugin = subpath?.[`${name}Plugin`];
+        if (!plugin) {
+            throw new Error(
+                `shallot.json enables unknown engine plugin "${name}" (no export named "${name}Plugin"${
+                    SUBPATH_PLUGIN_MODULES[name] ? ` on ${SUBPATH_PLUGIN_MODULES[name]}` : ""
+                })`,
+            );
+        }
+        plugins.push(plugin as Plugin);
+    }
+    return plugins;
+}
+
+/**
+ * import a plan's enabled local plugins, in manifest order. Each module's **default export** is the
+ * Plugin — the same runtime contract the generated browser module enforces — and a module that resolved
+ * but default-exports something else fails loud, naming the manifest key. A disabled plugin is not in
+ * the plan, so it is never imported and its module code never runs.
+ */
+export async function loadLocalPlugins(plan: ProjectPlan): Promise<Plugin[]> {
+    const plugins: Plugin[] = [];
+    for (const local of plan.locals) {
+        const mod = (await import(local.path)) as { default?: Plugin };
+        const plugin = mod.default;
+        if (!plugin || typeof plugin.name !== "string") {
+            throw new Error(
+                `shallot.json plugin "${local.name}": its module must default-export a Plugin`,
+            );
+        }
+        plugins.push(plugin);
+    }
+    return plugins;
+}
+
+/** the plugins a headless command runs: the plan's engine set minus Glaze, then its locals. One call so
+ *  a tool never re-derives the headless set or the load order. */
+export async function loadHeadlessPlugins(plan: ProjectPlan): Promise<Plugin[]> {
+    const engine = await loadEnginePlugins(headlessEngineNames(plan));
+    return [...engine, ...(await loadLocalPlugins(plan))];
+}

--- a/packages/shallot/src/project/generate.test.ts
+++ b/packages/shallot/src/project/generate.test.ts
@@ -1,40 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { generateModule, plan } from "./generate";
+import { generateModule } from "./generate";
 import type { Manifest } from "./manifest";
 
+// `plan` moved to the project host (`host.ts`) with the A1 seam — its own arms live in `host.test.ts`.
+// What stays here is the emission half: a plan (however it was produced) becoming module source.
+
 const DIR = "/proj";
-
-describe("plan", () => {
-    test("an empty manifest enables every default, no locals", () => {
-        const { engine, locals } = plan({}, DIR);
-        expect(engine).toEqual(["Slab", "Transforms", "Input", "Render", "Part", "Sear", "Glaze"]);
-        expect(locals).toEqual([]);
-    });
-
-    test("a disabled default drops out; an enabled extra joins the engine set", () => {
-        const { engine } = plan({ plugins: { Glaze: false, Orbit: true } }, DIR);
-        expect(engine).toContain("Orbit");
-        expect(engine).not.toContain("Glaze");
-    });
-
-    test("a local specifier resolves project-relative → project-absolute", () => {
-        const { locals } = plan({ plugins: { Spin: "./src/spin" } }, DIR);
-        expect(locals).toEqual([{ name: "Spin", path: "/proj/src/spin" }]);
-    });
-
-    test("a disabled local is not imported; a bare package passes through", () => {
-        const { locals } = plan({ plugins: { Off: ["./src/off", false], Pkg: "@scope/foo" } }, DIR);
-        expect(locals).toEqual([{ name: "Pkg", path: "@scope/foo" }]);
-    });
-
-    test("an arbitrary engine plugin (true, not a default) joins the engine set by name", () => {
-        // the generator trusts any `true` name as an engine plugin — no catalog gate, since it runs
-        // headless (no plugin objects to check against). Where it imports FROM (barrel vs. a
-        // backend plugin's own subpath) is generateModule's concern, not plan's — see below.
-        const { engine } = plan({ plugins: { Foo: true } }, DIR);
-        expect(engine).toContain("Foo");
-    });
-});
 
 describe("generateModule", () => {
     test("emits a lean named barrel import for enabled engine plugins", () => {

--- a/packages/shallot/src/project/generate.ts
+++ b/packages/shallot/src/project/generate.ts
@@ -1,6 +1,6 @@
-import { join } from "node:path";
-import { DEFAULT_PLUGIN_NAMES, SUBPATH_PLUGIN_MODULES } from "./engine";
-import { localOf, type Manifest } from "./manifest";
+import { SUBPATH_PLUGIN_MODULES } from "./engine";
+import { type ProjectPlan, plan } from "./host";
+import type { Manifest } from "./manifest";
 
 // Generates the `virtual:project` module source from a `shallot.json` manifest — the one place a manifest
 // becomes static imports. Pure over (manifest, absDir, scenes), so `generate.test.ts` pins the emitted
@@ -19,41 +19,10 @@ function engineSource(name: string): string {
     return SUBPATH_PLUGIN_MODULES[name] ?? ENGINE;
 }
 
-// a local specifier resolved for the generated module: project-relative → project-absolute (the virtual
-// module resolves against the host root, not the project), a bare package or absolute path → passed through.
-function localPath(spec: string, absDir: string): string {
-    return spec.startsWith(".") ? join(absDir, spec) : spec;
-}
-
-interface Plan {
-    /** engine plugin names to import as `{ ${name}Plugin }` from the barrel (enabled defaults + extras) */
-    readonly engine: string[];
-    /** enabled local plugins, by name + resolved import path */
-    readonly locals: { name: string; path: string }[];
-}
-
-/** classify a manifest into the engine + local plugins to statically import. */
-export function plan(manifest: Manifest, absDir: string | null): Plan {
-    const plugins = manifest.plugins ?? {};
-    const defaults = new Set<string>(DEFAULT_PLUGIN_NAMES);
-    const engine: string[] = [];
-    const locals: Plan["locals"] = [];
-
-    // every default is enabled unless explicitly turned off
-    for (const name of DEFAULT_PLUGIN_NAMES) {
-        if (plugins[name] !== false) engine.push(name);
-    }
-    // then the declared entries: an engine extra (true), or a local (a specifier). defaults already handled.
-    for (const [name, value] of Object.entries(plugins)) {
-        if (defaults.has(name)) continue;
-        if (value === true) engine.push(name);
-        else {
-            const local = localOf(value);
-            if (local?.enabled) locals.push({ name, path: localPath(local.spec, absDir ?? "") });
-        }
-    }
-    return { engine, locals };
-}
+// Planning itself lives in `host.ts` — the browser generator and the terminal command consume the same
+// resolved plan, so a manifest classifies once. Re-exported here because the CLI's feature reader
+// already imports `plan` through this module.
+export { plan };
 
 /**
  * build the `virtual:project` module source for a project dir with a (possibly empty) manifest. The
@@ -61,7 +30,13 @@ export function plan(manifest: Manifest, absDir: string | null): Plan {
  * edit, which the page reload cleans up (dev and a production build agree).
  */
 export function generateModule(manifest: Manifest, dir: string | null, scenes: string[]): string {
-    const { engine, locals } = plan(manifest, dir);
+    return generateModuleFromPlan({ dir, manifest, scenes, ...plan(manifest, dir) });
+}
+
+/** the same module source, built from an already-resolved {@link ProjectPlan} — the shape both consumers
+ *  share, so the terminal command and this generator provably run the same plugin set. */
+export function generateModuleFromPlan(project: ProjectPlan): string {
+    const { dir, manifest, scenes, engine, locals } = project;
     const idents = engine.map((n) => `${n}Plugin`);
     const lines: string[] = [];
 

--- a/packages/shallot/src/project/host.test.ts
+++ b/packages/shallot/src/project/host.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    discoverScenes,
+    headlessEngineNames,
+    isProject,
+    localModuleErrors,
+    missingProjectMessage,
+    plan,
+    readProject,
+} from "./host";
+
+const DIR = "/proj";
+
+/** an external project root: a temp dir outside this repo, the shape a real installed consumer has. */
+function externalRoot(name: string): string {
+    return mkdtempSync(join(tmpdir(), `shallot-host-${name}-`));
+}
+
+/** an installed bare plugin — a real `node_modules/<name>` package the project root resolves. */
+function installBarePlugin(root: string, name: string): void {
+    const dir = join(root, "node_modules", name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+        join(dir, "package.json"),
+        JSON.stringify({ name, version: "1.0.0", main: "index.js" }),
+    );
+    writeFileSync(join(dir, "index.js"), `export default { name: ${JSON.stringify(name)} };\n`);
+}
+
+describe("plan", () => {
+    test("an empty manifest enables every default, no locals, nothing disabled", () => {
+        const { engine, locals, disabled } = plan({}, DIR);
+        expect(engine).toEqual(["Slab", "Transforms", "Input", "Render", "Part", "Sear", "Glaze"]);
+        expect(locals).toEqual([]);
+        expect(disabled).toEqual([]);
+    });
+
+    test("a disabled default drops out and is recorded; an enabled extra joins the engine set", () => {
+        const { engine, disabled } = plan({ plugins: { Glaze: false, Orbit: true } }, DIR);
+        expect(engine).toContain("Orbit");
+        expect(engine).not.toContain("Glaze");
+        expect(disabled).toEqual(["Glaze"]);
+    });
+
+    test("a local specifier keeps its authored spec and resolves project-relative → absolute", () => {
+        const { locals } = plan({ plugins: { Spin: "./src/spin" } }, DIR);
+        expect(locals).toEqual([{ name: "Spin", spec: "./src/spin", path: "/proj/src/spin" }]);
+    });
+
+    test("a disabled local is not planned but is recorded; a bare specifier passes through", () => {
+        const { locals, disabled } = plan(
+            { plugins: { Off: ["./src/off", false], Pkg: "@scope/foo" } },
+            DIR,
+        );
+        expect(locals).toEqual([{ name: "Pkg", spec: "@scope/foo", path: "@scope/foo" }]);
+        expect(disabled).toEqual(["Off"]);
+    });
+
+    test("an arbitrary engine plugin (true, not a default) joins the engine set by name", () => {
+        // the host trusts any `true` name as an engine plugin — no catalog gate, since it classifies
+        // headless with no plugin objects to check against (`assets.ts`'s manifest warning is the
+        // reader that names an unknown one).
+        expect(plan({ plugins: { Foo: true } }, DIR).engine).toContain("Foo");
+    });
+});
+
+describe("headlessEngineNames", () => {
+    test("drops Glaze (no swapchain headless) and keeps every other enabled engine plugin", () => {
+        const names = headlessEngineNames(plan({ plugins: { Cells: true } }, DIR));
+        expect(names).not.toContain("Glaze");
+        expect(names).toContain("Cells");
+        expect(names).toContain("Render");
+    });
+
+    test("a manifest that already disabled Glaze gets the same set (the drop is unconditional)", () => {
+        const names = headlessEngineNames(plan({ plugins: { Glaze: false, Cells: true } }, DIR));
+        expect(names).toEqual(["Slab", "Transforms", "Input", "Render", "Part", "Sear", "Cells"]);
+    });
+});
+
+describe("isProject / missingProjectMessage", () => {
+    test("a manifest project, a scene-only project and neither", () => {
+        const manifestOnly = externalRoot("manifest-only");
+        writeFileSync(join(manifestOnly, "shallot.json"), "{}\n");
+        expect(isProject(manifestOnly)).toBe(true);
+
+        const sceneOnly = externalRoot("scene-only");
+        mkdirSync(join(sceneOnly, "scenes"));
+        writeFileSync(join(sceneOnly, "scenes", "main.scene"), "");
+        expect(isProject(sceneOnly)).toBe(true);
+
+        expect(isProject(externalRoot("empty"))).toBe(false);
+    });
+
+    test("the missing-project diagnostic names the dir and the scaffold command", () => {
+        const lines = missingProjectMessage("/nope").join("\n");
+        expect(lines).toContain("/nope");
+        expect(lines).toContain("bun create shallot");
+    });
+});
+
+describe("readProject", () => {
+    test("a manifest-only external root: manifest, no scenes, resolved locals", () => {
+        const root = externalRoot("read-manifest");
+        installBarePlugin(root, "bare-plugin");
+        mkdirSync(join(root, "src"));
+        writeFileSync(join(root, "src", "spin.ts"), "export default { name: 'Spin' };\n");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({ plugins: { Cells: true, Spin: "./src/spin", Bare: "bare-plugin" } }),
+        );
+        const project = readProject(root);
+        expect(project.dir).toBe(root);
+        expect(project.scenes).toEqual([]);
+        expect(project.engine).toContain("Cells");
+        expect(project.locals.map((l) => l.name)).toEqual(["Spin", "Bare"]);
+        expect(project.locals[0].path).toBe(join(root, "src/spin"));
+        expect(project.locals[1].path).toBe("bare-plugin");
+    });
+
+    test("a scene-only external root: empty manifest, discovered scenes, default engine set", () => {
+        const root = externalRoot("read-scene");
+        mkdirSync(join(root, "public", "scenes"), { recursive: true });
+        writeFileSync(join(root, "public", "scenes", "main.scene"), "");
+        const project = readProject(root);
+        expect(project.manifest).toEqual({});
+        expect(project.scenes).toEqual([join("public", "scenes", "main.scene")]);
+        expect(project.engine).toContain("Render");
+        expect(project.locals).toEqual([]);
+    });
+
+    test("reads the project's own manifest only — never a planted private engine file", () => {
+        // the seam takes a project root and nothing else: a private export target planted beside a
+        // pretend installed engine must never enter its read set (the export-map read the TUI used to
+        // do). The read set is pinned exactly, so a new read of any private path reds here.
+        const root = externalRoot("read-set");
+        writeFileSync(join(root, "shallot.json"), JSON.stringify({ plugins: { Cells: true } }));
+        const engineRoot = externalRoot("planted-engine");
+        mkdirSync(join(engineRoot, "src", "project"), { recursive: true });
+        writeFileSync(join(engineRoot, "src", "project", "planted.ts"), "export const p = 1;\n");
+        writeFileSync(
+            join(engineRoot, "package.json"),
+            JSON.stringify({ exports: { "./planted": "./src/project/planted.ts" } }),
+        );
+
+        const reads: string[] = [];
+        const scanned: string[] = [];
+        readProject(root, {
+            readFile(path) {
+                reads.push(path);
+                return readFileSync(path, "utf8");
+            },
+            discoverScenes(dir) {
+                scanned.push(dir);
+                return discoverScenes(dir);
+            },
+        });
+        expect(reads).toEqual([join(root, "shallot.json")]);
+        expect(scanned).toEqual([root]);
+        expect(reads.concat(scanned).some((p) => p.startsWith(engineRoot))).toBe(false);
+    });
+});
+
+describe("localModuleErrors", () => {
+    test("an installed bare plugin and a present relative plugin both resolve", () => {
+        const root = externalRoot("deps-ok");
+        installBarePlugin(root, "bare-plugin");
+        mkdirSync(join(root, "src"));
+        writeFileSync(join(root, "src", "spin.ts"), "export default { name: 'Spin' };\n");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({ plugins: { Spin: "./src/spin", Bare: "bare-plugin" } }),
+        );
+        expect(localModuleErrors(readProject(root))).toEqual([]);
+    });
+
+    test("a missing bare dependency and a missing relative file each name their manifest key", () => {
+        const root = externalRoot("deps-missing");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({ plugins: { Gone: "not-installed", Spin: "./src/spin" } }),
+        );
+        const errors = localModuleErrors(readProject(root));
+        expect(errors.length).toBe(2);
+        expect(errors[0]).toContain('"Gone"');
+        expect(errors[0]).toContain("not-installed");
+        expect(errors[1]).toContain('"Spin"');
+    });
+
+    test("a disabled plugin's missing module is not a dependency error (it is never loaded)", () => {
+        const root = externalRoot("deps-disabled");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({ plugins: { Gone: ["not-installed", false] } }),
+        );
+        expect(localModuleErrors(readProject(root))).toEqual([]);
+    });
+});

--- a/packages/shallot/src/project/host.ts
+++ b/packages/shallot/src/project/host.ts
@@ -1,0 +1,203 @@
+// The project host: plan, discovery and resolution for a project directory, as pure data. One module
+// answers "what is this project, and which plugins does it enable" for both consumers — the browser
+// generator (`generate.ts` → `virtual:project`, through `vite.ts`) and the terminal command
+// (`command.ts` → `bin/tui.ts`) — so the two cannot drift in how a manifest becomes a plugin set.
+//
+// Nothing here imports Vite, a browser API or a GPU global, and nothing here loads a plugin module: a
+// plan is data the caller may inspect, log or refuse before any module evaluation happens
+// (`command.ts` owns the loading half and runs it only after `localModuleErrors` is empty). That split
+// is what lets a dependency mistake fail with an exit code instead of a half-imported project.
+//
+// Presentation is deliberately absent: the host names the enabled plugins and, for a headless run, says
+// which of them a terminal presentation must drop (`headlessEngineNames` — Glaze composites a swapchain
+// that does not exist headless). Terminal canvas/input/readback/encoding stay in `bin/tui.ts`.
+
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { manifestPath, readManifest } from "./assets";
+import { DEFAULT_PLUGIN_NAMES } from "./engine";
+import { localOf, type Manifest, normalize } from "./manifest";
+
+/** one enabled local/external plugin: its manifest key, the specifier as authored, and the module the
+ *  generator emits / the command imports — a project-relative spec absolutized against the project dir,
+ *  a bare package or absolute path passed through (the project root's own resolver owns those). */
+export interface PlannedLocal {
+    readonly name: string;
+    readonly spec: string;
+    readonly path: string;
+}
+
+/** a project directory reduced to what both consumers need: its manifest, its scenes, and the plugin
+ *  set the manifest enables. `dir` is null only for the host's own no-project fallback. */
+export interface ProjectPlan {
+    readonly dir: string | null;
+    readonly manifest: Manifest;
+    readonly scenes: readonly string[];
+    /** engine plugin names to resolve as `${name}Plugin` (enabled defaults + declared extras) */
+    readonly engine: readonly string[];
+    readonly locals: readonly PlannedLocal[];
+    /** manifest keys explicitly turned off — never resolved, never imported; kept so a caller can say so */
+    readonly disabled: readonly string[];
+}
+
+/** the reads a plan is allowed to make, injectable so a test can pin the read set (the seam takes a
+ *  project root and reads inside it — never this package's own layout or export map). */
+export interface ProjectIo {
+    /** the file's text, or null when it does not exist (a scene-only project has no manifest) */
+    readFile(path: string): string | null;
+    discoverScenes(dir: string): string[];
+}
+
+// a local specifier resolved for its consumers: project-relative → project-absolute (the generated
+// virtual module resolves against the host root, not the project), a bare package or absolute path
+// passed through.
+function localPath(spec: string, absDir: string): string {
+    return spec.startsWith(".") ? join(absDir, spec) : spec;
+}
+
+/** classify a manifest into the engine plugins, local plugins and explicitly disabled keys. */
+export function plan(
+    manifest: Manifest,
+    absDir: string | null,
+): { engine: string[]; locals: PlannedLocal[]; disabled: string[] } {
+    const plugins = manifest.plugins ?? {};
+    const defaults = new Set<string>(DEFAULT_PLUGIN_NAMES);
+    const engine: string[] = [];
+    const locals: PlannedLocal[] = [];
+    const disabled: string[] = [];
+
+    // every default is enabled unless explicitly turned off
+    for (const name of DEFAULT_PLUGIN_NAMES) {
+        if (plugins[name] !== false) engine.push(name);
+        else disabled.push(name);
+    }
+    // then the declared entries: an engine extra (true), or a local (a specifier). defaults already handled.
+    for (const [name, value] of Object.entries(plugins)) {
+        if (defaults.has(name)) continue;
+        if (value === true) engine.push(name);
+        else if (value === false) disabled.push(name);
+        else {
+            const local = localOf(value);
+            if (!local) continue;
+            if (local.enabled)
+                locals.push({ name, spec: local.spec, path: localPath(local.spec, absDir ?? "") });
+            else disabled.push(name);
+        }
+    }
+    return { engine, locals, disabled };
+}
+
+/** the engine plugins a headless presentation runs: the plan's set minus Glaze, which composites the
+ *  rendered scene onto a swapchain no headless run owns. Unconditional, not a manifest toggle — a
+ *  terminal run has no swapchain to disable it against. */
+export function headlessEngineNames(plan: Pick<ProjectPlan, "engine">): string[] {
+    return plan.engine.filter((name) => name !== "Glaze");
+}
+
+/** every `.scene` under `dir`, project-relative and sorted. */
+export function discoverScenes(dir: string): string[] {
+    const scenes: string[] = [];
+    // per-directory try/catch, not one around the whole walk: an unreadable subtree (permissions, a
+    // broken symlink) used to throw out of the recursive `walk`, which the outer catch swallowed —
+    // silently truncating every sibling not yet visited at every ancestor level, not just the bad
+    // subtree, with no warning that the scene list was incomplete.
+    function walk(current: string) {
+        let entries: string[];
+        try {
+            entries = readdirSync(current);
+        } catch (e) {
+            console.warn(`  ! scene discovery: skipping unreadable directory "${current}": ${e}`);
+            return;
+        }
+        for (const entry of entries) {
+            if (entry === "node_modules" || entry === "dist") continue;
+            const full = join(current, entry);
+            let isDirectory: boolean;
+            try {
+                isDirectory = statSync(full).isDirectory();
+            } catch (e) {
+                console.warn(`  ! scene discovery: skipping unreadable entry "${full}": ${e}`);
+                continue;
+            }
+            if (isDirectory) walk(full);
+            else if (entry.endsWith(".scene")) scenes.push(relative(dir, full));
+        }
+    }
+    walk(dir);
+    return scenes.sort();
+}
+
+/** dir holds a shallot project — a shallot.json manifest or a .scene file. */
+export function isProject(dir: string): boolean {
+    return existsSync(manifestPath(dir)) || discoverScenes(dir).length > 0;
+}
+
+/** the diagnostic for a directory that is no project — one message, printed by every command that
+ *  needs one (`bin/toolchain.ts`'s `requireProject`, the terminal command's setup exit). */
+export function missingProjectMessage(dir: string): string[] {
+    return [
+        `\n  ✗ No shallot project found at ${dir}`,
+        "    Expected a shallot.json manifest or a .scene file\n",
+        "    To create a project:",
+        "      bun create shallot my-game",
+        "      cd my-game && bun install",
+        "      bunx shallot dev\n",
+    ];
+}
+
+const REAL_IO: ProjectIo = {
+    readFile(path) {
+        try {
+            return readFileSync(path, "utf-8");
+        } catch {
+            return null;
+        }
+    },
+    discoverScenes,
+};
+
+/** read a project directory into a plan: its manifest (absent → a scene-only project's empty one), its
+ *  scenes, and the classified plugin set. Reads only inside `dir`. */
+export function readProject(dir: string, io: ProjectIo = REAL_IO): ProjectPlan {
+    // the real path goes through `readManifest`, which also emits the manifest-boundary warnings; an
+    // injected io (a test pinning the read set) parses the same text through the same `normalize`.
+    const manifest = io === REAL_IO ? readManifest(dir) : normalize(io.readFile(manifestPath(dir)));
+    const scenes = io.discoverScenes(dir);
+    return { dir, manifest, scenes, ...plan(manifest, dir) };
+}
+
+/** the plan for no project at all — the generator's empty-manifest fallback (`projectPlugin()` with no
+ *  dir), kept here so "no project" is one shape rather than an inline literal per consumer. */
+export function emptyPlan(): ProjectPlan {
+    return { dir: null, manifest: {}, scenes: [], ...plan({}, null) };
+}
+
+/** resolve a module specifier from the project root, or null when nothing resolves. */
+function resolveFromProject(spec: string, dir: string): string | null {
+    try {
+        return Bun.resolveSync(spec, dir);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * the dependency errors of a plan: every enabled local plugin whose module does not resolve from the
+ * project root — a missing install (`bare-plugin` never installed) or a missing file. Pure and
+ * side-effect free: the caller refuses with an exit code before anything is imported, which is what
+ * keeps a bad manifest from leaving a half-loaded project behind. A disabled plugin is never resolved.
+ */
+export function localModuleErrors(
+    project: ProjectPlan,
+    resolver: (spec: string, dir: string) => string | null = resolveFromProject,
+): string[] {
+    if (!project.dir) return [];
+    const errors: string[] = [];
+    for (const local of project.locals) {
+        if (resolver(local.path, project.dir)) continue;
+        errors.push(
+            `shallot.json plugin "${local.name}": cannot resolve its module "${local.spec}" from ${project.dir}`,
+        );
+    }
+    return errors;
+}

--- a/packages/shallot/src/project/vite.ts
+++ b/packages/shallot/src/project/vite.ts
@@ -1,14 +1,18 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { dirname, isAbsolute, join, relative, resolve } from "path";
 import typegpu from "unplugin-typegpu/vite";
 import type { Plugin, Rollup, ViteDevServer } from "vite";
-import { contentType, manifestPath, readManifest, resolveAssetPath } from "./assets";
-import { generateModule } from "./generate";
+import { contentType, manifestPath, resolveAssetPath } from "./assets";
+import { generateModuleFromPlan } from "./generate";
+import { emptyPlan, readProject } from "./host";
 
 // the manifest descriptor half of `assets.ts` is part of this subpath's published surface — the CLI
 // (`bin/build.ts`, `bin/features.ts`, `bin/toolchain.ts`) and consumers already resolve both through
 // `@dylanebert/shallot/vite`. The readers beside them stay internal to `src/project/`.
 export { manifestPath, manifestWarnings } from "./assets";
+// scene discovery is the project host's (`host.ts`) — re-exported here because the CLI and consumers
+// already resolve it through `@dylanebert/shallot/vite`.
+export { discoverScenes } from "./host";
 
 /**
  * cross-origin isolation headers, applied by every serve surface (`shallot dev`, `shallot run`'s preview,
@@ -40,38 +44,6 @@ export const CROSS_ORIGIN_ISOLATION = {
  */
 export function typegpuPlugin(): Plugin {
     return typegpu() as unknown as Plugin;
-}
-
-export function discoverScenes(dir: string): string[] {
-    const scenes: string[] = [];
-    // per-directory try/catch, not one around the whole walk: an unreadable subtree (permissions, a
-    // broken symlink) used to throw out of the recursive `walk`, which the outer catch swallowed —
-    // silently truncating every sibling not yet visited at every ancestor level, not just the bad
-    // subtree, with no warning that the scene list was incomplete.
-    function walk(current: string) {
-        let entries: string[];
-        try {
-            entries = readdirSync(current);
-        } catch (e) {
-            console.warn(`  ! scene discovery: skipping unreadable directory "${current}": ${e}`);
-            return;
-        }
-        for (const entry of entries) {
-            if (entry === "node_modules" || entry === "dist") continue;
-            const full = join(current, entry);
-            let isDirectory: boolean;
-            try {
-                isDirectory = statSync(full).isDirectory();
-            } catch (e) {
-                console.warn(`  ! scene discovery: skipping unreadable entry "${full}": ${e}`);
-                continue;
-            }
-            if (isDirectory) walk(full);
-            else if (entry.endsWith(".scene")) scenes.push(relative(dir, full));
-        }
-    }
-    walk(dir);
-    return scenes.sort();
 }
 
 export function findPublicDirs(projectDir: string): string[] {
@@ -217,9 +189,10 @@ export function projectPlugin(projectDir?: string): Plugin {
         // enabled plugin (engine via the barrel, locals via their specifier) + the scene + manifest.
         load(id) {
             if (id !== resolvedId) return;
-            if (!projectDir) return generateModule({}, null, []);
-            const absDir = resolve(projectDir);
-            return generateModule(readManifest(absDir), absDir, discoverScenes(absDir));
+            if (!projectDir) return generateModuleFromPlan(emptyPlan());
+            // one resolved plan, the same shape `bin/tui.ts` runs (src/project/command.ts) — the
+            // browser module and the terminal command classify a manifest exactly once.
+            return generateModuleFromPlan(readProject(resolve(projectDir)));
         },
         configureServer(server) {
             viteServer = server;

--- a/packages/shallot/tests/cli-coverage.ts
+++ b/packages/shallot/tests/cli-coverage.ts
@@ -545,10 +545,38 @@ export const CLI_COVERAGE: readonly CoverageRow[] = [
             "wrong entry there would break that equality).",
     },
     {
+        file: "packages/shallot/src/project/host.ts",
+        arm: "unit",
+        reason:
+            "the A1 project host: plan/discovery/resolution as pure data. Every export is directly " +
+            "asserted by host.test.ts from a real external project root (a temp dir with its own " +
+            "node_modules) — plan's default/extra/local/disabled classification and its authored-spec " +
+            "plus resolved-path pair, headlessEngineNames' unconditional Glaze drop, discoverScenes and " +
+            "isProject over manifest-only/scene-only/neither roots, missingProjectMessage's dir + " +
+            "scaffold command, readProject's manifest/scene/local resolution and its pinned read set " +
+            "(no path outside the project root), localModuleErrors' installed-bare and relative grants " +
+            "plus its missing-module and never-resolve-a-disabled-plugin refusals. emptyPlan is the " +
+            "no-project fallback vite.test.ts drives through projectPlugin()'s load hook.",
+    },
+    {
+        file: "packages/shallot/src/project/command.ts",
+        arm: "unit",
+        reason:
+            "the command entry `bin/tui.ts` reaches a project through. planProject's exit codes " +
+            "(missing project, clean manifest-only, clean scene-only, installed bare plugin, missing " +
+            "dependency before any evaluation), loadLocalPlugins' enabled-evaluated/disabled-never-" +
+            "evaluated sentinel pair and its missing-default refusal, the shared-plan identity against " +
+            "generateModuleFromPlan, and the bare-bun purity arms (no Vite in the loaded module graph, " +
+            "no browser/GPU global, with the Vite-importing toolchain as the reader's control) are all " +
+            "asserted by command.test.ts. SUBPATH_PLUGIN_LOADERS is gated against SUBPATH_PLUGIN_MODULES " +
+            "by catalog.test.ts; loadEnginePlugins/loadHeadlessPlugins reach a real device and are " +
+            "executed by the `shallot tui` runs in bin/tui.probes.ts and scripts/install-test.ts.",
+    },
+    {
         file: "packages/shallot/src/project/generate.ts",
         arm: "unit",
         reason:
-            "plan and generateModule's emitted import lines (engine-barrel grouping by source, local " +
+            "generateModule/generateModuleFromPlan's emitted import lines (engine-barrel grouping by source, local " +
             "default imports and their project-relative path resolution, the missing-default runtime " +
             "guard, capacity threading) are directly asserted by generate.test.ts.",
     },
@@ -558,9 +586,9 @@ export const CLI_COVERAGE: readonly CoverageRow[] = [
         reason:
             "normalize's tolerant-parse (absent/corrupt/non-object storage, $schema/capacity, each " +
             "PluginValue field) is directly asserted by manifest.test.ts. localOf has no row of its own " +
-            "test but is exercised through every one of generate.test.ts's plan() cases with a local " +
+            "test but is exercised through every one of host.test.ts's plan() cases with a local " +
             "plugin (Spin's bare-string enabled form, Off's disabled-tuple form, Pkg's bare-package form) " +
-            "— verified: generate.ts's plan() calls localOf(value) directly for every non-default, " +
+            "— verified: host.ts's plan() calls localOf(value) directly for every non-default, " +
             "non-true manifest entry.",
     },
     {

--- a/packages/shallot/tests/composition-census.test.ts
+++ b/packages/shallot/tests/composition-census.test.ts
@@ -17,6 +17,7 @@ const COMPOSITION_SURFACES: readonly RegExp[] = [
     /^examples\/(?:flows|recipes|showcase|gym)\//,
     /^evals\/tasks\//,
     /^packages\/shallot\/bin\/tui\.ts$/,
+    /^packages\/shallot\/src\/project\/command\.ts$/,
     /^packages\/shallot\/scripts\/dump-cells-ascii\.ts$/,
 ];
 
@@ -28,6 +29,7 @@ const PROJECT_GATES: readonly Gate[] = [
     [/^examples\/gym\//, "bun bench"],
     [/^evals\/tasks\/[^/]+\/gate\.ts$/, "bun run test"],
     [/^packages\/shallot\/bin\/tui\.ts$/, "bun test ./packages/shallot/bin"],
+    [/^packages\/shallot\/src\/project\/command\.ts$/, "bun test ./packages/shallot/src/project"],
     [
         /^packages\/shallot\/scripts\/dump-cells-ascii\.ts$/,
         "bun run --cwd packages/shallot dump-cells-ascii",
@@ -43,7 +45,10 @@ function isComposition({ path, source }: SourceFile): boolean {
     return (
         path.endsWith("shallot.json") ||
         /^evals\/tasks\/[^/]+\/gate\.ts$/.test(path) ||
-        /\bplugins\s*:\s*(?:\[|[A-Za-z_$])/.test(source)
+        // both surface forms of a composed plugin list: the explicit property (`plugins: […]`,
+        // `plugins: project.plugins`) and the shorthand a host uses once it holds the list in a
+        // variable of that name (`build({ plugins, … })`, which `bin/tui.ts` now does).
+        /\bplugins\s*:\s*(?:\[|[A-Za-z_$])|\bplugins\s*,\s*$/m.test(source)
     );
 }
 

--- a/scripts/boundary-seams.ts
+++ b/scripts/boundary-seams.ts
@@ -14,15 +14,13 @@ export const TOOLING_SEAMS: Record<string, string> = {
         "manifest resolution, pending the A1 project-host seam",
     'packages/shallot/bin/native.ts "../src/project/manifest"':
         "manifest resolution, pending the A1 project-host seam",
-    'packages/shallot/bin/tui.ts "../src/project/assets"':
-        "manifest read, pending the A1 project-host seam",
-    'packages/shallot/bin/tui.ts "../src/project/engine"':
-        "subpath plugin modules, pending the A1 project-host seam",
-    'packages/shallot/bin/tui.ts "../src/project/generate"':
-        "shared project plan, pending the A1 project-host seam",
-    // the TUI's own engine reach: the barrel type only. `../src` (the published `.` target) is what it
-    // actually loads at runtime.
-    'packages/shallot/bin/tui.ts "../src/engine"': "Plugin type for the loaded manifest plugins",
+    // the A1 project-host seam itself: one command entry per tool, carrying plan/discovery/resolution
+    // and the plugin loaders. Bounded on purpose — a tool reaches the project through this module or
+    // not at all, so a future tooling extraction moves one import, not a private-path family.
+    'packages/shallot/bin/tui.ts "../src/project/command"':
+        "the shared project-host command entry (plan, discovery, resolution, plugin loading)",
+    'packages/shallot/bin/toolchain.ts "../src/project/command"':
+        "project discovery and its missing-project diagnostic, shared with the terminal command",
     // verify's node-side diagnostics. These are tool-facing readings with no author-facing contract, so
     // they stay unpublished rather than growing the surface.
     'packages/shallot/bin/verify.ts "../src/engine/runtime/gpu"':
@@ -43,8 +41,6 @@ export const COMPUTED_LOADERS: Record<string, string> = {
         "browser-evaluated /src/ URLs into Roads' own src/, served by playwright.config.ts webServer shallot dev .; non-literal spelling leaves imports to the browser instead of Playwright's CJS transform",
     "examples/showcase/roads/test/touch-smoke.playwright.ts":
         "browser-evaluated /src/ URLs into Roads' own src/, served by playwright.config.ts webServer shallot dev .; non-literal spelling leaves imports to the browser instead of Playwright's CJS transform",
-    "packages/shallot/bin/tui.ts":
-        "loads the project's own manifest-declared plugin files, resolved under the project root",
     "packages/shallot/bin/features.ts":
         "loads the project's own manifest-declared local plugins to read their feature declarations",
     "packages/shallot/bin/bun-native.ts":

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -78,6 +78,160 @@ async function waitFor(cond: () => Promise<boolean>, ms: number): Promise<boolea
 }
 
 /** Exercise the shipped native loader in physical, external installs; retain raw child receipts. */
+/**
+ * The A1 project-host arms, on the real packed install: a manifest whose local plugins are observable at
+ * evaluation (each writes a sentinel file when its module runs), so "a disabled plugin does not load" and
+ * "an invalid dependency fails before side effects" are read from the filesystem rather than from a log
+ * line. Both arms restore the project's own manifest, so the native controls after them are unaffected.
+ */
+function hostSeamArms(
+    layout: string,
+    project: string,
+    cli: (args: string[]) => string[],
+    exec: (name: string, cmd: string[], cwd: string) => { exit: number; out: string },
+    expect: (
+        name: string,
+        result: { exit: number; out: string },
+        exit: number,
+        text: RegExp,
+    ) => void,
+): void {
+    const manifest = join(project, "shallot.json");
+    const original = readFileSync(manifest, "utf8");
+    const sentinel = (name: string) => join(project, `${name}.evaluated`);
+    const plugin = (name: string) => {
+        mkdirSync(join(project, "src"), { recursive: true });
+        writeFileSync(
+            join(project, "src", `${name}.ts`),
+            `import { writeFileSync } from "node:fs";\n` +
+                `writeFileSync(${JSON.stringify(sentinel(name))}, "evaluated");\n` +
+                `export default { name: ${JSON.stringify(name)} };\n`,
+        );
+    };
+    try {
+        plugin("Enabled");
+        plugin("Disabled");
+        for (const name of ["Enabled", "Disabled"]) rmSync(sentinel(name), { force: true });
+        writeFileSync(
+            manifest,
+            JSON.stringify({
+                scene: "main.scene",
+                plugins: {
+                    Cells: true,
+                    Enabled: "./src/Enabled",
+                    Disabled: ["./src/Disabled", false],
+                },
+            }),
+        );
+        expect(
+            `${layout}-tui-disabled-plugin`,
+            exec(
+                `${layout}-tui-disabled-plugin`,
+                cli(["tui", ".", "--frames", "1", "--tier", "plain"]),
+                project,
+            ),
+            0,
+            /./s,
+        );
+        assert(existsSync(sentinel("Enabled")), "the enabled local plugin's module ran");
+        assert(
+            !existsSync(sentinel("Disabled")),
+            "the disabled local plugin's module must never be evaluated",
+        );
+
+        // an invalid dependency: the setup exit, with the sibling plugin still unevaluated
+        for (const name of ["Enabled", "Disabled"]) rmSync(sentinel(name), { force: true });
+        writeFileSync(
+            manifest,
+            JSON.stringify({
+                scene: "main.scene",
+                plugins: { Cells: true, Enabled: "./src/Enabled", Gone: "not-installed-plugin" },
+            }),
+        );
+        expect(
+            `${layout}-tui-missing-dependency`,
+            exec(`${layout}-tui-missing-dependency`, cli(["tui", ".", "--frames", "1"]), project),
+            2,
+            /not-installed-plugin/,
+        );
+        assert(
+            !existsSync(sentinel("Enabled")),
+            "a missing dependency must fail before any plugin module is evaluated",
+        );
+
+        writeFileSync(manifest, original);
+        privateTargetArm(layout, project, exec);
+    } finally {
+        writeFileSync(manifest, original);
+        for (const name of ["Enabled", "Disabled"]) rmSync(sentinel(name), { force: true });
+    }
+}
+
+/**
+ * No private filesystem traversal: a private export target planted inside the installed engine — a real
+ * file, published by a real `exports` key, poisoned so importing it throws — must never be read by a TUI
+ * run. The audit patches `node:fs` before importing the installed command, so every read the run makes
+ * through the fs API is recorded; the arm then requires that none of them lands in the engine's own
+ * `src/` or on its `package.json` (the export-map read this seam removed). Two-sided by construction:
+ * restoring the old export-map read makes `package.json` appear in the audit and reds this arm.
+ */
+function privateTargetArm(
+    layout: string,
+    project: string,
+    exec: (name: string, cmd: string[], cwd: string) => { exit: number; out: string },
+): void {
+    const engineRoot = join(project, "node_modules/@dylanebert/shallot");
+    const enginePkg = join(engineRoot, "package.json");
+    const originalPkg = readFileSync(enginePkg, "utf8");
+    const planted = join(engineRoot, "src/project/planted-target.ts");
+    try {
+        writeFileSync(
+            planted,
+            `throw new Error("PLANTED_PRIVATE_TARGET_READ");\nexport const planted = true;\n`,
+        );
+        const parsed = JSON.parse(originalPkg) as { exports: Record<string, unknown> };
+        parsed.exports = { ...parsed.exports, "./planted": "./src/project/planted-target.ts" };
+        writeFileSync(enginePkg, `${JSON.stringify(parsed, null, 2)}\n`);
+        writeFileSync(
+            join(project, "read-audit.ts"),
+            [
+                `const fsmod = require("node:fs");`,
+                `const engineRoot = ${JSON.stringify(engineRoot)};`,
+                `const reads: string[] = [];`,
+                `for (const fn of ["readFileSync", "existsSync", "readdirSync", "statSync", "openSync"]) {`,
+                `    const orig = fsmod[fn];`,
+                `    fsmod[fn] = (p: unknown, ...rest: unknown[]) => { reads.push(String(p)); return orig(p, ...rest); };`,
+                `}`,
+                `const { runTui } = await import(\`\${engineRoot}/bin/tui.ts\`);`,
+                `const code = await runTui([".", "--frames", "1", "--tier", "plain"]);`,
+                `const forbidden = reads.filter((p) => p.startsWith(\`\${engineRoot}/src/\`) || p === \`\${engineRoot}/package.json\`);`,
+                `console.error(\`READ_AUDIT \${JSON.stringify({ code, forbidden })}\`);`,
+                "",
+            ].join("\n"),
+        );
+        const audit = exec(`${layout}-tui-read-audit`, ["bun", "read-audit.ts"], project);
+        assert.equal(audit.exit, 0, audit.out.slice(-600));
+        assert(!audit.out.includes("PLANTED_PRIVATE_TARGET_READ"), "planted target was imported");
+        const record = /READ_AUDIT (\{.*\})/.exec(audit.out);
+        assert(record, `no read audit recorded: ${audit.out.slice(-400)}`);
+        const { code, forbidden } = JSON.parse(record[1]) as {
+            code: number;
+            forbidden: string[];
+        };
+        assert.equal(code, 0, audit.out.slice(-400));
+        assert.deepEqual(
+            forbidden,
+            [],
+            `the TUI read private engine paths: ${forbidden.join(", ")}`,
+        );
+        console.log(`native: ${layout}-tui-read-audit`);
+    } finally {
+        writeFileSync(enginePkg, originalPkg);
+        rmSync(planted, { force: true });
+        rmSync(join(project, "read-audit.ts"), { force: true });
+    }
+}
+
 export function nativeFlow(work: string, engineTgz: string): void {
     const evidence = join(work, "native");
     mkdirSync(evidence, { recursive: true });
@@ -222,6 +376,7 @@ export function nativeFlow(work: string, engineTgz: string): void {
             0,
             /./s,
         );
+        hostSeamArms(layout, project, cli, exec, expect);
         const peer = join(project, "node_modules/bun-webgpu");
         const platformName = `bun-webgpu-${process.platform}-${process.arch}`;
         const platform =


### PR DESCRIPTION
- **shallot-release-boundaries: shared project-host plan seam**
- **shallot-release-boundaries: TUI through the host command seam**
- **shallot-release-boundaries: packed host-seam install arms**
- **shallot-release-boundaries: gate the headless subpath loaders**
- **shallot-release-boundaries: repoint coverage and census rows**
- **shallot-release-boundaries: keep the absent-peer refusal first**
