### PR TITLE
satellite-surfaces: enforce root manifest authority

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,11 @@ replacing it. In `bunfig.toml`, compose the entries as
 `preload = ["./src/project-preload.ts", "@dylanebert/shallot/harness/preload"]`.
 
 A root `shallot.json` may admit one check entry or an array of `{ "file": "..." }` entries.
-Every admitted file is still discovered and must use `check()`; malformed, duplicate, or missing
-entries refuse. `.oracle.ts` files are named evidence and stay out of ordinary `test` and
+When its `check` field is present, that list is the complete project population: every visible
+`.test.ts`, `.tier.ts` and `.oracle.ts` file must appear exactly once, and an omitted file refuses.
+Every admitted file must use `check()`; malformed, duplicate, missing and moved entries refuse.
+Without a root `check` field, project-rooted discovery remains in force, including nested recipe
+manifests. `.oracle.ts` files are named evidence and stay out of ordinary `test` and
 subject-selected integration sweeps; run one explicitly with `--oracle <claim>`.
 
 `bun run examples:index` regenerates `examples/AGENTS.md`; `check` reds when it drifts. `check` is the gate before every push.

--- a/scripts/surface.test.ts
+++ b/scripts/surface.test.ts
@@ -14,6 +14,7 @@ import { join, resolve } from "node:path";
 import { check } from "@dylanebert/shallot/harness/check";
 import {
     collectPopulation,
+    discoverTestFiles,
     readSurface,
     renderWorkflow,
     selectIntegrationRows,
@@ -229,6 +230,97 @@ check(
             ).toEqual(["added path selects"]);
         } finally {
             rmSync(tree.root, { recursive: true, force: true });
+        }
+    },
+);
+
+check(
+    "root manifests are complete authorities for static and launched populations",
+    {
+        claim: "root shallot.json check arrays admit exactly every visible entrypoint and keep named oracles out of ordinary launches",
+        size: "integration",
+    },
+    () => {
+        const tree = mkdtempSync(join(tmpdir(), "shallot-surface-root-authority-"));
+        mkdirSync(join(tree, "src"), { recursive: true });
+        mkdirSync(join(tree, "tests"), { recursive: true });
+        const checkModule = resolve(ROOT, "src/harness/check");
+        writeFileSync(
+            join(tree, "src/kept.test.ts"),
+            `import { check } from ${JSON.stringify(checkModule)};\ncheck("kept", { claim: "kept" }, () => {});\n`,
+        );
+        writeFileSync(
+            join(tree, "tests/named.oracle.ts"),
+            `import { check } from ${JSON.stringify(checkModule)};\ncheck("named", { claim: "named" }, () => {});\n`,
+        );
+        writeFileSync(
+            join(tree, "shallot.json"),
+            JSON.stringify(
+                {
+                    check: [{ file: "src/kept.test.ts" }, { file: "tests/named.oracle.ts" }],
+                },
+                null,
+                2,
+            ),
+        );
+        try {
+            let population = collectPopulation(tree);
+            expect(population.invalid).toEqual([]);
+            expect(population.undeclared).toEqual([]);
+            expect(population.files).toEqual(["src/kept.test.ts", "tests/named.oracle.ts"]);
+            expect(discoverTestFiles(tree)).toEqual(["src/kept.test.ts"]);
+            expect(discoverTestFiles(tree, true)).toEqual([
+                "src/kept.test.ts",
+                "tests/named.oracle.ts",
+            ]);
+
+            writeFileSync(
+                join(tree, "shallot.json"),
+                JSON.stringify({ check: [{ file: "src/kept.test.ts" }] }),
+            );
+            population = collectPopulation(tree);
+            expect(population.invalid).toContain(
+                "unlisted check file: tests/named.oracle.ts; root shallot.json check is authoritative",
+            );
+            expect(population.files).toEqual(["src/kept.test.ts"]);
+
+            writeFileSync(
+                join(tree, "shallot.json"),
+                JSON.stringify({
+                    check: [
+                        { file: "src/kept.test.ts" },
+                        { file: "src/kept.test.ts" },
+                        { file: "src/moved.test.ts" },
+                    ],
+                }),
+            );
+            population = collectPopulation(tree);
+            expect(population.invalid).toEqual([
+                "duplicate manifest entry: src/kept.test.ts",
+                "manifest entry does not exist: src/moved.test.ts",
+                "unlisted check file: tests/named.oracle.ts; root shallot.json check is authoritative",
+            ]);
+
+            writeFileSync(
+                join(tree, "src/unlisted.test.ts"),
+                `import { check } from ${JSON.stringify(checkModule)};\ncheck("unlisted", { claim: "unlisted" }, () => { throw new Error("UNLISTED_RAN"); });\n`,
+            );
+            writeFileSync(
+                join(tree, "shallot.json"),
+                JSON.stringify({ check: [{ file: "src/kept.test.ts" }] }),
+            );
+            const runner = Bun.spawnSync(
+                ["bun", resolve(ROOT, "scripts/test-runner.ts"), "--root", tree],
+                { cwd: ROOT, stdout: "pipe", stderr: "pipe" },
+            );
+            expect(runner.exitCode).toBe(1);
+            expect(runner.stderr.toString()).toContain(
+                "unlisted check file: tests/named.oracle.ts",
+            );
+            expect(runner.stderr.toString()).toContain("unlisted check file: src/unlisted.test.ts");
+            expect(runner.stderr.toString()).not.toContain("UNLISTED_RAN");
+        } finally {
+            rmSync(tree, { recursive: true, force: true });
         }
     },
 );

