### PR TITLE
satellite-surfaces: expose public preload carrier

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "./harness": "./src/harness/index.ts",
         "./harness/check": "./src/harness/check.ts",
         "./harness/surface": "./src/harness/surface.ts",
+        "./harness/preload": "./src/harness/preload.ts",
         "./harness/pixels": "./src/harness/pixels.ts",
         "./harness/browser": {
             "types": "./src/harness/browser.d.ts",


### PR DESCRIPTION
Problem
Bench cannot consume the carrier preload through a package export.

Cause
The carrier package exports harness, check, and surface but not harness/preload.

Fix
Add the minimal @dylanebert/shallot/harness/preload export mapped to src/harness/preload.ts.

Evidence
bun run test; bun run check; bun scripts/surface.ts --list; generated workflow byte-identical; consumer-package public resolution/import; S0 baseline integration.