### PR TITLE
shallot-surface: declare checks, refuse undeclared, list the population

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ bun run prepack        # compile the Node-reachable tooling
 
 ## Tests
 
-`bun run test` runs `cargo test` over the Cargo workspace, every crate except the native host, and then `bun test`, which finds nothing today. The TypeScript tests were retired to the `archive/tests-pre-slice` tag. Each one comes back only as a declared claim with a class and a tier, physics gold replays first; [`ARCHIVE.md`](ARCHIVE.md) lists the order.
+`bun run test` runs `cargo test` over the Cargo workspace, every crate except the native host, and then `bun test`, which runs every declared check. A check is `check(name, { claim, class, tier, premises, budget }, body)` from `@dylanebert/shallot/harness/check`; an undeclared test file refuses at load, and `bun scripts/surface.ts --list` prints the population. The TypeScript tests were retired to the `archive/tests-pre-slice` tag. Each one comes back only as a declared claim with a class and a tier, physics gold replays first; [`ARCHIVE.md`](ARCHIVE.md) lists the order.
 
 ## Pins and freshness
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./src/harness/preload.ts"]

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         ".": "./src/index.ts",
         "./extras": "./src/extras/index.ts",
         "./harness": "./src/harness/index.ts",
+        "./harness/check": "./src/harness/check.ts",
         "./harness/pixels": "./src/harness/pixels.ts",
         "./harness/browser": {
             "types": "./src/harness/browser.d.ts",

--- a/scripts/check-surface.ts
+++ b/scripts/check-surface.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { STEP_BUDGET_MS } from "../src/harness/declaration";
+import { collectPopulation } from "./surface";
+
+// `check` arm for the check surface itself: every test-suffix file declares, claims are unique,
+// no declaration overruns its tier ceiling, and no quarantine row names a claim nobody has.
+
+const TIER_CEILING_MS: Record<string, number> = { step: STEP_BUDGET_MS };
+
+interface QuarantineRow {
+    claim?: unknown;
+}
+
+function quarantineClaims(root: string): string[] {
+    const path = resolve(root, "quarantine.json");
+    if (!existsSync(path)) return [];
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as
+        | QuarantineRow[]
+        | { rows?: QuarantineRow[] };
+    const rows = Array.isArray(parsed) ? parsed : (parsed.rows ?? []);
+    return rows.map((row) => String(row?.claim ?? ""));
+}
+
+/** Read one tree's surface and return every violation, most specific message first. */
+export function readSurface(root: string): string[] {
+    const population = collectPopulation(root);
+    const violations: string[] = [...population.invalid];
+    for (const file of population.undeclared) {
+        violations.push(`undeclared check file: ${file.file} ${file.reason}`);
+    }
+    const seen = new Map<string, string>();
+    for (const row of population.rows) {
+        const first = seen.get(row.claim);
+        if (first !== undefined) {
+            violations.push(`duplicate claim: "${row.claim}" declared in ${first} and ${row.file}`);
+        } else {
+            seen.set(row.claim, row.file);
+        }
+        const ceiling = TIER_CEILING_MS[row.tier];
+        if (ceiling !== undefined && row.budget > ceiling) {
+            violations.push(
+                `over-budget declaration: "${row.claim}" in ${row.file} declares ${row.budget}ms above the ${row.tier} ceiling of ${ceiling}ms`,
+            );
+        }
+    }
+    for (const claim of quarantineClaims(root)) {
+        if (!seen.has(claim)) {
+            violations.push(`orphan quarantine row: "${claim}" names no check in the population`);
+        }
+    }
+    return violations;
+}
+
+if (import.meta.main) {
+    const args = Bun.argv.slice(2);
+    const rootIndex = args.indexOf("--root");
+    const root =
+        rootIndex === -1 ? resolve(import.meta.dir, "..") : resolve(args[rootIndex + 1] ?? ".");
+    const violations = readSurface(root);
+    for (const violation of violations) console.error(violation);
+    if (violations.length > 0) process.exit(1);
+    console.log(`${collectPopulation(root).rows.length} declared checks`);
+}

--- a/scripts/fixtures/surface/clean/examples/demo/shallot.json
+++ b/scripts/fixtures/surface/clean/examples/demo/shallot.json
@@ -1,0 +1,11 @@
+{
+    "kind": "recipe",
+    "check": {
+        "claim": "demo recipe runs",
+        "class": "process",
+        "tier": "browser",
+        "premises": ["playwright"],
+        "budget": 20000,
+        "file": "check.test.ts"
+    }
+}

--- a/scripts/fixtures/surface/clean/scripts/beta.tier.ts.fixture
+++ b/scripts/fixtures/surface/clean/scripts/beta.tier.ts.fixture
@@ -1,0 +1,3 @@
+import { check } from "@dylanebert/shallot/harness/check";
+
+check("beta builds", { claim: "beta builds", class: "process", tier: "built", premises: [], budget: 30000 }, () => {});

--- a/scripts/fixtures/surface/clean/src/alpha.test.ts.fixture
+++ b/scripts/fixtures/surface/clean/src/alpha.test.ts.fixture
@@ -1,0 +1,4 @@
+import { check } from "@dylanebert/shallot/harness/check";
+
+check("alpha holds", { claim: "alpha holds", class: "pure", tier: "step", premises: [], budget: 50 }, () => {});
+check("alpha refuses", { claim: "alpha refuses", class: "pure", tier: "step", premises: ["cmake"], budget: 200 }, () => {});

--- a/scripts/fixtures/surface/duplicate/src/one.test.ts.fixture
+++ b/scripts/fixtures/surface/duplicate/src/one.test.ts.fixture
@@ -1,0 +1,3 @@
+import { check } from "@dylanebert/shallot/harness/check";
+
+check("same claim", { claim: "same claim", class: "pure", tier: "step", premises: [], budget: 10 }, () => {});

--- a/scripts/fixtures/surface/duplicate/src/two.test.ts.fixture
+++ b/scripts/fixtures/surface/duplicate/src/two.test.ts.fixture
@@ -1,0 +1,3 @@
+import { check } from "@dylanebert/shallot/harness/check";
+
+check("same claim again", { claim: "same claim", class: "pure", tier: "step", premises: [], budget: 10 }, () => {});

--- a/scripts/fixtures/surface/orphan/quarantine.json
+++ b/scripts/fixtures/surface/orphan/quarantine.json
@@ -1,0 +1,8 @@
+[
+    {
+        "claim": "claim nobody declares",
+        "reason": "flaked on the seat",
+        "expiry": "2026-12-01",
+        "spec": "shallot-surface-dogfood"
+    }
+]

--- a/scripts/fixtures/surface/orphan/src/kept.test.ts.fixture
+++ b/scripts/fixtures/surface/orphan/src/kept.test.ts.fixture
@@ -1,0 +1,3 @@
+import { check } from "@dylanebert/shallot/harness/check";
+
+check("kept claim", { claim: "kept claim", class: "pure", tier: "step", premises: [], budget: 10 }, () => {});

--- a/scripts/fixtures/surface/over-budget/src/slow.test.ts.fixture
+++ b/scripts/fixtures/surface/over-budget/src/slow.test.ts.fixture
@@ -1,0 +1,3 @@
+import { check } from "@dylanebert/shallot/harness/check";
+
+check("slow step", { claim: "slow step", class: "pure", tier: "step", premises: [], budget: 1500 }, () => {});

--- a/scripts/fixtures/surface/undeclared/src/naked.test.ts.fixture
+++ b/scripts/fixtures/surface/undeclared/src/naked.test.ts.fixture
@@ -1,0 +1,1 @@
+export const nothing = 1;

--- a/scripts/surface.test.ts
+++ b/scripts/surface.test.ts
@@ -1,0 +1,176 @@
+import { expect } from "bun:test";
+import { cpSync, mkdirSync, mkdtempSync, readdirSync, renameSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { check } from "@dylanebert/shallot/harness/check";
+
+const ROOT = resolve(import.meta.dir, "..");
+const FIXTURES = resolve(ROOT, "scripts/fixtures/surface");
+
+// Fixture check files are stored with a trailing `.fixture` so the real discovery and the real
+// runner never see them; materializing strips it, giving the production readers a real tree.
+function unfixture(dir: string): void {
+    for (const entry of readdirSync(dir)) {
+        const path = join(dir, entry);
+        if (statSync(path).isDirectory()) {
+            unfixture(path);
+        } else if (entry.endsWith(".fixture")) {
+            renameSync(path, path.slice(0, -".fixture".length));
+        }
+    }
+}
+
+function seed(name: string): string {
+    const tree = mkdtempSync(join(tmpdir(), `shallot-surface-${name}-`));
+    cpSync(resolve(FIXTURES, name), tree, { recursive: true });
+    for (const dir of ["src", "scripts", "examples"])
+        mkdirSync(join(tree, dir), { recursive: true });
+    unfixture(tree);
+    return tree;
+}
+
+function run(script: string, tree: string): { code: number; out: string; err: string } {
+    const proc = Bun.spawnSync(
+        ["bun", resolve(ROOT, "scripts", script), "--list", "--root", tree],
+        {
+            cwd: ROOT,
+        },
+    );
+    return {
+        code: proc.exitCode ?? -1,
+        out: proc.stdout.toString().trim(),
+        err: proc.stderr.toString().trim(),
+    };
+}
+
+function reader(name: string): { code: number; out: string; err: string } {
+    const tree = seed(name);
+    try {
+        return run("check-surface.ts", tree);
+    } finally {
+        rmSync(tree, { recursive: true, force: true });
+    }
+}
+
+check(
+    "--list prints exactly the declared population",
+    {
+        claim: "surface.ts --list prints one row per declared check in the tree, from files and manifests, and nothing else",
+        class: "process",
+        tier: "step",
+        premises: [],
+        budget: 1000,
+    },
+    () => {
+        const tree = seed("clean");
+        try {
+            const { code, out } = run("surface.ts", tree);
+            expect(code).toBe(0);
+            expect(out.split("\n")).toEqual([
+                "claim             class    tier     premises    budget   file",
+                "alpha holds       pure     step     -           50ms     src/alpha.test.ts",
+                "alpha refuses     pure     step     cmake       200ms    src/alpha.test.ts",
+                "beta builds       process  built    -           30000ms  scripts/beta.tier.ts",
+                "demo recipe runs  process  browser  playwright  20000ms  examples/demo/check.test.ts",
+                "4 checks",
+            ]);
+        } finally {
+            rmSync(tree, { recursive: true, force: true });
+        }
+    },
+);
+
+check(
+    "an undeclared check file reds the reader",
+    {
+        claim: "check-surface.ts reds on a test-suffix file that registers no check() declaration",
+        class: "process",
+        tier: "step",
+        premises: [],
+        budget: 1000,
+    },
+    () => {
+        const { code, err } = reader("undeclared");
+        expect(code).toBe(1);
+        expect(err).toContain(
+            "undeclared check file: src/naked.test.ts registers no check() declaration",
+        );
+    },
+);
+
+check(
+    "a duplicate claim reds the reader",
+    {
+        claim: "check-surface.ts reds when two checks declare the same claim, naming both files",
+        class: "process",
+        tier: "step",
+        premises: [],
+        budget: 1000,
+    },
+    () => {
+        const { code, err } = reader("duplicate");
+        expect(code).toBe(1);
+        expect(err).toContain('duplicate claim: "same claim" declared in');
+        expect(err).toContain("src/one.test.ts");
+        expect(err).toContain("src/two.test.ts");
+    },
+);
+
+check(
+    "an over-budget step declaration reds the reader",
+    {
+        claim: "check-surface.ts reds on a step-tier declaration whose budget is above the 1000 ms ceiling",
+        class: "process",
+        tier: "step",
+        premises: [],
+        budget: 1000,
+    },
+    () => {
+        const { code, err } = reader("over-budget");
+        expect(code).toBe(1);
+        expect(err).toContain(
+            'over-budget declaration: "slow step" in src/slow.test.ts declares 1500ms above the step ceiling of 1000ms',
+        );
+    },
+);
+
+check(
+    "an orphan quarantine row reds the reader",
+    {
+        claim: "check-surface.ts reds when quarantine.json names a claim no check declares, and treats an absent file as zero rows",
+        class: "process",
+        tier: "step",
+        premises: [],
+        budget: 1000,
+    },
+    () => {
+        const orphan = reader("orphan");
+        expect(orphan.code).toBe(1);
+        expect(orphan.err).toContain(
+            'orphan quarantine row: "claim nobody declares" names no check in the population',
+        );
+        const absent = reader("clean");
+        expect(absent.code).toBe(0);
+        expect(absent.err).toBe("");
+    },
+);
+
+check(
+    "the reader passes the shipped tree",
+    {
+        claim: "check-surface.ts is green on the engine's own tree, so the population is never an empty scan",
+        class: "process",
+        tier: "step",
+        premises: [],
+        budget: 1000,
+    },
+    () => {
+        const proc = Bun.spawnSync(["bun", resolve(ROOT, "scripts/check-surface.ts")], {
+            cwd: ROOT,
+        });
+        expect(proc.stderr.toString().trim()).toBe("");
+        expect(proc.exitCode).toBe(0);
+        expect(proc.stdout.toString()).toMatch(/^\d+ declared checks/);
+        expect(Number(proc.stdout.toString().split(" ")[0])).toBeGreaterThan(0);
+    },
+);

--- a/scripts/surface.ts
+++ b/scripts/surface.ts
@@ -1,0 +1,221 @@
+import { existsSync, readFileSync } from "node:fs";
+import { relative, resolve } from "node:path";
+import { parse } from "@babel/parser";
+import { Glob } from "bun";
+import { CHECK_CLASSES, CHECK_TIERS, validateDeclaration } from "../src/harness/declaration";
+
+// The check population, derived by discovery and never hand-written: every declared check under
+// `src/` and `scripts/`, plus every recipe check declared in an `examples/*/shallot.json`.
+// `--list` prints it; `scripts/check-surface.ts` reads the same collection.
+
+/** one row of the population. */
+export interface SurfaceRow {
+    claim: string;
+    class: string;
+    tier: string;
+    premises: string[];
+    budget: number;
+    /** path relative to the tree root. */
+    file: string;
+}
+
+/** a test-suffix file that declared nothing, or reached for the runner directly. */
+export interface UndeclaredFile {
+    file: string;
+    reason: string;
+}
+
+/** the whole discovered surface of one tree. */
+export interface Population {
+    root: string;
+    rows: SurfaceRow[];
+    undeclared: UndeclaredFile[];
+    invalid: string[];
+}
+
+const SUFFIX = /\.(test|tier|oracle)\.ts$/;
+const SKIP = new Set(["node_modules", "fixtures", "target", "dist", "generate"]);
+const BUN_TEST_IMPORT = /import\s*(?:type\s*)?\{([^}]*)\}\s*from\s*["']bun:test["']/g;
+const REGISTRARS = new Set(["test", "it", "describe"]);
+
+function literal(node: unknown): unknown {
+    const n = node as { type?: string; value?: unknown; elements?: unknown[] };
+    if (
+        n?.type === "StringLiteral" ||
+        n?.type === "NumericLiteral" ||
+        n?.type === "BooleanLiteral"
+    ) {
+        return n.value;
+    }
+    if (n?.type === "ArrayExpression") return (n.elements ?? []).map(literal);
+    return undefined;
+}
+
+function objectOf(node: unknown): Record<string, unknown> | undefined {
+    const n = node as { type?: string; properties?: unknown[] };
+    if (n?.type !== "ObjectExpression") return undefined;
+    const out: Record<string, unknown> = {};
+    for (const raw of n.properties ?? []) {
+        const prop = raw as {
+            type?: string;
+            key?: { name?: string; value?: string };
+            value?: unknown;
+        };
+        if (prop.type !== "ObjectProperty") continue;
+        const key = prop.key?.name ?? prop.key?.value;
+        if (typeof key !== "string") continue;
+        out[key] = literal(prop.value);
+    }
+    return out;
+}
+
+function walk(node: unknown, visit: (call: Record<string, unknown>) => void): void {
+    if (node === null || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+        for (const item of node) walk(item, visit);
+        return;
+    }
+    const n = node as Record<string, unknown>;
+    if (n.type === "CallExpression") {
+        const callee = n.callee as { type?: string; name?: string } | undefined;
+        if (callee?.type === "Identifier" && callee.name === "check") visit(n);
+    }
+    for (const [key, value] of Object.entries(n)) {
+        if (key === "loc" || key === "leadingComments" || key === "trailingComments") continue;
+        walk(value, visit);
+    }
+}
+
+function readFileDeclarations(root: string, path: string, population: Population): void {
+    const file = relative(root, path);
+    const source = readFileSync(path, "utf8");
+    for (const match of source.matchAll(BUN_TEST_IMPORT)) {
+        const names = match[1]
+            .split(",")
+            .map((part) =>
+                part
+                    .trim()
+                    .split(/\s+as\s+/)[0]
+                    .trim(),
+            )
+            .filter((name) => REGISTRARS.has(name));
+        if (names.length > 0) {
+            population.undeclared.push({
+                file,
+                reason: `imports ${names.join(", ")} from bun:test instead of declaring through check()`,
+            });
+            return;
+        }
+    }
+    const ast = parse(source, { sourceType: "module", plugins: ["typescript"] });
+    let found = 0;
+    walk(ast.program, (call) => {
+        found += 1;
+        const args = call.arguments as unknown[];
+        const name = literal(args?.[0]);
+        const where = `${file} check(${typeof name === "string" ? JSON.stringify(name) : "?"})`;
+        const decl = objectOf(args?.[1]);
+        try {
+            const valid = validateDeclaration(where, decl);
+            population.rows.push({
+                claim: valid.claim,
+                class: valid.class,
+                tier: valid.tier,
+                premises: [...valid.premises],
+                budget: valid.budget,
+                file,
+            });
+        } catch (error) {
+            population.invalid.push((error as Error).message);
+        }
+    });
+    if (found === 0)
+        population.undeclared.push({ file, reason: "registers no check() declaration" });
+}
+
+function readManifest(root: string, path: string, population: Population): void {
+    const manifest = JSON.parse(readFileSync(path, "utf8")) as { check?: unknown };
+    if (manifest.check === undefined) return;
+    const dir = relative(root, resolve(path, ".."));
+    const entries = Array.isArray(manifest.check) ? manifest.check : [manifest.check];
+    for (const entry of entries) {
+        const decl = entry as Record<string, unknown> | null;
+        const file = typeof decl?.file === "string" ? `${dir}/${decl.file}` : `${dir}/shallot.json`;
+        try {
+            const valid = validateDeclaration(`${dir}/shallot.json check`, decl);
+            population.rows.push({
+                claim: valid.claim,
+                class: valid.class,
+                tier: valid.tier,
+                premises: [...valid.premises],
+                budget: valid.budget,
+                file,
+            });
+        } catch (error) {
+            population.invalid.push((error as Error).message);
+        }
+    }
+}
+
+/** Walk one tree and return every declared check, plus the files that declared nothing. */
+export function collectPopulation(root: string): Population {
+    const population: Population = { root, rows: [], undeclared: [], invalid: [] };
+    for (const dir of ["src", "scripts"]) {
+        const base = resolve(root, dir);
+        if (!existsSync(base)) continue;
+        for (const match of new Glob("**/*.ts").scanSync({ cwd: base, dot: false })) {
+            if (!SUFFIX.test(match)) continue;
+            if (match.split("/").some((part) => SKIP.has(part))) continue;
+            readFileDeclarations(root, resolve(base, match), population);
+        }
+    }
+    const examples = resolve(root, "examples");
+    if (!existsSync(examples)) return finish(population);
+    for (const match of new Glob("*/shallot.json").scanSync({ cwd: examples })) {
+        readManifest(root, resolve(examples, match), population);
+    }
+    return finish(population);
+}
+
+function finish(population: Population): Population {
+    population.rows.sort((a, b) => a.claim.localeCompare(b.claim));
+    population.undeclared.sort((a, b) => a.file.localeCompare(b.file));
+    return population;
+}
+
+const COLUMNS = ["claim", "class", "tier", "premises", "budget", "file"] as const;
+
+/** Render the population as the table `--list` prints. */
+export function formatPopulation(population: Population): string {
+    const cells = population.rows.map((row) => [
+        row.claim,
+        row.class,
+        row.tier,
+        row.premises.join(" ") || "-",
+        `${row.budget}ms`,
+        row.file,
+    ]);
+    const widths = COLUMNS.map((name, index) =>
+        Math.max(name.length, ...cells.map((cell) => cell[index].length), 0),
+    );
+    const line = (cell: readonly string[]) =>
+        cell
+            .map((value, index) => value.padEnd(widths[index]))
+            .join("  ")
+            .trimEnd();
+    return [line(COLUMNS), ...cells.map(line), `${population.rows.length} checks`].join("\n");
+}
+
+if (import.meta.main) {
+    const args = Bun.argv.slice(2);
+    const rootIndex = args.indexOf("--root");
+    const root =
+        rootIndex === -1 ? resolve(import.meta.dir, "..") : resolve(args[rootIndex + 1] ?? ".");
+    if (!args.includes("--list")) {
+        console.error("usage: bun scripts/surface.ts --list [--root <dir>]");
+        process.exit(1);
+    }
+    console.log(formatPopulation(collectPopulation(root)));
+}
+
+export { CHECK_CLASSES, CHECK_TIERS };

--- a/src/harness/check.test.ts
+++ b/src/harness/check.test.ts
@@ -1,0 +1,120 @@
+import { expect } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { check } from "@dylanebert/shallot/harness/check";
+import { validateDeclaration } from "./declaration";
+
+const BASE = { claim: "base", class: "pure", tier: "step", premises: [], budget: 10 };
+
+check(
+    "a declaration missing a field refuses",
+    {
+        claim: "check() refuses a declaration missing any of claim, class, tier, premises, budget",
+        class: "pure",
+        tier: "step",
+        premises: [],
+        budget: 100,
+    },
+    () => {
+        for (const field of ["claim", "class", "tier", "premises", "budget"]) {
+            const partial: Record<string, unknown> = { ...BASE };
+            delete partial[field];
+            expect(() => validateDeclaration("here", partial)).toThrow(
+                `invalid declaration: here is missing \`${field}\``,
+            );
+        }
+        expect(() => validateDeclaration("here", BASE)).not.toThrow();
+    },
+);
+
+check(
+    "a declaration outside the class and tier vocabulary refuses",
+    {
+        claim: "check() refuses a class or tier outside the four classes and six tiers",
+        class: "pure",
+        tier: "step",
+        premises: [],
+        budget: 100,
+    },
+    () => {
+        expect(() => validateDeclaration("here", { ...BASE, class: "unit" })).toThrow(
+            "has class `unit`",
+        );
+        expect(() => validateDeclaration("here", { ...BASE, tier: "smoke" })).toThrow(
+            "has tier `smoke`",
+        );
+        for (const value of ["pure", "process", "seat", "oracle"]) {
+            expect(() => validateDeclaration("here", { ...BASE, class: value })).not.toThrow();
+        }
+        for (const value of ["step", "gpu", "browser", "headed", "built", "live"]) {
+            expect(() => validateDeclaration("here", { ...BASE, tier: value })).not.toThrow();
+        }
+    },
+);
+
+check(
+    "a bad premises list or budget refuses",
+    {
+        claim: "check() refuses non-string premises and a budget that is not a positive finite number",
+        class: "pure",
+        tier: "step",
+        premises: [],
+        budget: 100,
+    },
+    () => {
+        expect(() => validateDeclaration("here", { ...BASE, premises: "cmake" })).toThrow(
+            "array of strings",
+        );
+        expect(() => validateDeclaration("here", { ...BASE, premises: [1] })).toThrow(
+            "array of strings",
+        );
+        for (const budget of [0, -1, Number.NaN, "10"]) {
+            expect(() => validateDeclaration("here", { ...BASE, budget })).toThrow(
+                "positive finite `budget`",
+            );
+        }
+    },
+);
+
+check(
+    "the declared budget is the runner timeout",
+    {
+        claim: "check() passes the declared budget to the runner, so a body that overruns it fails as a timeout",
+        class: "process",
+        tier: "step",
+        premises: [],
+        budget: 1000,
+    },
+    () => {
+        const root = resolve(import.meta.dir, "../..");
+        const tree = mkdtempSync(join(root, ".surface-budget-"));
+        const file = join(tree, "overrun.test.ts");
+        writeFileSync(
+            file,
+            'import { check } from "@dylanebert/shallot/harness/check";\n' +
+                'check("overruns", { claim: "overruns its budget", class: "pure", tier: "step", premises: [], budget: 20 }, async () => {\n' +
+                "    await Bun.sleep(2000);\n});\n",
+        );
+        try {
+            const proc = Bun.spawnSync(["bun", "test", file], { cwd: root });
+            expect(proc.exitCode).not.toBe(0);
+            expect(proc.stderr.toString()).toContain("timed out after 20ms");
+        } finally {
+            rmSync(tree, { recursive: true, force: true });
+        }
+    },
+);
+
+check(
+    "the public import path resolves",
+    {
+        claim: "check() is reachable at @dylanebert/shallot/harness/check, the path an extension imports",
+        class: "pure",
+        tier: "step",
+        premises: [],
+        budget: 100,
+    },
+    () => {
+        expect(typeof check).toBe("function");
+    },
+);

--- a/src/harness/check.ts
+++ b/src/harness/check.ts
@@ -1,0 +1,46 @@
+import { test } from "bun:test";
+import { type CheckDeclaration, validateDeclaration } from "./declaration";
+
+// The one call every check is registered through: Bun's `test` behind a mandatory typed
+// declaration, with the declared budget as the runner's timeout.
+
+export * from "./declaration";
+
+let currentFile: string | null = null;
+const declared = new Map<string, number>();
+
+/** Preload hook: open a check file. Not part of the public call shape. */
+export function beginFile(path: string): void {
+    currentFile = path;
+    declared.set(path, 0);
+}
+
+/** Preload hook: refuse a check file that declared nothing. */
+export function assertDeclared(path: string): void {
+    const seen = currentFile;
+    currentFile = null;
+    if (seen !== null && seen !== path) {
+        throw new Error(`undeclared check file: ${path} loaded while ${seen} was still open`);
+    }
+    if ((declared.get(path) ?? 0) === 0) {
+        throw new Error(
+            `undeclared check file: ${path} registers no check(); declare each test with check(name, { claim, class, tier, premises, budget }, body)`,
+        );
+    }
+}
+
+/**
+ * Register one check. The declaration is mandatory and its budget is the runner's timeout.
+ * @param name what the runner prints.
+ * @param declaration the claim, class, tier, premises and budget.
+ * @param body the check itself.
+ */
+export function check(
+    name: string,
+    declaration: CheckDeclaration,
+    body: () => void | Promise<void>,
+): void {
+    const decl = validateDeclaration(`check(${JSON.stringify(name)})`, declaration);
+    if (currentFile !== null) declared.set(currentFile, (declared.get(currentFile) ?? 0) + 1);
+    test(name, body, decl.budget);
+}

--- a/src/harness/declaration.ts
+++ b/src/harness/declaration.ts
@@ -1,4 +1,4 @@
-/** the four check classes: what a check costs to run, from `checks.md` § Surface Law. */
+/** the four check classes: what a check costs to run, under the Kex surface law. */
 export const CHECK_CLASSES = ["pure", "process", "seat", "oracle"] as const;
 /** the six tiers: which runner and cadence a check belongs to. */
 export const CHECK_TIERS = ["step", "gpu", "browser", "headed", "built", "live"] as const;

--- a/src/harness/declaration.ts
+++ b/src/harness/declaration.ts
@@ -1,0 +1,62 @@
+/** the four check classes: what a check costs to run, from `checks.md` § Surface Law. */
+export const CHECK_CLASSES = ["pure", "process", "seat", "oracle"] as const;
+/** the six tiers: which runner and cadence a check belongs to. */
+export const CHECK_TIERS = ["step", "gpu", "browser", "headed", "built", "live"] as const;
+/** the wall-clock ceiling a `step`-tier check may declare, in milliseconds. Never raised. */
+export const STEP_BUDGET_MS = 1000;
+
+export type CheckClass = (typeof CHECK_CLASSES)[number];
+export type CheckTier = (typeof CHECK_TIERS)[number];
+
+/** the mandatory options object every check declares. */
+export interface CheckDeclaration {
+    /** unique sentence naming the defect this check would catch. */
+    claim: string;
+    /** what running it costs. */
+    class: CheckClass;
+    /** which runner and cadence owns it. */
+    tier: CheckTier;
+    /** external things that must exist for it to run; empty means hermetic. */
+    premises: readonly string[];
+    /** wall-clock ceiling in milliseconds; also the runner's timeout. */
+    budget: number;
+}
+
+const FIELDS = ["claim", "class", "tier", "premises", "budget"] as const;
+
+/**
+ * Validate a declaration, throwing on the first bad field.
+ * Shared with `scripts/check-surface.ts`, which reads declarations statically.
+ */
+export function validateDeclaration(where: string, value: unknown): CheckDeclaration {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error(`invalid declaration: ${where} needs an options object`);
+    }
+    const decl = value as Record<string, unknown>;
+    for (const field of FIELDS) {
+        if (!(field in decl))
+            throw new Error(`invalid declaration: ${where} is missing \`${field}\``);
+    }
+    if (typeof decl.claim !== "string" || decl.claim.trim() === "") {
+        throw new Error(`invalid declaration: ${where} needs a non-empty \`claim\``);
+    }
+    if (!CHECK_CLASSES.includes(decl.class as CheckClass)) {
+        throw new Error(
+            `invalid declaration: ${where} has class \`${String(decl.class)}\`, not one of ${CHECK_CLASSES.join(", ")}`,
+        );
+    }
+    if (!CHECK_TIERS.includes(decl.tier as CheckTier)) {
+        throw new Error(
+            `invalid declaration: ${where} has tier \`${String(decl.tier)}\`, not one of ${CHECK_TIERS.join(", ")}`,
+        );
+    }
+    if (!Array.isArray(decl.premises) || decl.premises.some((p) => typeof p !== "string")) {
+        throw new Error(`invalid declaration: ${where} needs \`premises\` as an array of strings`);
+    }
+    if (typeof decl.budget !== "number" || !Number.isFinite(decl.budget) || decl.budget <= 0) {
+        throw new Error(
+            `invalid declaration: ${where} needs a positive finite \`budget\` in milliseconds`,
+        );
+    }
+    return decl as unknown as CheckDeclaration;
+}

--- a/src/harness/preload.ts
+++ b/src/harness/preload.ts
@@ -1,0 +1,40 @@
+import { resolve } from "node:path";
+import { plugin } from "bun";
+
+// Bun test preload: every `.test.ts`, `.tier.ts` and `.oracle.ts` file must declare its checks
+// through `check()`. A file that reaches for `bun:test` directly, or that declares nothing at all,
+// refuses at load rather than running undeclared.
+
+const CHECK_MODULE = resolve(import.meta.dir, "check.ts");
+const SUFFIX = /\.(test|tier|oracle)\.ts$/;
+const BUN_TEST_IMPORT = /import\s*(?:type\s*)?\{([^}]*)\}\s*from\s*["']bun:test["']/g;
+const REGISTRARS = new Set(["test", "it", "describe"]);
+
+plugin({
+    name: "surface-declaration",
+    setup(build) {
+        build.onLoad({ filter: SUFFIX }, async (args) => {
+            const source = await Bun.file(args.path).text();
+            for (const match of source.matchAll(BUN_TEST_IMPORT)) {
+                const names = match[1]
+                    .split(",")
+                    .map((part) =>
+                        part
+                            .trim()
+                            .split(/\s+as\s+/)[0]
+                            .trim(),
+                    )
+                    .filter((name) => REGISTRARS.has(name));
+                if (names.length > 0) {
+                    throw new Error(
+                        `undeclared check file: ${args.path} imports ${names.join(", ")} from bun:test; register through check() from @dylanebert/shallot/harness/check`,
+                    );
+                }
+            }
+            const module = JSON.stringify(CHECK_MODULE);
+            const path = JSON.stringify(args.path);
+            const header = `import { beginFile as __beginFile, assertDeclared as __assertDeclared } from ${module};\n__beginFile(${path});\n`;
+            return { contents: `${header}${source}\n__assertDeclared(${path});\n`, loader: "ts" };
+        });
+    },
+});


### PR DESCRIPTION
## Problem

`bun run test` ran `cargo test` and then a Bun run that found nothing, and nothing stopped an undeclared test file from coming back.

## Cause

There was no declaration for a check and no authority over the population: no shared call, no loader that refuses, no list.

## Fix

- `src/harness/check.ts` exports `check(name, { claim, class, tier, premises, budget }, body)` over `bun:test`, published at `@dylanebert/shallot/harness/check`, with the declared budget as the runner's timeout. `src/harness/declaration.ts` holds the vocabulary and validation with no `bun:test` import, so the scripts can read it.
- `src/harness/preload.ts` (wired through `bunfig.toml`) refuses a `.test.ts`, `.tier.ts` or `.oracle.ts` file that declares no check, or that imports `test`, `it` or `describe` from `bun:test`.
- `scripts/surface.ts --list` prints the population — claim, class, tier, premises, budget, file — discovered by parsing `src/**` and `scripts/**` test suffixes and reading each `examples/*/shallot.json` `check` entry.
- `scripts/check-surface.ts` joins `bun run check` and reds on an undeclared file, a duplicate claim, a step-tier budget above 1000 ms, and an orphan `quarantine.json` row (an absent file is zero rows).

## Evidence

- `bun run check`: green, including the new `check-surface` arm.
- `bun run test`: 11 pass, 0 fail. The wrapper's own checks are the first declared population.
- `bun scripts/surface.ts --list`: 11 rows. On the seeded fixture tree it prints exactly the 4 seeded rows, and `check-surface.ts` on the same tree exits 0.
- Adversarial fixtures under `scripts/fixtures/surface/` seed an undeclared file, a duplicate claim, an over-budget declaration and an orphan quarantine row; each reds the production reader with its own message.
- Every check was watched red under a deliberate break of its subject; the breaks are listed in the commit body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAD8wEpa1bCSY3xBBzFK1y