### PR TITLE
shallot: root self-link replaces member file: engine deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Newest first. **Breaking:** marks a change that needs consumer action; [`MIGRATI
 
 ## Unreleased
 
+- **repo** — The root manifest self-links (`"@dylanebert/shallot": "link:."`) and workspace members declare no engine dependency, so shipped recipe manifests carry no local path; `shallot recipe` inserts the installed engine version into the copy.
 - **build** — toolchains are pinned so shipped WASM bytes reproduce: Rust 1.98.1 via `rust-toolchain.toml`, `nightly-2026-09-01` for the shared physics kernel (the build fails naming the install command when it's missing), and binaryen 132 as a devDependency whose `wasm-opt` now always runs over the audio WASM and both kernels. Bun is pinned to 1.4.2 (`packageManager`, `engines`, `.bun-version`).
 - **site** — Moved the site to dylanebert/shallot-site.
 - **build** — `bun run build` compiles `dist/`, the audio WASM and the physics kernel, and no longer compiles `rust/window`; `shallot build --target` builds the window host per project. The Linux non-portable refusal now names `--portable` directly.

--- a/bin/recipe.test.ts
+++ b/bin/recipe.test.ts
@@ -16,7 +16,7 @@ function corpus(): { recipesDir: string; version: string } {
         writeFileSync(
             join(dir, "package.json"),
             `${JSON.stringify(
-                { name, private: true, dependencies: { "@dylanebert/shallot": "file:../../.." } },
+                { name, private: true, dependencies: { typegpu: "~0.12.5" } },
                 null,
                 4,
             )}\n`,
@@ -54,6 +54,20 @@ describe("pinEngine", () => {
             const out = pinEngine(`{"dependencies":{"@dylanebert/shallot":"${spec}"}}`, "0.8.0");
             expect(JSON.parse(out).dependencies["@dylanebert/shallot"]).toBe("0.8.0");
         }
+    });
+
+    test("an absent engine dep is inserted at the exact version, other deps kept", () => {
+        const out = JSON.parse(pinEngine('{"dependencies":{"typegpu":"~0.12.5"}}', "0.8.0"));
+        expect(out.dependencies).toEqual({ "@dylanebert/shallot": "0.8.0", typegpu: "~0.12.5" });
+        const bare = JSON.parse(pinEngine('{"name":"x"}', "0.8.0"));
+        expect(bare.dependencies).toEqual({ "@dylanebert/shallot": "0.8.0" });
+    });
+
+    test("an engine dep in another field is not duplicated", () => {
+        const out = JSON.parse(
+            pinEngine('{"devDependencies":{"@dylanebert/shallot":"^0.7.0"}}', "0.8.0"),
+        );
+        expect(out.dependencies).toBeUndefined();
     });
 
     test("leaves a registry dep untouched", () => {

--- a/bin/recipe.ts
+++ b/bin/recipe.ts
@@ -5,7 +5,7 @@ import { CLAUDE_IMPORT, RECIPE_TSCONFIG, recipeDoc } from "./scaffold";
 // `shallot recipe [name] [dir]` — copy a recipe out of the installed package into a runnable project.
 // The recipes ship in the tarball under this package's `examples/recipes/`; running
 // one in place breaks its own dep resolution and users shouldn't edit inside node_modules, so copy-out is
-// the path. The copy's local dep on the engine is rewritten to the installed version so a plain
+// the path. The copy gains (or has its local dep rewritten to) the installed engine version so a plain
 // `bun install && bunx shallot dev` runs green. Paths resolve relative to this package, never cwd — the
 // corpus lives beside the CLI (`bin/` and `examples/` are siblings at the package root).
 
@@ -69,6 +69,9 @@ export function pinEngine(pkgText: string, version: string): string {
                   ? `${marker}${version}`
                   : marker;
     }
+    // in-repo members declare no engine dep (the root self-links); a standalone copy needs one
+    if (!DEP_FIELDS.some((field) => typeof pkg[field]?.[ENGINE] === "string"))
+        pkg.dependencies = { [ENGINE]: version, ...pkg.dependencies };
     return `${JSON.stringify(pkg, null, 4)}\n`;
 }
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "@babel/parser": "^8.0.4",
         "@babel/plugin-syntax-typescript": "^8.0.3",
         "@biomejs/biome": "^2.5.13",
+        "@dylanebert/shallot": "link:.",
         "@playwright/test": "^1.63.0",
         "@types/bun": "latest",
         "@types/jpeg-js": "^0.3.7",
@@ -50,7 +51,6 @@
       "name": "gym",
       "version": "0.0.0",
       "dependencies": {
-        "@dylanebert/shallot": "file:../..",
         "typegpu": "~0.12.5",
       },
       "devDependencies": {
@@ -62,199 +62,117 @@
     "examples/recipes/animate-with-clips": {
       "name": "animate-with-clips",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/annotate-the-world": {
       "name": "annotate-the-world",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/billboards-and-sprites": {
       "name": "billboards-and-sprites",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/breakable-joints": {
       "name": "breakable-joints",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/build-a-scene": {
       "name": "build-a-scene",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/compute-and-readback": {
       "name": "compute-and-readback",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/custom-material": {
       "name": "custom-material",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/day-night-sky": {
       "name": "day-night-sky",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/drive-a-vehicle": {
       "name": "drive-a-vehicle",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/first-person": {
       "name": "first-person",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/fog-and-light-shafts": {
       "name": "fog-and-light-shafts",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/game-loop": {
       "name": "game-loop",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/gpu-particles": {
       "name": "gpu-particles",
       "version": "0.0.0",
       "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5",
       },
     },
     "examples/recipes/import-a-model": {
       "name": "import-a-model",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/joints": {
       "name": "joints",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/measure-performance": {
       "name": "measure-performance",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/moving-platform": {
       "name": "moving-platform",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/orbit-camera": {
       "name": "orbit-camera",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/overlay-ui": {
       "name": "overlay-ui",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/physics-playground": {
       "name": "physics-playground",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/play-sound": {
       "name": "play-sound",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/ragdoll": {
       "name": "ragdoll",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/render-to-a-terminal": {
       "name": "render-to-a-terminal",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/respond-to-input": {
       "name": "respond-to-input",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/save-and-restore": {
       "name": "save-and-restore",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/stylize-the-look": {
       "name": "stylize-the-look",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/recipes/surface-friction": {
       "name": "surface-friction",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
     },
     "examples/showcase/ascii": {
       "name": "ascii",
       "version": "0.0.0",
-      "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
-      },
       "devDependencies": {
         "@playwright/test": "^1.63.0",
         "@types/pngjs": "^6.0.5",
@@ -265,7 +183,6 @@
       "name": "collapse",
       "version": "0.0.0",
       "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "@dylanebert/shallot-avbd-physics": "file:../../../packages/shallot-avbd-physics",
       },
       "devDependencies": {
@@ -276,7 +193,6 @@
       "name": "ocean",
       "version": "0.0.0",
       "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5",
       },
     },
@@ -284,7 +200,6 @@
       "name": "roads",
       "version": "0.0.0",
       "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5",
       },
       "devDependencies": {
@@ -297,7 +212,6 @@
       "name": "sandbox",
       "version": "0.0.0",
       "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "@dylanebert/shallot-avbd-physics": "file:../../../packages/shallot-avbd-physics",
       },
       "devDependencies": {
@@ -308,7 +222,6 @@
       "name": "visualization",
       "version": "0.0.0",
       "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5",
       },
       "devDependencies": {
@@ -321,7 +234,6 @@
       "name": "voxel",
       "version": "0.0.0",
       "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5",
       },
       "devDependencies": {
@@ -336,9 +248,6 @@
     "packages/shallot-avbd-physics": {
       "name": "@dylanebert/shallot-avbd-physics",
       "version": "0.10.0",
-      "devDependencies": {
-        "@dylanebert/shallot": "file:../..",
-      },
       "peerDependencies": {
         "@dylanebert/shallot": "0.10.0",
       },

--- a/examples/gym/package.json
+++ b/examples/gym/package.json
@@ -10,7 +10,6 @@
         "gate": "playwright test"
     },
     "dependencies": {
-        "@dylanebert/shallot": "file:../..",
         "typegpu": "~0.12.5"
     },
     "devDependencies": {

--- a/examples/recipes/animate-with-clips/package.json
+++ b/examples/recipes/animate-with-clips/package.json
@@ -2,8 +2,5 @@
     "name": "animate-with-clips",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/annotate-the-world/package.json
+++ b/examples/recipes/annotate-the-world/package.json
@@ -2,8 +2,5 @@
     "name": "annotate-the-world",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/billboards-and-sprites/package.json
+++ b/examples/recipes/billboards-and-sprites/package.json
@@ -2,8 +2,5 @@
     "name": "billboards-and-sprites",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/breakable-joints/package.json
+++ b/examples/recipes/breakable-joints/package.json
@@ -2,8 +2,5 @@
     "name": "breakable-joints",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/build-a-scene/package.json
+++ b/examples/recipes/build-a-scene/package.json
@@ -2,8 +2,5 @@
     "name": "build-a-scene",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/compute-and-readback/package.json
+++ b/examples/recipes/compute-and-readback/package.json
@@ -2,8 +2,5 @@
     "name": "compute-and-readback",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/custom-material/package.json
+++ b/examples/recipes/custom-material/package.json
@@ -2,8 +2,5 @@
     "name": "custom-material",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/day-night-sky/package.json
+++ b/examples/recipes/day-night-sky/package.json
@@ -2,8 +2,5 @@
     "name": "day-night-sky",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/drive-a-vehicle/package.json
+++ b/examples/recipes/drive-a-vehicle/package.json
@@ -2,8 +2,5 @@
     "name": "drive-a-vehicle",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/first-person/package.json
+++ b/examples/recipes/first-person/package.json
@@ -2,8 +2,5 @@
     "name": "first-person",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/fog-and-light-shafts/package.json
+++ b/examples/recipes/fog-and-light-shafts/package.json
@@ -2,8 +2,5 @@
     "name": "fog-and-light-shafts",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/game-loop/package.json
+++ b/examples/recipes/game-loop/package.json
@@ -2,8 +2,5 @@
     "name": "game-loop",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/gpu-particles/package.json
+++ b/examples/recipes/gpu-particles/package.json
@@ -4,7 +4,6 @@
     "private": true,
     "type": "module",
     "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5"
     }
 }

--- a/examples/recipes/import-a-model/package.json
+++ b/examples/recipes/import-a-model/package.json
@@ -2,8 +2,5 @@
     "name": "import-a-model",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/joints/package.json
+++ b/examples/recipes/joints/package.json
@@ -2,8 +2,5 @@
     "name": "joints",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/measure-performance/package.json
+++ b/examples/recipes/measure-performance/package.json
@@ -2,8 +2,5 @@
     "name": "measure-performance",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/moving-platform/package.json
+++ b/examples/recipes/moving-platform/package.json
@@ -2,8 +2,5 @@
     "name": "moving-platform",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/orbit-camera/package.json
+++ b/examples/recipes/orbit-camera/package.json
@@ -2,8 +2,5 @@
     "name": "orbit-camera",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/overlay-ui/package.json
+++ b/examples/recipes/overlay-ui/package.json
@@ -2,8 +2,5 @@
     "name": "overlay-ui",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/physics-playground/package.json
+++ b/examples/recipes/physics-playground/package.json
@@ -2,8 +2,5 @@
     "name": "physics-playground",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/play-sound/package.json
+++ b/examples/recipes/play-sound/package.json
@@ -2,8 +2,5 @@
     "name": "play-sound",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/ragdoll/package.json
+++ b/examples/recipes/ragdoll/package.json
@@ -2,8 +2,5 @@
     "name": "ragdoll",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/render-to-a-terminal/package.json
+++ b/examples/recipes/render-to-a-terminal/package.json
@@ -2,8 +2,5 @@
     "name": "render-to-a-terminal",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/respond-to-input/package.json
+++ b/examples/recipes/respond-to-input/package.json
@@ -2,8 +2,5 @@
     "name": "respond-to-input",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/save-and-restore/package.json
+++ b/examples/recipes/save-and-restore/package.json
@@ -2,8 +2,5 @@
     "name": "save-and-restore",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/stylize-the-look/package.json
+++ b/examples/recipes/stylize-the-look/package.json
@@ -2,8 +2,5 @@
     "name": "stylize-the-look",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/recipes/surface-friction/package.json
+++ b/examples/recipes/surface-friction/package.json
@@ -2,8 +2,5 @@
     "name": "surface-friction",
     "version": "0.0.0",
     "private": true,
-    "type": "module",
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    }
+    "type": "module"
 }

--- a/examples/showcase/ascii/package.json
+++ b/examples/showcase/ascii/package.json
@@ -6,9 +6,6 @@
     "scripts": {
         "gate": "playwright test"
     },
-    "dependencies": {
-        "@dylanebert/shallot": "file:../../.."
-    },
     "devDependencies": {
         "@playwright/test": "^1.63.0",
         "@types/pngjs": "^6.0.5",

--- a/examples/showcase/collapse/package.json
+++ b/examples/showcase/collapse/package.json
@@ -7,7 +7,6 @@
         "gate": "playwright test"
     },
     "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "@dylanebert/shallot-avbd-physics": "file:../../../packages/shallot-avbd-physics"
     },
     "devDependencies": {

--- a/examples/showcase/ocean/package.json
+++ b/examples/showcase/ocean/package.json
@@ -7,7 +7,6 @@
         "gate": "bunx shallot verify . --screenshot ocean.png"
     },
     "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5"
     }
 }

--- a/examples/showcase/roads/package.json
+++ b/examples/showcase/roads/package.json
@@ -8,7 +8,6 @@
         "gate": "playwright test"
     },
     "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5"
     },
     "devDependencies": {

--- a/examples/showcase/sandbox/package.json
+++ b/examples/showcase/sandbox/package.json
@@ -7,7 +7,6 @@
         "gate": "playwright test"
     },
     "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "@dylanebert/shallot-avbd-physics": "file:../../../packages/shallot-avbd-physics"
     },
     "devDependencies": {

--- a/examples/showcase/visualization/package.json
+++ b/examples/showcase/visualization/package.json
@@ -10,7 +10,6 @@
         "gate": "bun test --cwd ../../.. ./examples/showcase/visualization/test/rendered.test.ts && playwright test"
     },
     "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5"
     },
     "devDependencies": {

--- a/examples/showcase/voxel/package.json
+++ b/examples/showcase/voxel/package.json
@@ -8,7 +8,6 @@
         "gate": "playwright test"
     },
     "dependencies": {
-        "@dylanebert/shallot": "file:../../..",
         "typegpu": "~0.12.5"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
         "@babel/parser": "^8.0.4",
         "@babel/plugin-syntax-typescript": "^8.0.3",
         "@biomejs/biome": "^2.5.13",
+        "@dylanebert/shallot": "link:.",
         "@playwright/test": "^1.63.0",
         "@types/bun": "latest",
         "@types/jpeg-js": "^0.3.7",

--- a/packages/shallot-avbd-physics/package.json
+++ b/packages/shallot-avbd-physics/package.json
@@ -12,8 +12,5 @@
     },
     "peerDependencies": {
         "@dylanebert/shallot": "0.10.0"
-    },
-    "devDependencies": {
-        "@dylanebert/shallot": "file:../.."
     }
 }

--- a/scripts/check-boundary.test.ts
+++ b/scripts/check-boundary.test.ts
@@ -44,7 +44,7 @@ const make = (): string => {
             name: "@dylanebert/shallot",
             workspaces: ["packages/*", "examples/recipes/*"],
             dependencies: { typegpu: "~0.12.4" },
-            devDependencies: { vite: "^7.0.0" },
+            devDependencies: { "@dylanebert/shallot": "link:.", vite: "^7.0.0" },
             exports: {
                 ".": "./src/index.ts",
                 "./render/core": "./src/standard/render/core.ts",
@@ -60,7 +60,7 @@ const make = (): string => {
     write(
         root,
         "examples/recipes/demo/package.json",
-        JSON.stringify({ name: "demo", dependencies: { "@dylanebert/shallot": "workspace:*" } }),
+        JSON.stringify({ name: "demo", dependencies: { typegpu: "~0.12.4" } }),
     );
     write(root, "examples/recipes/demo/src/main.ts", 'import "@dylanebert/shallot";\n');
     return root;
@@ -385,6 +385,50 @@ describe("two-way completeness", () => {
         expect(checkBoundary(root, EMPTY).errors.join("\n")).toContain(
             "local production dependency",
         );
+    });
+});
+
+describe("engine self-link", () => {
+    const rootWith = (devDependencies: Record<string, string>) =>
+        JSON.stringify({
+            name: "@dylanebert/shallot",
+            workspaces: ["packages/*", "examples/recipes/*"],
+            devDependencies,
+            exports: { ".": "./src/index.ts", "./render/core": "./src/standard/render/core.ts" },
+        });
+
+    test("a root without the link:. self-link refuses", () => {
+        const devs: Record<string, string>[] = [{}, { "@dylanebert/shallot": "file:." }];
+        for (const dev of devs) {
+            const root = make();
+            write(root, "package.json", rootWith(dev));
+            expect(checkBoundary(root, EMPTY).errors.join("\n")).toContain("lacks the self-link");
+        }
+    });
+
+    test("a member linking the engine locally refuses, in every install field", () => {
+        for (const field of ["dependencies", "devDependencies", "optionalDependencies"])
+            for (const spec of ["file:../../..", "link:../../..", "workspace:*"]) {
+                const root = make();
+                write(
+                    root,
+                    "examples/recipes/demo/package.json",
+                    JSON.stringify({ name: "demo", [field]: { "@dylanebert/shallot": spec } }),
+                );
+                expect(checkBoundary(root, EMPTY).errors.join("\n")).toContain(
+                    `examples/recipes/demo/package.json: ${field} links the engine locally (${spec})`,
+                );
+            }
+    });
+
+    test("a member's registry range and peer range stay green", () => {
+        const root = make();
+        write(
+            root,
+            "examples/recipes/demo/package.json",
+            JSON.stringify({ name: "demo", peerDependencies: { "@dylanebert/shallot": "0.10.0" } }),
+        );
+        expect(checkBoundary(root, EMPTY).errors).toEqual([]);
     });
 });
 

--- a/scripts/check-boundary.ts
+++ b/scripts/check-boundary.ts
@@ -575,6 +575,23 @@ export function checkBoundary(repoRoot: string, ledger: Ledger = REPO_LEDGER): B
             );
     }
 
+    // Members reach the engine through the root's `link:.` self-link, never a path of their own: a local
+    // engine spec in a member manifest ships in the tarball (recipes) and names a path outside any copy.
+    if (rootPkg.devDependencies?.[PKG] !== "link:.")
+        errors.push(`root package.json lacks the self-link devDependencies["${PKG}"]: "link:."`);
+    for (const dir of consumerDirs) {
+        const manifest = resolve(repoRoot, dir, "package.json");
+        if (!existsSync(manifest)) continue;
+        const pkg = JSON.parse(readFileSync(manifest, "utf8"));
+        for (const field of ["dependencies", "devDependencies", "optionalDependencies"]) {
+            const range = pkg[field]?.[PKG];
+            if (typeof range === "string" && local.test(range))
+                errors.push(
+                    `${dir}/package.json: ${field} links the engine locally (${range}); the root self-link supplies it`,
+                );
+        }
+    }
+
     for (const file of Object.keys(ledger.computedLoaders)) {
         if (!usedLoaders.has(file))
             errors.push(`declared computed loader names no live call site: ${file}`);

--- a/scripts/check-pack.ts
+++ b/scripts/check-pack.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { resolve } from "path";
 import { TEST_TIER_SUFFIXES } from "../tests/test-tiers";
 
@@ -63,6 +64,18 @@ const required = [
     "examples/AGENTS.md",
     "shallot.schema.json",
 ];
+// A shipped manifest must not name the engine by a local path: copy-out pins the installed version,
+// and a `file:`/`link:`/`workspace:` spec in the tarball points at a directory no consumer has.
+const ENGINE = "@dylanebert/shallot";
+for (const f of files.filter((f) => f.endsWith("package.json") && f !== "package.json")) {
+    const pkg = JSON.parse(readFileSync(resolve(pkgDir, f), "utf8"));
+    for (const field of ["dependencies", "devDependencies", "optionalDependencies"]) {
+        const range = pkg[field]?.[ENGINE];
+        if (typeof range === "string" && /^(?:workspace:|file:|link:|portal:)/.test(range))
+            violations.push(`${f} (local engine dependency ${field}: ${range})`);
+    }
+}
+
 const missing = required.filter((f) => !files.includes(f));
 if (!files.some((f) => f.startsWith("rust/audio/pkg/"))) missing.push("rust/audio/pkg/");
 if (!files.some((f) => f.startsWith("examples/recipes/"))) missing.push("examples/recipes/");


### PR DESCRIPTION
Root devDependencies carry "@dylanebert/shallot": "link:."; recipes, showcase, gym and avbd-physics declare no engine dep. Recipe copy-out inserts the installed version; check-boundary and check-pack refuse local engine specs.
