### PR TITLE
shallot-release-boundaries: refuse unmet required feature floors

### DIFF
--- a/.claude/rules/gpu.md
+++ b/.claude/rules/gpu.md
@@ -58,7 +58,7 @@ Strip empty→reads→atomics→math→suspects; restore. Active set (solver col
 
 ## Native targets and webview backends
 
-Default wry webviews; portable CEF. Mac LDS/no subgroups; Linux needs portable. Build mismatch warns. Admission by features/limits, not browser name: a floor-meeting configuration owes rendered proof, and Firefox/Windows is unqualified. Intel Mac unaudited.
+Default wry webviews; portable CEF. Mac LDS/no subgroups; Linux needs portable. Admission by features/limits, not browser name: a floor-meeting configuration owes rendered proof, and Firefox/Windows is unqualified. Intel Mac unaudited.
 
 ## DXC shader compilation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Before Bevy machinery/analogues, read ecs.md "Bevy as the structural reference":
 
 One WebGPU 1.0 floor: indirect-first-instance, bgra8unorm-storage, rg11b10ufloat-renderable. Only default-plugin needs belong here; others declare required/preferred plugin features. Missing required fails before loading; only preferred features may fall back (BVH subgroups→LDS). Don't gate guaranteed features. Keep feature use behind narrow interfaces.
 
-Targets: desktop Chrome/Edge, recent Android Chrome, Safari26+ Apple Silicon, Steam Deck. Native defaults: wry WebView2/WKWebView/WebKitGTK; portable CEF required on Linux. Build mismatch warns, never blocks. Admission by features/limits, not browser name; a missing floor boots, explains, exits. Details: `gpu.md`.
+Targets: desktop Chrome/Edge, recent Android Chrome, Safari26+ Apple Silicon, Steam Deck. Native defaults: wry WebView2/WKWebView/WebKitGTK; portable CEF required on Linux. Admission by features/limits, not browser name; a missing floor boots, explains, exits. Details: `gpu.md`.
 
 ## Commands
 

--- a/packages/shallot-cli/bin/build.ts
+++ b/packages/shallot-cli/bin/build.ts
@@ -9,7 +9,7 @@ import {
     projectPlugin,
     typegpuPlugin,
 } from "../src/project/vite";
-import { requiredFeatures, verdict } from "./features";
+import { requireBackend } from "./features";
 import { bundleNativeLinux, bundleNativeMac, bundleNativeWindows, nativeOutDir } from "./native";
 import { composeViteConfig, loadProjectConfig } from "./toolchain";
 
@@ -120,11 +120,7 @@ export async function buildProject(
         const release = opts.release ?? false;
         const portable = opts.portable ?? false;
 
-        // warn (don't block) when the chosen backend can't satisfy the app's required features — the
-        // build still produces an artifact that reaches the engine's diagnostic tier at launch.
-        for (const line of verdict(target, portable, await requiredFeatures(projectDir))) {
-            console.warn(`  ! ${line}`);
-        }
+        await requireBackend(projectDir, target, portable);
 
         const outputDir = nativeOutDir(projectDir, target, release, portable);
         const label = relative(projectDir, outputDir);

--- a/packages/shallot-cli/bin/features-command.test.ts
+++ b/packages/shallot-cli/bin/features-command.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const dirs: string[] = [];
+afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+// Only replace the native emit/launch leaf, in a fresh process. Keep CLI parsing, command dispatch,
+// feature discovery, verdict and nativeOutDir real; the allowed arm writes to the caller's output.
+for (const command of ["build", "run"]) {
+    for (const [target, portable, allowed, gap, required] of [
+        ["linux", false, false, false, false],
+        ["linux", true, true, false, false],
+        ["mac", false, true, false, false],
+        ["windows", false, true, false, false],
+        ["mac", false, false, true, true],
+        ["mac", false, true, true, false],
+        ["mac", true, true, true, true],
+    ] as const) {
+        test(`${command} ${target} portable=${portable} gap=${gap} required=${required}: ${allowed ? "emits" : "refuses before emit"}`, () => {
+            const dir = mkdtempSync(join(tmpdir(), "shallot-floor-command-"));
+            dirs.push(dir);
+            writeFileSync(
+                join(dir, "shallot.json"),
+                JSON.stringify({ plugins: { Physics: true, Local: "./plugin.ts" } }),
+            );
+            writeFileSync(
+                join(dir, "plugin.ts"),
+                `
+console.log("PLUGIN_LOADED");
+export default { name: "Local", ${required ? "features" : "preferredFeatures"}: ["timestamp-query", "subgroups"] };
+`,
+            );
+            const preload = join(dir, "preload.ts");
+            const native = resolve(import.meta.dir, "native.ts");
+            writeFileSync(
+                preload,
+                `
+import { mock } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import * as native from ${JSON.stringify(native)};
+import { WEBVIEW_UNSUPPORTED } from ${JSON.stringify(resolve(import.meta.dir, "features.ts"))};
+${gap ? `WEBVIEW_UNSUPPORTED.mac = ["timestamp-query"];` : ""}
+const emit = async (projectDir, outputDir, opts) => {
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(join(outputDir, "emitted.json"), JSON.stringify({ projectDir, opts }));
+    console.log("NATIVE_EMIT");
+    process.exit(0);
+};
+mock.module(${JSON.stringify(native)}, () => ({ ...native,
+    bundleNativeLinux: emit, bundleNativeMac: emit, bundleNativeWindows: emit,
+}));
+`,
+            );
+            const result = Bun.spawnSync(
+                [
+                    process.execPath,
+                    "--preload",
+                    preload,
+                    resolve(import.meta.dir, "cli.ts"),
+                    command,
+                    dir,
+                    "--target",
+                    target,
+                    ...(portable ? ["--portable"] : []),
+                ],
+                { cwd: dir, env: process.env },
+            );
+            const output = result.stdout.toString() + result.stderr.toString();
+            const artifact = join(
+                dir,
+                "build",
+                target,
+                `debug-${portable ? "portable" : "system"}`,
+                "emitted.json",
+            );
+            if (allowed) {
+                expect(output).toContain("NATIVE_EMIT");
+                expect(result.exitCode).toBe(0);
+                expect(JSON.parse(readFileSync(artifact, "utf8"))).toEqual({
+                    projectDir: dir,
+                    opts: { release: false, portable },
+                });
+            } else {
+                expect(output).toContain("Cannot build");
+                expect(output).toContain(gap ? "timestamp-query" : "WebGPU base floor");
+                expect(output).toContain("--portable");
+                expect(result.exitCode).toBe(1);
+                expect(output).not.toContain("NATIVE_EMIT");
+                expect(existsSync(artifact)).toBe(false);
+                expect(existsSync(join(dir, "build"))).toBe(false);
+                expect(existsSync(join(dir, "dist"))).toBe(false);
+            }
+            expect(output).toContain("PLUGIN_LOADED");
+        });
+    }
+}

--- a/packages/shallot-cli/bin/features.test.ts
+++ b/packages/shallot-cli/bin/features.test.ts
@@ -1,24 +1,65 @@
-import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { requiredFeatures, verdict } from "./features";
+import { requiredFeatures, verdict, WEBVIEW_UNSUPPORTED } from "./features";
+
+const dirs: string[] = [];
+function temporary() {
+    const dir = mkdtempSync(join(tmpdir(), "shallot-features-"));
+    dirs.push(dir);
+    return dir;
+}
+afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
 
 describe("verdict", () => {
+    test("the same rule covers every backend row and required versus preferred gaps", () => {
+        const rows = {
+            unavailable: null,
+            populated: ["timestamp-query", "subgroups"],
+            complete: [],
+        };
+        try {
+            Object.assign(WEBVIEW_UNSUPPORTED, rows);
+            expect(Object.keys(WEBVIEW_UNSUPPORTED).sort()).toEqual([
+                "complete",
+                "linux",
+                "mac",
+                "populated",
+                "unavailable",
+                "windows",
+            ]);
+            for (const target of Object.keys(WEBVIEW_UNSUPPORTED)) {
+                for (const required of [[], ["timestamp-query"], ["unrelated-feature"]]) {
+                    expect(verdict(target, true, required)).toEqual([]);
+                    const refused =
+                        target === "linux" ||
+                        target === "unavailable" ||
+                        (target === "populated" && required.includes("timestamp-query"));
+                    expect(verdict(target, false, required).length > 0).toBe(refused);
+                }
+            }
+        } finally {
+            for (const target of Object.keys(rows)) delete WEBVIEW_UNSUPPORTED[target];
+        }
+    });
+
     test("portable is always clean — CEF ships its own Chromium", () => {
         expect(verdict("linux", true, ["subgroups"])).toEqual([]);
         expect(verdict("mac", true, ["subgroups"])).toEqual([]);
         expect(verdict("windows", true, ["subgroups"])).toEqual([]);
     });
 
-    test("linux default always warns — WebKitGTK has no usable WebGPU", () => {
+    test("linux default refuses — WebKitGTK has no usable WebGPU", () => {
         expect(verdict("linux", false, []).length).toBeGreaterThan(0);
         expect(verdict("linux", false, []).join(" ")).toContain("--portable");
     });
 
     test("mac default is clean — subgroups is preferred (LDS fallback), not a required gap", () => {
         // subgroups is a preferred feature, so it never reaches `required`; and mac WKWebView has no
-        // standing required-feature gap, so even passing it in warns nothing.
+        // standing required-feature gap, so even passing it in refuses nothing.
         expect(verdict("mac", false, ["subgroups"])).toEqual([]);
         expect(verdict("mac", false, [])).toEqual([]);
     });
@@ -31,7 +72,7 @@ describe("verdict", () => {
 
 describe("requiredFeatures", () => {
     function project(manifest: object): string {
-        const dir = mkdtempSync(join(tmpdir(), "shallot-features-"));
+        const dir = temporary();
         writeFileSync(join(dir, "shallot.json"), JSON.stringify(manifest));
         return dir;
     }

--- a/packages/shallot-cli/bin/features.ts
+++ b/packages/shallot-cli/bin/features.ts
@@ -5,19 +5,14 @@ import { normalize } from "../src/project/manifest";
 import { manifestPath } from "../src/project/vite";
 import { installGpuGlobals } from "./gpu-globals";
 
-// Required features (beyond the base floor) a wry/system-webview backend can't provide, keyed by
-// target — the hard "won't run" gaps the build warns about. `subgroups` is NOT one: physics lists it
-// as a `preferredFeatures` (LDS fallback on WKWebView), so it's never in the required set and a macOS
-// system-webview physics build runs. Windows WebView2 is full Chromium. Linux WebKitGTK has no usable
-// WebGPU at all — a different shape, handled directly in verdict(). Every CEF (`--portable`) build
-// ships its own Chromium, so it never appears here. One required feature beyond the floor exists today
-// — `ProfilePlugin`'s `timestamp-query`. WebView2 has every feature, and the 2026-06-19 WKWebView audit
-// (CLAUDE.md "Targets") recorded the then-floor complete with only `subgroups` absent, which is what
-// records it as having `timestamp-query` — so no gap stands, and the map is the seam for the first one
-// that does. See gpu.ts BASE_FEATURES + Plugin.features.
-const WEBVIEW_UNSUPPORTED: Record<string, readonly string[]> = {
+/** System-webview gaps beyond the base floor; null means the base floor itself is unavailable.
+ * WKWebView's Safari 26.5 / Apple Silicon audit met the floor including timestamp-query;
+ * subgroups is preferred (LDS fallback). WebView2 is Chromium; WebKitGTK has no usable WebGPU.
+ */
+export const WEBVIEW_UNSUPPORTED: Record<string, readonly string[] | null> = {
     mac: [],
     windows: [],
+    linux: null,
 };
 
 function readManifest(absDir: string) {
@@ -60,23 +55,26 @@ export async function requiredFeatures(projectDir: string): Promise<string[]> {
     return [...features];
 }
 
-/**
- * build-time warning lines for a (target, portable) backend given the project's required features —
- * empty when the chosen backend can render the app. Never blocks: a warned build still produces an
- * artifact that reaches the engine's diagnostic tier at launch, matching the loud-boundary contract.
- */
+/** Refusal lines for a backend missing the base floor or required plugin features; preferred
+ * features never enter `required`. Empty means allowed. Portable CEF supplies its own Chromium. */
 export function verdict(target: string, portable: boolean, required: readonly string[]): string[] {
-    if (portable) return []; // CEF ships its own Chromium — every feature, every platform
-    if (target === "linux") {
-        return [
-            "linux default uses WebKitGTK, which has no usable WebGPU — the app reaches the diagnostic",
-            "tier at launch. Rebuild with --portable for the bundled Chromium runtime.",
-        ];
-    }
-    const missing = (WEBVIEW_UNSUPPORTED[target] ?? []).filter((f) => required.includes(f));
+    if (portable) return [];
+    const unsupported = WEBVIEW_UNSUPPORTED[target];
+    const missing =
+        unsupported === null
+            ? ["WebGPU base floor"]
+            : (unsupported ?? []).filter((f) => required.includes(f));
     if (missing.length === 0) return [];
     return [
-        `${target} default uses the system webview, which lacks: ${missing.join(", ")} (required by`,
-        "the project's plugins). Rebuild with --portable for the bundled Chromium runtime.",
+        `Cannot build ${target}: the system webview lacks required ${missing.join(", ")}.`,
+        "Rebuild with --portable for the bundled Chromium runtime.",
     ];
+}
+
+/** Refuse before native emission or launch when the selected backend cannot run the project. */
+export async function requireBackend(projectDir: string, target: string, portable: boolean) {
+    const lines = verdict(target, portable, await requiredFeatures(projectDir));
+    if (lines.length === 0) return;
+    for (const line of lines) console.error(`  ${line}`);
+    process.exit(1);
 }

--- a/packages/shallot-cli/bin/run.ts
+++ b/packages/shallot-cli/bin/run.ts
@@ -3,6 +3,7 @@ import { basename, resolve } from "node:path";
 import { preview } from "vite";
 import { CROSS_ORIGIN_ISOLATION } from "../src/project/vite";
 import { buildWeb } from "./build";
+import { requireBackend } from "./features";
 import { bundleNativeLinux, bundleNativeMac, bundleNativeWindows, nativeOutDir } from "./native";
 
 export type RunTarget =
@@ -65,6 +66,12 @@ export async function runProject(
         return;
     }
 
+    if (runTarget.kind === "unknown") {
+        console.error(`unknown target: ${runTarget.target}`);
+        process.exit(1);
+    }
+    await requireBackend(projectDir, runTarget.kind, portable);
+
     if (runTarget.kind === "mac") {
         const outputDir = nativeOutDir(projectDir, "mac", release, portable);
         console.log(`\n  building ${basename(projectDir)}...\n`);
@@ -95,11 +102,6 @@ export async function runProject(
         process.stdout.write(result.stdout);
         process.stderr.write(result.stderr);
         process.exit(result.exitCode);
-    }
-
-    if (runTarget.kind === "unknown") {
-        console.error(`unknown target: ${runTarget.target}`);
-        process.exit(1);
     }
 
     const outputDir = nativeOutDir(projectDir, "windows", release, portable);

--- a/scripts/instruction-budget.json
+++ b/scripts/instruction-budget.json
@@ -1,5 +1,5 @@
 {
-    "total": 68365,
+    "total": 68218,
     "files": {
         ".claude/rules/audio.md": {
             "bytes": 3714,
@@ -18,11 +18,11 @@
             "paragraph": 432
         },
         ".claude/rules/exports.md": {
-            "bytes": 4296,
+            "bytes": 4284,
             "paragraph": 539
         },
         ".claude/rules/gpu.md": {
-            "bytes": 6916,
+            "bytes": 6894,
             "paragraph": 462
         },
         ".claude/rules/physics.md": {
@@ -38,7 +38,7 @@
             "paragraph": 473
         },
         ".claude/rules/testing.md": {
-            "bytes": 7781,
+            "bytes": 7773,
             "paragraph": 464
         },
         ".claude/rules/tumble.md": {
@@ -50,7 +50,7 @@
             "paragraph": 288
         },
         "AGENTS.md": {
-            "bytes": 4402,
+            "bytes": 4305,
             "paragraph": 614
         },
         "CLAUDE.md": {


### PR DESCRIPTION
## Problem
Native build and run could emit a project for a backend that cannot meet its required WebGPU floor.

## Cause
Build treated the classifier as advisory; run bypassed it. The advisory assumed a diagnostic tier could launch even on a backend without usable WebGPU.

## Fix
Use one table-driven refusal rule for unavailable base floors and missing required plugin features. Both commands consume it before native emission. Preferred-only gaps retain fallbacks; portable and floor-meeting defaults remain allowed. Remove the contradictory warning clauses.

## Evidence
Independent intake accepted candidate 731e08dfdd8144065fe47d1d2a17fdf7a542bfcd. Landed tree 552bec10d8e721853e505a5e4fbedfa6a56c60d0 matches it exactly. Final format/check and 68 focused tests passed; original-red and guard-deletion controls reached emission at both commands. Real CLI composition uses an isolated mocked native emit leaf, not native platform proof. Actual own-commit selection is zero CPU/zero display rows, not executed roster evidence. No unchanged member-gate replay on ship.
