### PR TITLE
shallot-brand-surfaces: sweep the old tokens

### DIFF
--- a/examples/gym/index.html
+++ b/examples/gym/index.html
@@ -12,7 +12,7 @@
                 padding: 0;
             }
             body {
-                background: #0c0a09;
+                background: #141210;
                 overflow: hidden;
             }
             #app {
@@ -30,7 +30,7 @@
                 flex-direction: column;
                 padding: 48px;
                 font-family: "JetBrains Mono", ui-monospace, monospace;
-                color: #f0ece8;
+                color: #f0e6d6;
                 /* the list overflows the viewport at ~60 scenarios (body is overflow:hidden); scroll it.
                    max-height (not height) leaves a short list unchanged — no scrollbar, no reflow. */
                 max-height: 100vh;
@@ -43,7 +43,7 @@
             #index p {
                 margin: 4px 0 16px;
                 font-size: 12px;
-                color: #a09890;
+                color: #a08c78;
             }
             #index nav {
                 display: flex;
@@ -63,7 +63,7 @@
             }
             #index a:hover {
                 background: rgba(212, 149, 96, 0.08);
-                color: #e8a86b;
+                color: #d49560;
             }
             /* top-right panel: live readout + auto-populated scenario controls */
             #panel {
@@ -76,8 +76,8 @@
                 padding: 8px 12px;
                 font-family: "JetBrains Mono", ui-monospace, monospace;
                 font-size: 12px;
-                color: #f0ece8;
-                background: rgba(14, 13, 12, 0.72);
+                color: #f0e6d6;
+                background: rgba(20, 18, 16, 0.72);
                 border: 1px solid rgba(255, 255, 255, 0.09);
                 border-radius: 4px;
             }
@@ -108,7 +108,7 @@
                 font-size: 11px;
             }
             .control span {
-                color: #a09890;
+                color: #a08c78;
             }
             .control input[type="number"],
             .control select {
@@ -116,13 +116,13 @@
                 padding: 2px 4px;
                 font: inherit;
                 font-size: 11px;
-                color: #f0ece8;
+                color: #f0e6d6;
                 background: #1c1917;
                 border: 1px solid rgba(255, 255, 255, 0.12);
                 border-radius: 3px;
             }
             .control input[type="checkbox"] {
-                accent-color: #e8a86b;
+                accent-color: #d49560;
             }
         </style>
     </head>

