### PR TITLE
browser-check-serve-command: accept consumer serve command

### DIFF
--- a/examples/surface-friction/check.test.ts
+++ b/examples/surface-friction/check.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, expect } from "bun:test";
+import { resolve } from "node:path";
 import { State, Time } from "../../src/engine";
 import { clear, register } from "../../src/engine/ecs/traits";
 import { check } from "../../src/harness/check";
@@ -77,7 +78,16 @@ check(
         requires: ["chromium"],
     },
     async () => {
-        const verdict = await runBrowserCheck(import.meta.dir);
+        const verdict = await runBrowserCheck((port) => [
+            process.execPath,
+            resolve(import.meta.dir, "../../bin/shallot.ts"),
+            "dev",
+            import.meta.dir,
+            "--port",
+            String(port),
+            "--strict-port",
+            "--no-open",
+        ]);
         if (!verdict.ok) {
             throw Object.assign(
                 new Error("the browser harness did not observe the friction claim"),

--- a/src/harness/driver.ts
+++ b/src/harness/driver.ts
@@ -1,4 +1,3 @@
-import { resolve } from "node:path";
 import { REAL_GPU_LAUNCH } from "./index";
 import type { Verdict } from "./runtime";
 
@@ -24,7 +23,7 @@ async function waitForServer(url: string, process: ReturnType<typeof Bun.spawn>)
     const deadline = performance.now() + 15_000;
     while (performance.now() < deadline) {
         if (process.exitCode !== null)
-            throw new Error(`shallot dev exited with ${process.exitCode}`);
+            throw new Error(`serve command exited with ${process.exitCode}`);
         try {
             const response = await fetch(url, { signal: AbortSignal.timeout(500) });
             if (response.ok) return;
@@ -33,7 +32,7 @@ async function waitForServer(url: string, process: ReturnType<typeof Bun.spawn>)
         }
         await Bun.sleep(50);
     }
-    throw new Error(`timed out waiting for shallot dev at ${url}`);
+    throw new Error(`timed out waiting for serve command at ${url}`);
 }
 
 async function adapterLabel(page: import("playwright").Page): Promise<string> {
@@ -50,30 +49,21 @@ async function adapterLabel(page: import("playwright").Page): Promise<string> {
     });
 }
 
+export type BrowserServeCommand = (port: number) => string[];
+
 /**
- * Boot a manifest recipe through the normal dev host and return the page's in-engine Verdict.
- * The page owns the stepped-clock assertion; this process only waits for readiness and transports
- * the resulting JSON across the browser boundary.
+ * Boot a project through its serve command and return the page's in-engine Verdict. The driver
+ * supplies an unused port; the command owns its host-specific arguments. The page owns the
+ * stepped-clock assertion; this process only waits for readiness and transports the resulting JSON
+ * across the browser boundary.
  */
-export async function runBrowserCheck(projectDir: string): Promise<BrowserVerdict> {
+export async function runBrowserCheck(serveCommand: BrowserServeCommand): Promise<BrowserVerdict> {
     const { chromium } = await import("playwright");
     const browser = await chromium.launch({ headless: true, ...REAL_GPU_LAUNCH });
     const runtime = `bun ${Bun.version} + chromium ${browser.version()}`;
     const port = 4000 + Math.floor(Math.random() * 1000);
     const url = `http://localhost:${port}/`;
-    const server = Bun.spawn(
-        [
-            process.execPath,
-            resolve(import.meta.dir, "../../bin/shallot.ts"),
-            "dev",
-            resolve(projectDir),
-            "--port",
-            String(port),
-            "--strict-port",
-            "--no-open",
-        ],
-        { cwd: resolve(import.meta.dir, "../.."), stdout: "ignore", stderr: "ignore" },
-    );
+    const server = Bun.spawn(serveCommand(port), { stdout: "ignore", stderr: "ignore" });
     const page = await browser.newPage();
     const pageErrors: string[] = [];
     page.on("pageerror", (error) => pageErrors.push(error.message));

--- a/src/harness/index.ts
+++ b/src/harness/index.ts
@@ -4,4 +4,5 @@ import launch from "./browser.json" with { type: "json" };
 export type { RealGpuLaunch };
 /** the real-GPU Chromium launch recipe; the same data `./harness/browser` publishes as JSON. */
 export const REAL_GPU_LAUNCH: RealGpuLaunch = launch as RealGpuLaunch;
+export * from "./driver";
 export * from "./runtime";


### PR DESCRIPTION
## Problem
The browser-check driver hardcodes `shallot dev`, so ejected consumers cannot reuse it.

## Cause
`runBrowserCheck` owns the server command instead of only the browser protocol.

## Fix
Accept a port-aware serve-command factory, export the driver from the public harness path, and update the Shallot browser witness.

## Evidence
- `bun run test`
- `bun run check`
- `bun run test:integration -- --base c9c3118^ --diff c9c3118`