### PR TITLE
site: release-source builds, RUM on the pages, llms.txt in production

### DIFF
--- a/scripts/build-pages.ts
+++ b/scripts/build-pages.ts
@@ -15,6 +15,7 @@ import { brandPage } from "../site/brand/page";
 import { toPng } from "../site/brand/png";
 import { llmsTxt, siteIndex } from "../site/home";
 import { ROSTER } from "../site/roster";
+import { datadogInitSnippet } from "../site/rum-config";
 
 // `bun run site:pages` — the site's own pages without the demos: out/site/index.html, llms.txt and
 // out/site/brand/ with its downloads. `build-site.ts` calls the same function after the demo
@@ -52,14 +53,18 @@ function framed(grid: ReturnType<typeof fromBlocks>, size: number): ReturnType<t
 }
 
 /** Writes the brand page and every download into `out/brand/`. */
-export async function buildBrand(outDir: string, clientScript?: string): Promise<void> {
+export async function buildBrand(
+    outDir: string,
+    clientScript?: string,
+    rum: string = "",
+): Promise<void> {
     const dir = resolve(outDir, "brand");
     mkdirSync(dir, { recursive: true });
     const mark = fromBlocks(MARK.m);
     const lock = lockup();
     const write = (name: string, data: string | Uint8Array) =>
         writeFileSync(resolve(dir, name), data);
-    write("index.html", brandPage(clientScript ?? (await bundleClient())));
+    write("index.html", brandPage(clientScript ?? (await bundleClient()), rum));
     write("mark.svg", toSvg(mark, DARK, 1));
     write("mark.png", toPng(mark, DARK, 8));
     write("mark-16.png", toPng(framed(mark, 16), DARK, 1));
@@ -74,18 +79,25 @@ export async function buildBrand(outDir: string, clientScript?: string): Promise
     write("mark.ts", readFileSync(resolve(root, "site/brand/mark.ts"), "utf8"));
 }
 
-/** Writes the home index, `llms.txt`, and the brand pages. */
+/** Writes the home index, `llms.txt`, and the brand pages. `rumMode` picks the Datadog env
+ * derivation the pages carry: the hostname-derived prod snippet tags a localhost preview
+ * "local", so a standalone pages build uses it even while labelling itself staging. */
 export async function buildPages(
     outDir: string,
     version: string,
     ref: string,
     mode: "prod" | "staging",
+    rumMode: "prod" | "staging" = mode,
 ): Promise<void> {
     mkdirSync(outDir, { recursive: true });
     const client = await bundleClient();
-    writeFileSync(resolve(outDir, "index.html"), siteIndex(ROSTER, version, ref, mode, client));
+    const rum = datadogInitSnippet(rumMode);
+    writeFileSync(
+        resolve(outDir, "index.html"),
+        siteIndex(ROSTER, version, ref, mode, client, rum),
+    );
     writeFileSync(resolve(outDir, "llms.txt"), llmsTxt(version, ref, mode));
-    await buildBrand(outDir, client);
+    await buildBrand(outDir, client, rum);
 }
 
 if (import.meta.main) {
@@ -97,7 +109,7 @@ if (import.meta.main) {
     const ref = Bun.spawnSync(["git", "rev-parse", "--short", "HEAD"], { cwd: root });
     const refShort = ref.stdout.toString().trim() || "unknown";
     const outDir = resolve(root, "out/site");
-    await buildPages(outDir, pkg.version, refShort, "staging");
+    await buildPages(outDir, pkg.version, refShort, "staging", "prod");
     console.log(
         `pages (staging · ${refShort}): ${outDir}/index.html, ${outDir}/llms.txt, ${outDir}/brand/`,
     );

--- a/scripts/build-site.test.ts
+++ b/scripts/build-site.test.ts
@@ -104,8 +104,8 @@ test("build-site — the index always lists the full roster (ROSTER, not demos)"
     // Before the fix, a single-demo build's index only listed the filtered demos.
     // The call site is `siteIndex(ROSTER, version, refShort)` — check the call, not the function
     // definition (whose parameter is named `demos`).
-    expect(src).toMatch(/siteIndex\(ROSTER,\s*version/);
+    expect(src).toMatch(/siteIndex\(roster,\s*source\.version/);
     // Ensure the call does NOT pass the filtered `demos` variable to siteIndex.
     // The filtered list is `const demos = only ? ROSTER.filter(...) : ROSTER` — the call must use ROSTER.
-    expect(src).not.toMatch(/siteIndex\(demos,\s*version/);
+    expect(src).not.toMatch(/siteIndex\(demos,/);
 });

--- a/scripts/build-site.ts
+++ b/scripts/build-site.ts
@@ -22,16 +22,14 @@ import { Glob } from "bun";
 // docblock records the same measurement for the reader who only sees the pure module.
 import { PIPELINE_COMPILE_MEASURE_PREFIX } from "../packages/shallot-runtime/src/engine/runtime/gpu";
 import { llmsTxt, siteIndex } from "../site/home";
-import { ROSTER } from "../site/roster";
-import {
-    RUM_CONFIG,
-    RUM_ENV_SNIPPET,
-    RUM_ENV_SNIPPET_STAGING,
-    RUM_ENV_USAGE,
-    RUM_INJECTION_MARKER,
-} from "../site/rum-config";
+import { type DemoEntry, ROSTER } from "../site/roster";
+import { datadogInitSnippet } from "../site/rum-config";
 import { demoFingerprints, type SiteMode, writeStamp } from "../site/site-stamp";
 import { buildBrand, bundleClient } from "./build-pages";
+
+// the RUM init snippet lives in `site/rum-config.ts` so the pages build can inject it too;
+// re-exported here because the site tests import it from this module
+export { datadogInitSnippet };
 
 // `bun run site` — build every showcase demo as an ejected consumer of the *published* package,
 // then assemble the site index. Each demo is copied out of the workspace to a scratch tree under
@@ -59,40 +57,6 @@ import { buildBrand, bundleClient } from "./build-pages";
 const root = resolve(import.meta.dir, "..");
 const showcaseDir = resolve(root, "examples/showcase");
 const outDir = resolve(root, "out/site");
-
-// Datadog RUM browser-agent CDN major, pinned — checked 2026-08-25 against the served
-// `/us1/v6/datadog-rum.js` bundle: `addDurationVital(name, {startTime, duration, context})` is
-// present as the one-shot form the Locked decision calls for (`startDurationVital`/
-// `stopDurationVital` also exist, unused here). Bump this only after re-checking that shape.
-const DATADOG_RUM_CDN_MAJOR = 6;
-const DATADOG_RUM_CDN_URL = `https://www.datadoghq-browser-agent.com/us1/v${DATADOG_RUM_CDN_MAJOR}/datadog-rum.js`;
-
-// `crossOrigin='anonymous'` on the injected script element: `shallot verify`'s dist/dev preview sends
-// `Cross-Origin-Embedder-Policy: require-corp` (`packages/shallot-tooling/src/project/vite.ts`, unconditional on
-// every serve surface — for the multithreaded WASM kernel, unrelated to RUM) and the CDN never sends a
-// `Cross-Origin-Resource-Policy` header, so a plain no-cors `<script src>` load is blocked
-// (`net::ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep`, reproduced 2026-08-25 —
-// every `bun run demos` entry point failed on it). The CDN does answer a CORS request with
-// `Access-Control-Allow-Origin: *` (verified against a request carrying an `Origin` header), and a
-// CORS-mode load is exempt from the CORP check entirely — so `crossOrigin` fixes the verify-only failure
-// without needing a header change in `packages/shallot` (out of scope) or the deployed site, which never
-// sets COEP (a static host can't set headers, the doc comment above `CROSS_ORIGIN_ISOLATION` already notes).
-export function datadogInitSnippet(mode: "prod" | "staging" = "prod"): string {
-    const envSnippet = mode === "staging" ? RUM_ENV_SNIPPET_STAGING : RUM_ENV_SNIPPET;
-    return `${RUM_INJECTION_MARKER}
-<script>
-(function(h,o,u,n,d) {
-    h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
-    d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin='anonymous'
-    n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-})(window,document,'script','${DATADOG_RUM_CDN_URL}','DD_RUM')
-window.DD_RUM.onReady(function() {
-    ${envSnippet}
-    window.DD_RUM.init(${RUM_ENV_USAGE}${JSON.stringify(RUM_CONFIG)}));
-});
-</script>
-`;
-}
 
 /** Bundles `site/rum-runtime.ts` (which imports the pure sampler) to a single browser-target ESM
  * script — inlined so every demo page, at any output depth (`visualization/demos/*.html`
@@ -195,10 +159,6 @@ Options:
 
     const idx = args.indexOf("--demo");
     const only = idx !== -1 ? args[idx + 1] : undefined;
-    if (only && !ROSTER.some((d) => d.slug === only)) {
-        console.error(`no demo "${only}" — one of: ${ROSTER.map((d) => d.slug).join(", ")}`);
-        process.exit(2);
-    }
 
     const staging = args.includes("--staging");
     const mode: "prod" | "staging" = staging ? "staging" : "prod";
@@ -211,7 +171,21 @@ Options:
     const ref = Bun.spawnSync(["git", "rev-parse", "--short", "HEAD"], { cwd: root });
     const refShort = ref.stdout.toString().trim() || "unknown";
 
-    const demos = only ? ROSTER.filter((d) => d.slug === only) : ROSTER;
+    // where the demo sources come from: this tree, or the last release tag when the tree's
+    // version is ahead of what npm serves (`demoSource` below)
+    const source = staging ? treeSource(version) : await releaseSource(version);
+    if (only && !source.roster.some((d) => d.slug === only)) {
+        console.error(`no demo "${only}" — one of: ${source.roster.map((d) => d.slug).join(", ")}`);
+        process.exit(2);
+    }
+    const roster = source.roster;
+    const showcase = source.showcaseDir;
+    const demos = only ? roster.filter((d) => d.slug === only) : roster;
+    if (source.kind === "tag") {
+        console.log(
+            `release source: workspace is ${version}, npm latest is ${source.version} — demos from ${source.tag}`,
+        );
+    }
 
     // clean + recreate the output dir — a single-demo build only clears that demo's slot,
     // so a prior full build's other demos survive
@@ -230,12 +204,12 @@ Options:
     const extensionNames = new Set<string>();
     for (const demo of demos) {
         const demoPkg = (await Bun.file(
-            resolve(showcaseDir, demo.slug, "package.json"),
+            resolve(showcase, demo.slug, "package.json"),
         ).json()) as DemoPackage;
         for (const name of workspaceExtensionDependencies(demoPkg)) extensionNames.add(name);
     }
 
-    let enginePin = version;
+    let enginePin = source.version;
     const packDest = mkdtempSync(join(tmpdir(), "shallot-site-pack-"));
     const extensionPins = new Map<string, string>();
     const pack = (name: string, packageDir: string): string => {
@@ -264,7 +238,7 @@ Options:
     try {
         for (const demo of demos) {
             const slug = demo.slug;
-            const srcDir = resolve(showcaseDir, slug);
+            const srcDir = resolve(showcase, slug);
             if (!existsSync(srcDir)) {
                 console.error(`✗ showcase dir not found: ${srcDir}`);
                 process.exit(1);
@@ -354,16 +328,17 @@ Options:
         rmSync(packDest, { recursive: true, force: true });
     }
 
-    // emit the site index — always lists the full roster so a single-demo build's index
-    // still references the other demos from a prior full build
-    // the site's own pages beside the demos: the index and /brand/ with its downloads
-    // (`scripts/build-pages.ts`); one client bundle serves both
+    // the site's own pages beside the demos: the index (always the full roster, so a `--demo`
+    // build's index still lists the others), llms.txt, and /brand/ with its downloads
+    // (`scripts/build-pages.ts`); one client bundle and one RUM init snippet serve them all
     const client = await bundleClient();
+    const rum = datadogInitSnippet(mode);
     writeFileSync(
         resolve(outDir, "index.html"),
-        siteIndex(ROSTER, version, refShort, mode, client),
+        siteIndex(roster, source.version, refShort, mode, client, rum),
     );
-    await buildBrand(outDir, client);
+    writeFileSync(resolve(outDir, "llms.txt"), llmsTxt(source.version, refShort, mode));
+    await buildBrand(outDir, client, rum);
 
     // record what each demo was built from, so `check-site.ts` can tell an artifact of *these*
     // sources from an artifact of some other sources before it judges the artifact
@@ -371,15 +346,19 @@ Options:
     // `mode` is not merged — it names the mode this run built in.
     const siteMode: SiteMode = staging
         ? { kind: "staging", pin: enginePin }
-        : { kind: "prod", version };
-    writeStamp(
-        outDir,
-        demoFingerprints(
-            root,
-            demos.map((d) => d.slug),
-        ),
-        siteMode,
-    );
+        : source.kind === "tag"
+          ? { kind: "prod", version: source.version, tag: source.tag }
+          : { kind: "prod", version };
+    // tag sources are immutable, so their entries record the tag rather than a tree fingerprint
+    const fingerprints =
+        source.kind === "tag"
+            ? Object.fromEntries(demos.map((d) => [d.slug, `tag:${source.tag}`]))
+            : demoFingerprints(
+                  root,
+                  demos.map((d) => d.slug),
+              );
+    writeStamp(outDir, fingerprints, siteMode);
+    if (source.kind === "tag") rmSync(source.root, { recursive: true, force: true });
 
     const total = sizes.reduce((sum, s) => sum + parseSize(s.size), 0);
     console.log(`\n=== summary ===`);
@@ -389,8 +368,91 @@ Options:
     console.log(`  total: ${formatSize(total)}`);
     console.log(`\n  index: ${resolve(outDir, "index.html")}`);
     console.log(
-        `  built from: ${staging ? `staging (${enginePin})` : `v${version}`} (${refShort})`,
+        `  built from: ${staging ? `staging (${enginePin})` : `v${source.version}`} (${refShort})${source.kind === "tag" ? `, demos from ${source.tag}` : ""}`,
     );
+}
+
+/** Where the demos' sources come from. `tree` is this checkout; `tag` is an extracted release tag. */
+type DemoSource =
+    | { kind: "tree"; version: string; roster: DemoEntry[]; showcaseDir: string; root: string }
+    | {
+          kind: "tag";
+          version: string;
+          tag: string;
+          roster: DemoEntry[];
+          showcaseDir: string;
+          root: string;
+      };
+
+function treeSource(version: string): DemoSource {
+    return { kind: "tree", version, roster: ROSTER, showcaseDir, root };
+}
+
+const deriveTitle = (slug: string): string =>
+    slug
+        .split("-")
+        .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+        .join(" ");
+
+/** The version npm serves as `latest`. A production build pins demos to a published package, so
+ * this is the only version it can build against. */
+export async function publishedLatest(): Promise<string> {
+    const response = await fetch("https://registry.npmjs.org/@dylanebert%2Fshallot/latest");
+    if (!response.ok)
+        throw new Error(`npm registry answered ${response.status} for @dylanebert/shallot`);
+    const body = (await response.json()) as { version?: string };
+    if (!body.version) throw new Error("npm registry returned no version for @dylanebert/shallot");
+    return body.version;
+}
+
+/**
+ * Production demo source. When the workspace version is what npm serves, the tree is the source
+ * (a tag-push deploy, right after publish). When the workspace is ahead — a dispatch deploy
+ * between releases — the demos come from the last release tag, extracted with `git archive`, so
+ * the published package builds the showcase it shipped with while the pages come from this tree.
+ */
+async function releaseSource(version: string): Promise<DemoSource> {
+    const latest = await publishedLatest();
+    if (latest === version) return treeSource(version);
+    const tag = `v${latest}`;
+    const exists = Bun.spawnSync(["git", "rev-parse", "--verify", "--quiet", `refs/tags/${tag}`], {
+        cwd: root,
+    });
+    if (exists.exitCode !== 0) {
+        const fetched = Bun.spawnSync(["git", "fetch", "--quiet", "origin", "tag", tag], {
+            cwd: root,
+        });
+        if (fetched.exitCode !== 0)
+            throw new Error(`release tag ${tag} is not in this checkout and could not be fetched`);
+    }
+    const dir = mkdtempSync(join(tmpdir(), "shallot-site-release-"));
+    const tar = join(dir, "showcase.tar");
+    const archive = Bun.spawnSync(
+        ["git", "archive", "--format=tar", "-o", tar, tag, "examples/showcase"],
+        { cwd: root },
+    );
+    if (archive.exitCode !== 0) throw new Error(`git archive ${tag} examples/showcase failed`);
+    const extract = Bun.spawnSync(["tar", "-xf", tar, "-C", dir]);
+    if (extract.exitCode !== 0) throw new Error(`could not extract ${tar}`);
+    rmSync(tar, { force: true });
+    const tree = Bun.spawnSync(["git", "ls-tree", "--name-only", "-d", tag, "examples/showcase/"], {
+        cwd: root,
+    });
+    const slugs = tree.stdout
+        .toString()
+        .split("\n")
+        .filter(Boolean)
+        .map((p) => p.slice("examples/showcase/".length))
+        .sort();
+    const roster = slugs.map((slug) => ({ slug, title: deriveTitle(slug) }));
+    return {
+        kind: "tag",
+        version: latest,
+        tag,
+        roster,
+        showcaseDir: resolve(dir, "examples/showcase"),
+        root: dir,
+    };
 }
 
 // The standalone tsconfig — the root tsconfig.json's compilerOptions inlined, minus the

--- a/scripts/check-site.test.ts
+++ b/scripts/check-site.test.ts
@@ -86,8 +86,11 @@ ${datadogInitSnippet()}    </body>
 `,
         );
     }
-    // the site index carries no RUM injection (clause 5's index leg)
-    writeFileSync(resolve(out, "index.html"), `<!doctype html>\n<html><body></body></html>\n`);
+    // the site index carries the init alone (clause 5's page leg)
+    writeFileSync(
+        resolve(out, "index.html"),
+        `<!doctype html>\n<html><body>${datadogInitSnippet()}</body></html>\n`,
+    );
     return out;
 }
 
@@ -290,7 +293,10 @@ ${datadogInitSnippet(mode)}    </body>
 `,
         );
     }
-    writeFileSync(resolve(out, "index.html"), `<!doctype html>\n<html><body></body></html>\n`);
+    writeFileSync(
+        resolve(out, "index.html"),
+        `<!doctype html>\n<html><body>${datadogInitSnippet(mode)}</body></html>\n`,
+    );
     return out;
 }
 
@@ -376,7 +382,10 @@ ${datadogInitSnippet("prod")}    <!-- var ddEnv='staging'; -->
 `,
             );
         }
-        writeFileSync(resolve(out, "index.html"), `<!doctype html>\n<html><body></body></html>\n`);
+        writeFileSync(
+            resolve(out, "index.html"),
+            `<!doctype html>\n<html><body>${datadogInitSnippet()}</body></html>\n`,
+        );
         stampFresh(out, PROD_MODE);
         const { exitCode, out: log } = runCheck(out, { SITE_OUT_REQUIRED: "1" });
         expect(exitCode).toBe(1);

--- a/scripts/check-site.ts
+++ b/scripts/check-site.ts
@@ -39,7 +39,8 @@ import { nonWorkspaceShallotDependencies } from "./build-site";
 //   4. no generated path is root-absolute — the site must work at any base path (GitHub Pages
 //      serves at `/shallot/`, a dry-run artifact at root, a local out dir at `file://`). Scans
 //      the output dir if it exists; skips with a note if not (the build hasn't run yet).
-//   5. the Datadog RUM slow-frame injection reaches every demo page and skips the index — every
+//   5. the Datadog RUM slow-frame injection reaches every demo page, and the site pages carry the
+//      init alone — every
 //      `*.html` under each `out/site/<slug>/` (including a nested page like
 //      `visualization/demos/*.html`) carries `RUM_INJECTION_MARKER`, `RUM_ENV_SNIPPET` (the
 //      hostname-derived `env: "prod" | "local"` derivation — localhost previews tag "local" so
@@ -49,7 +50,9 @@ import { nonWorkspaceShallotDependencies } from "./build-site";
 //      injected `<script>` block also has to parse (`new Function(src)`) — the substring checks
 //      pin the seam, this pins that the composed call is runnable, since a dropped paren between
 //      two present fragments passes every substring check while still being broken syntax.
-//      `out/site/index.html` does not carry any of this, since it has no frame loop to observe.
+//      `out/site/index.html` and `brand/index.html` carry the marker, env and wiring for page
+//      views, and must not carry the sampler bundle (`slow_frame`), since a page of text has no
+//      frame loop to observe.
 //      Same `SITE_OUT_REQUIRED` gate as clause 4.
 //   6. every built demo root page has a human-readable <title> — a manifest demo's is the bare
 //      slug (`synthIndex` titles from the ejected dir's basename); an own-index demo's just must
@@ -233,13 +236,23 @@ if (stale.length > 0) {
 // `package.json` exists only in a scratch tree that `scripts/build-site.ts` deletes before this
 // script ever runs. So the build stamp records which pin the run used
 // (`site/site-stamp.ts`'s `SiteMode`), and this leg reads it back: a prod-mode stamp must have
-// pinned the current release version, a staging-mode stamp must have pinned a `file:`-form
+// pinned the current release version (or, for a release-source build, the tag it took the demos
+// from), a staging-mode stamp must have pinned a `file:`-form
 // workspace tarball — never the other way, so a mode mix-up reds here instead of the built
 // artifact silently carrying the wrong pin.
 const stamp = readStamp(outDir);
 if (stamp) {
     if (stamp.mode.kind === "prod") {
-        if (stamp.mode.version !== version) {
+        // a release-source build (`tag` recorded) pins the published version by design: the tree
+        // is ahead of npm and the demos came from that tag, so the pin cannot equal the tree's
+        if (stamp.mode.tag) {
+            if (stamp.mode.tag !== `v${stamp.mode.version}`) {
+                fail(
+                    `✗ build stamp records demos from ${stamp.mode.tag} but a pin of ` +
+                        `v${stamp.mode.version} — the two must name the same release`,
+                );
+            }
+        } else if (stamp.mode.version !== version) {
             fail(
                 `✗ build stamp records prod mode pinned to v${stamp.mode.version}, but ` +
                     `packages/shallot/package.json now names v${version} — rebuild with ` +
@@ -414,11 +427,26 @@ if (noParse.length > 0) {
     process.exit(1);
 }
 
-const indexPath = resolve(outDir, "index.html");
-if (existsSync(indexPath) && readFileSync(indexPath, "utf8").includes(RUM_INJECTION_MARKER)) {
+// The site's own pages carry the init snippet (page views) but never the sampler bundle — there
+// is no frame loop on a page of text, and `slow_frame` vitals from one would be noise.
+const pages = ["index.html", "brand/index.html"];
+const pageDefects: string[] = [];
+for (const rel of pages) {
+    const full = resolve(outDir, rel);
+    if (!existsSync(full)) continue;
+    const html = readFileSync(full, "utf8");
+    if (!html.includes(RUM_INJECTION_MARKER)) pageDefects.push(`${rel}: no RUM injection`);
+    if (!html.includes(ownEnvSnippet)) pageDefects.push(`${rel}: no ${mode} env derivation`);
+    if (html.includes(otherEnvSnippet)) pageDefects.push(`${rel}: carries the other mode's env`);
+    if (!html.includes(RUM_ENV_USAGE)) pageDefects.push(`${rel}: env never wired into init`);
+    if (html.includes("slow_frame")) pageDefects.push(`${rel}: carries the frame sampler`);
+}
+if (pageDefects.length > 0) {
+    console.error(`✗ site page(s) with a RUM defect:\n`);
+    for (const d of pageDefects) console.error(`  ${d}`);
     console.error(
-        "✗ out/site/index.html carries the RUM injection marker — the index has no frame loop" +
-            " to observe and must stay JS-free.",
+        "\nThe home and brand pages carry the Datadog init snippet for page views and nothing" +
+            " else (`scripts/build-pages.ts`).",
     );
     process.exit(1);
 }
@@ -501,5 +529,5 @@ if (process.env.RUM_CONFIG_REQUIRED === "1" && existsSync(outDir)) {
 console.log(
     `✓ site roster clean (${ROSTER.length} demos, ` +
         `all manifested, all workspace-pinned, no escaping imports, no root-absolute paths, ` +
-        `RUM injection + env snippet present on every demo page and absent from the index)`,
+        `RUM injection + env snippet present on every demo page, init alone on the site pages)`,
 );

--- a/site/brand/page.ts
+++ b/site/brand/page.ts
@@ -14,7 +14,7 @@ const svg = (grid: ReturnType<typeof fromBlocks>, scale: number) => toSvg(grid, 
 const swatch = (name: string, dark: string, light: string) =>
     `<div class="sw"><i style="--d:${dark};--l:${light}"></i><span>${name}</span><span class="muted">${dark} · ${light}</span></div>`;
 
-export function brandPage(clientScript: string): string {
+export function brandPage(clientScript: string, rum: string = ""): string {
     const mark = fromBlocks(MARK.m);
     const lock = lockup();
     return `<!doctype html>
@@ -113,7 +113,7 @@ ${swatch("muted", "#a08c78", "#6e655c")}
 
 </main>
 <script type="module">${clientScript}</script>
-</body>
+${rum}</body>
 </html>
 `;
 }

--- a/site/home.ts
+++ b/site/home.ts
@@ -4,7 +4,8 @@ import type { DemoEntry } from "./roster";
 
 // The site home at /shallot/: the lockup splashing in, the one-line promise, quick start, the
 // demos, and the build label in the foot. The nav is the one both pages share. The demos themselves are built
-// separately; `clientScript` is the bundled `site/brand/client.ts`.
+// separately; `clientScript` is the bundled `site/brand/client.ts`, `rum` the Datadog init
+// snippet (page views only, no frame sampler).
 
 export function siteIndex(
     demos: DemoEntry[],
@@ -12,6 +13,7 @@ export function siteIndex(
     ref: string,
     mode: "prod" | "staging",
     clientScript: string = "",
+    rum: string = "",
 ): string {
     // staging labels by ref, never by version tag — a staging build routinely runs ahead of the
     // last release, so `v${version}` may name a GitHub tag that doesn't exist yet.
@@ -95,7 +97,7 @@ ${rows}
 <footer>${label}</footer>
 </main>
 <script type="module">${clientScript}</script>
-</body>
+${rum}</body>
 </html>
 `;
 }

--- a/site/rum-config.ts
+++ b/site/rum-config.ts
@@ -44,3 +44,37 @@ export const RUM_ENV_SNIPPET_STAGING = "var ddEnv='staging';";
 // and one that drops the wiring (leaving `ddEnv` computed but never read) each red on their own
 // clause instead of one silently covering for the other.
 export const RUM_ENV_USAGE = "Object.assign({env:ddEnv},";
+
+// Datadog RUM browser-agent CDN major, pinned — checked 2026-08-25 against the served
+// `/us1/v6/datadog-rum.js` bundle: `addDurationVital(name, {startTime, duration, context})` is
+// present as the one-shot form the Locked decision calls for (`startDurationVital`/
+// `stopDurationVital` also exist, unused here). Bump this only after re-checking that shape.
+const DATADOG_RUM_CDN_MAJOR = 6;
+const DATADOG_RUM_CDN_URL = `https://www.datadoghq-browser-agent.com/us1/v${DATADOG_RUM_CDN_MAJOR}/datadog-rum.js`;
+
+// `crossOrigin='anonymous'` on the injected script element: `shallot verify`'s dist/dev preview sends
+// `Cross-Origin-Embedder-Policy: require-corp` (`packages/shallot-tooling/src/project/vite.ts`, unconditional on
+// every serve surface — for the multithreaded WASM kernel, unrelated to RUM) and the CDN never sends a
+// `Cross-Origin-Resource-Policy` header, so a plain no-cors `<script src>` load is blocked
+// (`net::ERR_BLOCKED_BY_RESPONSE.NotSameOriginAfterDefaultedToSameOriginByCoep`, reproduced 2026-08-25 —
+// every `bun run demos` entry point failed on it). The CDN does answer a CORS request with
+// `Access-Control-Allow-Origin: *` (verified against a request carrying an `Origin` header), and a
+// CORS-mode load is exempt from the CORP check entirely — so `crossOrigin` fixes the verify-only failure
+// without needing a header change in `packages/shallot` (out of scope) or the deployed site, which never
+// sets COEP (a static host can't set headers, the doc comment above `CROSS_ORIGIN_ISOLATION` already notes).
+export function datadogInitSnippet(mode: "prod" | "staging" = "prod"): string {
+    const envSnippet = mode === "staging" ? RUM_ENV_SNIPPET_STAGING : RUM_ENV_SNIPPET;
+    return `${RUM_INJECTION_MARKER}
+<script>
+(function(h,o,u,n,d) {
+    h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
+    d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin='anonymous'
+    n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
+})(window,document,'script','${DATADOG_RUM_CDN_URL}','DD_RUM')
+window.DD_RUM.onReady(function() {
+    ${envSnippet}
+    window.DD_RUM.init(${RUM_ENV_USAGE}${JSON.stringify(RUM_CONFIG)}));
+});
+</script>
+`;
+}

--- a/site/site-stamp.ts
+++ b/site/site-stamp.ts
@@ -48,12 +48,15 @@ export const STAMP_FILE = "build-stamp.json";
  * carries the release version it pinned; staging carries the `file:<tgz>` pin `bun pm pack`
  * produced, so a mode mix-up (prod artifact stamped staging, or vice versa) reds on the pin shape
  * instead of passing silently. */
-export type SiteMode = { kind: "prod"; version: string } | { kind: "staging"; pin: string };
+export type SiteMode =
+    | { kind: "prod"; version: string; tag?: string }
+    | { kind: "staging"; pin: string };
 
 function isSiteMode(v: unknown): v is SiteMode {
     if (typeof v !== "object" || v === null) return false;
     const m = v as Record<string, unknown>;
-    if (m.kind === "prod") return typeof m.version === "string";
+    if (m.kind === "prod")
+        return typeof m.version === "string" && (m.tag === undefined || typeof m.tag === "string");
     if (m.kind === "staging") return typeof m.pin === "string";
     return false;
 }
@@ -218,6 +221,9 @@ export function staleDemos(rootDir: string, outDirPath: string, slugs: string[])
             reason: `no readable ${STAMP_FILE} — built before the artifact recorded its sources`,
         }));
     }
+    // demos built from a release tag were never this tree's sources; the tag is immutable, so the
+    // artifact cannot go stale against it
+    if (stamp.mode.kind === "prod" && stamp.mode.tag) return [];
     const current = demoFingerprints(rootDir, present);
     const stale: StaleDemo[] = [];
     for (const slug of present) {


### PR DESCRIPTION
## Problem

A production site deploy between releases fails: `bun run site` pins every demo to the workspace version (`0.10.0`), npm serves `0.9.5`, the first install dies. The new home and brand pages carry no Datadog. Production never wrote `llms.txt`.

## Cause

The site build assumed publish-then-tag ordering and had no answer for a tree ahead of npm. RUM was only ever injected into demo pages. One replacement in the previous branch silently missed, and Cloudflare's fallback masked the missing file as a 200.

## Fix

- `build-site.ts`: resolve npm latest; when the tree is ahead, extract the demos from that release tag with `git archive` and build them against the published package. Pages come from the tree. Stamp records the tag; `check-site.ts` accepts a tag pin, and `site-stamp.ts` treats tag sources as never stale.
- RUM init moves to `site/rum-config.ts`; `build-pages.ts` injects it into the home and brand pages (init only, no sampler). `check-site.ts` asserts the pages carry init alone with the mode's env. A standalone pages build uses the hostname-derived env.
- Production writes `llms.txt`.

## Evidence

- `bun run site` locally: release source, demos from `v0.9.5`, five demos built, footer `v0.9.5 · <ref>`, `llms.txt` pinned to `v0.9.5`.
- `SITE_OUT_REQUIRED=1 RUM_CONFIG_REQUIRED=1 bun run scripts/check-site.ts` on that artifact: green.
- Headless probe of the served artifact: SDK loaded, service `shallot-site`, env `local`, one intake request each on `/`, `/brand/`, `/collapse/`.
- Site tests, tsc, biome, eslint, exports, boundary, projection, format, scripts, docs: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3VcHkQvuuKdMLPMQB28gT
