### PR TITLE
shallot manifest css assets/E1

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -70,7 +70,7 @@ Bump all pins together, resolve lock, confirm one TypeGPU identity before gates.
 
 Evals tools: `bun run evals/setup.ts`, `bun run evals/grade.ts`.
 
-`bun run test:install`: pack, not link; browser plus build. Plain-Node export/brand checks before display guards, on intended realpaths. Boot doc recipes; inspect artifact imports, not erasable markers. Controls must yield false, not absence. Brand identity, not autonaming; pnpm needs distinct versions. Native packed build manual on packaging edits; presence isn't compile proof.
+`bun run test:install`: pack not link; browser/build; plain-Node export/brand/realpath/docs/imports, fail-closed; no selector. Reachability repairs owe `bun test --timeout 120000 ./packages/shallot-cli/bin/build.probes.ts`: source + physical public-build proof, retain/prune. Other CLI/manifest/deps/prebundle/launch/runtime/scaffold/native-package changes retain full install.
 
 ## Release gate
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ OS: windows/mac/linux; web build emits dist, run builds/previews; native dev run
 
 Before completion: format, check, test above. Release order: `testing.md` (all-roster AND separate demos). After AVBD/physics: `bun test ./packages/shallot/tests/avbd/*.oracle.ts`; engine/host/twin: `bun test ./examples/gym/src`; tumble fixtures from package per `tumble.md`; Rust audio: `cargo test` from `packages/shallot-runtime/rust/audio`.
 
-GPU changes owe bench; serialize/restore, config.ui/mountOverlay or dev-server changes owe flows; physics-recipe/substrate/tumble changes owe recipes. Display gates self-terminate, run headed on the seat's own display and run alone; no display refuses, never skips green. Packaging/CLI/manifest/assets/scaffold changes owe test:install; symlinks hide install defects.
+GPU/serialize/restore/config.ui/dev-server/physics changes owe bench/flow/recipe gates. Display gates self-terminate; unavailable refuses. Build-output reachability repairs owe source + physical public-build proof via build.probes.ts; other CLI/manifest/dependency/launch/runtime/scaffold/native-package changes owe full test:install; links don't prove it.
 
 ## Examples
 

