### PR TITLE
shallot-brand: third promise back to runs where webgpu does

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ webgpu game engine
 
 - fast by default
 - instant iteration
-- checks itself
+- runs where webgpu does
 
 ## live demos
 

--- a/site/home.ts
+++ b/site/home.ts
@@ -40,7 +40,7 @@ export function siteIndex(
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>shallot</title>
-<meta name="description" content="webgpu game engine. fast by default, instant iteration, checks itself.">
+<meta name="description" content="webgpu game engine. fast by default, instant iteration, runs where webgpu does.">
 <link rel="icon" href="./brand/mark-32.png">
 ${AGENTS_LINK("home")}
 ${FONTS}
@@ -69,7 +69,7 @@ ${TOGGLE}
 ${nav("home")}
 <header>
 <div data-splash-svg data-scale="5">${toSvg(lockup(), CSS_PALETTE, 5)}</div>
-<p>webgpu game engine. fast by default, instant iteration, checks itself.</p>
+<p>webgpu game engine. fast by default, instant iteration, runs where webgpu does.</p>
 </header>
 
 <section>
@@ -112,7 +112,7 @@ export function llmsTxt(version: string, ref: string, mode: "prod" | "staging"):
         `https://raw.githubusercontent.com/dylanebert/shallot/${at}/${path}`;
     return `# shallot
 
-> webgpu game engine. fast by default, instant iteration, checks itself.
+> webgpu game engine. fast by default, instant iteration, runs where webgpu does.
 
 The source is the reference: every public export carries a JSDoc contract, and there is no docs site to drift from it. Two files carry the consumer surface. Read the first before writing a project; grep the second for the problem you have.
 


### PR DESCRIPTION
## Problem
The third promise read "checks itself", which lands as a slogan.

## Fix
Page, meta description, llms.txt and the README list say "runs where webgpu does".

## Evidence
Docs check green; no other occurrence in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q3VcHkQvuuKdMLPMQB28gT