--- a/src/harness/surface.ts
+++ b/src/harness/surface.ts
@@ -223,25 +223,31 @@ interface ManifestEntry {
     file: string;
 }
 
-function manifestEntries(root: string, path: string, population: Population): ManifestEntry[] {
+interface ManifestRead {
+    entries: ManifestEntry[];
+    hasCheck: boolean;
+}
+
+function manifestEntries(root: string, path: string, population: Population): ManifestRead {
     const label = relativeFile(root, path);
     let parsed: unknown;
     try {
         parsed = JSON.parse(readFileSync(path, "utf8"));
     } catch (error) {
         population.invalid.push(`invalid manifest: ${label}: ${(error as Error).message}`);
-        return [];
+        return { entries: [], hasCheck: false };
     }
     if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
         population.invalid.push(`invalid manifest: ${label}: expected an object`);
-        return [];
+        return { entries: [], hasCheck: false };
     }
-    const check = (parsed as Record<string, unknown>).check;
-    if (check === undefined) return [];
+    const manifest = parsed as Record<string, unknown>;
+    if (!Object.hasOwn(manifest, "check")) return { entries: [], hasCheck: false };
+    const check = manifest.check;
     const entries = Array.isArray(check) ? check : [check];
     if (entries.length === 0) {
         population.invalid.push(`invalid manifest: ${label}: check array must not be empty`);
-        return [];
+        return { entries: [], hasCheck: true };
     }
     const seen = new Set<string>();
     const result: ManifestEntry[] = [];
@@ -264,6 +270,10 @@ function manifestEntries(root: string, path: string, population: Population): Ma
         }
         const file = resolve(path, "..", entry.file);
         const relativePath = relativeFile(root, file);
+        if (relativePath === ".." || relativePath.startsWith("../")) {
+            population.invalid.push(`manifest entry escapes project root: ${relativePath}`);
+            continue;
+        }
         if (seen.has(relativePath)) {
             population.invalid.push(`duplicate manifest entry: ${relativePath}`);
             continue;
@@ -277,7 +287,7 @@ function manifestEntries(root: string, path: string, population: Population): Ma
             population.invalid.push(`manifest entry is not a check file: ${relativePath}`);
         result.push({ file });
     }
-    return result;
+    return { entries: result, hasCheck: true };
 }
 
 /** Read one manifest-selected check file through the same carrier reader. */
@@ -335,14 +345,28 @@ export function collectPopulation(root: string): Population {
     const manifestFiles = [...manifests]
         .filter((match) => !match.split("/").some((part) => SKIP.has(part)))
         .sort();
-    const admitted = new Set<string>(files);
-    for (const match of manifestFiles) {
-        for (const entry of manifestEntries(
-            population.root,
-            resolve(population.root, match),
-            population,
-        ))
-            admitted.add(resolve(entry.file));
+    const manifestResults = new Map<string, ManifestRead>();
+    for (const match of manifestFiles)
+        manifestResults.set(
+            match,
+            manifestEntries(population.root, resolve(population.root, match), population),
+        );
+    const rootResult = manifestResults.get("shallot.json");
+    const rootIsAuthoritative = rootResult?.hasCheck === true;
+    const admitted = rootIsAuthoritative
+        ? new Set((rootResult?.entries ?? []).map((entry) => resolve(entry.file)))
+        : new Set<string>(files);
+    if (rootIsAuthoritative) {
+        const listed = new Set(admitted);
+        for (const file of files) {
+            if (!listed.has(file))
+                population.invalid.push(
+                    `unlisted check file: ${relativeFile(population.root, file)}; root shallot.json check is authoritative`,
+                );
+        }
+    } else {
+        for (const result of manifestResults.values())
+            for (const entry of result.entries) admitted.add(resolve(entry.file));
     }
     for (const path of [...admitted].sort()) {
         if (!SUFFIX.test(path) || path.split(sep).some((part) => SKIP.has(part))) continue;
@@ -635,9 +659,10 @@ export function writeWorkflow(root: string): "written" | "removed" | "empty" {
 }
 
 export function discoverTestFiles(root: string, includeOracles = false): string[] {
-    return discoveredFiles(root)
+    const population = collectPopulation(root);
+    return population.files
         .filter((path) => includeOracles || !ORACLE_SUFFIX.test(path))
-        .map((path) => relativeFile(root, path));
+        .map((path) => relativeFile(root, resolve(root, path)));
 }
 
 export { CHECK_REQUIREMENTS, CHECK_SIZES };


### PR DESCRIPTION
## Problem
A root `shallot.json` check array was additive, so omitted visible check files stayed in the static population and runner launch set.

## Cause
Population collection seeded admission from project-wide discovery and the runner independently rediscovered the same set.

## Fix
Root manifests now validate a complete visible suffix population, refuse unlisted/duplicate/missing/moved entries, and drive runner launch files. Projects without a root `check` retain project-rooted discovery and nested recipe manifests. Added focused authority/refusal/oracle tests and corrected the public contract.

## Evidence
`bun run test`, `bun run check`, `bun run list`, byte-clean `bun run workflow`, pack dry-run, installed scratch import, and focused surface tests pass.