### PR TITLE
Bind plugin loads to project roots

### DIFF
--- a/packages/shallot-cli/bin/features-command.test.ts
+++ b/packages/shallot-cli/bin/features-command.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -25,10 +25,16 @@ for (const command of ["build", "run"]) {
             dirs.push(dir);
             writeFileSync(
                 join(dir, "shallot.json"),
-                JSON.stringify({ plugins: { Physics: true, Local: "./plugin.ts" } }),
+                JSON.stringify({ plugins: { Physics: true, Local: "external-floor-plugin" } }),
+            );
+            const plugin = join(dir, "node_modules/external-floor-plugin");
+            mkdirSync(plugin, { recursive: true });
+            writeFileSync(
+                join(plugin, "package.json"),
+                JSON.stringify({ name: "external-floor-plugin", main: "index.js" }),
             );
             writeFileSync(
-                join(dir, "plugin.ts"),
+                join(plugin, "index.js"),
                 `
 console.log("PLUGIN_LOADED");
 export default { name: "Local", ${required ? "features" : "preferredFeatures"}: ["timestamp-query", "subgroups"] };

--- a/packages/shallot-cli/bin/features.test.ts
+++ b/packages/shallot-cli/bin/features.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { requiredFeatures, verdict, WEBVIEW_UNSUPPORTED } from "./features";
 
 const dirs: string[] = [];
@@ -71,11 +71,59 @@ describe("verdict", () => {
 });
 
 describe("requiredFeatures", () => {
+    for (const missing of [false, true])
+        test(`external bare required union, missing=${missing}`, () => {
+            const dir = temporary();
+            const plugin = join(dir, "node_modules/root-features");
+            mkdirSync(plugin, { recursive: true });
+            writeFileSync(
+                join(plugin, "package.json"),
+                JSON.stringify({ name: "root-features", main: "index.js" }),
+            );
+            const sentinel = join(dir, "evaluated");
+            writeFileSync(
+                join(plugin, "index.js"),
+                `import { writeFileSync } from "node:fs";
+            writeFileSync(${JSON.stringify(sentinel)}, "yes");
+            export default { name: "Local", features: ["timestamp-query"], preferredFeatures: ["subgroups"] };`,
+            );
+            writeFileSync(
+                join(dir, "shallot.json"),
+                JSON.stringify({
+                    plugins: {
+                        Local: "root-features",
+                        ...(missing ? { Gone: "missing-enabled-entry" } : {}),
+                        Disabled: ["not-installed-disabled", false],
+                    },
+                }),
+            );
+            const script = `
+            import assert from "node:assert/strict";
+            import { existsSync } from "node:fs";
+            import { requiredFeatures } from ${JSON.stringify(resolve(import.meta.dir, "features.ts"))};
+            ${
+                missing
+                    ? `await assert.rejects(requiredFeatures(${JSON.stringify(dir)}), /Gone/);
+            assert.equal(existsSync(${JSON.stringify(sentinel)}), false, "feature preflight before effects");`
+                    : `assert.deepEqual(await requiredFeatures(${JSON.stringify(dir)}), ["timestamp-query"], "external project required union");`
+            }
+        `;
+            const run = Bun.spawnSync([process.execPath, "-e", script], { cwd: dir });
+            expect(run.stderr.toString()).toBe("");
+            expect(run.exitCode).toBe(0);
+        });
     function project(manifest: object): string {
         const dir = temporary();
         writeFileSync(join(dir, "shallot.json"), JSON.stringify(manifest));
         return dir;
     }
+
+    test("resolved evaluation failures and absent defaults retain their feature-reader policy", async () => {
+        const dir = project({ plugins: { Throwing: "./throwing.js", NoDefault: "./empty.js" } });
+        writeFileSync(join(dir, "throwing.js"), "throw new Error('evaluation failure');");
+        writeFileSync(join(dir, "empty.js"), "export const notDefault = true;");
+        expect(await requiredFeatures(dir)).toEqual([]);
+    });
 
     test("a physics project requires nothing beyond the base floor — subgroups is preferred", async () => {
         // the BVH broadphase prefers subgroups but falls back to LDS, so physics lists it as a

--- a/packages/shallot-cli/bin/features.ts
+++ b/packages/shallot-cli/bin/features.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { plan } from "../src/project/generate";
+import { resolveLocalModules } from "../src/project/host";
 import { normalize } from "../src/project/manifest";
 import { manifestPath } from "../src/project/vite";
 import { installGpuGlobals } from "./gpu-globals";
@@ -28,12 +29,15 @@ function readManifest(absDir: string) {
  * runtime computes at `build()` (engine/app: `plugins.flatMap(p => p.features)`), resolved statically
  * from `shallot.json`. Imports the engine barrel under the GPU-constants shim, since the barrel
  * evaluates GPU module code at import (sear's top-level `GPUShaderStage`); local plugins import from
- * their specifier the same way. A local that fails to import is the web build's problem to surface.
+ * their project-resolved identity. Missing entries refuse before evaluation; an already-resolved
+ * local that fails during evaluation remains the web build's problem to surface.
  */
 export async function requiredFeatures(projectDir: string): Promise<string[]> {
     installGpuGlobals(); // install GPUShaderStage etc. so the barrel + locals import under the plain `bun` CLI
     const absDir = resolve(projectDir);
-    const { engine, locals } = plan(readManifest(absDir), absDir);
+    const project = plan(readManifest(absDir), absDir);
+    const locals = resolveLocalModules({ dir: absDir, locals: project.locals });
+    const { engine } = project;
 
     const shallot = (await import("@dylanebert/shallot")) as unknown as Record<
         string,

--- a/packages/shallot-cli/src/project/command.test.ts
+++ b/packages/shallot-cli/src/project/command.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { EXIT_OK, EXIT_SETUP, loadLocalPlugins, planProject } from "./command";
@@ -57,7 +57,7 @@ describe("planProject", () => {
         expect(result.plan?.scenes).toEqual([join("public", "main.scene")]);
     });
 
-    test("an installed bare plugin beside a local one plans clean from the project root", () => {
+    test("an installed bare plugin beside a local one loads from the project root", () => {
         const root = externalRoot("bare-plugin");
         const dir = join(root, "node_modules", "bare-plugin");
         mkdirSync(dir, { recursive: true });
@@ -74,6 +74,26 @@ describe("planProject", () => {
         const result = planProject(root);
         expect(result.code).toBe(EXIT_OK);
         expect(result.plan?.locals.map((l) => l.name)).toEqual(["Spin", "Bare"]);
+        const run = spawnSync(
+            process.execPath,
+            [
+                "-e",
+                `
+            import assert from "node:assert/strict";
+            const { planProject, loadLocalPlugins } = await import(${JSON.stringify(resolve(import.meta.dir, "command.ts"))});
+            const project = ${JSON.stringify(root)};
+            const result = planProject(project);
+            assert.equal(result.code, 0);
+            let loaded;
+            try { loaded = await loadLocalPlugins(result.plan); } catch { loaded = []; }
+            assert.equal(loaded.length, 2, "external project entries must load");
+            assert.strictEqual(loaded[1], (await import(Bun.resolveSync("bare-plugin", project))).default, "project module identity");
+        `,
+            ],
+            { encoding: "utf8", cwd: root },
+        );
+        expect(run.stderr).toBe("");
+        expect(run.status).toBe(0);
     });
 
     test("a missing dependency exits setup before any plugin module is evaluated", () => {
@@ -95,6 +115,38 @@ describe("planProject", () => {
 });
 
 describe("loadLocalPlugins", () => {
+    test("direct readProject loading refuses all entries before earlier effects", () => {
+        const root = externalRoot("eager");
+        const sentinel = join(root, "early.txt");
+        writeLocalPlugin(root, "early.ts", sentinel, "Early");
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({
+                plugins: {
+                    Early: "./src/early",
+                    Gone: "missing-enabled-entry",
+                },
+            }),
+        );
+        const run = spawnSync(
+            process.execPath,
+            [
+                "-e",
+                `
+            import assert from "node:assert/strict";
+            import { existsSync } from "node:fs";
+            const { readProject, loadLocalPlugins } = await import(${JSON.stringify(resolve(import.meta.dir, "command.ts"))});
+            let error;
+            try { await loadLocalPlugins(readProject(${JSON.stringify(root)})); } catch (e) { error = e; }
+            assert.equal(existsSync(${JSON.stringify(sentinel)}), false, "later missing entry must prevent earlier evaluation");
+            assert.match(String(error), /Gone/);
+        `,
+            ],
+            { encoding: "utf8", cwd: root },
+        );
+        expect(run.stderr).toBe("");
+        expect(run.status).toBe(0);
+    });
     test("an enabled local is evaluated; a disabled local is never evaluated", async () => {
         const root = externalRoot("disabled");
         const onSentinel = join(root, "on.txt");
@@ -127,6 +179,74 @@ describe("loadLocalPlugins", () => {
         if (!result.plan) throw new Error("no plan");
         await expect(loadLocalPlugins(result.plan)).rejects.toThrow('"Nope"');
     });
+});
+
+test("nested loaders discriminate same-name CLI decoys and scoped subpaths", () => {
+    const parent = externalRoot("binding");
+    const root = join(parent, "game");
+    const owner = resolve(import.meta.dir, "../..");
+    const name = "nested-binding-fixture";
+    const decoy = join(owner, "node_modules", name);
+    expect(existsSync(decoy)).toBe(false);
+    const sentinel = join(parent, "decoy");
+    try {
+        for (const dir of [join(root, "node_modules", name), decoy]) {
+            mkdirSync(dir, { recursive: true });
+            writeFileSync(join(dir, "package.json"), JSON.stringify({ name, main: "index.js" }));
+            writeFileSync(
+                join(dir, "index.js"),
+                dir === decoy
+                    ? `import { writeFileSync } from 'node:fs'; writeFileSync(${JSON.stringify(sentinel)}, 'yes'); export default { name: 'Decoy', features: ['decoy-only'] };`
+                    : `export default { name: 'Project', features: ['timestamp-query'], preferredFeatures: ['subgroups'] };`,
+            );
+        }
+        const scoped = join(root, "node_modules/@fixture/scoped");
+        mkdirSync(scoped, { recursive: true });
+        writeFileSync(
+            join(scoped, "package.json"),
+            JSON.stringify({ name: "@fixture/scoped", exports: { "./entry": "./index.js" } }),
+        );
+        writeFileSync(join(scoped, "index.js"), `export default { name: 'Scoped' };`);
+        writeFileSync(
+            join(root, "shallot.json"),
+            JSON.stringify({
+                plugins: {
+                    Local: name,
+                    Scoped: "@fixture/scoped/entry",
+                    Disabled: ["uninstalled-disabled", false],
+                },
+            }),
+        );
+        const run = spawnSync(
+            process.execPath,
+            [
+                "-e",
+                `
+            import assert from 'node:assert/strict';
+            import { existsSync } from 'node:fs';
+            import { requiredFeatures } from ${JSON.stringify(resolve(owner, "bin/features.ts"))};
+            const { planProject, loadLocalPlugins } = await import(${JSON.stringify(resolve(import.meta.dir, "command.ts"))});
+            const dir = ${JSON.stringify(root)};
+            const result = planProject(dir); assert.equal(result.code, 0);
+            const first = await loadLocalPlugins({ ...result.plan, locals: result.plan.locals.slice(0, 1) });
+            assert.strictEqual(first[0], (await import(Bun.resolveSync(${JSON.stringify(name)}, dir))).default, 'project identity, not CLI decoy');
+            const loaded = await loadLocalPlugins(result.plan);
+            for (const [i, spec] of [${JSON.stringify(name)}, '@fixture/scoped/entry'].entries())
+                assert.strictEqual(loaded[i], (await import(Bun.resolveSync(spec, dir))).default, 'project identity, not CLI decoy');
+            assert.deepEqual(await requiredFeatures(dir), ['timestamp-query'], 'project required union, not CLI decoy');
+            assert.equal(existsSync(${JSON.stringify(sentinel)}), false);
+            const decoy = (await import(Bun.resolveSync(${JSON.stringify(name)}, ${JSON.stringify(owner)}))).default;
+            assert.notStrictEqual(decoy, loaded[0]);
+            assert.equal(existsSync(${JSON.stringify(sentinel)}), true, 'CLI-root foil evaluates decoy');
+        `,
+            ],
+            { encoding: "utf8", cwd: parent },
+        );
+        expect(run.stderr).toBe("");
+        expect(run.status).toBe(0);
+    } finally {
+        rmSync(decoy, { recursive: true, force: true });
+    }
 });
 
 describe("one resolved plan, two consumers", () => {

--- a/packages/shallot-cli/src/project/command.ts
+++ b/packages/shallot-cli/src/project/command.ts
@@ -26,6 +26,7 @@ import {
     type ProjectIo,
     type ProjectPlan,
     readProject,
+    resolveLocalModules,
 } from "./host";
 
 export {
@@ -117,7 +118,7 @@ export async function loadEnginePlugins(names: readonly string[]): Promise<Plugi
  */
 export async function loadLocalPlugins(plan: ProjectPlan): Promise<Plugin[]> {
     const plugins: Plugin[] = [];
-    for (const local of plan.locals) {
+    for (const local of resolveLocalModules(plan)) {
         const mod = (await import(local.path)) as { default?: Plugin };
         const plugin = mod.default;
         if (!plugin || typeof plugin.name !== "string") {

--- a/packages/shallot-cli/src/project/host.ts
+++ b/packages/shallot-cli/src/project/host.ts
@@ -5,7 +5,7 @@
 //
 // Nothing here imports Vite, a browser API or a GPU global, and nothing here loads a plugin module: a
 // plan is data the caller may inspect, log or refuse before any module evaluation happens
-// (`command.ts` owns the loading half and runs it only after `localModuleErrors` is empty). That split
+// (Bun loaders resolve the complete entry set again at load time). That split
 // is what lets a dependency mistake fail with an exit code instead of a half-imported project.
 //
 // Presentation is deliberately absent: the host names the enabled plugins and, for a headless run, says
@@ -191,13 +191,29 @@ export function localModuleErrors(
     project: ProjectPlan,
     resolver: (spec: string, dir: string) => string | null = resolveFromProject,
 ): string[] {
-    if (!project.dir) return [];
+    return resolveModules(project, resolver).errors;
+}
+
+function resolveModules(
+    project: Pick<ProjectPlan, "dir" | "locals">,
+    resolver = resolveFromProject,
+) {
     const errors: string[] = [];
+    const locals: PlannedLocal[] = [];
     for (const local of project.locals) {
-        if (resolver(local.path, project.dir)) continue;
-        errors.push(
-            `shallot.json plugin "${local.name}": cannot resolve its module "${local.spec}" from ${project.dir}`,
-        );
+        const path = project.dir ? resolver(local.path, project.dir) : null;
+        if (path) locals.push({ ...local, path });
+        else
+            errors.push(
+                `shallot.json plugin "${local.name}": cannot resolve its module "${local.spec}" from ${project.dir}`,
+            );
     }
-    return errors;
+    return { locals, errors };
+}
+
+/** resolve every enabled entry before evaluation, retaining browser-authored paths in the plan. */
+export function resolveLocalModules(project: Pick<ProjectPlan, "dir" | "locals">): PlannedLocal[] {
+    const { locals, errors } = resolveModules(project);
+    if (errors.length) throw new Error(errors.join("\n"));
+    return locals;
 }

--- a/packages/shallot-cli/src/project/vite.test.ts
+++ b/packages/shallot-cli/src/project/vite.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { Rollup } from "vite";
+import { build, type Rollup } from "vite";
+import { loadLocalPlugins } from "./command";
+import { readProject } from "./host";
 import {
     assetSrc,
     classifyProjectFile,
@@ -25,6 +27,68 @@ const asset = (fileName: string, source: string | Uint8Array) =>
     ({ type: "asset", fileName, source }) as Rollup.OutputAsset;
 const bundle = (...files: (Rollup.OutputChunk | Rollup.OutputAsset)[]) =>
     Object.fromEntries(files.map((f) => [f.fileName, f])) as Rollup.OutputBundle;
+
+test("real project build preserves browser conditions separately from Bun", async () => {
+    const dir = projectDir();
+    const pkg = join(dir, "node_modules/conditional-binding");
+    mkdirSync(pkg, { recursive: true });
+    writeFileSync(
+        join(pkg, "package.json"),
+        JSON.stringify({
+            name: "conditional-binding",
+            exports: { ".": { browser: "./browser.js", bun: "./bun.js", default: "./default.js" } },
+        }),
+    );
+    for (const [file, name] of [
+        ["browser", "BrowserEntry"],
+        ["bun", "BunEntry"],
+        ["default", "WrongDefault"],
+    ])
+        writeFileSync(join(pkg, `${file}.js`), `export default { name: '${name}' };`);
+    const defaults = readProject(dir).engine;
+    writeFileSync(
+        join(dir, "shallot.json"),
+        JSON.stringify({
+            plugins: {
+                ...Object.fromEntries(defaults.map((name) => [name, false])),
+                Local: "conditional-binding",
+            },
+        }),
+    );
+    expect((await loadLocalPlugins(readProject(dir)))[0].name).toBe("BunEntry");
+    writeFileSync(
+        join(dir, "entry.js"),
+        `import project from 'virtual:project'; export default project.locals[0].plugin.name;`,
+    );
+    const result = await build({
+        configFile: false,
+        root: dir,
+        logLevel: "silent",
+        plugins: [projectPlugin(dir)],
+        build: {
+            write: false,
+            minify: false,
+            lib: { entry: join(dir, "entry.js"), formats: ["es"] },
+        },
+    });
+    const chunks = [result]
+        .flat()
+        .flatMap((result) => ("output" in result ? result.output : []))
+        .filter((output) => output.type === "chunk");
+    expect(chunks).toHaveLength(1);
+    const output = join(dir, "built.mjs");
+    writeFileSync(output, chunks[0].code);
+    const evaluated = Bun.spawnSync(
+        [
+            process.execPath,
+            "-e",
+            `import value from ${JSON.stringify(output)}; console.log(value);`,
+        ],
+        { cwd: dir },
+    );
+    expect(evaluated.exitCode).toBe(0);
+    expect(evaluated.stdout.toString().trim()).toBe("BrowserEntry");
+});
 
 describe("orphanedAssets", () => {
     test("drops a wasm no chunk references (the new-URL over-emit), keeps the live entry", () => {

--- a/scripts/boundary-seams.ts
+++ b/scripts/boundary-seams.ts
@@ -45,7 +45,7 @@ export const COMPUTED_LOADERS: Record<string, string> = {
     "packages/shallot-tumble/src/standard/tumble/engine/pool.ts":
         "the Node-only branch loads the fixed node:worker_threads specifier with vite-ignore; the browser branch creates an embedded Blob worker",
     "packages/shallot-cli/src/project/command.ts":
-        "loads enabled manifest plugins only after project planning resolves their paths",
+        "eagerly resolves every enabled entry from the project root, then imports those resolved identities",
     "packages/shallot-cli/src/project/command.test.ts":
         "the bare-process isolation fixture imports the named command entry under test",
     "examples/showcase/roads/test/edit-safety.playwright.ts":
@@ -53,7 +53,7 @@ export const COMPUTED_LOADERS: Record<string, string> = {
     "examples/showcase/roads/test/touch-smoke.playwright.ts":
         "browser-evaluated /src/ URLs into Roads' own src/, served by playwright.config.ts webServer shallot dev .; non-literal spelling leaves imports to the browser instead of Playwright's CJS transform",
     "packages/shallot-cli/bin/features.ts":
-        "loads the project's own manifest-declared local plugins to read their feature declarations",
+        "preflights all enabled project-root entry identities before engine/local evaluation, then reads required features from those identities",
     "packages/shallot-cli/bin/bun-native.ts":
         "loads the downloaded native projection, after its sha256 matches the pinned hash",
     "packages/shallot-cli/bin/verify.ts":

--- a/scripts/install-test.ts
+++ b/scripts/install-test.ts
@@ -25,6 +25,7 @@ import { dirname, join, resolve } from "node:path";
 import { compatibilityFlow } from "./install-test/compatibility";
 import { harnessArms, harnessContract } from "./install-test/harness";
 import { outputFlow } from "./install-test/output";
+import { projectFlow } from "./install-test/project";
 import { runtimeArms } from "./install-test/runtime";
 import { projectTumble, tumbleArms } from "./install-test/tumble";
 import { type ShaderArtifactSummary, skipReason, type VerifyResult, verify } from "./verify";
@@ -1832,6 +1833,7 @@ if (import.meta.main) {
         const particlesTgz = pack(PARTICLES_DIR, join(work, "particles-pack"));
 
         // display-independent, so it runs first: no GPU, no `skipReason()` guard anywhere above it
+        projectFlow(engineTgz, join(work, "project-seam"));
         identityFlow(work, engineTgz);
         pmIdentityFlow(work, engineTgz, "npm");
         pmIdentityFlow(work, engineTgz, "pnpm");

--- a/scripts/install-test/project.ts
+++ b/scripts/install-test/project.ts
@@ -1,0 +1,413 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    realpathSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { gunzipSync } from "node:zlib";
+import { inspectRuntime } from "./runtime";
+
+const root = resolve(import.meta.dir, "../..");
+const hash = (bytes: Uint8Array) => createHash("sha256").update(bytes).digest("hex");
+const json = (path: string, value: unknown) => writeFileSync(path, JSON.stringify(value, null, 2));
+const quote = JSON.stringify;
+
+function execute(evidence: string, name: string, argv: string[], cwd: string) {
+    mkdirSync(evidence, { recursive: true });
+    const result = Bun.spawnSync(argv, { cwd, stdout: "pipe", stderr: "pipe" });
+    const out = result.stdout.toString() + result.stderr.toString();
+    writeFileSync(join(evidence, `${name}.log`), out);
+    json(join(evidence, `${name}.json`), { argv, cwd, exit: result.exitCode });
+    assert.equal(result.exitCode, 0, `${name}: ${out}`);
+    return out;
+}
+
+function packageAt(dir: string, name: string, code: string, exports?: object) {
+    const path = join(dir, "node_modules", name);
+    mkdirSync(path, { recursive: true });
+    json(join(path, "package.json"), {
+        name,
+        version: "1.0.0",
+        type: "module",
+        main: "index.js",
+        ...(exports ? { exports } : {}),
+    });
+    writeFileSync(join(path, "index.js"), code);
+    return path;
+}
+
+/** Exercise project-root identity and all-entry preflight in fresh Bun processes, without a device. */
+function projectArms(
+    command: string,
+    features: string,
+    parent: string,
+    evidence: string,
+    identity = false,
+) {
+    const external = mkdtempSync(join(tmpdir(), "shallot-project-external-"));
+    const nested = mkdtempSync(join(parent, "game-"));
+    const name = "shallot-project-binding-fixture";
+    const decoyRoot = resolve(dirname(features), "..");
+    const decoy = join(decoyRoot, "node_modules", name);
+    assert(!existsSync(decoy), "owned decoy destination must be absent");
+    const decoySentinel = join(nested, "decoy-evaluated");
+    try {
+        for (const [layout, project] of [
+            ["external", external],
+            ["nested", nested],
+        ]) {
+            if (layout === "nested")
+                packageAt(
+                    decoyRoot,
+                    name,
+                    `import { writeFileSync } from 'node:fs'; writeFileSync(${quote(decoySentinel)}, 'yes'); export default { name: 'Decoy', features: ['decoy-only'] };`,
+                );
+            const disabled = join(project, "disabled");
+            const code = `export default { name: 'Project', features: ['timestamp-query'], preferredFeatures: ['subgroups'] };`;
+            packageAt(project, name, code);
+            packageAt(
+                project,
+                "@fixture/scoped",
+                `export default { name: 'Scoped', features: ['shader-f16'] };`,
+                { "./entry": "./index.js" },
+            );
+            packageAt(
+                project,
+                "disabled-binding",
+                `import { writeFileSync } from 'node:fs'; writeFileSync(${quote(disabled)}, 'yes'); export default { name: 'Disabled' };`,
+            );
+            writeFileSync(join(project, "relative.js"), `export default { name: 'Relative' };`);
+            writeFileSync(
+                join(project, "disabled.js"),
+                `import { writeFileSync } from 'node:fs'; writeFileSync(${quote(disabled)}, 'yes'); export default { name: 'Disabled' };`,
+            );
+            const manifest = {
+                plugins: {
+                    Bare: name,
+                    Scoped: "@fixture/scoped/entry",
+                    Relative: "./relative.js",
+                    Off: ["disabled-binding", false],
+                    OffFile: ["./disabled.js", false],
+                    Absent: ["uninstalled-disabled-binding", false],
+                },
+            };
+            json(join(project, "shallot.json"), manifest);
+            const prelude = `import assert from 'node:assert/strict'; import { existsSync, realpathSync } from 'node:fs';
+                const dir = ${quote(project)};
+                const { planProject, readProject, loadLocalPlugins } = await import(${quote(command)});
+                const { requiredFeatures } = await import(${quote(features)});`;
+            execute(
+                evidence,
+                `${layout}-identity`,
+                [
+                    process.execPath,
+                    "-e",
+                    `${prelude}
+                const planned = planProject(dir); assert.equal(planned.code, 0);
+                assert.deepEqual(planned.plan.locals.map(l => l.path), [${quote(name)}, '@fixture/scoped/entry', dir + '/relative.js']);
+                let loaded; try { loaded = await loadLocalPlugins(planned.plan); } catch { loaded = []; }
+                assert.equal(loaded.length, 3, 'all project entries load');
+                for (const [i, spec] of [${quote(name)}, '@fixture/scoped/entry', './relative.js'].entries())
+                    assert.strictEqual(loaded[i], (await import(Bun.resolveSync(spec, dir))).default, 'project object identity');
+                assert.equal(existsSync(${quote(disabled)}), false, 'disabled modules untouched');
+                assert.equal(existsSync(${quote(decoySentinel)}), false, 'CLI decoy untouched');
+                console.log('PASS project object identity, authored paths, disabled/decoy non-evaluation');
+            `,
+                ],
+                parent,
+            );
+            execute(
+                evidence,
+                `${layout}-features`,
+                [
+                    process.execPath,
+                    "-e",
+                    `${prelude}
+                assert.deepEqual(await requiredFeatures(dir), ['timestamp-query', 'shader-f16'], 'project required union excludes preferred and decoy');
+                assert.equal(existsSync(${quote(disabled)}), false);
+                assert.equal(existsSync(${quote(decoySentinel)}), false);
+                console.log('PASS project required union and non-evaluation');
+            `,
+                ],
+                parent,
+            );
+            for (const consumer of ["command", "features"]) {
+                const sentinel = join(project, `${consumer}-early`);
+                writeFileSync(
+                    join(project, "early.js"),
+                    `import { writeFileSync } from 'node:fs'; writeFileSync(${quote(sentinel)}, 'yes'); export default { name: 'Early' };`,
+                );
+                json(join(project, "shallot.json"), {
+                    plugins: { Early: "./early.js", Gone: "missing-enabled-binding" },
+                });
+                execute(
+                    evidence,
+                    `${layout}-${consumer}-missing`,
+                    [
+                        process.execPath,
+                        "-e",
+                        `${prelude}
+                    const setup = planProject(dir); assert.equal(setup.code, 2);
+                    let error; try { await ${consumer === "command" ? "loadLocalPlugins(readProject(dir))" : "requiredFeatures(dir)"}; } catch (e) { error = e; }
+                    assert.equal(existsSync(${quote(sentinel)}), false, 'all entries resolve before earlier effects');
+                    assert.match(String(error), /plugin "Gone".*missing-enabled-binding/);
+                    assert.ok(String(error).includes(dir));
+                    console.log('PASS setup exit 2, direct loader preflight, diagnostic identity');
+                `,
+                    ],
+                    parent,
+                );
+            }
+            if (layout === "nested") {
+                execute(
+                    evidence,
+                    "decoy-foil",
+                    [
+                        process.execPath,
+                        "-e",
+                        `${prelude}
+                    const wrong = (await import(Bun.resolveSync(${quote(name)}, ${quote(decoyRoot)}))).default;
+                    const right = (await import(Bun.resolveSync(${quote(name)}, dir))).default;
+                    assert.throws(() => assert.strictEqual(wrong, right), /same|equal|reference/i);
+                    assert.equal(existsSync(${quote(decoySentinel)}), true);
+                    console.log('PASS deliberately CLI-root import fails project identity');
+                `,
+                    ],
+                    parent,
+                );
+                if (identity) {
+                    const plugin = join(project, "node_modules", name, "index.js");
+                    writeFileSync(
+                        plugin,
+                        `import * as engine from '@dylanebert/shallot'; import tgpu from 'typegpu'; export { engine, tgpu }; export default { name: 'Identity' };`,
+                    );
+                    execute(
+                        evidence,
+                        "engine-typegpu-identity",
+                        [
+                            process.execPath,
+                            "-e",
+                            `${prelude}
+                        const { installGpuGlobals } = await import(${quote(join(dirname(features), "gpu-globals.ts"))}); installGpuGlobals();
+                        const origin = ${quote(dirname(plugin))};
+                        const bindings = {};
+                        for (const spec of ['@dylanebert/shallot', 'typegpu']) {
+                            const cli = realpathSync(Bun.resolveSync(spec, ${quote(decoyRoot)}));
+                            const child = realpathSync(Bun.resolveSync(spec, origin));
+                            assert.equal(cli, child, 'one dependency realpath'); bindings[spec] = { cli, child };
+                        }
+                        const plugin = await import(${quote(plugin)});
+                        assert.strictEqual(plugin.engine, await import(bindings['@dylanebert/shallot'].cli));
+                        assert.strictEqual(plugin.tgpu, (await import(bindings.typegpu.cli)).default);
+                        console.log(JSON.stringify(bindings));
+                    `,
+                        ],
+                        parent,
+                    );
+                }
+            }
+        }
+        execute(
+            evidence,
+            "purity",
+            [
+                process.execPath,
+                "-e",
+                `import assert from 'node:assert/strict'; await import(${quote(command)});
+            assert.equal(Object.keys(require.cache).some(p => ['vite', 'rollup', 'esbuild'].some(n => p.includes('/' + n + '/'))), false);
+            for (const key of ['window','document','GPUShaderStage','GPUBufferUsage']) assert.equal(key in globalThis, false);
+            console.log('PASS pure command import');`,
+            ],
+            parent,
+        );
+    } finally {
+        rmSync(decoy, { recursive: true, force: true });
+    }
+}
+
+/** Build and evaluate the actual virtual project with browser exports; Bun must choose its own entry. */
+function browserArm(command: string, viteEntry: string, parent: string, evidence: string) {
+    const project = mkdtempSync(join(parent, "conditions-"));
+    const pkg = packageAt(project, "conditional-binding", `export default { name: 'BunEntry' };`, {
+        ".": { browser: "./browser.js", bun: "./index.js", default: "./default.js" },
+    });
+    writeFileSync(join(pkg, "browser.js"), `export default { name: 'BrowserEntry' };`);
+    writeFileSync(join(pkg, "default.js"), `export default { name: 'WrongDefault' };`);
+    const script = `import assert from 'node:assert/strict';
+        import { writeFileSync } from 'node:fs';
+        const { readProject, loadLocalPlugins } = await import(${quote(command)});
+        const { projectPlugin } = await import(${quote(viteEntry)});
+        const { build } = await import(Bun.resolveSync('vite', ${quote(dirname(viteEntry))}));
+        const dir = ${quote(project)};
+        const defaults = readProject(dir).engine;
+        writeFileSync(dir + '/shallot.json', JSON.stringify({ plugins: { ...Object.fromEntries(defaults.map(n => [n, false])), Conditional: 'conditional-binding' } }));
+        assert.equal((await loadLocalPlugins(readProject(dir)))[0].name, 'BunEntry');
+        const result = await build({ configFile: false, root: dir, logLevel: 'silent', plugins: [projectPlugin(dir)],
+            build: { write: false, minify: false, lib: { entry: dir + '/entry.js', formats: ['es'] } } });
+        const outputs = [result].flat().flatMap(r => r.output);
+        assert.equal(outputs.filter(o => o.type === 'chunk').length, 1);
+        const code = outputs.find(o => o.type === 'chunk').code;
+        writeFileSync(dir + '/built.mjs', code);
+        console.log('PASS Bun marker and one browser output chunk');`;
+    writeFileSync(
+        join(project, "entry.js"),
+        `import project from 'virtual:project'; export default project.locals[0].plugin.name;`,
+    );
+    execute(evidence, "browser-conditions", [process.execPath, "-e", script], parent);
+    execute(
+        evidence,
+        "browser-evaluate",
+        [
+            process.execPath,
+            "-e",
+            `
+        import assert from 'node:assert/strict';
+        import marker from ${quote(join(project, "built.mjs"))};
+        assert.equal(marker, 'BrowserEntry', 'Vite project browser condition');
+        console.log('PASS evaluated browser marker differs from Bun marker');
+    `,
+        ],
+        parent,
+    );
+}
+
+/** Qualify one physical candidate installation, not the display/install roster. */
+export function projectFlow(tarball: string, evidence: string) {
+    assert(existsSync(tarball), "candidate tarball required");
+    assert(!existsSync(join(evidence, "binding.json")), "fresh evidence destination required");
+    mkdirSync(evidence, { recursive: true });
+    const bytes = readFileSync(tarball);
+    const tar = gunzipSync(bytes);
+    const archive: Record<string, string> = {};
+    let directories = 0;
+    let pax = 0;
+    for (let offset = 0; offset + 512 <= tar.length; ) {
+        const header = tar.subarray(offset, offset + 512);
+        if (header.every((b) => b === 0)) break;
+        const text = (start: number, length: number) =>
+            header
+                .subarray(start, start + length)
+                .toString()
+                .replace(/\0.*$/s, "");
+        const size = Number.parseInt(text(124, 12).trim(), 8) || 0;
+        const type = text(156, 1);
+        const name = [text(345, 155), text(0, 100)].filter(Boolean).join("/");
+        const content = tar.subarray(offset + 512, offset + 512 + size);
+        if (type === "x" || type === "g") {
+            pax++;
+            assert(
+                !/\d+ (?:path|linkpath)=/.test(content.toString()),
+                "unsupported PAX path override",
+            );
+        } else if (type === "5") directories++;
+        else {
+            assert(type === "0" || type === "", `unexpected archive type ${type}`);
+            assert(
+                name.startsWith("package/") &&
+                    !name.split("/").some((p) => p === ".." || p.startsWith("._")),
+            );
+            const file = name.slice(8);
+            assert(!Object.hasOwn(archive, file), `duplicate ${file}`);
+            archive[file] = hash(content);
+        }
+        offset += 512 + Math.ceil(size / 512) * 512;
+    }
+    assert(Object.keys(archive).length > 250, "nonempty physical archive population");
+    const fixture = join(evidence, "fixture.json");
+    const prior = existsSync(fixture) ? JSON.parse(readFileSync(fixture, "utf8")) : null;
+    if (prior)
+        assert.equal(prior.sha256, hash(bytes), "retained install must bind the same tarball");
+    const parent: string = prior?.parent ?? mkdtempSync(join(tmpdir(), "shallot-project-pack-"));
+    if (!prior) {
+        json(join(parent, "package.json"), {
+            private: true,
+            type: "module",
+            dependencies: { typegpu: "~0.12.4", vite: "^8.0.16" },
+        });
+        execute(evidence, "peers-install", [process.execPath, "install"], parent);
+        execute(evidence, "candidate-install", [process.execPath, "add", resolve(tarball)], parent);
+        json(fixture, { parent, sha256: hash(bytes) });
+    }
+    const bin = realpathSync(join(parent, "node_modules/.bin/shallot"));
+    const shipped = resolve(dirname(bin), "..");
+    const installed: Record<string, string> = {};
+    for (const entry of readdirSync(shipped, { recursive: true, withFileTypes: true })) {
+        const path = join(entry.parentPath, entry.name);
+        assert(!lstatSync(path).isSymbolicLink(), `package symlink ${path}`);
+        if (entry.isFile()) installed[relative(shipped, path)] = hash(readFileSync(path));
+    }
+    assert.deepEqual(installed, archive, "archive/install exact file hashes");
+    inspectRuntime(shipped);
+    const runtime = JSON.parse(readFileSync(join(shipped, "runtime-inputs.json"), "utf8"));
+    const cli = JSON.parse(readFileSync(join(shipped, "dist/cli-inputs.json"), "utf8"));
+    for (const [file, expected] of Object.entries(cli.inputs))
+        assert.equal(
+            hash(readFileSync(resolve(root, "packages/shallot-cli", file))),
+            expected,
+            `canonical CLI input ${file}`,
+        );
+    for (const [file, expected] of Object.entries(cli.outputs))
+        assert.equal(installed[file], expected, `installed CLI output ${file}`);
+    const command = join(shipped, "src/project/command.ts");
+    projectArms(command, join(shipped, "bin/features.ts"), parent, evidence, true);
+    browserArm(command, Bun.resolveSync("@dylanebert/shallot/vite", parent), parent, evidence);
+    const restored = Object.fromEntries(
+        readdirSync(shipped, { recursive: true, withFileTypes: true })
+            .filter((entry) => !entry.isDirectory())
+            .map((entry) => {
+                const file = join(entry.parentPath, entry.name);
+                assert(
+                    entry.isFile() && !lstatSync(file).isSymbolicLink(),
+                    `post-control physical file ${file}`,
+                );
+                return [relative(shipped, file), hash(readFileSync(file))];
+            }),
+    );
+    assert.deepEqual(restored, archive, "post-control archive closure");
+    const git = (args: string[]) =>
+        execute(
+            evidence,
+            `git-${args.join("-").replaceAll("/", "_")}`,
+            ["git", ...args],
+            root,
+        ).trim();
+    json(join(evidence, "binding.json"), {
+        tarball,
+        driver: { path: import.meta.path, sha256: hash(readFileSync(import.meta.path)) },
+        sha256: hash(bytes),
+        parent,
+        shipped,
+        bin,
+        commit: git(["rev-parse", "HEAD"]),
+        tree: git(["rev-parse", "HEAD^{tree}"]),
+        status: git(["status", "--short"]),
+        regular: Object.keys(archive).length,
+        directories,
+        pax,
+        archive,
+        installed,
+        runtime,
+        cli,
+        arms: 13,
+    });
+    console.log(
+        `project seam: 13 subprocess arms passed; ${Object.keys(archive).length} regular files, ${directories} directories, ${pax} PAX headers; ${hash(bytes)}`,
+    );
+}
+
+if (import.meta.main) {
+    const args = process.argv.slice(2);
+    assert.equal(args.length, 4, "usage: --tarball <path> --evidence <dir>");
+    assert.equal(args[0], "--tarball");
+    assert.equal(args[2], "--evidence");
+    projectFlow(resolve(args[1]), resolve(args[3]));
+}


### PR DESCRIPTION
## Problem
External and nested projects could pass bare-plugin validation but fail loading, or silently lose required feature declarations.

## Cause
Validation resolved from the project directory, while command and feature loaders imported unresolved names from the CLI directory.

## Fix
Share eager project-root resolution across validation and both Bun loaders. Resolve every enabled entry before evaluation, preserve browser-authored specifiers and Vite conditions, and retain disabled non-evaluation and existing feature evaluation-error handling. Add a bounded physical installed project-seam driver to the existing install flow.

## Evidence
Independently accepted candidate 887b241c57a607037ff4cacbd87cdb87dd58654a, tree 8377d262ea550308f3a63779f6bd8b6b079110ac.

- Format/check passed; 128 focused tests passed, no failures or skips.
- Five assertion-level mutations distinguish unresolved imports, same-name CLI decoys and resolve/import interleaving.
- Thirteen packed project-seam subprocess arms passed, including installed browser/Bun conditional exports and shared engine/TypeGPU identities.
- Physical tar SHA-256 d8429da7337a940e3d88ee706526716b84e9736749ac8bd7056d20100c47b244: 465 regular files, exact installed/source/output hash bindings.
- Own-commit selector selected zero CPU and zero display rows.

This is targeted loader qualification, not a full install/render/native/corpus campaign or release certification. Unchanged accepted gates are reused for shipping.