--- a/examples/recipes/overlay-ui/src/hud.ts
+++ b/examples/recipes/overlay-ui/src/hud.ts
@@ -15,7 +15,7 @@ const HudSystem: System = {
             panel = document.createElement("div");
             panel.style.cssText =
                 "position:absolute;top:12px;left:12px;padding:6px 10px;border-radius:4px;" +
-                "background:rgba(14,13,12,0.85);color:#f0ece8;font:12px ui-monospace,monospace";
+                "background:rgba(20,18,16,0.85);color:#f0e6d6;font:12px ui-monospace,monospace";
             overlay.append(panel);
             // clear the module ref on teardown so a rebuilt State re-mounts (the overlay is already gone).
             state.onDispose(() => {

--- a/examples/showcase/visualization/index.html
+++ b/examples/showcase/visualization/index.html
@@ -8,7 +8,7 @@
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
         <link
-            href="https://fonts.googleapis.com/css2?family=Outfit:wght@600;700&family=JetBrains+Mono:wght@400&display=swap"
+            href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400&family=JetBrains+Mono:wght@400;600;700&display=swap"
             rel="stylesheet"
         />
         <style>
@@ -18,9 +18,9 @@
                 padding: 0;
             }
             body {
-                background: #0e0d0c;
-                color: #f0ece8;
-                font-family: "JetBrains Mono", monospace;
+                background: #141210;
+                color: #f0e6d6;
+                font-family: "IBM Plex Sans", sans-serif;
                 padding: 4rem 1.5rem;
                 -webkit-font-smoothing: antialiased;
             }
@@ -29,12 +29,12 @@
                 margin: 0 auto;
             }
             h1 {
-                font-family: "Outfit", sans-serif;
+                font-family: "JetBrains Mono", monospace;
                 font-weight: 700;
                 font-size: 1.75rem;
             }
             .sub {
-                color: #a09890;
+                color: #a08c78;
                 font-size: 0.85rem;
                 margin: 0.6rem 0 2.5rem;
                 line-height: 1.6;
@@ -49,18 +49,18 @@
                 border: 0;
                 display: block;
                 border-radius: 10px;
-                background: #161514;
+                background: #141210;
             }
             .cap {
                 margin-top: 0.7rem;
-                color: #a09890;
+                color: #a08c78;
                 font-size: 0.82rem;
                 line-height: 1.5;
             }
             .cap b {
-                font-family: "Outfit", sans-serif;
+                font-family: "JetBrains Mono", monospace;
                 font-weight: 600;
-                color: #f0ece8;
+                color: #f0e6d6;
             }
         </style>
     </head>

--- a/examples/showcase/voxel/src/carve.ts
+++ b/examples/showcase/voxel/src/carve.ts
@@ -206,10 +206,10 @@ const POINTER_ICON = `<svg viewBox="0 0 24 24" width="18" height="18" fill="none
 const TERRAIN_ICON = `<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m8 3 4 8 5-5 5 15H2L8 3z"/></svg>`;
 
 const TOOLBAR_CSS = `
-.voxel-toolbar { position: absolute; top: 12px; left: 50%; transform: translateX(-50%); display: flex; gap: 4px; padding: 4px; pointer-events: auto; background: rgba(14, 13, 12, 0.72); border: 1px solid rgba(255, 255, 255, 0.09); border-radius: 10px; backdrop-filter: blur(8px); z-index: 20; }
-.voxel-tool { display: flex; align-items: center; justify-content: center; width: 36px; height: 36px; padding: 0; background: transparent; border: none; border-radius: 7px; color: #a09890; cursor: pointer; transition: background 120ms, color 120ms; }
-.voxel-tool:hover { background: rgba(255, 255, 255, 0.06); color: #f0ece8; }
-.voxel-tool.active { background: rgba(232, 168, 107, 0.16); color: #e8a86b; }
+.voxel-toolbar { position: absolute; top: 12px; left: 50%; transform: translateX(-50%); display: flex; gap: 4px; padding: 4px; pointer-events: auto; background: rgba(20, 18, 16, 0.72); border: 1px solid rgba(255, 255, 255, 0.09); border-radius: 10px; backdrop-filter: blur(8px); z-index: 20; }
+.voxel-tool { display: flex; align-items: center; justify-content: center; width: 36px; height: 36px; padding: 0; background: transparent; border: none; border-radius: 7px; color: #a08c78; cursor: pointer; transition: background 120ms, color 120ms; }
+.voxel-tool:hover { background: rgba(255, 255, 255, 0.06); color: #f0e6d6; }
+.voxel-tool.active { background: rgba(212, 149, 96, 0.16); color: #d49560; }
 `;
 
 // the modern top toolbar: two Lucide icon buttons (pointer / terrain), the active one warm-accented. Returns

--- a/packages/shallot-runtime/src/extras/orbit/overlay.ts
+++ b/packages/shallot-runtime/src/extras/orbit/overlay.ts
@@ -4,8 +4,8 @@ import { Orbit } from "./index";
 import { OrbitSmooth } from "./smooth";
 
 // palette + font match the profile HUD (extras/profile) so the two overlays read as one toolset
-const BG = "rgba(14,13,12,0.88)";
-const FG = "#f0ece8";
+const BG = "rgba(20,18,16,0.88)";
+const FG = "#f0e6d6";
 const ACCENT = "#d49560";
 const BORDER = "rgba(255,255,255,0.06)";
 const FONT = "'JetBrains Mono', ui-monospace, 'Cascadia Code', 'Fira Code', monospace";

--- a/packages/shallot-runtime/src/extras/orbit/tuning.ts
+++ b/packages/shallot-runtime/src/extras/orbit/tuning.ts
@@ -72,8 +72,8 @@ const TuningSystem: System = {
             top: "12px",
             right: "12px",
             padding: "8px",
-            background: "rgba(14,13,12,0.9)",
-            color: "#f0ece8",
+            background: "rgba(20,18,16,0.9)",
+            color: "#f0e6d6",
             font: "11px 'JetBrains Mono', monospace",
             pointerEvents: "auto",
         });

--- a/packages/shallot-runtime/src/extras/profile/index.ts
+++ b/packages/shallot-runtime/src/extras/profile/index.ts
@@ -537,9 +537,9 @@ interface OverlayOptions {
     position?: "top-left" | "top-right" | "bottom-left" | "bottom-right";
 }
 
-const BG = "rgba(14,13,12,0.88)";
+const BG = "rgba(20,18,16,0.88)";
 const FG = "#cdc5bc";
-const FG_BRIGHT = "#f0ece8";
+const FG_BRIGHT = "#f0e6d6";
 const DIM = "#706860";
 const ACCENT = "#d49560";
 const WARN = "#e05050";


### PR DESCRIPTION
Replace #f0ece8 with #f0e6d6 (ink), #e8a86b with #d49560 (gold), #a09890 with #a08c78 (muted), near-black (#0a0a0a-ish) with #141210. Update visualization index Google Fonts link to IBM Plex Sans for body, JetBrains Mono for headings. Swap font assignments in visualization and voxel toolbars.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