--- a/packages/shallot-cli/bin/build.probes.ts
+++ b/packages/shallot-cli/bin/build.probes.ts
@@ -1,0 +1,353 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+    existsSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    realpathSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { buildWeb } from "./build";
+
+// G2's permanent command is:
+//     bun test --timeout 120000 ./packages/shallot-cli/bin/build.probes.ts
+// The source and installed arms both drive `bin/cli.ts build`'s buildWeb → viteBuild → projectPlugin
+// `generateBundle` path; the capture plugin is ordered before `projectPlugin` to prove the unused
+// tree-shaken new-URL asset existed before the pruning hook ran. This is deliberately a build probe,
+// not a browser/native/default-suite gate.
+
+const SHALL0T_ROOT = resolve(import.meta.dir, "../../..");
+const ENGINE_PACKAGE = resolve(SHALL0T_ROOT, "packages/shallot");
+const EVIDENCE = join(tmpdir(), "shallot-manifest-css-assets-build-probe");
+const CHILD_BYTES = Buffer.alloc(5_001, 0x43);
+const UNUSED_BYTES = Buffer.alloc(5_001, 0x55);
+CHILD_BYTES.write("SHALLOT-CSS-CHILD-v1");
+UNUSED_BYTES.write("SHALLOT-UNUSED-v1");
+
+const sha256 = (bytes: Uint8Array) => createHash("sha256").update(bytes).digest("hex");
+const quote = JSON.stringify;
+
+interface CapturedFile {
+    type: string;
+    fileName: string;
+    bytes: number | null;
+    sha256: string | null;
+}
+
+interface Capture {
+    files: CapturedFile[];
+}
+
+interface BundleFacts {
+    html: { bytes: number; sha256: string };
+    css: { file: string; bytes: number; sha256: string };
+    child: { file: string; bytes: number; sha256: string; prefix: string };
+    distFiles: string[];
+    distHashes: Record<string, string>;
+    prunedUnused: boolean;
+}
+
+function writeJson(path: string, value: unknown): void {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function filesUnder(root: string): string[] {
+    return readdirSync(root, { recursive: true, withFileTypes: true })
+        .filter((entry) => entry.isFile())
+        .map((entry) => join(entry.parentPath, entry.name));
+}
+
+function sourceFixture(parent: string) {
+    const project = mkdtempSync(join(parent, "source-"));
+    return createFixture(project);
+}
+
+function createFixture(project: string) {
+    const src = join(project, "src");
+    const dist = join(project, "dist");
+    const plugin = join(src, "css-plugin.ts");
+    const prePrune = join(project, "pre-prune.json");
+    mkdirSync(src, { recursive: true });
+    writeJson(join(project, "package.json"), { type: "module" });
+    writeJson(join(project, "shallot.json"), {
+        plugins: {
+            Slab: false,
+            Transforms: false,
+            Input: false,
+            Render: false,
+            Part: false,
+            Sear: false,
+            Glaze: false,
+            CssFixture: "./src/css-plugin.ts",
+        },
+    });
+    writeFileSync(
+        plugin,
+        'import "./style.css";\nexport function unusedAsset() { return new URL("./unused.bin", import.meta.url); }\nexport default { name: "CssFixture" };\n',
+    );
+    writeFileSync(join(src, "style.css"), 'body{background-image:url("./child.bin")}\n');
+    writeFileSync(join(src, "child.bin"), CHILD_BYTES);
+    writeFileSync(join(src, "unused.bin"), UNUSED_BYTES);
+    // This project plugin runs before Shallot's output hook. It records bytes/hashes, not only names, so
+    // the post-build assertion proves a real unused asset was emitted and then removed.
+    writeFileSync(
+        join(project, "vite.config.ts"),
+        `import { createHash } from "node:crypto";
+import { writeFileSync } from "node:fs";
+const receipt = ${quote(prePrune)};
+const hash = (bytes) => createHash("sha256").update(bytes).digest("hex");
+export default { plugins: [{ name: "capture-css-assets-before-prune", enforce: "pre", generateBundle(_options, bundle) {
+    writeFileSync(receipt, JSON.stringify({ files: Object.values(bundle).map((file) => {
+        if (file.type !== "asset") return { type: file.type, fileName: file.fileName, bytes: null, sha256: null };
+        const bytes = Buffer.from(file.source);
+        return { type: file.type, fileName: file.fileName, bytes: bytes.byteLength, sha256: hash(bytes) };
+    }) }, null, 2));
+} }] };
+`,
+    );
+    assert.equal(
+        existsSync(join(project, "index.html")),
+        false,
+        "fixture must begin without source HTML",
+    );
+    return { project, src, plugin, prePrune, dist };
+}
+
+function run(name: string, argv: string[], cwd: string) {
+    const result = Bun.spawnSync(argv, {
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 120_000,
+    });
+    const output = `${result.stdout.toString()}\n${result.stderr.toString()}`;
+    writeFileSync(join(EVIDENCE, `${name}.log`), output);
+    writeJson(join(EVIDENCE, `${name}.json`), {
+        argv,
+        cwd,
+        exit: result.exitCode,
+        signal: result.signalCode,
+        runtime: Bun.version,
+    });
+    assert.equal(result.exitCode, 0, `${name} failed:\n${output}`);
+    return output;
+}
+
+function outputPath(dist: string, reference: string): string {
+    const withoutQuery = reference.split(/[?#]/, 1)[0];
+    return resolve(dist, withoutQuery.replace(/^\.\//, ""));
+}
+
+function verifyBundle(fixture: ReturnType<typeof createFixture>): BundleFacts {
+    assert(existsSync(fixture.prePrune), "the pre-prune output capture must run");
+    const capture = JSON.parse(readFileSync(fixture.prePrune, "utf8")) as Capture;
+    const unusedHash = sha256(UNUSED_BYTES);
+    const unusedBeforePrune = capture.files.find(
+        (file) =>
+            file.type === "asset" &&
+            file.bytes === UNUSED_BYTES.byteLength &&
+            file.sha256 === unusedHash,
+    );
+    assert(
+        unusedBeforePrune,
+        "the tree-shaken new-URL asset must exist before generateBundle pruning",
+    );
+
+    const htmlPath = join(fixture.dist, "index.html");
+    assert(existsSync(htmlPath), "build must emit synthesized HTML");
+    const html = readFileSync(htmlPath, "utf8");
+    const cssReferences = [...html.matchAll(/href=["']([^"']+\.css(?:\?[^"']*)?)["']/g)].map(
+        (match) => match[1],
+    );
+    assert.equal(cssReferences.length, 1, "HTML must point to one emitted CSS asset");
+    const cssFile = outputPath(fixture.dist, cssReferences[0]);
+    assert(existsSync(cssFile), `HTML CSS reference must resolve: ${cssReferences[0]}`);
+    const css = readFileSync(cssFile);
+    assert(css.byteLength > 0, "emitted CSS must be nonempty");
+
+    const childReference = /url\(["']?([^)"']+)["']?\)/.exec(css.toString())?.[1];
+    assert(childReference, "emitted CSS must retain its child-asset reference");
+    const childFile = outputPath(dirname(cssFile), childReference);
+    assert(existsSync(childFile), `CSS child reference must resolve: ${childReference}`);
+    const child = readFileSync(childFile);
+    assert.deepEqual(child, CHILD_BYTES, "CSS child bytes/signature must survive unchanged");
+
+    const distFiles = filesUnder(fixture.dist);
+    const distHashes = Object.fromEntries(
+        distFiles.map((file) => [relative(fixture.dist, file), sha256(readFileSync(file))]),
+    );
+    assert(
+        !distFiles.some((file) => sha256(readFileSync(file)) === unusedHash),
+        "the genuinely unused asset must be absent after generateBundle pruning",
+    );
+    assert(
+        !distFiles.some((file) => readFileSync(file).includes(UNUSED_BYTES)),
+        "the unused asset bytes must be absent after generateBundle pruning",
+    );
+    return {
+        html: { bytes: Buffer.byteLength(html), sha256: sha256(Buffer.from(html)) },
+        css: {
+            file: relative(fixture.dist, cssFile),
+            bytes: css.byteLength,
+            sha256: sha256(css),
+        },
+        child: {
+            file: relative(fixture.dist, childFile),
+            bytes: child.byteLength,
+            sha256: sha256(child),
+            prefix: child.subarray(0, "SHALLOT-CSS-CHILD-v1".length).toString(),
+        },
+        distFiles: distFiles.map((file) => relative(fixture.dist, file)),
+        distHashes,
+        prunedUnused: true,
+    };
+}
+
+function installedIdentity(consumer: string) {
+    const installed = join(consumer, "node_modules/@dylanebert/shallot");
+    const bin = join(consumer, "node_modules/.bin/shallot");
+    assert(existsSync(installed), "packed engine must be installed");
+    assert(existsSync(bin), "installed public shallot bin must exist");
+    assert.equal(
+        lstatSync(installed).isSymbolicLink(),
+        false,
+        "installed engine must not be a symlink",
+    );
+    const packageRealpath = realpathSync(installed);
+    const binRealpath = realpathSync(bin);
+    assert.equal(packageRealpath, installed, "installed package realpath must be physical");
+    assert.equal(
+        binRealpath,
+        resolve(packageRealpath, "bin/cli.ts"),
+        "public bin must target installed CLI",
+    );
+    return { packageRealpath, binRealpath };
+}
+
+test("manifest build retains imported CSS/child assets and prunes a tree-shaken new-URL asset in source and pack installs", async () => {
+    rmSync(EVIDENCE, { recursive: true, force: true });
+    mkdirSync(EVIDENCE, { recursive: true });
+    const sourceParent = mkdtempSync(join(SHALL0T_ROOT, ".shallot-css-build-"));
+    const consumer = realpathSync(mkdtempSync(join(tmpdir(), "shallot-css-consumer-")));
+    let sourceFixtureValue: ReturnType<typeof createFixture> | undefined;
+    let consumerFixture: ReturnType<typeof createFixture> | undefined;
+    try {
+        sourceFixtureValue = sourceFixture(sourceParent);
+        await buildWeb(sourceFixtureValue.project);
+        const sourceBundle = verifyBundle(sourceFixtureValue);
+
+        const originalPlugin = readFileSync(sourceFixtureValue.plugin, "utf8");
+        writeFileSync(
+            sourceFixtureValue.plugin,
+            'import "./this-local-plugin-does-not-exist.css"; export default { name: "CssFixture" };\n',
+        );
+        let invalidError: unknown;
+        try {
+            await buildWeb(sourceFixtureValue.project);
+        } catch (error) {
+            invalidError = error;
+        } finally {
+            writeFileSync(sourceFixtureValue.plugin, originalPlugin);
+        }
+        assert(invalidError, "an invalid local plugin must fail the build");
+        assert.equal(
+            existsSync(join(sourceFixtureValue.project, "index.html")),
+            false,
+            "failed build must remove synthesized source HTML",
+        );
+
+        consumerFixture = createFixture(join(consumer, "game"));
+        assert.equal(
+            existsSync(join(consumer, "node_modules")),
+            false,
+            "consumer starts absent-only",
+        );
+        writeJson(join(consumer, "package.json"), {
+            name: "shallot-css-asset-consumer",
+            private: true,
+            type: "module",
+            dependencies: {
+                "@dylanebert/shallot": "PACK_TARBALL",
+                typegpu: "~0.12.4",
+            },
+        });
+
+        const packDir = join(EVIDENCE, "pack");
+        mkdirSync(packDir, { recursive: true });
+        const packOutput = run(
+            "pack",
+            ["bun", "pm", "pack", "--destination", packDir, "--quiet"],
+            ENGINE_PACKAGE,
+        );
+        const tarballs = readdirSync(packDir).filter((file) => file.endsWith(".tgz"));
+        assert.equal(tarballs.length, 1, `pack must produce exactly one tarball:\n${packOutput}`);
+        const tarball = join(packDir, tarballs[0]);
+        const packageJson = JSON.parse(readFileSync(join(consumer, "package.json"), "utf8")) as {
+            dependencies: Record<string, string>;
+        };
+        packageJson.dependencies["@dylanebert/shallot"] = `file:${tarball}`;
+        writeJson(join(consumer, "package.json"), packageJson);
+
+        run("install", ["bun", "install", "--no-progress"], consumer);
+        const lockPath = join(consumer, "bun.lock");
+        assert(existsSync(lockPath), "first physical install must write bun.lock");
+        const lockHash = sha256(readFileSync(lockPath));
+        rmSync(join(consumer, "node_modules"), { recursive: true, force: true });
+        run(
+            "install-frozen-repeat",
+            ["bun", "install", "--frozen-lockfile", "--no-progress"],
+            consumer,
+        );
+        assert.equal(
+            sha256(readFileSync(lockPath)),
+            lockHash,
+            "frozen repeat must retain lock bytes",
+        );
+        const identity = installedIdentity(consumer);
+
+        const physicalBuildOutput = run(
+            "physical-build",
+            ["bunx", "shallot", "build", "."],
+            consumerFixture.project,
+        );
+        const physicalBundle = verifyBundle(consumerFixture);
+        assert.match(physicalBuildOutput, /done\./, "public bin build must complete");
+
+        writeJson(join(EVIDENCE, "receipt.json"), {
+            command: "bun test --timeout 120000 ./packages/shallot-cli/bin/build.probes.ts",
+            runtime: Bun.version,
+            source: {
+                project: sourceFixtureValue.project,
+                bundle: sourceBundle,
+                failedLocalPluginRemovedIndex: true,
+            },
+            pack: {
+                tarball,
+                sha256: sha256(readFileSync(tarball)),
+                output: packOutput,
+            },
+            consumer: {
+                project: consumerFixture.project,
+                lock: lockPath,
+                lockSha256: lockHash,
+                packageRealpath: identity.packageRealpath,
+                binRealpath: identity.binRealpath,
+                bundle: physicalBundle,
+            },
+        });
+        console.log(
+            `G2 source+pack passed: tarball ${sha256(readFileSync(tarball))}; lock ${lockHash}; ` +
+                `bin ${identity.binRealpath}`,
+        );
+    } finally {
+        rmSync(sourceParent, { recursive: true, force: true });
+        rmSync(consumer, { recursive: true, force: true });
+    }
+});

--- a/packages/shallot-cli/bin/features-command.test.ts
+++ b/packages/shallot-cli/bin/features-command.test.ts
@@ -1,15 +1,380 @@
 import { afterEach, expect, test } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    realpathSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { parse, parseExpression } from "@babel/parser";
 
 const dirs: string[] = [];
 afterEach(() => {
     for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
-// Only replace the native emit/launch leaf, in a fresh process. Keep CLI parsing, command dispatch,
-// feature discovery, verdict and nativeOutDir real; the allowed arm writes to the caller's output.
+function fixture(required: boolean, gap: boolean) {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), "shallot-floor-command-")));
+    dirs.push(dir);
+    writeFileSync(
+        join(dir, "shallot.json"),
+        JSON.stringify({ plugins: { Physics: true, Local: "external-floor-plugin" } }),
+    );
+    const plugin = join(dir, "node_modules/external-floor-plugin");
+    mkdirSync(plugin, { recursive: true });
+    writeFileSync(
+        join(plugin, "package.json"),
+        JSON.stringify({ name: "external-floor-plugin", main: "index.js" }),
+    );
+    writeFileSync(
+        join(plugin, "index.js"),
+        `console.log("PLUGIN_LOADED"); export default { name: "Local", ${required ? "features" : "preferredFeatures"}: ["timestamp-query", "subgroups"] };`,
+    );
+    const preload = join(dir, "preload.ts");
+    writeFileSync(
+        preload,
+        `import { WEBVIEW_UNSUPPORTED } from ${JSON.stringify(resolve(import.meta.dir, "features.ts"))}; ${gap ? 'WEBVIEW_UNSUPPORTED.mac = ["timestamp-query"];' : ""}`,
+    );
+    const id = crypto.randomUUID();
+    const receipt = join(dir, "config-receipt.json");
+    // The real native bundle functions load project configuration before cargo or app launch. This
+    // fixture exits at that boundary, so the receipt proves the production path without compiling or
+    // launching a native target.
+    writeFileSync(
+        join(dir, "vite.config.ts"),
+        `
+import { writeFileSync } from "node:fs";
+export default function config({ command, mode }) {
+    writeFileSync(${JSON.stringify(receipt)}, JSON.stringify({ id: ${JSON.stringify(id)}, command, mode, project: process.cwd(), configDir: import.meta.dirname }));
+    console.log("PROJECT_CONFIG_REACHED");
+    process.exit(0);
+}
+`,
+    );
+    return { dir, preload, receipt, id };
+}
+
+function commandReceipt(
+    command: string,
+    target: string,
+    portable: boolean,
+    project: ReturnType<typeof fixture>,
+) {
+    expect(existsSync(join(project.dir, "index.html"))).toBe(false);
+    const result = Bun.spawnSync(
+        [
+            process.execPath,
+            "--preload",
+            project.preload,
+            resolve(import.meta.dir, "cli.ts"),
+            command,
+            project.dir,
+            "--target",
+            target,
+            ...(portable ? ["--portable"] : []),
+        ],
+        { cwd: project.dir, env: process.env },
+    );
+    return { result, output: result.stdout.toString() + result.stderr.toString() };
+}
+
+function reached(project: ReturnType<typeof fixture>) {
+    expect(JSON.parse(readFileSync(project.receipt, "utf8"))).toEqual({
+        id: project.id,
+        command: "build",
+        mode: "production",
+        project: project.dir,
+        configDir: project.dir,
+    });
+    expect(existsSync(join(project.dir, "build"))).toBe(false);
+    expect(existsSync(join(project.dir, "dist"))).toBe(false);
+    expect(existsSync(join(project.dir, "index.html"))).toBe(false);
+}
+
+test("qualified real project config receipt precedes native tooling", () => {
+    const project = fixture(false, false);
+    const { result, output } = commandReceipt("build", "mac", false, project);
+    expect({ exit: result.exitCode, output }).toEqual({
+        exit: 0,
+        output: expect.stringContaining("PROJECT_CONFIG_REACHED"),
+    });
+    expect(output).toContain("PLUGIN_LOADED");
+    reached(project);
+});
+
+type Syntax = { type: string; [key: string]: unknown };
+type Site = { node: Syntax; parents: Syntax[] };
+
+// The receipt cannot observe native output/options, so this independently parses the live CLI
+// binding and follows the imported function, branch and argument cardinality rather than matching text.
+function sites(value: unknown, parents: Syntax[] = []): Site[] {
+    if (!value || typeof value !== "object") return [];
+    if (Array.isArray(value)) return value.flatMap((child) => sites(child, parents));
+    const node = value as Syntax;
+    if (typeof node.type !== "string") return [];
+    return [
+        { node, parents },
+        ...Object.entries(node).flatMap(([key, child]) =>
+            [
+                "loc",
+                "start",
+                "end",
+                "extra",
+                "comments",
+                "leadingComments",
+                "trailingComments",
+                "innerComments",
+            ].includes(key)
+                ? []
+                : sites(child, [...parents, node]),
+        ),
+    ];
+}
+
+function semantic(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(semantic);
+    if (!value || typeof value !== "object") return value;
+    return Object.fromEntries(
+        Object.entries(value)
+            .filter(
+                ([key]) =>
+                    ![
+                        "loc",
+                        "start",
+                        "end",
+                        "extra",
+                        "errors",
+                        "comments",
+                        "leadingComments",
+                        "trailingComments",
+                        "innerComments",
+                    ].includes(key),
+            )
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([key, child]) => [key, semantic(child)]),
+    );
+}
+
+const ast = (file: string) =>
+    parse(readFileSync(resolve(import.meta.dir, file), "utf8"), {
+        sourceType: "module",
+        plugins: ["typescript"],
+    });
+const expression = (source: string) => semantic(parseExpression(source));
+const isName = (node: unknown, name: string) =>
+    (node as Syntax)?.type === "Identifier" && (node as Syntax).name === name;
+
+function imported(tree: ReturnType<typeof ast>, name: string, from: string): string {
+    const matches = tree.program.body
+        .filter((node) => node.type === "ImportDeclaration")
+        .flatMap((node) =>
+            node.specifiers
+                .filter(
+                    (specifier) =>
+                        specifier.type === "ImportSpecifier" &&
+                        specifier.imported.type === "Identifier" &&
+                        specifier.imported.name === name,
+                )
+                .map((specifier) => ({ local: specifier.local.name, from: node.source.value })),
+        );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].from).toBe(from);
+    const local = matches[0].local;
+    // A same-spelled local would hide the imported binding. Refuse that ambiguous production shape
+    // rather than claiming the AST check resolved a different symbol.
+    for (const { node } of sites(tree)) {
+        const declarations =
+            node.type === "VariableDeclarator"
+                ? [node.id]
+                : ["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"].includes(
+                        node.type,
+                    )
+                  ? [node.id, node.params]
+                  : node.type === "CatchClause"
+                    ? [node.param]
+                    : [];
+        expect(
+            declarations.flatMap((decl) => sites(decl)).some(({ node }) => isName(node, local)),
+        ).toBe(false);
+        if (node.type === "AssignmentExpression") expect(isName(node.left, local)).toBe(false);
+    }
+    return local;
+}
+
+function calls(tree: unknown, name: string): Site[] {
+    return sites(tree).filter(
+        ({ node }) => node.type === "CallExpression" && isName(node.callee, name),
+    );
+}
+
+function owner(site: Site, name: string): Syntax {
+    const fn = site.parents.findLast((node) => node.type === "FunctionDeclaration");
+    expect((fn?.id as Syntax)?.name).toBe(name);
+    return fn!;
+}
+
+function declaration(site: Site, name: string): Syntax {
+    for (const block of site.parents.toReversed()) {
+        if (block.type !== "BlockStatement" && block.type !== "Program") continue;
+        const matches = (block.body as Syntax[])
+            .filter((node) => node.type === "VariableDeclaration")
+            .flatMap((node) =>
+                (node.declarations as Syntax[])
+                    .filter((decl) => isName(decl.id, name))
+                    .map((decl) => ({ kind: node.kind, decl })),
+            );
+        if (!matches.length) continue;
+        expect(matches).toHaveLength(1);
+        expect(matches[0].kind).toBe("const");
+        expect(matches[0].decl.start as number).toBeLessThan(site.node.start as number);
+        return matches[0].decl.init as Syntax;
+    }
+    throw new Error(`missing local binding ${name}`);
+}
+
+function argumentsAre(site: Site, args: string): void {
+    expect(semantic(site.node.arguments)).toEqual(
+        semantic((parseExpression(`[${args}]`) as unknown as Syntax).elements),
+    );
+}
+
+for (const command of ["build", "run"] as const) {
+    test(`CLI ${command} dispatch binding preserves project and options`, () => {
+        const tree = ast("cli.ts");
+        const local = imported(tree, `${command}Project`, `./${command}`);
+        const branch = sites(tree).filter(
+            ({ node }) =>
+                node.type === "IfStatement" &&
+                JSON.stringify(semantic(node.test)) ===
+                    JSON.stringify(expression(`parsed.subcmd === "${command}"`)),
+        );
+        expect(branch).toHaveLength(1);
+        const invokes = calls(branch[0].node.consequent, local);
+        expect(invokes).toHaveLength(1);
+        expect(
+            calls(branch[0].node.consequent, command === "build" ? "runProject" : "buildProject"),
+        ).toHaveLength(0);
+        const full = calls(tree, local).find((site) => site.node === invokes[0].node)!;
+        expect(semantic(declaration(full, "projectDir"))).toEqual(
+            expression("resolve(parsed.dir)"),
+        );
+        imported(tree, "resolve", "node:path");
+        argumentsAre(
+            full,
+            command === "build"
+                ? "projectDir, { target: parsed.target, release: parsed.release, portable: parsed.portable }"
+                : "projectDir, { target: parsed.target, port: parsed.port, release: parsed.release, portable: parsed.portable }",
+        );
+    });
+
+    for (const target of ["windows", "mac", "linux"] as const) {
+        test(`${command} ${target} native binding preserves target, output and options`, () => {
+            const tree = ast(`${command}.ts`);
+            const bundle = `bundleNative${target[0].toUpperCase()}${target.slice(1)}`;
+            const local = imported(tree, bundle, "./native");
+            const output = imported(tree, "nativeOutDir", "./native");
+            const invokes = calls(tree, local);
+            expect(invokes).toHaveLength(1);
+            const call = invokes[0];
+            const fn = owner(call, `${command}Project`);
+            expect((fn.params as Syntax[]).map((node) => node.name)).toEqual([
+                "projectDir",
+                "opts",
+            ]);
+            argumentsAre(
+                call,
+                command === "build"
+                    ? "projectDir, outputDir, bundleOpts"
+                    : "projectDir, outputDir, { release, portable }",
+            );
+            expect(semantic(declaration(call, "release"))).toEqual(
+                expression("opts.release ?? false"),
+            );
+            expect(semantic(declaration(call, "portable"))).toEqual(
+                expression("opts.portable ?? false"),
+            );
+            const out = declaration(call, "outputDir");
+            expect(isName(out.callee, output)).toBe(true);
+            expect(semantic(out.arguments)).toEqual(
+                semantic(
+                    (
+                        parseExpression(
+                            command === "build"
+                                ? "[projectDir, target, release, portable]"
+                                : `[projectDir, "${target}", release, portable]`,
+                        ) as unknown as Syntax
+                    ).elements,
+                ),
+            );
+            if (command === "build") {
+                expect(semantic(declaration(call, "target"))).toEqual(expression("opts.target"));
+                expect(semantic(declaration(call, "bundleOpts"))).toEqual(
+                    expression("({ release, portable })"),
+                );
+                const branches = call.parents.filter((node) => node.type === "IfStatement");
+                const last = branches.at(-1)!;
+                expect(semantic(last.test)).toEqual(
+                    expression(`target === "${target === "linux" ? "mac" : target}"`),
+                );
+                expect(
+                    sites(target === "linux" ? last.alternate : last.consequent).some(
+                        ({ node }) => node === call.node,
+                    ),
+                ).toBe(true);
+            } else {
+                expect(semantic(declaration(call, "runTarget"))).toEqual(
+                    expression("resolveRunTarget(opts.target)"),
+                );
+                const branches = call.parents.filter((node) => node.type === "IfStatement");
+                if (target === "windows") {
+                    expect(branches).toHaveLength(0);
+                    const guards = (fn.body as Syntax).body as Syntax[];
+                    for (const other of ["web", "unknown", "mac", "linux"]) {
+                        const guard = guards.find(
+                            (node) =>
+                                node.type === "IfStatement" &&
+                                JSON.stringify(semantic(node.test)) ===
+                                    JSON.stringify(expression(`runTarget.kind === "${other}"`)),
+                        );
+                        expect(guard).toBeDefined();
+                        expect(guard!.start as number).toBeLessThan(call.node.start as number);
+                    }
+                } else {
+                    expect(semantic(branches.at(-1)!.test)).toEqual(
+                        expression(`runTarget.kind === "${target}"`),
+                    );
+                }
+            }
+        });
+    }
+}
+
+for (const target of ["Windows", "Mac", "Linux"]) {
+    test(`native ${target} binding reaches real buildWeb with its project`, () => {
+        const tree = ast("native.ts");
+        const local = imported(tree, "buildWeb", "./build");
+        const all = calls(tree, local);
+        expect(all).toHaveLength(3);
+        const invokes = all.filter(
+            (site) =>
+                (site.parents.findLast((node) => node.type === "FunctionDeclaration")?.id as Syntax)
+                    ?.name === `bundleNative${target}`,
+        );
+        expect(invokes).toHaveLength(1);
+        const fn = owner(invokes[0], `bundleNative${target}`);
+        expect((fn.params as Syntax[]).map((node) => node.name)).toEqual([
+            "projectDir",
+            "outputDir",
+            "opts",
+        ]);
+        argumentsAre(invokes[0], "projectDir");
+    });
+}
+
 for (const command of ["build", "run"]) {
     for (const [target, portable, allowed, gap, required] of [
         ["linux", false, false, false, false],
@@ -20,86 +385,24 @@ for (const command of ["build", "run"]) {
         ["mac", false, true, true, false],
         ["mac", true, true, true, true],
     ] as const) {
-        test(`${command} ${target} portable=${portable} gap=${gap} required=${required}: ${allowed ? "emits" : "refuses before emit"}`, () => {
-            const dir = mkdtempSync(join(tmpdir(), "shallot-floor-command-"));
-            dirs.push(dir);
-            writeFileSync(
-                join(dir, "shallot.json"),
-                JSON.stringify({ plugins: { Physics: true, Local: "external-floor-plugin" } }),
-            );
-            const plugin = join(dir, "node_modules/external-floor-plugin");
-            mkdirSync(plugin, { recursive: true });
-            writeFileSync(
-                join(plugin, "package.json"),
-                JSON.stringify({ name: "external-floor-plugin", main: "index.js" }),
-            );
-            writeFileSync(
-                join(plugin, "index.js"),
-                `
-console.log("PLUGIN_LOADED");
-export default { name: "Local", ${required ? "features" : "preferredFeatures"}: ["timestamp-query", "subgroups"] };
-`,
-            );
-            const preload = join(dir, "preload.ts");
-            const native = resolve(import.meta.dir, "native.ts");
-            writeFileSync(
-                preload,
-                `
-import { mock } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import * as native from ${JSON.stringify(native)};
-import { WEBVIEW_UNSUPPORTED } from ${JSON.stringify(resolve(import.meta.dir, "features.ts"))};
-${gap ? `WEBVIEW_UNSUPPORTED.mac = ["timestamp-query"];` : ""}
-const emit = async (projectDir, outputDir, opts) => {
-    mkdirSync(outputDir, { recursive: true });
-    writeFileSync(join(outputDir, "emitted.json"), JSON.stringify({ projectDir, opts }));
-    console.log("NATIVE_EMIT");
-    process.exit(0);
-};
-mock.module(${JSON.stringify(native)}, () => ({ ...native,
-    bundleNativeLinux: emit, bundleNativeMac: emit, bundleNativeWindows: emit,
-}));
-`,
-            );
-            const result = Bun.spawnSync(
-                [
-                    process.execPath,
-                    "--preload",
-                    preload,
-                    resolve(import.meta.dir, "cli.ts"),
-                    command,
-                    dir,
-                    "--target",
-                    target,
-                    ...(portable ? ["--portable"] : []),
-                ],
-                { cwd: dir, env: process.env },
-            );
-            const output = result.stdout.toString() + result.stderr.toString();
-            const artifact = join(
-                dir,
-                "build",
-                target,
-                `debug-${portable ? "portable" : "system"}`,
-                "emitted.json",
-            );
+        test(`${command} ${target} portable=${portable} gap=${gap} required=${required}: ${allowed ? "reaches project config" : "refuses before config"}`, () => {
+            const project = fixture(required, gap);
+            const { result, output } = commandReceipt(command, target, portable, project);
             if (allowed) {
-                expect(output).toContain("NATIVE_EMIT");
-                expect(result.exitCode).toBe(0);
-                expect(JSON.parse(readFileSync(artifact, "utf8"))).toEqual({
-                    projectDir: dir,
-                    opts: { release: false, portable },
+                expect({ exit: result.exitCode, output }).toEqual({
+                    exit: 0,
+                    output: expect.stringContaining("PROJECT_CONFIG_REACHED"),
                 });
+                reached(project);
             } else {
                 expect(output).toContain("Cannot build");
                 expect(output).toContain(gap ? "timestamp-query" : "WebGPU base floor");
                 expect(output).toContain("--portable");
                 expect(result.exitCode).toBe(1);
-                expect(output).not.toContain("NATIVE_EMIT");
-                expect(existsSync(artifact)).toBe(false);
-                expect(existsSync(join(dir, "build"))).toBe(false);
-                expect(existsSync(join(dir, "dist"))).toBe(false);
+                expect(output).not.toContain("PROJECT_CONFIG_REACHED");
+                expect(existsSync(project.receipt)).toBe(false);
+                expect(existsSync(join(project.dir, "build"))).toBe(false);
+                expect(existsSync(join(project.dir, "dist"))).toBe(false);
             }
             expect(output).toContain("PLUGIN_LOADED");
         });

--- a/packages/shallot-cli/src/project/vite.test.ts
+++ b/packages/shallot-cli/src/project/vite.test.ts
@@ -20,9 +20,14 @@ function projectDir(): string {
     return mkdtempSync(join(tmpdir(), "shallot-vite-test-"));
 }
 
-// minimal bundle builders — the pure prune reads only type / fileName / code|source
-const chunk = (fileName: string, code: string) =>
-    ({ type: "chunk", fileName, code }) as Rollup.OutputChunk;
+// minimal bundle builders — include Vite's CSS metadata when a chunk represents an imported stylesheet
+const chunk = (fileName: string, code: string, importedCss?: string[]) =>
+    ({
+        type: "chunk",
+        fileName,
+        code,
+        ...(importedCss ? { viteMetadata: { importedCss: new Set(importedCss) } } : {}),
+    }) as Rollup.OutputChunk;
 const asset = (fileName: string, source: string | Uint8Array) =>
     ({ type: "asset", fileName, source }) as Rollup.OutputAsset;
 const bundle = (...files: (Rollup.OutputChunk | Rollup.OutputAsset)[]) =>
@@ -635,6 +640,31 @@ describe("projectPlugin", () => {
 
             expect(outputBundle).toEqual(before);
             expect(infoMsgs).toEqual([]);
+        });
+
+        test("retains metadata-imported CSS and its binary child before HTML exists", () => {
+            const plugin = projectPlugin();
+            const css = "body{background:url(./font-BBB.woff2)}";
+            const font = new Uint8Array([3, 1, 4, 1, 5]);
+            const outputBundle = bundle(
+                chunk("assets/index-AAA.js", 'console.log("no CSS text edge")', [
+                    "assets/style-CCC.css",
+                ]),
+                asset("assets/style-CCC.css", css),
+                asset("assets/font-BBB.woff2", font),
+                asset("assets/dead-DDD.wasm", new Uint8Array([9, 2, 6])),
+            );
+            const infoMsgs: string[] = [];
+            generateBundleHook(plugin).call({ info: (m) => infoMsgs.push(m) }, {}, outputBundle);
+
+            const style = outputBundle["assets/style-CCC.css"] as Rollup.OutputAsset | undefined;
+            const fontOutput = outputBundle["assets/font-BBB.woff2"] as
+                | Rollup.OutputAsset
+                | undefined;
+            expect(style?.source).toBe(css);
+            expect(fontOutput?.source).toEqual(font);
+            expect(outputBundle["assets/dead-DDD.wasm"]).toBeUndefined();
+            expect(infoMsgs).toEqual(["pruned 1 orphaned asset(s), 0KB"]);
         });
     });
 });

--- a/packages/shallot-cli/src/project/vite.ts
+++ b/packages/shallot-cli/src/project/vite.ts
@@ -122,8 +122,20 @@ export function orphanedAssets(bundle: Rollup.OutputBundle): string[] {
     const files = Object.values(bundle);
     const text = (f: Rollup.OutputAsset | Rollup.OutputChunk) =>
         f.type === "chunk" ? f.code : typeof f.source === "string" ? f.source : "";
-    // never prune a chunk (tree-shaking already pruned JS) or an html entry — seed them as kept roots
+    // never prune a chunk (tree-shaking already pruned JS) or an html entry — seed them as kept roots.
+    // Vite records chunk→CSS edges in metadata because the CSS import is not part of chunk.code; read
+    // that edge before the textual asset fixpoint so a manifest build can retain CSS before HTML exists.
     const kept = new Set(files.filter((f) => f.type === "chunk" || f.fileName.endsWith(".html")));
+    for (const file of files) {
+        if (file.type !== "chunk") continue;
+        const metadata = file as Rollup.OutputChunk & {
+            viteMetadata?: { importedCss?: ReadonlySet<string> };
+        };
+        for (const css of metadata.viteMetadata?.importedCss ?? []) {
+            const imported = bundle[css];
+            if (imported?.type === "asset") kept.add(imported);
+        }
+    }
     const assets = files.filter(
         (f): f is Rollup.OutputAsset => f.type === "asset" && !f.fileName.endsWith(".html"),
     );


### PR DESCRIPTION
- **shallot-manifest-css-assets: admit real build boundary**
- **shallot-manifest-css-assets: retain metadata CSS assets**
