### PR TITLE
shallot-surface-dogfood/D3b: Trim check declarations

### DIFF
--- a/.github/workflows/test-surface.yml
+++ b/.github/workflows/test-surface.yml
@@ -21,6 +21,8 @@ jobs:
       - run: bun run build
       - run: bun run check
       - run: bun run test
+      - name: Run built tier
+        run: bun run test
       - name: Record refused seat checks
         if: always()
         shell: bash
@@ -40,6 +42,8 @@ jobs:
       - run: bun run build
       - run: bun run check
       - run: bun run test
+      - name: Run built tier
+        run: bun run test
       - name: Record refused seat checks
         if: always()
         shell: bash
@@ -59,6 +63,8 @@ jobs:
       - run: bun run build
       - run: bun run check
       - run: bun run test
+      - name: Run built tier
+        run: bun run test
       - name: Record refused seat checks
         if: always()
         shell: bash

--- a/examples/surface-friction/check.test.ts
+++ b/examples/surface-friction/check.test.ts
@@ -45,10 +45,7 @@ check(
     "a low-friction box slides off the ramp while a high-friction box holds",
     {
         claim: "Body.friction makes a low-friction box leave the ramp while a high-friction box holds",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     async () => {
         const state = await headlessRecipeState();

--- a/examples/surface-friction/shallot.json
+++ b/examples/surface-friction/shallot.json
@@ -5,10 +5,7 @@
     "check": {
         "file": "check.test.ts",
         "claim": "Body.friction makes a low-friction box leave the ramp while a high-friction box holds",
-        "class": "pure",
-        "tier": "step",
-        "premises": [],
-        "budget": 1000
+        "tier": "step"
     },
     "scene": "scenes/surface-friction.scene",
     "plugins": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "build": "bun run ./scripts/build.ts",
         "check": "bun run scripts/check.ts",
         "format": "biome check --write && bun run scripts/format.ts",
-        "test": "cargo test --workspace --exclude shallot-native --quiet && bun scripts/surface.ts --test",
+        "test": "cargo test --workspace --exclude shallot-native --quiet && bun test --pass-with-no-tests src scripts examples",
         "assets": "bun run scripts/assets.ts",
         "examples:index": "bun run scripts/examples-index.ts",
         "prepack": "bun run ./scripts/tooling.ts"

--- a/scripts/check-surface.ts
+++ b/scripts/check-surface.ts
@@ -1,13 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { STEP_BUDGET_MS } from "../src/harness/declaration";
+import { TIER_DEFAULTS } from "../src/harness/declaration";
 import { collectPopulation, readQuarantine, renderWorkflow } from "./surface";
 
 // `check` arm for the check surface itself: every test-suffix file declares, claims are unique,
 // no declaration overruns its tier ceiling, quarantine rows are live and current, and the hosted
 // workflow is exactly the one the population emits.
-
-const TIER_CEILING_MS: Record<string, number> = { step: STEP_BUDGET_MS };
 
 function isShallotRoot(root: string): boolean {
     const packagePath = resolve(root, "package.json");
@@ -37,8 +35,8 @@ export function readSurface(root: string): string[] {
         } else {
             seen.set(row.claim, row.file);
         }
-        const ceiling = TIER_CEILING_MS[row.tier];
-        if (ceiling !== undefined && row.budget > ceiling) {
+        const ceiling = TIER_DEFAULTS[row.tier as keyof typeof TIER_DEFAULTS].ceiling;
+        if (ceiling !== undefined && row.budget !== undefined && row.budget > ceiling) {
             violations.push(
                 `over-budget declaration: "${row.claim}" in ${row.file} declares ${row.budget}ms above the ${row.tier} ceiling of ${ceiling}ms`,
             );

--- a/scripts/fixtures/surface/clean/scripts/beta.tier.ts.fixture
+++ b/scripts/fixtures/surface/clean/scripts/beta.tier.ts.fixture
@@ -1,3 +1,3 @@
 import { check } from "@dylanebert/shallot/harness/check";
 
-check("beta builds", { claim: "beta builds", class: "process", tier: "built", premises: [], budget: 30000 }, () => {});
+check("beta builds", { claim: "beta builds", tier: "built" }, () => {});

--- a/scripts/fixtures/surface/clean/src/alpha.test.ts.fixture
+++ b/scripts/fixtures/surface/clean/src/alpha.test.ts.fixture
@@ -1,4 +1,4 @@
 import { check } from "@dylanebert/shallot/harness/check";
 
-check("alpha holds", { claim: "alpha holds", class: "pure", tier: "step", premises: [], budget: 50 }, () => {});
-check("alpha refuses", { claim: "alpha refuses", class: "pure", tier: "step", premises: ["cmake"], budget: 200 }, () => {});
+check("alpha holds", { claim: "alpha holds", tier: "step", budget: 50 }, () => {});
+check("alpha refuses", { claim: "alpha refuses", tier: "step", premises: ["cmake"], budget: 200 }, () => {});

--- a/scripts/fixtures/surface/defaults/src/browser.test.ts.fixture
+++ b/scripts/fixtures/surface/defaults/src/browser.test.ts.fixture
@@ -1,0 +1,3 @@
+import { check } from "@dylanebert/shallot/harness/check";
+
+check("browser defaults", { claim: "browser defaults", tier: "browser" }, () => {});

--- a/scripts/reference-pin.test.ts
+++ b/scripts/reference-pin.test.ts
@@ -38,10 +38,7 @@ check(
     "the shipped solver fixtures carry the declared Box3D commit",
     {
         claim: "check-reference-pin.ts passes only when the committed Box3D reference commit equals the solver fixture generator record",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const result = run(ROOT);
@@ -55,10 +52,7 @@ check(
     "editing the reference commit reds the freshness reader",
     {
         claim: "check-reference-pin.ts reds when reference.json is changed without regenerating the solver fixtures",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const tree = seed(RECORDED);

--- a/scripts/surface.test.ts
+++ b/scripts/surface.test.ts
@@ -56,10 +56,7 @@ check(
     "--list prints exactly the declared population",
     {
         claim: "surface.ts --list prints one row per declared check in the tree, from files and manifests, and nothing else",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const tree = seed("clean");
@@ -70,12 +67,22 @@ check(
                 "claim             class    tier     premises    budget   file                         status",
                 "alpha holds       pure     step     -           50ms     src/alpha.test.ts            -",
                 "alpha refuses     pure     step     cmake       200ms    src/alpha.test.ts            -",
-                "beta builds       process  built    -           30000ms  scripts/beta.tier.ts         -",
+                "beta builds       process  built    -           20000ms  scripts/beta.tier.ts         -",
                 "demo recipe runs  process  browser  playwright  20000ms  examples/demo/check.test.ts  -",
                 "4 checks (parsed 4; 0 quarantined)",
             ]);
         } finally {
             rmSync(tree, { recursive: true, force: true });
+        }
+        const defaults = seed("defaults");
+        try {
+            const { code, out } = run("surface.ts", defaults);
+            expect(code).toBe(0);
+            expect(out).toContain("browser defaults");
+            expect(out).toContain("process  browser");
+            expect(out).toContain("20000ms");
+        } finally {
+            rmSync(defaults, { recursive: true, force: true });
         }
     },
 );
@@ -84,10 +91,7 @@ check(
     "an undeclared check file reds the reader",
     {
         claim: "check-surface.ts reds on a test-suffix file that registers no check() declaration",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const { code, err } = reader("undeclared");
@@ -102,10 +106,7 @@ check(
     "a duplicate claim reds the reader",
     {
         claim: "check-surface.ts reds when two checks declare the same claim, naming both files",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const { code, err } = reader("duplicate");
@@ -120,16 +121,13 @@ check(
     "an over-budget step declaration reds the reader",
     {
         claim: "check-surface.ts reds on a step-tier declaration whose budget is above the 1000 ms ceiling",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const { code, err } = reader("over-budget");
         expect(code).toBe(1);
         expect(err).toContain(
-            'over-budget declaration: "slow step" in src/slow.test.ts declares 1500ms above the step ceiling of 1000ms',
+            'invalid declaration: src/slow.test.ts check("slow step") budget 1500ms is above the step ceiling of 1000ms',
         );
     },
 );
@@ -138,10 +136,7 @@ check(
     "an orphan quarantine row reds the reader",
     {
         claim: "check-surface.ts reds when quarantine.json names a claim no check declares, and treats an absent file as zero rows",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const orphan = reader("orphan");
@@ -159,10 +154,7 @@ check(
     "a non-literal declaration reds the reader",
     {
         claim: "check-surface.ts reds a check whose options use a spread, identifier or computed value, naming its file",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const nonLiteral = reader("non-literal");
@@ -179,10 +171,7 @@ check(
     "an expired quarantine row reds the reader",
     {
         claim: "check-surface.ts reds a quarantine row whose ISO expiry is in the past",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const expired = reader("expired");
@@ -195,10 +184,7 @@ check(
     "the reader passes the shipped tree",
     {
         claim: "check-surface.ts is green on the engine's own tree, so the population is never an empty scan",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const proc = Bun.spawnSync(["bun", resolve(ROOT, "scripts/check-surface.ts")], {

--- a/scripts/surface.ts
+++ b/scripts/surface.ts
@@ -1,6 +1,4 @@
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { relative, resolve } from "node:path";
 import { parse } from "@babel/parser";
 import { Glob } from "bun";
@@ -18,7 +16,7 @@ export interface SurfaceRow {
     class: string;
     tier: string;
     premises: string[];
-    budget: number;
+    budget?: number;
     /** path relative to the tree root. */
     file: string;
 }
@@ -296,7 +294,7 @@ export function formatPopulation(
         row.class,
         row.tier,
         row.premises.join(" ") || "-",
-        `${row.budget}ms`,
+        row.budget === undefined ? "-" : `${row.budget}ms`,
         row.file,
         marked.has(quarantineKey(row.file, row.claim))
             ? `quarantined: ${marked.get(quarantineKey(row.file, row.claim))}`
@@ -315,39 +313,6 @@ export function formatPopulation(
         ...cells.map(line),
         `${population.rows.length} checks (parsed ${population.rows.length}; ${quarantines.length} quarantined)`,
     ].join("\n");
-}
-
-function runtimeRegistrationCount(root: string): { count: number | null; error?: string } {
-    const dir = mkdtempSync(resolve(tmpdir(), "shallot-surface-runtime-"));
-    const report = resolve(dir, "report.xml");
-    try {
-        const proc = spawnSync(
-            "bun",
-            [
-                "test",
-                "--reporter=junit",
-                "--reporter-outfile",
-                report,
-                "--pass-with-no-tests",
-                "src",
-                "scripts",
-                "examples",
-            ],
-            { cwd: root, encoding: "utf8", stdio: ["ignore", "ignore", "pipe"] },
-        );
-        if (proc.status !== 0) {
-            return {
-                count: null,
-                error: `runtime registration probe failed with exit ${proc.status}: ${proc.stderr.trim()}`,
-            };
-        }
-        if (!existsSync(report))
-            return { count: null, error: "runtime registration probe wrote no report" };
-        const xml = readFileSync(report, "utf8");
-        return { count: (xml.match(/<testcase(?:\s|>)/g) ?? []).length };
-    } finally {
-        rmSync(dir, { recursive: true, force: true });
-    }
 }
 
 function shellQuote(value: string): string {
@@ -465,33 +430,6 @@ export function renderWorkflow(population: Population): string {
     ].join("\n");
 }
 
-function escapeRegex(value: string): string {
-    return value.replace(/[.*+?^${}()|[[\]\\]/g, "\\$&");
-}
-
-function runTests(root: string, population: Population): number {
-    const quarantine = readQuarantine(root).rows;
-    const marked = population.rows.filter((row) =>
-        quarantine.some((entry) => entry.file === row.file && entry.claim === row.claim),
-    );
-    for (const row of marked) {
-        const entry = quarantine.find(
-            (candidate) => candidate.file === row.file && candidate.claim === row.claim,
-        );
-        console.log(
-            `verdict claim=${JSON.stringify(row.claim)} file=${row.file} result=refused reason=${JSON.stringify(entry?.reason ?? "quarantined")}`,
-        );
-    }
-    const args = ["test", "--pass-with-no-tests", "src", "scripts", "examples"];
-    if (marked.length > 0) {
-        const excluded = marked.map((row) => escapeRegex(row.name)).join("|");
-        args.push("--test-name-pattern", `^(?!(${excluded})$).*$`);
-    }
-    const proc = spawnSync("bun", args, { cwd: root, stdio: "inherit" });
-    if (marked.length > 0) return 1;
-    return proc.status ?? 1;
-}
-
 if (import.meta.main) {
     const args = Bun.argv.slice(2);
     const rootIndex = args.indexOf("--root");
@@ -505,22 +443,13 @@ if (import.meta.main) {
         console.log(`wrote ${relative(root, workflow)}`);
         process.exit(0);
     }
-    if (args.includes("--test")) process.exit(runTests(root, population));
+
     if (!args.includes("--list")) {
-        console.error("usage: bun scripts/surface.ts --list|--workflow|--test [--root <dir>]");
+        console.error("usage: bun scripts/surface.ts --list|--workflow [--root <dir]");
         process.exit(1);
     }
     const quarantine = readQuarantine(root);
     console.log(formatPopulation(population, quarantine.rows));
-    if (resolve(root) === resolve(import.meta.dir, "..")) {
-        const runtime = runtimeRegistrationCount(root);
-        if (runtime.error !== undefined) {
-            console.error(runtime.error);
-            process.exit(1);
-        }
-        console.log(`runtime registrations: ${runtime.count} (parsed ${population.rows.length})`);
-        if (runtime.count !== population.rows.length) process.exit(1);
-    }
     if (quarantine.errors.length > 0) process.exit(1);
 }
 

--- a/shallot.schema.json
+++ b/shallot.schema.json
@@ -25,7 +25,7 @@
         "check": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["file", "claim", "class", "tier", "premises", "budget"],
+            "required": ["file", "claim", "tier"],
             "properties": {
                 "file": {
                     "type": "string",
@@ -37,21 +37,21 @@
                 },
                 "class": {
                     "enum": ["pure", "process", "seat", "oracle"],
-                    "description": "What running the recipe check costs."
+                    "description": "What running the recipe check costs; defaults from tier."
                 },
                 "tier": {
                     "enum": ["step", "gpu", "browser", "headed", "built", "live"],
-                    "description": "Which runner and cadence owns the recipe check."
+                    "description": "Which runner and cadence owns the recipe check; also supplies class and budget defaults."
                 },
                 "premises": {
                     "type": "array",
                     "items": { "type": "string" },
-                    "description": "External things that must exist for the recipe check to run."
+                    "description": "External things that must exist for the recipe check to run; defaults to none."
                 },
                 "budget": {
                     "type": "number",
                     "exclusiveMinimum": 0,
-                    "description": "The recipe check's wall-clock budget in milliseconds."
+                    "description": "The recipe check's wall-clock budget in milliseconds; defaults from tier."
                 }
             }
         },

--- a/src/harness/check.test.ts
+++ b/src/harness/check.test.ts
@@ -9,20 +9,25 @@ const BASE = { claim: "base", class: "pure", tier: "step", premises: [], budget:
 check(
     "a declaration missing a field refuses",
     {
-        claim: "check() refuses a declaration missing any of claim, class, tier, premises, budget",
-        class: "pure",
+        claim: "check() requires claim and tier while deriving class, premises and budget defaults",
         tier: "step",
-        premises: [],
         budget: 100,
     },
     () => {
-        for (const field of ["claim", "class", "tier", "premises", "budget"]) {
+        for (const field of ["claim", "tier"]) {
             const partial: Record<string, unknown> = { ...BASE };
             delete partial[field];
             expect(() => validateDeclaration("here", partial)).toThrow(
                 `invalid declaration: here is missing \`${field}\``,
             );
         }
+        expect(validateDeclaration("here", { claim: "browser", tier: "browser" })).toEqual({
+            claim: "browser",
+            class: "process",
+            tier: "browser",
+            premises: [],
+            budget: 20000,
+        });
         expect(() => validateDeclaration("here", BASE)).not.toThrow();
     },
 );
@@ -30,10 +35,8 @@ check(
 check(
     "a declaration outside the class and tier vocabulary refuses",
     {
-        claim: "check() refuses a class or tier outside the four classes and six tiers",
-        class: "pure",
+        claim: "check() refuses a class or tier outside the four classes and six tiers, and rejects tier contradictions",
         tier: "step",
-        premises: [],
         budget: 100,
     },
     () => {
@@ -43,12 +46,24 @@ check(
         expect(() => validateDeclaration("here", { ...BASE, tier: "smoke" })).toThrow(
             "has tier `smoke`",
         );
-        for (const value of ["pure", "process", "seat", "oracle"]) {
-            expect(() => validateDeclaration("here", { ...BASE, class: value })).not.toThrow();
+        for (const [tier, className] of Object.entries({
+            step: "pure",
+            gpu: "seat",
+            browser: "process",
+            headed: "seat",
+            built: "process",
+            live: "oracle",
+        })) {
+            expect(() =>
+                validateDeclaration("here", { claim: "base", tier, class: className }),
+            ).not.toThrow();
         }
-        for (const value of ["step", "gpu", "browser", "headed", "built", "live"]) {
-            expect(() => validateDeclaration("here", { ...BASE, tier: value })).not.toThrow();
-        }
+        expect(() => validateDeclaration("here", { ...BASE, class: "process" })).toThrow(
+            "contradicts tier `step`",
+        );
+        expect(() => validateDeclaration("here", { ...BASE, budget: 1001 })).toThrow(
+            "above the step ceiling of 1000ms",
+        );
     },
 );
 
@@ -56,9 +71,7 @@ check(
     "a bad premises list or budget refuses",
     {
         claim: "check() refuses non-string premises and a budget that is not a positive finite number",
-        class: "pure",
         tier: "step",
-        premises: [],
         budget: 100,
     },
     () => {
@@ -80,10 +93,7 @@ check(
     "the declared budget is the runner timeout",
     {
         claim: "check() passes the declared budget to the runner, so a body that overruns it fails as a timeout",
-        class: "process",
-        tier: "step",
-        premises: [],
-        budget: 1000,
+        tier: "built",
     },
     () => {
         const root = resolve(import.meta.dir, "../..");
@@ -109,9 +119,7 @@ check(
     "the public import path resolves",
     {
         claim: "check() is reachable at @dylanebert/shallot/harness/check, the path an extension imports",
-        class: "pure",
         tier: "step",
-        premises: [],
         budget: 100,
     },
     () => {

--- a/src/harness/declaration.ts
+++ b/src/harness/declaration.ts
@@ -8,55 +8,94 @@ export const STEP_BUDGET_MS = 1000;
 export type CheckClass = (typeof CHECK_CLASSES)[number];
 export type CheckTier = (typeof CHECK_TIERS)[number];
 
-/** the mandatory options object every check declares. */
+/** Defaults coupled to each tier; `live` has no automatic wall-clock ceiling. */
+export const TIER_DEFAULTS = {
+    step: { class: "pure", ceiling: STEP_BUDGET_MS },
+    gpu: { class: "seat", ceiling: 60000 },
+    browser: { class: "process", ceiling: 20000 },
+    headed: { class: "seat", ceiling: 60000 },
+    built: { class: "process", ceiling: 20000 },
+    live: { class: "oracle", ceiling: undefined },
+} as const satisfies Record<CheckTier, { class: CheckClass; ceiling: number | undefined }>;
+
+/** The options object every check declares; class, premises and budget derive from its tier. */
 export interface CheckDeclaration {
     /** unique sentence naming the defect this check would catch. */
     claim: string;
-    /** what running it costs. */
-    class: CheckClass;
     /** which runner and cadence owns it. */
     tier: CheckTier;
-    /** external things that must exist for it to run; empty means hermetic. */
-    premises: readonly string[];
-    /** wall-clock ceiling in milliseconds; also the runner's timeout. */
-    budget: number;
+    /** what running it costs; defaults from `tier`. */
+    class?: CheckClass;
+    /** external things that must exist for it to run; defaults to hermetic. */
+    premises?: readonly string[];
+    /** wall-clock ceiling in milliseconds; defaults from `tier` when that tier has one. */
+    budget?: number;
 }
 
-const FIELDS = ["claim", "class", "tier", "premises", "budget"] as const;
+export interface ResolvedCheckDeclaration {
+    claim: string;
+    class: CheckClass;
+    tier: CheckTier;
+    premises: readonly string[];
+    budget?: number;
+}
 
 /**
- * Validate a declaration, throwing on the first bad field.
+ * Validate a declaration and fill its tier-derived values.
  * Shared with `scripts/check-surface.ts`, which reads declarations statically.
  */
-export function validateDeclaration(where: string, value: unknown): CheckDeclaration {
+export function validateDeclaration(where: string, value: unknown): ResolvedCheckDeclaration {
     if (typeof value !== "object" || value === null || Array.isArray(value)) {
         throw new Error(`invalid declaration: ${where} needs an options object`);
     }
     const decl = value as Record<string, unknown>;
-    for (const field of FIELDS) {
+    for (const field of ["claim", "tier"] as const) {
         if (!(field in decl))
             throw new Error(`invalid declaration: ${where} is missing \`${field}\``);
     }
     if (typeof decl.claim !== "string" || decl.claim.trim() === "") {
         throw new Error(`invalid declaration: ${where} needs a non-empty \`claim\``);
     }
-    if (!CHECK_CLASSES.includes(decl.class as CheckClass)) {
-        throw new Error(
-            `invalid declaration: ${where} has class \`${String(decl.class)}\`, not one of ${CHECK_CLASSES.join(", ")}`,
-        );
-    }
     if (!CHECK_TIERS.includes(decl.tier as CheckTier)) {
         throw new Error(
             `invalid declaration: ${where} has tier \`${String(decl.tier)}\`, not one of ${CHECK_TIERS.join(", ")}`,
         );
     }
-    if (!Array.isArray(decl.premises) || decl.premises.some((p) => typeof p !== "string")) {
+    const tier = decl.tier as CheckTier;
+    const defaults = TIER_DEFAULTS[tier];
+    if (decl.class !== undefined && !CHECK_CLASSES.includes(decl.class as CheckClass)) {
+        throw new Error(
+            `invalid declaration: ${where} has class \`${String(decl.class)}\`, not one of ${CHECK_CLASSES.join(", ")}`,
+        );
+    }
+    if (decl.class !== undefined && decl.class !== defaults.class) {
+        throw new Error(
+            `invalid declaration: ${where} class \`${String(decl.class)}\` contradicts tier \`${tier}\` (expected \`${defaults.class}\`)`,
+        );
+    }
+    const premises = decl.premises === undefined ? [] : decl.premises;
+    if (!Array.isArray(premises) || premises.some((p) => typeof p !== "string")) {
         throw new Error(`invalid declaration: ${where} needs \`premises\` as an array of strings`);
     }
-    if (typeof decl.budget !== "number" || !Number.isFinite(decl.budget) || decl.budget <= 0) {
+    if (
+        decl.budget !== undefined &&
+        (typeof decl.budget !== "number" || !Number.isFinite(decl.budget) || decl.budget <= 0)
+    ) {
         throw new Error(
             `invalid declaration: ${where} needs a positive finite \`budget\` in milliseconds`,
         );
     }
-    return decl as unknown as CheckDeclaration;
+    const budget = decl.budget ?? defaults.ceiling;
+    if (defaults.ceiling !== undefined && budget !== undefined && budget > defaults.ceiling) {
+        throw new Error(
+            `invalid declaration: ${where} budget ${budget}ms is above the ${tier} ceiling of ${defaults.ceiling}ms`,
+        );
+    }
+    return {
+        claim: decl.claim,
+        class: defaults.class,
+        tier,
+        premises,
+        budget,
+    };
 }

--- a/src/standard/physics/collision/broadphase.test.ts
+++ b/src/standard/physics/collision/broadphase.test.ts
@@ -54,10 +54,7 @@ check(
     "proxy key packs and unpacks id and body type",
     {
         claim: "the broad-phase proxy key loses the id or the body type across pack and unpack, so a moved proxy would be attributed to the wrong tree",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const types: BodyTypeValue[] = [BodyType.Static, BodyType.Kinematic, BodyType.Dynamic];
@@ -76,10 +73,7 @@ check(
     "the broad-phase move buffer takes dynamic creates and skips unforced static ones",
     {
         claim: "the broad-phase move buffer records a plain static proxy on create, so every static shape would be queried for new pairs on the step it is added",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const bp = fresh();
@@ -127,10 +121,7 @@ check(
     "the broad-phase move buffer dedups a key buffered twice",
     {
         claim: "the broad-phase move buffer appends a key it already holds, so one proxy moved twice in a step would be pair-queried twice",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const bp = fresh();
@@ -154,10 +145,7 @@ check(
     "the broad-phase move buffer keeps creates in insertion order",
     {
         claim: "the broad-phase move buffer reorders buffered keys against creation order, so pair finding would stop being deterministic across runs",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const bp = fresh();
@@ -184,10 +172,7 @@ check(
     "a destroyed proxy leaves the broad-phase move buffer and its bit",
     {
         claim: "the broad-phase move buffer keeps a destroyed proxy's key or its moved bit, so a freed tree slot would be pair-queried after destruction",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const bp = fresh();
@@ -213,10 +198,7 @@ check(
     "moveProxy re-enters a cleared proxy into the broad-phase move buffer",
     {
         claim: "the broad-phase move buffer misses a proxy moved after the per-step clear, so a body that moved would never be re-queried for pairs",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const bp = fresh();
@@ -244,10 +226,7 @@ check(
     "testOverlap on two proxy keys reflects their tree AABBs",
     {
         claim: "the broad-phase proxy key overlap test reads the wrong tree slot, so overlapping proxies would report separated and drop the contact",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const bp = fresh();
@@ -263,10 +242,7 @@ check(
     "enlarging a static proxy key throws",
     {
         claim: "the broad-phase proxy key guard lets a static proxy be enlarged, so the static tree would silently need rebuilding mid-step",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const bp = fresh();

--- a/src/standard/physics/collision/contact.test.ts
+++ b/src/standard/physics/collision/contact.test.ts
@@ -30,10 +30,7 @@ check(
     "createContact links both bodies and destroyContact unthreads them",
     {
         claim: "createContact leaves a body edge, an awake-set row or a broad-phase pair entry behind after destroyContact, leaking a contact into the next step",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const world = getWorld(createWorld(defaultWorldDef())) as WorldState;
@@ -71,10 +68,7 @@ check(
     "a contact between two sleeping bodies parks in the disabled set",
     {
         claim: "createContact files a non-touching contact between two asleep bodies into the awake set, so sleeping islands pay for contacts nothing is simulating",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // A body that starts asleep lands in a sleeping set; a contact where neither body is awake

--- a/src/standard/physics/collision/distance.test.ts
+++ b/src/standard/physics/collision/distance.test.ts
@@ -88,10 +88,7 @@ check(
     "shapeDistance matches the C reference bit for bit",
     {
         claim: "the GJK distance solver drifts from the pinned Box3D C reference on witness points, normal, distance, iteration count or simplex cache",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.distance) {
@@ -122,10 +119,7 @@ check(
     "shapeCast matches the C reference bit for bit",
     {
         claim: "the conservative-advancement shape cast drifts from the pinned Box3D C reference on hit flag, fraction, contact point, normal or iteration count",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.cast) {
@@ -152,10 +146,7 @@ check(
     "timeOfImpact matches the C reference bit for bit",
     {
         claim: "the swept time-of-impact root finder drifts from the pinned Box3D C reference on state, fraction, separation, witness point, normal or any of its three iteration counters",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.toi) {
@@ -188,10 +179,7 @@ check(
     "segmentDistance matches the C reference bit for bit",
     {
         claim: "the closest-points-between-two-segments primitive drifts from the pinned Box3D C reference on either witness point or either clamped fraction",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.segment) {
@@ -217,10 +205,7 @@ check(
     "segmentDistance finds the analytic closest pair on two perpendicular segments",
     {
         claim: "segmentDistance mis-parameterizes or fails to clamp a perpendicular segment pair, so the closest pair lands off the segments instead of at the midpoint and the endpoint",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const r = segmentDistance(v(-1, -1, 0), v(-1, 1, 0), v(2, 0, 0), v(1, 0, 0));
@@ -239,10 +224,7 @@ check(
     "shapeDistance reports the analytic gap between a quad and a separated segment",
     {
         claim: "shapeDistance returns a gap other than the analytic 1 between a unit quad and a segment standing one unit away, so separated pairs report the wrong distance",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const proxyA: ShapeProxy = {
@@ -268,10 +250,7 @@ check(
     "shapeCast stops the segment at the analytic half of its translation",
     {
         claim: "shapeCast misses the hit or reports a fraction away from the analytic 0.5 when a segment is swept two units into a quad one unit away",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const proxyA: ShapeProxy = {
@@ -297,10 +276,7 @@ check(
     "timeOfImpact lands the Hit state at the analytic half of the sweep",
     {
         claim: "timeOfImpact returns a state other than Hit or a fraction away from the analytic 0.5 when a segment sweeps two units into a stationary quad one unit away",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const proxyA: ShapeProxy = {

--- a/src/standard/physics/collision/manifold.test.ts
+++ b/src/standard/physics/collision/manifold.test.ts
@@ -131,10 +131,7 @@ check(
     "collideSpheres matches the C reference manifold bit for bit",
     {
         claim: "the sphere-sphere manifold drifts from the pinned Box3D C reference on point count, normal, contact point, separation or feature id",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const scene of gold.spheres) {
@@ -152,10 +149,7 @@ check(
     "collideCapsuleAndSphere matches the C reference manifold bit for bit",
     {
         claim: "the capsule-sphere manifold drifts from the pinned Box3D C reference on point count, normal, contact point, separation or feature id",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const scene of gold.capsuleSphere) {
@@ -173,10 +167,7 @@ check(
     "collideHullAndSphere matches the C reference manifold across repeated warm calls",
     {
         claim: "the hull-sphere manifold drifts from the pinned Box3D C reference, or its warm simplex cache changes the answer on the second call for the same pose",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const scene of gold.hullSphere) {
@@ -197,10 +188,7 @@ check(
     "collideCapsules matches the C reference manifold bit for bit",
     {
         claim: "the capsule-capsule manifold drifts from the pinned Box3D C reference on point count, normal, contact point, separation or feature id",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const scene of gold.capsules) {
@@ -218,10 +206,7 @@ check(
     "collideHullAndCapsule matches the C reference manifold across repeated warm calls",
     {
         claim: "the hull-capsule manifold drifts from the pinned Box3D C reference, or its warm simplex cache changes the answer on the second call for the same pose",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const scene of gold.hullCapsule) {
@@ -242,10 +227,7 @@ check(
     "collideHulls matches the C reference manifold and SAT cache across repeated warm calls",
     {
         claim: "the hull-hull SAT and clipping path drifts from the pinned Box3D C reference on the clipped manifold or on the separating-feature cache it warms for the next call",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const scene of gold.hulls) {
@@ -267,10 +249,7 @@ check(
     "collideSphereAndTriangle matches the C reference manifold bit for bit",
     {
         claim: "the sphere-triangle manifold drifts from the pinned Box3D C reference on its manifold or on the triangle feature mesh-contact reduction reads",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const scene of gold.sphereTriangle) {
@@ -287,10 +266,7 @@ check(
     "collideCapsuleAndTriangle matches the C reference manifold across repeated warm calls",
     {
         claim: "the capsule-triangle manifold drifts from the pinned Box3D C reference on its manifold, its triangle feature, or under its own warm simplex cache",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const scene of gold.capsuleTriangle) {
@@ -310,10 +286,7 @@ check(
     "collideHullAndTriangle matches the C reference manifold and SAT cache across repeated warm calls",
     {
         claim: "the hull-triangle manifold drifts from the pinned Box3D C reference on its manifold, its triangle feature, or on the separating-feature cache it warms",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const scene of gold.hullTriangle) {
@@ -334,10 +307,7 @@ check(
     "two unit cubes overlapping by 0.1 give a four-point face manifold",
     {
         claim: "hull-hull face clipping loses a corner or mis-scales penetration, so a 0.1 box-box overlap stops producing four points each separated by about -0.1",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // Analytic invariant from Box3D's LargeWorldManifoldTest (float path).
@@ -360,10 +330,7 @@ check(
     "pointToSegmentDistance projects inside and clamps to the endpoints",
     {
         claim: "pointToSegmentDistance fails to clamp a query beyond either end of the segment, returning an extrapolated point instead of the endpoint itself",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const a = v(0, 0, 0);
@@ -379,10 +346,7 @@ check(
     "lineDistance finds the closest points on two skew lines",
     {
         claim: "lineDistance solves the wrong pair on two skew infinite lines, so the capsule and edge-edge paths built on it pick the wrong closest points",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // Line 1 along x through origin; line 2 along y through (0,0,1). Closest points are the
@@ -398,10 +362,7 @@ check(
     "isWithinSegments rejects an out-of-range fraction",
     {
         claim: "isWithinSegments accepts a fraction outside [0,1], letting an infinite-line solution be used as if it lay on the finite segments",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         expect(

--- a/src/standard/physics/collision/mover.gold.test.ts
+++ b/src/standard/physics/collision/mover.gold.test.ts
@@ -87,10 +87,7 @@ check(
     "solvePlanes matches the C reference bit-for-bit over every gold vector",
     {
         claim: "the mover plane solver drifts from the Box3D C reference in its delta bits or iteration count, so a character resolves penetration differently than the pinned reference",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.solvePlanes) {
@@ -111,10 +108,7 @@ check(
     "clipVector matches the C reference bit-for-bit over every gold vector",
     {
         claim: "the mover velocity clip drifts from the Box3D C reference, so a character keeps or loses velocity against a contact plane differently than the pinned reference",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.clipVector) {
@@ -130,10 +124,7 @@ check(
     "collideMoverAndSphere matches the C reference bit-for-bit over every gold vector",
     {
         claim: "mover-versus-sphere collision drifts from the Box3D C reference in its plane count, normal, offset or contact point bits",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.sphere) {
@@ -152,10 +143,7 @@ check(
     "collideMoverAndCapsule matches the C reference bit-for-bit over every gold vector",
     {
         claim: "mover-versus-capsule collision drifts from the Box3D C reference in its plane count, normal, offset or contact point bits",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.capsule) {
@@ -188,10 +176,7 @@ check(
     "collideMoverAndHull matches the C reference bit-for-bit over every gold vector",
     {
         claim: "mover-versus-hull collision drifts from the Box3D C reference in its plane count, normal, offset or contact point bits",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.hull) {
@@ -222,10 +207,7 @@ check(
     "collideMoverAndMesh matches the C reference bit-for-bit over every gold vector",
     {
         claim: "mover-versus-triangle-mesh collision drifts from the Box3D C reference in its plane count, normal, offset or contact point bits",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.mesh) {
@@ -239,10 +221,7 @@ check(
     "collideMoverAndHeightField matches the C reference bit-for-bit over every gold vector",
     {
         claim: "mover-versus-height-field collision drifts from the Box3D C reference in its plane count, normal, offset or contact point bits",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.height) {
@@ -256,10 +235,7 @@ check(
     "collideMoverAndCompound matches the C reference bit-for-bit over every gold vector",
     {
         claim: "mover-versus-compound collision drifts from the Box3D C reference in its plane count, normal, offset or contact point bits",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.compound) {

--- a/src/standard/physics/collision/mover.test.ts
+++ b/src/standard/physics/collision/mover.test.ts
@@ -28,10 +28,7 @@ check(
     "solvePlanes converges two parallel planes in two iterations",
     {
         claim: "the mover plane solver stops converging on an easy pair of parallel planes, burning iterations or landing short of the deeper plane",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const planes = [rigidPlane(v(0, 0, 1), 0.5), rigidPlane(v(0, 0, 1), 1.0)];
@@ -45,10 +42,7 @@ check(
     "solvePlanes spends the full twenty iterations on a deep target",
     {
         claim: "the mover plane solver's iteration ceiling stops holding, so a deeply penetrating target exits early or runs unbounded",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const planes = [
@@ -67,10 +61,7 @@ check(
     "a mover clear of a sphere reports no collision plane",
     {
         claim: "mover-versus-sphere invents a contact plane for a mover nowhere near the sphere, so a character snags on empty space",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const shape: Sphere = { center: v(0, 0, 0), radius: 0.5 };
@@ -83,10 +74,7 @@ check(
     "a mover touching a sphere is pushed straight out by the overlap depth",
     {
         claim: "mover-versus-sphere returns an unnormalized normal, the wrong push direction, or a depth other than the actual overlap on a shallow touch",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const shape: Sphere = { center: v(0, 0, 0), radius: 0.5 };
@@ -104,10 +92,7 @@ check(
     "a mover concentric with a sphere falls back to a perpendicular normal at full depth",
     {
         claim: "mover-versus-sphere degenerates when the mover axis runs through the sphere centre, emitting a zero or axis-aligned-with-the-mover normal instead of the perpendicular fallback at the combined radius",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const shape: Sphere = { center: v(0, 0, 0), radius: 0.5 };
@@ -129,10 +114,7 @@ check(
     "a mover clear of a capsule reports no collision plane",
     {
         claim: "mover-versus-capsule invents a contact plane for a mover well above the capsule, so a character snags on empty space",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const mover: Capsule = { center1: v(-1, 5, 0), center2: v(1, 5, 0), radius: 0.2 };
@@ -144,10 +126,7 @@ check(
     "a mover touching a capsule is pushed straight out by the overlap depth",
     {
         claim: "mover-versus-capsule returns an unnormalized normal, the wrong push direction, or a depth other than the actual overlap on a shallow touch",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const mover: Capsule = { center1: v(-1, 0.4, 0), center2: v(1, 0.4, 0), radius: 0.2 };
@@ -164,10 +143,7 @@ check(
     "crossing capsule core segments fall back to a normal perpendicular to both axes",
     {
         claim: "mover-versus-capsule picks a normal in the plane of two crossing core segments instead of the mutual perpendicular, so a crossed character is pushed along a shape axis",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const mover: Capsule = { center1: v(0, 0, -1), center2: v(0, 0, 1), radius: 0.2 };
@@ -185,10 +161,7 @@ check(
     "coincident capsule axes fall back to a perpendicular of the mover axis",
     {
         claim: "mover-versus-capsule degenerates when both core segments lie on the same axis, emitting a zero or along-axis normal instead of a perpendicular at the combined radius",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const mover: Capsule = { center1: v(-1, 0, 0), center2: v(1, 0, 0), radius: 0.2 };
@@ -207,10 +180,7 @@ check(
     "a mover clear of a box hull reports no collision plane",
     {
         claim: "mover-versus-hull invents a contact plane for a mover far above the box, so a character snags on empty space",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const mover: Capsule = { center1: v(-0.3, 5, 0), center2: v(0.3, 5, 0), radius: 0.2 };
@@ -222,10 +192,7 @@ check(
     "a mover touching a box hull's +Y face is pushed up by the overlap depth",
     {
         claim: "mover-versus-hull returns an unnormalized normal, a push that is not the touched face normal, or a depth other than the actual overlap",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const mover: Capsule = { center1: v(-0.3, 0.6, 0), center2: v(0.3, 0.6, 0), radius: 0.2 };
@@ -242,10 +209,7 @@ check(
     "a mover buried inside a box hull is dropped rather than given a zero normal",
     {
         claim: "mover-versus-hull emits a plane with a degenerate zero normal for a mover fully inside the box instead of dropping the contact",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const mover: Capsule = { center1: v(-0.2, 0, 0), center2: v(0.2, 0, 0), radius: 0.1 };

--- a/src/standard/physics/collision/pairs.test.ts
+++ b/src/standard/physics/collision/pairs.test.ts
@@ -18,10 +18,7 @@ check(
     "category and mask must overlap in both directions",
     {
         claim: "collision filtering by category and mask lets a one-sided match through, so a shape that sees another collides with it even when that other shape's mask excludes it — and the default all-pass filter stops colliding with itself",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // the default filter is the all-pass case every fixture scene rides on.
@@ -44,10 +41,7 @@ check(
     "filter bits above 32 survive the u64 split",
     {
         claim: "collision filtering across the two u32 halves of the 64-bit filter drops or aliases the high half, so a category above bit 32 either misses its own mask or matches an unrelated low-half one, and a half's top bit reads as no match through a signed AND",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const hiOnly = 1n << 40n;
@@ -71,10 +65,7 @@ check(
     "a shared non-zero filter group overrides the mask",
     {
         claim: "collision filtering by group index stops taking precedence over the mask, so a shared positive group no longer forces the pair together, a shared negative group no longer keeps it apart, or two different groups skip the mask test instead of falling through to it",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // Same positive group forces collision despite disjoint masks.
@@ -97,10 +88,7 @@ check(
     "overlapping moved proxies create one contact and don't duplicate it across steps",
     {
         claim: "contact pair creation from the broad phase emits an overlapping pair once per moved side instead of deduplicating it, or re-creates a pair already in the pair set on a later step, so a single touching pair fires two begin-touch events",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // Two dynamic boxes overlap along x and both drift +y (zero gravity, sleep off) so both sit in

--- a/src/standard/physics/collision/query.gold.test.ts
+++ b/src/standard/physics/collision/query.gold.test.ts
@@ -153,10 +153,7 @@ check(
     "rayCastSphere bit-exact vs C reference",
     {
         claim: "a ray against a sphere lands on a different f32 hit point, normal or fraction than the C reference does, including the grazing and ray-origin-inside cases.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.raySphere) {
@@ -177,10 +174,7 @@ check(
     "rayCastCapsule bit-exact vs C reference",
     {
         claim: "a ray against a capsule picks the wrong segment region or rounds the endcap and skew hits away from the C reference bits.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.rayCapsule) {
@@ -202,10 +196,7 @@ check(
     "rayCastHull bit-exact vs C reference",
     {
         claim: "the hull slab clip picks a different entering plane or fraction than the C reference on face, edge, corner and interior-origin rays.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.rayHull) {
@@ -218,10 +209,7 @@ check(
     "shapeCast bit-exact vs C reference",
     {
         claim: "the GJK-backed shape cast against a sphere or hull drifts from the C reference's conservative-advancement fraction and witness point.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.shapeCast) {
@@ -251,10 +239,7 @@ check(
     "overlap bit-exact vs C reference",
     {
         claim: "the sphere and hull overlap predicate answers differently from the C reference at the touching and separated boundary.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.overlap) {
@@ -280,10 +265,7 @@ check(
     "rayCastMesh bit-exact vs C reference",
     {
         claim: "a ray through the mesh BVH reports a different triangle index or hit bits than the C reference, so traversal order or triangle clipping has moved.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.rayMesh) {
@@ -300,10 +282,7 @@ check(
     "shapeCastMesh bit-exact vs C reference",
     {
         claim: "sweeping a proxy through the mesh selects a different triangle or fraction than the C reference when several triangles are candidates.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.shapeCastMesh) {
@@ -321,10 +300,7 @@ check(
     "overlapMesh bit-exact vs C reference",
     {
         claim: "the mesh overlap predicate disagrees with the C reference about a proxy resting on or just clear of the grid surface.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.overlapMesh) {
@@ -338,10 +314,7 @@ check(
     "rayCastHeightField bit-exact vs C reference",
     {
         claim: "the height-field ray walk visits cells in a different order or clips the sampled column differently from the C reference.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.rayHeight) {
@@ -358,10 +331,7 @@ check(
     "shapeCastHeightField bit-exact vs C reference",
     {
         claim: "sweeping a proxy across the height field returns a different cell triangle or fraction than the C reference.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.shapeCastHeight) {
@@ -379,10 +349,7 @@ check(
     "overlapHeightField bit-exact vs C reference",
     {
         claim: "the height-field overlap predicate disagrees with the C reference about a proxy at the sampled column boundary.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.overlapHeight) {
@@ -400,10 +367,7 @@ check(
     "rayCastCompound bit-exact vs C reference",
     {
         claim: "a ray against a two-child compound reports the wrong child index or takes the farther child's hit, unlike the C reference.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.rayCompound) {
@@ -420,10 +384,7 @@ check(
     "shapeCastCompound bit-exact vs C reference",
     {
         claim: "sweeping a proxy through a compound fails to keep the nearest child's fraction and its child index together, unlike the C reference.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.shapeCastCompound) {
@@ -441,10 +402,7 @@ check(
     "overlapCompound bit-exact vs C reference",
     {
         claim: "the compound overlap predicate misses a proxy that touches only one child, or reports one in the gap between children, unlike the C reference.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const g of gold.overlapCompound) {

--- a/src/standard/physics/collision/table.test.ts
+++ b/src/standard/physics/collision/table.test.ts
@@ -11,10 +11,7 @@ check(
     "the pair hash set's power-of-two sizing rounds a capacity up to the next power",
     {
         claim: "the pair hash set sizes its table with a wrong power of two, so probing wraps over a non-power-of-two mask",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const power = boundingPowerOf2(3008);
@@ -27,10 +24,7 @@ check(
     "the pair hash set fills, removes its diagonal, answers reversed queries and drains",
     {
         claim: "the pair hash set loses or resurrects a pair across grows and backward-shift deletes, so the broad phase reports stale membership",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const N = 200;
@@ -83,10 +77,7 @@ check(
     "the pair hash set reports duplicates and separates pairs by child index",
     {
         claim: "the pair hash set treats a reversed insert as new or merges two child indices of one shape pair, so per-child manifolds collide",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const set = createSet(16);
@@ -135,10 +126,7 @@ check(
     "the pair key's split halves match the u64 oracle on packing edge cases",
     {
         claim: "the pair key packs a field across the word boundary wrongly at its extremes, so saturated shape or child indices alias",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (const [s1, s2, c] of [
@@ -166,10 +154,7 @@ check(
     "the pair key and its fmix match the u64 oracle over random triples",
     {
         claim: "the pair key's split fmix drops a carry on some triple, so its hash diverges from Box3D's u64 fmix64",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // Deterministic LCG — a failing seed is reproducible.
@@ -188,10 +173,7 @@ check(
     "the pair key is symmetric in its shapes and injective over distinct triples",
     {
         claim: "the pair key maps two distinct shape-child triples to one key or answers differently for a reversed pair, so the broad phase drops a pair",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const seen = new Set<string>();

--- a/src/standard/physics/collision/tree.test.ts
+++ b/src/standard/physics/collision/tree.test.ts
@@ -218,10 +218,7 @@ check(
     "dynamic tree replays tree.gold.json bit-exactly against the C reference",
     {
         claim: "the dynamic tree's insert, move, enlarge, destroy, rebuild and query paths drift from the Box3D C reference, so node layout, AABB bits or visit counts diverge from the recorded op stream",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const tree = createTree(gold.proxyCapacity);
@@ -282,10 +279,7 @@ check(
     "an empty dynamic tree visits no nodes for a query",
     {
         claim: "the dynamic tree walks a root that does not exist when it holds no proxies, so an empty broad phase reports visits or hits instead of nothing",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const tree = createTree(16);
@@ -307,10 +301,7 @@ check(
     "a dynamic tree with one proxy makes that leaf the root at height zero",
     {
         claim: "the dynamic tree synthesizes an internal parent for its first proxy, so a one-proxy broad phase reports the wrong root, height or proxy count",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const tree = createTree(16);
@@ -327,10 +318,7 @@ check(
     "destroying every dynamic tree proxy empties the tree and leaves it valid",
     {
         claim: "the dynamic tree leaks internal parents when its proxies are all destroyed, so the root or proxy count survives an emptied broad phase",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const tree = createTree(16);
@@ -360,10 +348,7 @@ check(
     "setCategoryBits ORs a dynamic tree leaf's category up to the root",
     {
         claim: "a dynamic tree leaf's category change stops at the leaf instead of ORing up its ancestors, so a mask-filtered query prunes a subtree that still contains a matching proxy",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const tree = createTree(16);
@@ -422,10 +407,7 @@ check(
     "a dynamic tree all-bits query matches a mask whose half has its top bit set",
     {
         claim: "the dynamic tree's requireAllBits filter compares a signed int32 AND, so an all-ones or bit-31/bit-63 category mask never matches and the query silently drops the proxy",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const cases: [string, number, number, number, number, number][] = [
@@ -446,10 +428,7 @@ check(
     "a dynamic tree any-bit query keeps the category halves distinct",
     {
         claim: "the dynamic tree's any-bit filter aliases the high and low category words, so a proxy above bit 32 matches a low-half mask and vice versa",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const cases: [string, number, number, number, number, number][] = [
@@ -468,10 +447,7 @@ check(
     "dynamic tree category words survive the node-pool grow copy",
     {
         claim: "the dynamic tree's node-pool grow drops or truncates the 0xffffffff category words it copies, so proxies added past the initial capacity stop matching an all-bits query",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // createTree floors nodeCapacity at 2*16-1 = 31 nodes; each proxy past the first costs 2
@@ -510,10 +486,7 @@ check(
     "a dynamic tree query nested inside another query leaves the outer traversal intact",
     {
         claim: "the dynamic tree's traversal stack and visit stats are a shared singleton rather than pooled by depth, so a compound leaf's inner query clobbers the outer query's stack and counts",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const boxAt = (x: number): AABB => ({

--- a/src/standard/physics/common/array.test.ts
+++ b/src/standard/physics/common/array.test.ts
@@ -10,10 +10,7 @@ check(
     "GrowVec push, get and count agree",
     {
         claim: "GrowVec.push writes past or before its own tail, so the value read back at index zero is not the value pushed and count does not advance",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const a = intVec();
@@ -32,10 +29,7 @@ check(
     "GrowVec emplace returns writable indices across regrowth",
     {
         claim: "GrowVec.emplace hands back an index outside the backing store or loses earlier elements when it doubles capacity",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const a = intVec();
@@ -56,10 +50,7 @@ check(
     "GrowVec reserve sizes capacity and removeSwap preserves the multiset",
     {
         claim: "GrowVec.reserve leaves count nonzero or removeSwap drops or duplicates an element while draining from the head",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const a = intVec();
@@ -85,10 +76,7 @@ check(
     "GrowVec removeSwap reports the moved index",
     {
         claim: "GrowVec.removeSwap returns the wrong moved index or fails to return NULL_INDEX for the tail, so callers fix up a back-index that never moved",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const a = intVec();
@@ -105,10 +93,7 @@ check(
     "GrowVec resize sets capacity and count, and pop drains",
     {
         claim: "GrowVec.resize sets capacity without count, or pop returns elements in an order other than last in first out",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const a = intVec();
@@ -149,10 +134,7 @@ check(
     "qsort orders a large array through the partition and stack path",
     {
         claim: "the qsort port mishandles its subfile stack or the i>=j partition boundary above the insertion cutoff, leaving 200 duplicate-heavy keys out of order",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // 200 elements (>> the cutoff of 16) with many duplicates (values 0..49) exercises the
@@ -166,10 +148,7 @@ check(
     "qsort orders duplicate keys through the insertion path",
     {
         claim: "the qsort insertion-sort cutoff branch mis-sorts a short run containing repeated keys",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         expect(sorted([5, 1, 5, 3, 1, 2, 5, 0, 3, 2])).toEqual([0, 1, 1, 2, 2, 3, 3, 5, 5, 5]);
@@ -180,10 +159,7 @@ check(
     "qsort handles empty, single and pair inputs",
     {
         claim: "the qsort port indexes out of bounds or swaps needlessly on inputs of length zero, one or two",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         expect(sorted([])).toEqual([]);

--- a/src/standard/physics/common/bitset.test.ts
+++ b/src/standard/physics/common/bitset.test.ts
@@ -17,10 +17,7 @@ check(
     "clz32 counts leading zeros the way the C intrinsic does",
     {
         claim: "the physics clz32 binding is off by one against the bit position it reports for a small operand",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         expect(clz32(9)).toBe(31 - 3);
@@ -31,10 +28,7 @@ check(
     "lowerPowerOf2Exponent equals floor of log2",
     {
         claim: "lowerPowerOf2Exponent is off by one at or near a power of two, so a broadphase bucket sizes to the wrong exponent",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (let i = 1; i < 1000; ++i) {
@@ -51,10 +45,7 @@ check(
     "setBit and getBit agree over a Fibonacci pattern",
     {
         claim: "the bit set indexes the wrong 32-bit block or shift, so a Fibonacci-indexed pattern reads back with bits in the wrong slots",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const Count = 169;
@@ -84,10 +75,7 @@ check(
     "setBitGrow extends past the initial block count",
     {
         claim: "setBitGrow fails to grow the backing blocks for a far index, or clobbers its neighbour while growing",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const bitSet = createBitSet(8);
@@ -103,10 +91,7 @@ check(
     "countSetBits and inPlaceUnion agree on set algebra",
     {
         claim: "countSetBits miscounts across block boundaries or inPlaceUnion double-counts the overlap of two bit sets",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const a = createBitSet(128);

--- a/src/standard/physics/common/ids.test.ts
+++ b/src/standard/physics/common/ids.test.ts
@@ -9,10 +9,7 @@ check(
     "storeId after loadId is the identity on a packed id",
     {
         claim: "the entity id packing loses or reorders bits on a full round trip through loadId and storeId",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const x = 0x0123456789abcdefn;
@@ -24,10 +21,7 @@ check(
     "id fields decode from the u64 layout",
     {
         claim: "loadId reads index1, world0 or generation from the wrong bit field of the packed u64",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const id = loadId(0x0123456789abcdefn);
@@ -41,10 +35,7 @@ check(
     "a high-bit index1 sign-extends and still round-trips",
     {
         claim: "an index1 with its top bit set fails to sign-extend on load, so a negative index round-trips as a large positive one",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const id = { index1: -1, world0: 0x1234, generation: 0x5678 };
@@ -56,10 +47,7 @@ check(
     "the id pool hands out dense ids and reuses freed ones last in first out",
     {
         claim: "the id pool leaves holes in its dense range, miscounts live ids against capacity, or recycles freed ids in the wrong order",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const pool = createIdPool();

--- a/src/standard/physics/common/math.test.ts
+++ b/src/standard/physics/common/math.test.ts
@@ -107,10 +107,7 @@ check(
     "atan2 sweep is bit-exact vs the C reference",
     {
         claim: "the physics atan2 polynomial drifts from the Box3D C reference by at least one f32 bit somewhere on the quadrant sweep",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         expect(g.atan2.length).toBeGreaterThan(0);
@@ -124,10 +121,7 @@ check(
     "computeCosSin sweep is bit-exact vs the C reference",
     {
         claim: "the physics computeCosSin approximation drifts from the Box3D C reference by at least one f32 bit on the angle sweep",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         expect(g.cosSin.length).toBeGreaterThan(0);
@@ -143,10 +137,7 @@ check(
     "vec/quat/matrix/transform gold cases are bit-exact",
     {
         claim: "one of the vec3, quat, mat2, mat3 or transform ports returns different f32 bits than the recorded Box3D C reference case",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         expect(g.cases.length).toBeGreaterThan(20);
@@ -172,10 +163,7 @@ check(
     "atan2 tracks libm within 0.0023 degrees",
     {
         claim: "the physics atan2 approximation is not merely imprecise but wrong in quadrant or branch, exceeding its 4e-5 radian tolerance against libm",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const AtanTol = 4e-5;
@@ -192,10 +180,7 @@ check(
     "computeCosSin tracks libm within 0.002",
     {
         claim: "the physics computeCosSin range reduction misplaces an angle outside the primary period, exceeding 0.002 absolute error against libm",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         for (let t = -10; t < 10; t += 0.05) {
@@ -211,10 +196,7 @@ check(
     "vec3.normalize yields unit length",
     {
         claim: "vec3.normalize divides by the wrong magnitude, so the result is not unit length within four float epsilons",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const u = m.vec3.normalize({ x: 0.2, y: -0.5, z: 3.0 });
@@ -226,10 +208,7 @@ check(
     "transform point round-trips through its inverse",
     {
         claim: "xf.invPoint does not undo xf.point, so the rotation is applied before instead of after the translation",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const axis = m.vec3.normalize({ x: 0.3, y: -0.7, z: 0.5 });
@@ -246,10 +225,7 @@ check(
     "mat3 times its inverse is identity",
     {
         claim: "mat3.invert or mat3.mul transposes a column or drops a cofactor, so their product is not the identity",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const mat: Mat3 = {
@@ -271,10 +247,7 @@ check(
     "mat3.solve agrees with invert then multiply",
     {
         claim: "mat3.solve's Cramer determinants disagree with inverting the same matrix and multiplying, so the solver picks a wrong column",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const mat: Mat3 = {
@@ -295,10 +268,7 @@ check(
     "quat compose then decompose recovers the operand",
     {
         claim: "quat.invMul is not the left inverse of quat.mul, so a relative rotation conjugates the wrong operand",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const q1 = m.quat.fromAxisAngle(m.vec3.axisZ(), -0.5 * Math.PI);
@@ -315,10 +285,7 @@ check(
     "computeQuatBetweenUnitVectors rotates the first onto the second",
     {
         claim: "computeQuatBetweenUnitVectors builds a rotation that lands v1 somewhere other than v2, or returns a non-finite quaternion",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const v1 = m.vec3.normalize({ x: 0.2, y: -0.5, z: 3.0 });
@@ -336,10 +303,7 @@ check(
     "nlerp twist angle tracks alpha across a 90 degree turn",
     {
         claim: "quat.nlerp or quat.getTwistAngle is non-monotonic in alpha across a quarter turn about z, straying more than a degree from the interpolated angle",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const q1 = m.quat.identity();
@@ -356,10 +320,7 @@ check(
     "arbitraryPerp is orthogonal to its input",
     {
         claim: "arbitraryPerp returns a vector with a nonzero dot against its input, so contact tangent frames would be skewed",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const n = { x: 0.50405544, y: 0.621548057, z: 0.599671543 };
@@ -371,10 +332,7 @@ check(
     "scalar min and max mirror the C branches, not Math.min/max",
     {
         claim: "minf or maxf delegates to Math.min/Math.max, so NaN poisons the result and signed zero orders the wrong way",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // minf(NaN, b) === b (Math.min would be NaN); minf(-0, +0) === +0.

--- a/src/standard/physics/compose.test.ts
+++ b/src/standard/physics/compose.test.ts
@@ -8,10 +8,7 @@ import { ShapeKind } from "./index";
 check(
     "nlerpShortest returns curr exactly at t=1 and prev exactly at t=0",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "render interpolation misses its endpoints, so a body at rest would show a pose that is neither the previous nor the current physics transform",
     },
     () => {
@@ -26,10 +23,7 @@ check(
 check(
     "nlerpShortest blends the shortest arc",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "render interpolation mixes quaternions without flipping the previous one into the current hemisphere, so a rotating body would spin the long way around between frames",
     },
     () => {
@@ -44,10 +38,7 @@ check(
 check(
     "nlerpShortest result is always unit-length",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "render interpolation leaves the blended quaternion unnormalized, so an interpolated body would shear or scale mid-rotation",
     },
     () => {
@@ -60,10 +51,7 @@ check(
 check(
     "renderScale doubles half-extents for box and hull",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "render scale passes box and hull half-extents through undoubled, so every box would draw at half the size the solver collides with",
     },
     () => {
@@ -75,10 +63,7 @@ check(
 check(
     "renderScale scales a sphere uniformly to twice its radius",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "render scale reads a sphere's size from its unused half-extents instead of its radius, so every sphere would draw at zero size",
     },
     () => {
@@ -89,10 +74,7 @@ check(
 check(
     "renderScale gives a capsule (2r, halfHeight + r, 2r)",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "render scale treats a capsule like a box, so its hemispherical caps would distort under a non-proportional height-to-radius ratio",
     },
     () => {

--- a/src/standard/physics/headless.test.ts
+++ b/src/standard/physics/headless.test.ts
@@ -20,10 +20,7 @@ check(
     "a headless State warms PhysicsPlugin and steps it with no GPU",
     {
         claim: "physics stops stepping without a GPU device, so every step-tier physics check would be unrunnable in Bun",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     async () => {
         const state = await headlessPhysicsState();

--- a/src/standard/physics/raycast.test.ts
+++ b/src/standard/physics/raycast.test.ts
@@ -18,10 +18,7 @@ import {
 check(
     "qRotate applies a 90-degree yaw and its conjugate inverts it",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the raycast quaternion rotation turns a vector the wrong way, so picking a rotated body would test the ray against a mirrored orientation",
     },
     () => {
@@ -41,10 +38,7 @@ check(
 check(
     "raySphere returns the near root with an outward normal, and null on a miss",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the ray-sphere solve takes the far root or an inward normal, so clicking a sphere would report the back surface",
     },
     () => {
@@ -64,10 +58,7 @@ check(
 check(
     "rayOBB hits each face at the analytic distance and misses cleanly",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the oriented-box slab test picks the wrong entry face or ignores the body rotation, so picking a turned box would report a wrong distance or normal",
     },
     () => {
@@ -93,10 +84,7 @@ check(
 check(
     "rayOBB from inside returns the exit distance paired with the exit face normal",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "an oriented-box hit from a ray origin inside the box reports the entry face the slab test tracks for tmin, so a camera inside geometry would pick a surface behind it",
     },
     () => {
@@ -120,10 +108,7 @@ check(
 check(
     "rayCapsule separates the cylinder body from the hemispherical caps",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the ray-capsule solve treats the caps as part of the infinite cylinder, so a ray along the capsule axis would hit at the wrong distance",
     },
     () => {
@@ -143,10 +128,7 @@ check(
 check(
     "raycast returns the nearest body, honours maxDist, and returns null on an empty list",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the raycast sweep over a body list keeps the last hit rather than the nearest or ignores maxDist, so clicking overlapping bodies would select the one behind",
     },
     () => {
@@ -175,10 +157,7 @@ check(
 check(
     "generateRay unprojects NDC through the camera's fov, aspect and pose",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the NDC-to-world ray drops the aspect ratio, the near offset or the camera rotation, so a pick would miss the object under the cursor on a non-square canvas or a turned camera",
     },
     () => {
@@ -223,10 +202,7 @@ check(
 check(
     "screenToRay maps pixels to NDC with the y axis flipped",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the pixel-to-NDC conversion drops the y flip or mis-centres the canvas, so a cursor above the centre would pick a body below it",
     },
     () => {

--- a/src/standard/physics/shapes/compound.test.ts
+++ b/src/standard/physics/shapes/compound.test.ts
@@ -240,10 +240,7 @@ check(
     "compound geometry gold — mixed, materials and transforms scenes bit for bit",
     {
         claim: "a compound's materials, inner tree nodes and resolved child transforms drift from the pinned Box3D compound gold, bit for bit.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const scenes: [string, () => CompoundData][] = [
@@ -266,10 +263,7 @@ check(
     "compound creation — mixed and single-type child counts",
     {
         claim: "createCompound mis-sorts a compound's children into the wrong per-type arrays, or leaves its inner tree unbuilt, for the mixed scene or for a lone capsule, hull, mesh or sphere.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         vector("CompoundCreateMixed — counts + shared diagnostics", () => {
@@ -334,10 +328,7 @@ check(
     "compound material table — dedup, distinct slots, cross-shape and mesh sharing",
     {
         claim: "a compound's material table collapses materials that differ, or duplicates identical ones, across capsules, hulls, spheres and mesh material arrays.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         vector("CompoundMaterialDedup — identical materials collapse to one slot", () => {
@@ -424,10 +415,7 @@ check(
     "compound geometry sharing — hull and mesh dedup by pointer, content and difference",
     {
         claim: "a compound's shared hull and shared mesh counts stop deduplicating identical geometry by content, or wrongly merge geometry that differs.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         vector(
@@ -508,10 +496,7 @@ check(
     "compound child addressing — dispatch by index, inner-tree query and root AABB cover",
     {
         claim: "a compound's child index stops resolving to the right child shape, its inner-tree AABB query visits the wrong children, or its root AABB fails to contain a child's own AABB.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         vector("CompoundChildDispatch — getCompoundChild resolves the right type per index", () => {
@@ -589,10 +574,7 @@ check(
     "compound casts — ray miss, nearest child, rotated hull normal, shape cast and overlap",
     {
         claim: "a compound's ray cast, shape cast or overlap query reports the wrong child, fraction, material or hull normal frame, or hits where the compound has a gap.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         vector("ray cast misses a compound it passes over", () => {
@@ -690,10 +672,7 @@ check(
     "compound mover collision — a plane per straddled child, capacity honored",
     {
         claim: "collideMoverAndCompound drops one of the up-facing planes a capsule mover straddling two compound box children should get, or overruns the plane capacity it was given.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // Ported from test_compound.c CompoundMover.

--- a/src/standard/physics/shapes/geometry.test.ts
+++ b/src/standard/physics/shapes/geometry.test.ts
@@ -60,10 +60,7 @@ check(
     "sphere/capsule mass bit-exact vs C reference",
     {
         claim: "computeSphereMass or computeCapsuleMass drifts from the Box3D C reference's f32 bits for a sphere or capsule vector, including the ragdoll bone capsule where an unrounded 0.4 sphere-inertia literal costs a ULP",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // f32-round non-exact literals (0.35, 0.3) to match the C float inputs bit-for-bit.
@@ -100,10 +97,7 @@ check(
     "sphere/capsule AABB",
     {
         claim: "computeSphereAABB or computeCapsuleAABB stops bounding a sphere or capsule at center +/- radius, or stops following the transform's translation",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // AABBs compose xf.point (bit-exact) with min/max/sub/add; concrete extremes pin the
@@ -147,10 +141,7 @@ check(
     "f32 geometry rounding at the storage boundary",
     {
         claim: "roundSphere or roundCapsule leaves an f64 sphere or capsule field unrounded at the storage boundary, so solver arithmetic on it diverges from the C's f32 struct fields",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // The C holds geometry as f32 struct fields; callers pass f64 JS numbers. A field that is

--- a/src/standard/physics/shapes/heightfield.test.ts
+++ b/src/standard/physics/shapes/heightfield.test.ts
@@ -122,10 +122,7 @@ check(
     "height field build is bit-exact against the C geometry gold",
     {
         claim: "a height field built by createGrid or createHeightField would drift from the pinned C reference in its quantized heights, bounds, edge flags, winding remap or decompressed triangle vertices",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const cases: Array<{ name: string; build: () => HeightFieldData }> = [
@@ -146,10 +143,7 @@ check(
     "height field wave authoring yields sound dimensions and finite triangles",
     {
         claim: "createWave would author a height field with the wrong row, column, material or flag counts, or a triangle decoding to a non-finite vertex or an invalid field AABB",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // createWave uses Math.sin (not the portable b3 trig or C's sinf), so it is authoring-only and
@@ -237,10 +231,7 @@ check(
     "height field ray cast lands on a flat surface with an up normal",
     {
         claim: "rayCastHeightField would miss a flat height field, or recover the wrong hit fraction or a surface normal that is not the field's up axis",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // Tight quantization range keeps the recovered surface within ~1e-5 of y=0.
@@ -271,10 +262,7 @@ check(
     "height field overlap separates a proxy above the surface from one through it",
     {
         claim: "overlapHeightField would report a hit for a proxy hovering clear above the field, or miss one whose radius reaches the field surface",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const hf = createGrid(4, 4, { x: 1, y: 1, z: 1 }, false);
@@ -303,10 +291,7 @@ check(
     "height field shape cast tests every cell the swept proxy straddles",
     {
         claim: "shapeCastHeightField would cull the one solid height field cell that sits on the trailing side of the swept proxy's x, z or corner boundary",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         // Only cell (0,0) is solid; the swept sphere's center is nudged just past each boundary so the
@@ -360,10 +345,7 @@ check(
     "height field shape cast grid walk matches the brute-force cast",
     {
         claim: "the grid walk in shapeCastHeightField would disagree with a brute-force cast over every wave height field triangle on hit or fraction for some origin, sweep and proxy radius",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const hf = createWave(10, 10, { x: 2, y: 1.5, z: 2 }, 0.1, 0.03333, false);
@@ -409,10 +391,7 @@ check(
     "height field ray cast grid walk matches the brute-force ray",
     {
         claim: "the grid walk in rayCastHeightField would disagree with a brute-force ray against every wave height field triangle on hit or fraction for some origin and translation",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const hf = createWave(10, 10, { x: 2, y: 1.5, z: 2 }, 0.1, 0.03333, false);

--- a/src/standard/physics/shapes/hull.test.ts
+++ b/src/standard/physics/shapes/hull.test.ts
@@ -153,10 +153,7 @@ const goldBox = (name: string) => gold.boxHulls.find((h) => h.name === name) as 
 check(
     "hull bit-exact vs C reference",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the convex hull builder's quickhull output — points, half-edges, planes, center, inertia, volume, surface area, inner radius and aabb — diverges by a bit from the Box3D C reference on any of the cube, tetrahedron, redundant-cloud, skew, cylinder, cylinder6, cone or rock cases",
     },
     () => {
@@ -179,10 +176,7 @@ check(
 check(
     "box hull bit-exact vs C reference",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a convex hull built from box half-extents — unit, oblong, or rotated by a quaternion through makeTransformedBoxHull — diverges by a bit from the Box3D C reference",
     },
     () => {
@@ -237,10 +231,7 @@ function fillSphereSample(count: number, seed: number): Vec3[] {
 check(
     "hull topology satisfies Euler",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a convex hull leaves a broken half-edge topology — counts off the expected 8/24/6 cube or 4/12/4 tetrahedron, or V - E + F away from 2 on dense sphere clouds driven through the merge cascade",
     },
     () => {
@@ -271,10 +262,7 @@ check(
 check(
     "hull vertex cap is honored and clamped",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the convex hull builder overruns its maxVertexCount cap or fails to clamp an out-of-range cap into [4, 255]",
     },
     () => {
@@ -298,10 +286,7 @@ check(
 check(
     "degenerate hull inputs are rejected",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the convex hull builder returns a hull instead of null for a degenerate point cloud: empty, fewer than four points, collinear, coincident or coplanar",
     },
     () => {
@@ -335,10 +320,7 @@ check(
 check(
     "hull support queries and world AABB",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a convex hull's support vertex is not the extreme point along the query direction, its support face normal is not the one aligned with that direction, or computeHullAABB fails to reproduce the local aabb under identity and translate it",
     },
     () => {
@@ -365,10 +347,7 @@ check(
 check(
     "hull determinism, mass and clone",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the convex hull builder is nondeterministic across two identical builds (structure or hash), computeHullMass ignores the hull's volume or center, or cloneHull returns a shallow copy that aliases the original's points",
     },
     () => {

--- a/src/standard/physics/shapes/mesh.test.ts
+++ b/src/standard/physics/shapes/mesh.test.ts
@@ -105,10 +105,7 @@ check(
     "triangle mesh builders match the C reference bit for bit",
     {
         claim: "a triangle mesh builder drifts from the Box3D C reference in its BVH nodes, vertices, winding, edge flags or surface area, and the mesh gold no longer describes what the TypeScript port builds",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const cases: [string, () => MeshData, string][] = [
@@ -141,10 +138,7 @@ check(
     "the triangle wave mesh grids, flattens its seed rows and stays inside its amplitude",
     {
         claim: "createWaveMesh emits the wrong triangle count for its cell grid, lifts the zero-sine boundary row or column off the plane, or rides its sine product past the requested amplitude",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         const xCount = 6;

--- a/src/standard/physics/solver/graph.test.ts
+++ b/src/standard/physics/solver/graph.test.ts
@@ -13,10 +13,7 @@ const { Static, Kinematic, Dynamic } = BodyType;
 check(
     "dynamic-dynamic pairs pack into the lowest non-conflicting color",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the constraint graph puts two dynamic-dynamic pairs sharing a body in one color, so the colored solver would write the same body from two constraints in the same batch",
     },
     () => {
@@ -37,10 +34,7 @@ check(
 check(
     "a dynamic body saturating every dynamic color spills to overflow",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a dynamic body already present in every dynamic graph color takes one more constraint into a color instead of the overflow batch, so that constraint would race its own body",
     },
     () => {
@@ -57,10 +51,7 @@ check(
 check(
     "dynamic-static constraints build from the high end, tracking only the dynamic body",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "dynamic-static constraints are colored from the low end or record the static body in the color's body set, so static-anchored constraints would crowd the dynamic-dynamic colors and false-conflict on a shared static body",
     },
     () => {
@@ -78,10 +69,7 @@ check(
 check(
     "the static side is symmetric on body B",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the graph colorer handles a static body only in the A slot, so a static-A/dynamic-B constraint would be colored as if both sides were dynamic",
     },
     () => {
@@ -95,10 +83,7 @@ check(
 check(
     "kinematic bodies color like static ones (only the dynamic bit is tracked)",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a kinematic body is colored on the dynamic-dynamic branch, so kinematic-anchored constraints would occupy the low colors and conflict with real dynamic pairs",
     },
     () => {

--- a/src/standard/physics/solver/joint.test.ts
+++ b/src/standard/physics/solver/joint.test.ts
@@ -37,10 +37,7 @@ function pendulum(): { world: World; joint: Joint } {
 check(
     "a created joint exposes its type, its bodies and the world's joint count",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a freshly created joint handle reports the wrong type or the wrong pair of bodies, so a caller could not tell which constraint it just made",
     },
     () => {
@@ -57,10 +54,7 @@ check(
 check(
     "destroying a joint invalidates its handle and frees the id",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a destroyed joint still reports itself valid or leaves its id counted, so the joint pool would leak slots across a scene teardown",
     },
     () => {
@@ -76,10 +70,7 @@ check(
 check(
     "a recycled joint slot invalidates the stale generation",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a joint handle kept past its destroy resolves again once its slot is reused, so a stale reference would silently drive somebody else's constraint",
     },
     () => {
@@ -98,10 +89,7 @@ check(
 check(
     "collideConnected decides whether jointed bodies also collide",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "the joint-connected contact filter ignores collideConnected, so two jointed touching bodies would either fight their own contact or pass through each other against the caller's setting",
     },
     () => {
@@ -132,10 +120,7 @@ check(
 check(
     "a revolute joint holds the arm at its hinge and reacts against gravity",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a revolute joint does not hold its hinge point, so a pendulum arm would drift away from its anchor or carry no constraint force",
     },
     () => {
@@ -160,10 +145,7 @@ check(
 check(
     "a weld joint rigidly holds a box fixed to a static anchor against gravity",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a weld joint lets its body sag, so a welded box would fall away from its start pose under gravity",
     },
     () => {
@@ -187,10 +169,7 @@ check(
 check(
     "a parallel joint applies a corrective torque against a body spinning off-axis",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a parallel joint carries no constraint torque, so a body spinning off its partner's axis would never be pulled back into alignment",
     },
     () => {
@@ -215,10 +194,7 @@ check(
 check(
     "a motor joint drives the arm's spin in the direction of the target angular velocity",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a motor joint's target angular velocity does not set which way its body turns, so a driven arm would spin the same way whatever sign the caller asks for",
     },
     () => {
@@ -252,10 +228,7 @@ check(
 check(
     "a prismatic motor drives the slider to its upper limit while the line holds it off-axis",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a prismatic joint ignores its translation limit or lets gravity pull the slider off its axis, so a driven slider would overshoot or drop off its rail",
     },
     () => {
@@ -286,10 +259,7 @@ check(
 check(
     "a spherical joint pins the arm's pivot at the anchor as it swings",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a spherical joint does not pin its pivot point, so a ball-jointed arm would drift off its socket while it swings",
     },
     () => {
@@ -311,10 +281,7 @@ check(
 check(
     "a wheel joint's spin motor drives the wheel in the target direction",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a wheel joint's spin motor ignores the sign of its target speed, so a vehicle wheel would turn the same way in forward and reverse",
     },
     () => {
@@ -344,10 +311,7 @@ check(
 check(
     "a filter joint suppresses the contact between its two bodies",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a filter joint fails to suppress the contact between its pair, so two overlapping bodies deliberately excluded from each other would still push apart",
     },
     () => {
@@ -376,10 +340,7 @@ check(
 check(
     "a mixed spherical/revolute ragdoll island settles and sleeps as a unit",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a multi-joint island never reaches sleep, so a settled ragdoll would keep every one of its bodies awake and burning solver time forever",
     },
     () => {
@@ -437,10 +398,7 @@ check(
 check(
     "a distance joint holds a rigid length between the anchors as the ball swings down",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a rigid distance joint lets its length change under load, so a swinging ball on a fixed rope would stretch away from its anchor",
     },
     () => {
@@ -552,10 +510,7 @@ function exerciseBase(joint: Joint, world: World, expectedType: JointType) {
 check(
     "parallel joint accessors round-trip and the joint steps",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a parallel joint's spring and max-torque accessors do not round-trip through the solver's storage, so tuning a parallel joint from script would silently keep the old value",
     },
     () => {
@@ -582,10 +537,7 @@ check(
 check(
     "distance joint accessors round-trip and the joint steps",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a distance joint's length, spring, limit and motor accessors do not round-trip, so retuning a rope or spring from script would silently keep the old value",
     },
     () => {
@@ -626,10 +578,7 @@ check(
 check(
     "filter joint carries the shared base API with no type-specific accessors",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a filter joint does not answer the shared joint API or refuses to step, so a contact-suppression joint would break the code paths every other joint type shares",
     },
     () => {
@@ -643,10 +592,7 @@ check(
 check(
     "motor joint accessors round-trip and the joint steps",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a motor joint's velocity targets, force caps and spring tuning do not round-trip, so retargeting a motor from script would silently keep the old drive",
     },
     () => {
@@ -685,10 +631,7 @@ check(
 check(
     "prismatic joint accessors round-trip and the joint steps",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a prismatic joint's spring, limit and motor accessors do not round-trip, so retuning a slider from script would silently keep the old rail settings",
     },
     () => {
@@ -726,10 +669,7 @@ check(
 check(
     "revolute joint accessors round-trip and the joint steps",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a revolute joint's target angle, limits and motor accessors do not round-trip, so retuning a hinge from script would silently keep the old settings",
     },
     () => {
@@ -766,10 +706,7 @@ check(
 check(
     "spherical joint accessors round-trip and the joint steps",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a spherical joint's cone, twist, spring and motor accessors do not round-trip, so retuning a ball socket from script would silently keep the old limits",
     },
     () => {
@@ -823,10 +760,7 @@ check(
 check(
     "weld joint accessors round-trip and the joint steps",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a weld joint's linear and angular softness accessors do not round-trip, so softening a weld from script would silently keep it rigid",
     },
     () => {
@@ -850,10 +784,7 @@ check(
 check(
     "wheel joint accessors round-trip and the joint steps",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "a wheel joint's suspension, spin-motor and steering accessors do not round-trip, so tuning a vehicle wheel from script would silently keep the old suspension or steering",
     },
     () => {
@@ -917,10 +848,7 @@ function rig() {
 check(
     "revolute setLimits orders reversed args and clamps to plus/minus 0.99 pi",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "revolute setLimits stores its arguments unordered or unclamped, so a hinge given reversed or out-of-range angles would hold an empty or wrapped limit range",
     },
     () => {
@@ -940,10 +868,7 @@ check(
 check(
     "prismatic setLimits orders reversed args with no clamp",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "prismatic setLimits stores its arguments unordered, so a slider given reversed translations would hold an empty limit range and jam",
     },
     () => {
@@ -959,10 +884,7 @@ check(
 check(
     "spherical setTwistLimits orders reversed args and clamps to plus/minus 0.99 pi",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "spherical setTwistLimits stores its arguments unordered or unclamped, so a ball socket given reversed or out-of-range twist angles would hold an empty or wrapped range",
     },
     () => {
@@ -982,10 +904,7 @@ check(
 check(
     "distance setLength clamps below the linear slop",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "distance setLength accepts a zero or negative length, so a collapsed rope would divide by its own degenerate axis in the solver",
     },
     () => {
@@ -1000,10 +919,7 @@ check(
 check(
     "distance setLengthRange clamps each value then orders the pair",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "distance setLengthRange orders before clamping or skips one of the two, so a reversed range with a degenerate low end would survive into the solver",
     },
     () => {
@@ -1020,10 +936,7 @@ check(
 check(
     "motor clamps a negative max spring force and torque to zero",
     {
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
         claim: "motor setMaxSpringForce and setMaxSpringTorque keep a negative cap, so a mis-set motor would drive its spring backwards instead of disabling it",
     },
     () => {

--- a/src/standard/physics/solver/step.gold.test.ts
+++ b/src/standard/physics/solver/step.gold.test.ts
@@ -20,10 +20,7 @@ check(
     "gold free-fall",
     {
         claim: "a body under gravity alone integrates bit-exactly like the C reference, so a changed gravity or velocity integration step reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("free-fall", false, false);
@@ -34,10 +31,7 @@ check(
     "gold sphere-drop",
     {
         claim: "a sphere dropped on a hull ground resolves its contact bit-exactly, so a changed sphere-hull manifold or contact solve reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("sphere-drop", false, false);
@@ -48,10 +42,7 @@ check(
     "gold box-stack",
     {
         claim: "a stack of boxes settles bit-exactly, so a changed hull-hull manifold, warm start or relax pass reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("box-stack", false, false);
@@ -62,10 +53,7 @@ check(
     "gold sphere-sleep",
     {
         claim: "a resting sphere falls asleep on the same step as the C reference, so a changed sleep threshold or island sleep bookkeeping reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("sphere-sleep", true, false);
@@ -76,10 +64,7 @@ check(
     "gold box-sleep",
     {
         claim: "a settled box stack falls asleep on the same step as the C reference, so a changed island sleep time accumulation reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("box-sleep", true, false);
@@ -90,10 +75,7 @@ check(
     "gold wake-drop",
     {
         claim: "a body dropped onto a sleeping island wakes it on the same step as the C reference, so a changed wake propagation reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("wake-drop", true, false);
@@ -104,10 +86,7 @@ check(
     "gold split-slide",
     {
         claim: "a sliding body splits its island bit-exactly, so a changed island split or constraint-graph removal reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("split-slide", true, false);
@@ -118,10 +97,7 @@ check(
     "gold revolute-dd",
     {
         claim: "a revolute joint between two dynamic bodies solves bit-exactly, so a changed revolute constraint block reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("revolute-dd", false, false);
@@ -132,10 +108,7 @@ check(
     "gold revolute-pendulum",
     {
         claim: "a revolute pendulum swings bit-exactly, so a changed joint frame or bias term reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("revolute-pendulum", false, false);
@@ -146,10 +119,7 @@ check(
     "gold revolute-motor",
     {
         claim: "a revolute motor drives its body bit-exactly, so a changed motor impulse clamp reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("revolute-motor", false, false);
@@ -160,10 +130,7 @@ check(
     "gold revolute-limit",
     {
         claim: "a revolute joint holds its angular limits bit-exactly, so a changed limit constraint or angle unwrap reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("revolute-limit", false, false);
@@ -174,10 +141,7 @@ check(
     "gold revolute-chain",
     {
         claim: "a chain of revolute joints sleeps and solves bit-exactly, so a changed joint island colouring reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("revolute-chain", true, false);
@@ -188,10 +152,7 @@ check(
     "gold weld-dd",
     {
         claim: "a weld joint between two dynamic bodies holds bit-exactly, so a changed weld linear or angular block reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("weld-dd", false, false);
@@ -202,10 +163,7 @@ check(
     "gold parallel",
     {
         claim: "a parallel joint keeps its axes aligned bit-exactly, so a changed parallel constraint basis reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("parallel", false, false);
@@ -216,10 +174,7 @@ check(
     "gold joint-contacts",
     {
         claim: "a jointed pair that also touches solves joints and contacts in the C reference's order, so a changed solve ordering reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("joint-contacts", false, false);
@@ -230,10 +185,7 @@ check(
     "gold motor",
     {
         claim: "a motor joint drives to its target bit-exactly, so a changed motor joint impulse or max-force clamp reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("motor", false, false);
@@ -244,10 +196,7 @@ check(
     "gold motor-spring",
     {
         claim: "a springy motor joint oscillates bit-exactly, so a changed soft-constraint softness derivation reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("motor-spring", false, false);
@@ -258,10 +207,7 @@ check(
     "gold distance",
     {
         claim: "a rigid distance joint holds its length bit-exactly, so a changed distance constraint block reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("distance", false, false);
@@ -272,10 +218,7 @@ check(
     "gold distance-spring",
     {
         claim: "a spring distance joint oscillates bit-exactly, so a changed hertz or damping-ratio softness reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("distance-spring", false, false);
@@ -286,10 +229,7 @@ check(
     "gold prismatic",
     {
         claim: "a prismatic joint slides along its axis bit-exactly, so a changed prismatic constraint basis reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("prismatic", false, false);
@@ -300,10 +240,7 @@ check(
     "gold prismatic-motor",
     {
         claim: "a prismatic motor drives along its axis bit-exactly, so a changed prismatic motor clamp reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("prismatic-motor", false, false);
@@ -314,10 +251,7 @@ check(
     "gold spherical",
     {
         claim: "a spherical joint holds its pivot bit-exactly, so a changed spherical point constraint reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("spherical", false, false);
@@ -328,10 +262,7 @@ check(
     "gold spherical-limits",
     {
         claim: "a spherical joint holds its cone and twist limits bit-exactly, so a changed swing-twist decomposition reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("spherical-limits", false, false);
@@ -342,10 +273,7 @@ check(
     "gold spherical-motor",
     {
         claim: "a spherical motor drives its orientation bit-exactly, so a changed spherical motor torque clamp reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("spherical-motor", false, false);
@@ -356,10 +284,7 @@ check(
     "gold wheel",
     {
         claim: "a wheel joint carries its suspension bit-exactly, so a changed wheel spring or lateral constraint reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("wheel", false, false);
@@ -370,10 +295,7 @@ check(
     "gold wheel-spin",
     {
         claim: "a spinning wheel joint solves bit-exactly, so a changed wheel motor axis reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("wheel-spin", false, false);
@@ -384,10 +306,7 @@ check(
     "gold wheel-steer",
     {
         claim: "a steered wheel joint solves bit-exactly, so a changed wheel steering frame reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("wheel-steer", false, false);
@@ -398,10 +317,7 @@ check(
     "gold ragdoll",
     {
         claim: "a fourteen-bone ragdoll island solves and sleeps bit-exactly, so a changed articulated joint ordering reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("ragdoll", true, false);
@@ -412,10 +328,7 @@ check(
     "gold ccd-drop",
     {
         claim: "a fast body dropped onto the ground is caught by continuous collision on the C reference's step, so a changed sweep or time-of-impact root find reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("ccd-drop", false, true);
@@ -426,10 +339,7 @@ check(
     "gold ccd-bullet",
     {
         claim: "a bullet body is swept against the ground bit-exactly, so a changed bullet classification or conservative advancement reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("ccd-bullet", false, true);
@@ -440,10 +350,7 @@ check(
     "gold mesh-box",
     {
         claim: "a box dropped on a static grid mesh resolves its triangle contacts bit-exactly, so a changed mesh-hull manifold reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("mesh-box", false, false);
@@ -454,10 +361,7 @@ check(
     "gold mesh-sphere",
     {
         claim: "a sphere dropped on a static grid mesh resolves bit-exactly, so a changed mesh-sphere manifold reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("mesh-sphere", false, false);
@@ -468,10 +372,7 @@ check(
     "gold mesh-capsule",
     {
         claim: "a capsule dropped on a static grid mesh resolves bit-exactly, so a changed mesh-capsule manifold reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("mesh-capsule", false, false);
@@ -482,10 +383,7 @@ check(
     "gold mesh-ccd",
     {
         claim: "a fast box swept onto a static mesh floor is caught bit-exactly, so a changed mesh sweep reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("mesh-ccd", false, true);
@@ -496,10 +394,7 @@ check(
     "gold height-box",
     {
         claim: "a box dropped on a static height field resolves bit-exactly, so a changed height-field cell lookup or triangulation reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("height-box", false, false);
@@ -510,10 +405,7 @@ check(
     "gold height-sphere",
     {
         claim: "a sphere dropped on a static height field resolves bit-exactly, so a changed height-field sphere manifold reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("height-sphere", false, false);
@@ -524,10 +416,7 @@ check(
     "gold height-capsule",
     {
         claim: "a capsule dropped on a static height field resolves bit-exactly, so a changed height-field capsule manifold reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("height-capsule", false, false);
@@ -538,10 +427,7 @@ check(
     "gold height-ccd",
     {
         claim: "a fast box swept onto a static height field is caught bit-exactly, so a changed height-field sweep reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("height-ccd", false, true);
@@ -552,10 +438,7 @@ check(
     "gold compound-hull",
     {
         claim: "a box dropped on a compound hull floor resolves every child bit-exactly, so a changed compound child transform reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("compound-hull", false, false);
@@ -566,10 +449,7 @@ check(
     "gold compound-capsule",
     {
         claim: "a box dropped on a compound capsule floor resolves bit-exactly, so a changed compound capsule child reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("compound-capsule", false, false);
@@ -580,10 +460,7 @@ check(
     "gold compound-sphere",
     {
         claim: "a box dropped on a compound sphere floor resolves bit-exactly, so a changed compound sphere child reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("compound-sphere", false, false);
@@ -594,10 +471,7 @@ check(
     "gold compound-mesh",
     {
         claim: "a box dropped on a compound mesh floor resolves bit-exactly, so a changed compound mesh child reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("compound-mesh", false, false);
@@ -608,10 +482,7 @@ check(
     "gold compound-ccd",
     {
         claim: "a fast box swept onto a two-hull compound floor is caught bit-exactly, so a changed compound sweep reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("compound-ccd", false, true);
@@ -622,10 +493,7 @@ check(
     "gold sensor",
     {
         claim: "a static sensor volume never perturbs the dynamics that pass through it, so a sensor leaking contact impulses reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("sensor", false, true);
@@ -636,10 +504,7 @@ check(
     "gold bench-pyramid",
     {
         claim: "a large single-island pyramid solves bit-exactly at scale, so a changed graph colouring or overflow-colour fallback reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("bench-pyramid", false, false);
@@ -650,10 +515,7 @@ check(
     "gold bench-many-pyramids",
     {
         claim: "many separate pyramid islands solve bit-exactly, so a changed island partition or solve order across islands reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("bench-many-pyramids", false, false);
@@ -664,10 +526,7 @@ check(
     "gold bench-joint-grid",
     {
         claim: "a large joint grid solves bit-exactly, so a changed joint colouring at scale reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("bench-joint-grid", false, false);
@@ -678,10 +537,7 @@ check(
     "gold bench-washer",
     {
         claim: "kinematic contact churn against a washer solves bit-exactly, so a changed contact begin-touch ordering reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("bench-washer", false, false);
@@ -692,10 +548,7 @@ check(
     "gold bench-large-world",
     {
         claim: "spheres spawned into a large world over time solve bit-exactly, so a changed broad-phase move buffer or proxy rebuild reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("bench-large-world", false, false);
@@ -706,10 +559,7 @@ check(
     "gold bench-trees",
     {
         claim: "cylinder stacks on the reference's wavy mesh ground solve bit-exactly, so a changed cylinder hull or mesh contact at scale reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("bench-trees", false, false);
@@ -720,10 +570,7 @@ check(
     "gold bench-junkyard",
     {
         claim: "a kinematic pusher swept by setTargetTransform pushes a rock pile bit-exactly, so a changed kinematic target pose or rock hull reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("bench-junkyard", false, false);
@@ -734,10 +581,7 @@ check(
     "gold bench-rain",
     {
         claim: "ragdolls created mid-replay with their joints solve bit-exactly, so a changed mid-step body or joint creation path reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("bench-rain", false, false);
@@ -748,10 +592,7 @@ check(
     "gold drift",
     {
         claim: "a settled box stack holds for two thousand steps bit-exactly, so slow numerical drift away from the C reference reds.",
-        class: "pure",
         tier: "step",
-        premises: [],
-        budget: 1000,
     },
     () => {
         runScene("drift", false, false);


### PR DESCRIPTION
## Problem
The surface declaration repeated class, premises, and budget on nearly every row, while `surface.ts --list` also ran a runtime census and JUnit probe through a wrapper.

## Cause
Tier defaults were not shared by runtime validation and the static reader, so declarations carried duplicated values and process checks used an illegal `process`/`step` pairing once class derivation became strict.

## Fix
- Add `TIER_DEFAULTS` and resolve class, premises, and budget from the required claim/tier pair.
- Reject class/tier contradictions and budgets over their tier ceiling in both readers.
- Remove the runtime census, JUnit probe, and `--test` wrapper; make `test` run cargo plus Bun directly.
- Trim the physics and recipe declarations, manifest, and schema; preserve custom budgets and premises.
- Add a browser-default fixture and regenerate the hosted workflow.

## Evidence
- `bun run check` — green, including tsc, surface reader, workflow drift, and cargo fmt.
- `bun run test` — 231 Rust tests plus 259 Bun checks, all passing.
- `bun scripts/surface.ts --list` — 259 rows, derived class and budget on every row, no runtime census.
- `scripts/surface.test.ts` — undeclared, duplicate, over-budget, orphan, expired, non-literal, and browser-default fixture arms pass.
